### PR TITLE
Feat/frontend admin print invoice button

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import vacademy.io.admin_core_service.features.fee_management.dto.FeeSearchFilterDTO;
+import vacademy.io.admin_core_service.features.fee_management.dto.ReceiptDetailsDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.SelectiveAllocationRequest;
 import vacademy.io.admin_core_service.features.fee_management.dto.StudentFeeAllocationLedgerDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.StudentFeePaymentDTO;
@@ -180,17 +181,18 @@ public class FeeTrackingAdminController {
                 userId, request.getInstituteId(), request.getStudentFeePaymentIds(),
                 request.getAmount(), request.getRemarks());
 
-        Map<String, String> response = new java.util.HashMap<>();
-        if (invoiceId != null) {
+        if (invoiceId == null) {
+            return ResponseEntity.ok(new java.util.HashMap<>());
+        }
+
+        ReceiptDetailsDTO receipt = feeTrackingService.buildReceiptDetails(invoiceId);
+        if (receipt != null) {
             Invoice invoice = invoiceRepository.findById(invoiceId).orElse(null);
             if (invoice != null && invoice.getPdfFileId() != null) {
-                String downloadUrl = mediaService.getFilePublicUrlById(invoice.getPdfFileId());
-                response.put("invoice_id", invoiceId);
-                response.put("receipt_number", invoice.getInvoiceNumber());
-                response.put("download_url", downloadUrl != null ? downloadUrl : "");
+                receipt.setDownloadUrl(mediaService.getFilePublicUrlById(invoice.getPdfFileId()));
             }
         }
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(receipt);
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
@@ -28,6 +28,8 @@ import vacademy.io.admin_core_service.features.fee_management.service.FeeLedgerA
 import vacademy.io.admin_core_service.features.fee_management.service.FeeTrackingService;
 import vacademy.io.admin_core_service.features.fee_management.service.StudentFeeDiscountService;
 import vacademy.io.admin_core_service.features.invoice.entity.Invoice;
+import vacademy.io.admin_core_service.features.invoice.entity.InvoiceLineItem;
+import vacademy.io.admin_core_service.features.invoice.repository.InvoiceLineItemRepository;
 import vacademy.io.admin_core_service.features.invoice.repository.InvoiceRepository;
 import vacademy.io.admin_core_service.features.media_service.service.MediaService;
 import vacademy.io.common.auth.model.CustomUserDetails;
@@ -54,6 +56,9 @@ public class FeeTrackingAdminController {
 
     @Autowired
     private InvoiceRepository invoiceRepository;
+
+    @Autowired
+    private InvoiceLineItemRepository invoiceLineItemRepository;
 
     @Autowired
     private MediaService mediaService;
@@ -156,7 +161,7 @@ public class FeeTrackingAdminController {
      * The admin picks specific installments and the amount to pay on each.
      */
     @PostMapping("/{userId}/allocate-selected")
-    public ResponseEntity<Void> allocatePaymentForSelectedInstallments(
+    public ResponseEntity<?> allocatePaymentForSelectedInstallments(
             @PathVariable("userId") String userId,
             @RequestBody SelectiveAllocationRequest request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -171,10 +176,21 @@ public class FeeTrackingAdminController {
             return ResponseEntity.badRequest().build();
         }
 
-        feeLedgerAllocationService.allocatePaymentForSelectedInstallments(
+        String invoiceId = feeLedgerAllocationService.allocatePaymentForSelectedInstallments(
                 userId, request.getInstituteId(), request.getStudentFeePaymentIds(),
                 request.getAmount(), request.getRemarks());
-        return ResponseEntity.noContent().build();
+
+        Map<String, String> response = new java.util.HashMap<>();
+        if (invoiceId != null) {
+            Invoice invoice = invoiceRepository.findById(invoiceId).orElse(null);
+            if (invoice != null && invoice.getPdfFileId() != null) {
+                String downloadUrl = mediaService.getFilePublicUrlById(invoice.getPdfFileId());
+                response.put("invoice_id", invoiceId);
+                response.put("receipt_number", invoice.getInvoiceNumber());
+                response.put("download_url", downloadUrl != null ? downloadUrl : "");
+            }
+        }
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -344,6 +360,38 @@ public class FeeTrackingAdminController {
                 "download_url", signedUrl,
                 "invoice_number", invoice.getInvoiceNumber(),
                 "file_name", "receipt_" + invoice.getInvoiceNumber() + ".pdf"
+        ));
+    }
+
+    /**
+     * Get receipt download URL for a specific paid installment.
+     * Looks up the InvoiceLineItem where source_id = installmentId,
+     * then returns the PDF download URL for the parent invoice.
+     */
+    @GetMapping("/installment/{installmentId}/receipt-url")
+    public ResponseEntity<?> getReceiptUrlForInstallment(
+            @PathVariable("installmentId") String installmentId) {
+        List<InvoiceLineItem> lineItems = invoiceLineItemRepository.findBySourceId(installmentId);
+        if (lineItems.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Invoice invoice = lineItems.get(0).getInvoice();
+        if (invoice == null || !StringUtils.hasText(invoice.getPdfFileId())) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "No receipt PDF found for this installment"));
+        }
+
+        String downloadUrl = mediaService.getFilePublicUrlById(invoice.getPdfFileId());
+        if (!StringUtils.hasText(downloadUrl)) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to generate download URL"));
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "invoice_id", invoice.getId(),
+                "receipt_number", invoice.getInvoiceNumber(),
+                "download_url", downloadUrl
         ));
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/ReceiptDetailsDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/ReceiptDetailsDTO.java
@@ -1,0 +1,47 @@
+package vacademy.io.admin_core_service.features.fee_management.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ReceiptDetailsDTO {
+    private String invoiceId;
+    private String receiptNumber;
+    private LocalDateTime receiptDate;
+    private String downloadUrl;
+    private String paymentMode;
+    private String transactionId;
+    private List<ReceiptLineItemDTO> lineItems;
+    private BigDecimal totalExpected;
+    private BigDecimal totalPaid;
+    private BigDecimal balanceDue;
+    private BigDecimal amountPaidNow;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class ReceiptLineItemDTO {
+        private String feeTypeName;
+        private String cpoName;
+        private Date dueDate;
+        private BigDecimal amountExpected;
+        private BigDecimal amountPaid;
+        private BigDecimal balance;
+        private String status;
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeLedgerAllocationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeLedgerAllocationService.java
@@ -224,7 +224,7 @@ public class FeeLedgerAllocationService {
     }
 
     @Transactional
-    public void allocatePaymentForSelectedInstallments(String userId, String instituteId,
+    public String allocatePaymentForSelectedInstallments(String userId, String instituteId,
             List<String> studentFeePaymentIds,
             BigDecimal amount, String remarks) {
         if (studentFeePaymentIds == null || studentFeePaymentIds.isEmpty()) {
@@ -308,7 +308,7 @@ public class FeeLedgerAllocationService {
         }
 
         if (!paidInstallmentIds.isEmpty()) {
-            schoolFeeReceiptService.generateAndSendReceipt(
+            return schoolFeeReceiptService.generateAndSendReceipt(
                     userId,
                     paymentLog.getId(),
                     instituteId,
@@ -317,6 +317,7 @@ public class FeeLedgerAllocationService {
                     "Cash",
                     paidInstallmentIds);
         }
+        return null;
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
@@ -15,6 +15,7 @@ import vacademy.io.admin_core_service.features.fee_management.dto.FeeSearchFilte
 import vacademy.io.admin_core_service.features.fee_management.dto.CollectionDashboardRequestDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.CollectionDashboardResponseDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.InvoiceReceiptDTO;
+import vacademy.io.admin_core_service.features.fee_management.dto.ReceiptDetailsDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.StudentFeeAllocationLedgerDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.StudentFeePaymentDTO;
 import vacademy.io.admin_core_service.features.fee_management.dto.StudentFeePaymentRowDTO;
@@ -674,6 +675,81 @@ public class FeeTrackingService {
                                 .remarks(entity.getRemarks())
                                 .createdAt(entity.getCreatedAt())
                                 .build();
+        }
+
+        @Transactional(readOnly = true)
+        public ReceiptDetailsDTO buildReceiptDetails(String invoiceId) {
+            Invoice invoice = invoiceRepository.findById(invoiceId).orElse(null);
+            if (invoice == null) return null;
+
+            List<InvoiceLineItem> lineItems = invoiceLineItemRepository.findByInvoiceId(invoiceId);
+
+            List<String> sourceIds = lineItems.stream()
+                    .map(InvoiceLineItem::getSourceId)
+                    .filter(s -> s != null && !s.isBlank())
+                    .collect(Collectors.toList());
+
+            Map<String, StudentFeePayment> paymentMap = studentFeePaymentRepository.findAllById(sourceIds)
+                    .stream().collect(Collectors.toMap(StudentFeePayment::getId, Function.identity(), (a, b) -> a));
+
+            List<StudentFeePayment> bills = new ArrayList<>(paymentMap.values());
+            Map<String, FeeMeta> metaMap = bills.isEmpty() ? Collections.emptyMap() : buildFeeMetaMap(bills);
+
+            // Parse payment mode and transaction ID from ledger remarks
+            String paymentMode = null;
+            String transactionId = null;
+            if (!sourceIds.isEmpty()) {
+                List<StudentFeeAllocationLedger> ledgers =
+                        studentFeeAllocationLedgerRepository.findByStudentFeePaymentId(sourceIds.get(0));
+                if (!ledgers.isEmpty() && ledgers.get(0).getRemarks() != null) {
+                    String[] parts = ledgers.get(0).getRemarks().split(" \\| ");
+                    for (String part : parts) {
+                        if (part.startsWith("Mode: ")) paymentMode = part.replace("Mode: ", "").trim();
+                        if (part.startsWith("Txn ID: ")) transactionId = part.replace("Txn ID: ", "").trim();
+                    }
+                }
+            }
+
+            // Build line item DTOs with fresh post-payment amounts
+            List<ReceiptDetailsDTO.ReceiptLineItemDTO> lineDTOs = new ArrayList<>();
+            for (String sourceId : sourceIds) {
+                StudentFeePayment sfp = paymentMap.get(sourceId);
+                if (sfp == null) continue;
+                FeeMeta meta = metaMap.get(sfp.getId());
+                BigDecimal expected = sfp.getAmountExpected() != null ? sfp.getAmountExpected() : BigDecimal.ZERO;
+                BigDecimal paid = sfp.getAmountPaid() != null ? sfp.getAmountPaid() : BigDecimal.ZERO;
+                BigDecimal discount = sfp.getDiscountAmount() != null ? sfp.getDiscountAmount() : BigDecimal.ZERO;
+                BigDecimal balance = expected.subtract(paid).subtract(discount).max(BigDecimal.ZERO);
+                lineDTOs.add(ReceiptDetailsDTO.ReceiptLineItemDTO.builder()
+                        .feeTypeName(meta != null ? meta.feeTypeName() : null)
+                        .cpoName(meta != null ? meta.cpoName() : null)
+                        .dueDate(sfp.getDueDate())
+                        .amountExpected(expected)
+                        .amountPaid(paid)
+                        .balance(balance)
+                        .status(sfp.getStatus())
+                        .build());
+            }
+
+            // Sort by due date
+            lineDTOs.sort(Comparator.comparing(
+                    ReceiptDetailsDTO.ReceiptLineItemDTO::getDueDate,
+                    Comparator.nullsLast(Comparator.naturalOrder())));
+
+            InvoiceDataFields dataFields = extractInvoiceDataFields(invoice.getInvoiceDataJson());
+
+            return ReceiptDetailsDTO.builder()
+                    .invoiceId(invoice.getId())
+                    .receiptNumber(invoice.getInvoiceNumber())
+                    .receiptDate(invoice.getInvoiceDate())
+                    .paymentMode(paymentMode)
+                    .transactionId(transactionId)
+                    .lineItems(lineDTOs)
+                    .totalExpected(dataFields.totalExpected())
+                    .totalPaid(dataFields.totalPaid())
+                    .balanceDue(dataFields.balanceDue())
+                    .amountPaidNow(dataFields.amountPaidNow())
+                    .build();
         }
 
         private Map<String, FeeMeta> buildFeeMetaMap(List<StudentFeePayment> bills) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
@@ -454,7 +454,6 @@ public class FeeTrackingService {
                 Map<String, FeeMeta> billIdToMeta = buildFeeMetaMap(allBills);
 
                 return allBills.stream()
-                                .filter(bill -> !"PAID".equals(bill.getStatus()))
                                 .map(bill -> mapToPaymentDTO(bill, billIdToMeta.get(bill.getId())))
                                 .collect(Collectors.toList());
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
@@ -229,9 +229,8 @@ public class SchoolFeeReceiptService {
      * @param paymentMode         Payment mode (e.g., "OFFLINE")
      * @param paidInstallmentIds  List of student_fee_payment IDs that were paid/partially paid in this allocation
      */
-    @Async
     @Transactional
-    public void generateAndSendReceipt(String userId, String paymentLogId,
+    public String generateAndSendReceipt(String userId, String paymentLogId,
             String instituteId, BigDecimal amountPaid, String transactionId, String paymentMode,
             List<String> paidInstallmentIds) {
         try {
@@ -240,7 +239,7 @@ public class SchoolFeeReceiptService {
 
             if (paidInstallmentIds == null || paidInstallmentIds.isEmpty()) {
                 log.warn("No paid installment IDs provided for receipt generation");
-                return;
+                return null;
             }
 
             // 1. Check if invoice email is enabled
@@ -255,14 +254,14 @@ public class SchoolFeeReceiptService {
             UserDTO user = authService.getUsersFromAuthServiceByUserIds(List.of(userId)).get(0);
             if (user == null) {
                 log.warn("User not found for receipt generation: {}", userId);
-                return;
+                return null;
             }
 
             // 3. Fetch ONLY the specific fee installments that were paid in this allocation
             List<StudentFeePayment> feePayments = studentFeePaymentRepository.findAllById(paidInstallmentIds);
             if (feePayments == null || feePayments.isEmpty()) {
                 log.warn("No fee payments found for provided installment IDs");
-                return;
+                return null;
             }
 
             // Sort fees chronologically (earliest due date first)
@@ -307,7 +306,7 @@ public class SchoolFeeReceiptService {
             // 11. Save line items (only for paid installments)
             saveLineItems(invoice, feePayments, currency);
 
-            log.info("School fee receipt generated successfully: {} for {} installments", 
+            log.info("School fee receipt generated successfully: {} for {} installments",
                     receiptNumber, feePayments.size());
 
             // 12. Send email if enabled
@@ -322,10 +321,13 @@ public class SchoolFeeReceiptService {
                 log.debug("Receipt email disabled by institute setting for institute: {}", instituteId);
             }
 
+            return invoice.getId();
+
         } catch (Exception e) {
             log.error("Error generating school fee receipt for userId: {}, instituteId: {}",
                     userId, instituteId, e);
             // Don't throw — receipt failure should never break allocation
+            return null;
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/repository/InvoiceLineItemRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/repository/InvoiceLineItemRepository.java
@@ -11,8 +11,10 @@ import java.util.List;
 public interface InvoiceLineItemRepository extends JpaRepository<InvoiceLineItem, String> {
     
     List<InvoiceLineItem> findByInvoice(Invoice invoice);
-    
+
     List<InvoiceLineItem> findByInvoiceId(String invoiceId);
+
+    List<InvoiceLineItem> findBySourceId(String sourceId);
 }
 
 

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/InstallmentSelectionStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/InstallmentSelectionStep.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, CurrencyInr, Wallet, WarningCircle, X } from '@phosphor-icons/react';
+import { ArrowLeft, CurrencyInr, DownloadSimple, Spinner, Wallet, WarningCircle, X } from '@phosphor-icons/react';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
@@ -11,6 +11,7 @@ import {
     generateInvoiceForInstallments,
     applyManualDiscount,
     sendInvoiceEmail,
+    getReceiptUrlForInstallment,
 } from '@/services/manage-finances';
 import { useTheme } from '@/providers/theme/theme-provider';
 import { InvoiceActionDialog } from './InvoiceActionDialog';
@@ -156,6 +157,20 @@ export function InstallmentSelectionStep({
 
     const [discountDrafts, setDiscountDrafts] = useState<Record<string, string>>({});
     const [reasonDrafts, setReasonDrafts] = useState<Record<string, string>>({});
+    const [downloadingReceiptId, setDownloadingReceiptId] = useState<string | null>(null);
+
+    const handleDownloadReceipt = async (installmentId: string, e: React.MouseEvent) => {
+        e.stopPropagation();
+        setDownloadingReceiptId(installmentId);
+        try {
+            const data = await getReceiptUrlForInstallment(installmentId);
+            window.open(data.download_url, '_blank');
+        } catch {
+            toast.error('No receipt found for this installment');
+        } finally {
+            setDownloadingReceiptId(null);
+        }
+    };
 
     const discountMutation = useMutation({
         mutationFn: ({
@@ -412,6 +427,7 @@ export function InstallmentSelectionStep({
                                         <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Due / Overdue</th>
                                         <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Due Date</th>
                                         <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Status</th>
+                                        <th className="py-3 px-4 w-10" />
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-gray-100 text-sm font-medium">
@@ -538,6 +554,21 @@ export function InstallmentSelectionStep({
                                                 </td>
                                                 <td className="py-3 px-4">
                                                     <StatusPill status={inst.status} />
+                                                </td>
+                                                <td className="py-3 px-2">
+                                                    {inst.status === 'PAID' && (
+                                                        <button
+                                                            title="Download Receipt"
+                                                            onClick={(e) => handleDownloadReceipt(inst.id, e)}
+                                                            disabled={downloadingReceiptId === inst.id}
+                                                            className="flex items-center justify-center h-7 w-7 rounded-md text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 transition-colors disabled:opacity-50"
+                                                        >
+                                                            {downloadingReceiptId === inst.id
+                                                                ? <Spinner size={14} className="animate-spin" />
+                                                                : <DownloadSimple size={14} weight="bold" />
+                                                            }
+                                                        </button>
+                                                    )}
                                                 </td>
                                             </tr>
                                         );

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/InstallmentSelectionStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/InstallmentSelectionStep.tsx
@@ -252,7 +252,7 @@ export function InstallmentSelectionStep({
         selectableDues.length > 0 && selectableDues.every((d) => selectedIds.has(d.id));
 
     return (
-        <div className="flex flex-col h-[calc(100vh-220px)]">
+        <div className="flex flex-col flex-1 min-h-0">
             {/* ── Top section ── */}
             <div className="space-y-4 mb-4">
                 {/* Header */}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
@@ -19,6 +19,8 @@ export function PayInstallmentsMain() {
     const [selectedStudent, setSelectedStudent] = useState<StudentFeePaymentRowDTO | null>(null);
     const [selectedDues, setSelectedDues] = useState<StudentFeeDueDTO[]>([]);
     const [paidAmount, setPaidAmount] = useState<number>(0);
+    const [receiptUrl, setReceiptUrl] = useState<string | undefined>();
+    const [receiptNumber, setReceiptNumber] = useState<string | undefined>();
 
     const handleSelectStudent = (student: StudentFeePaymentRowDTO) => {
         setSelectedStudent(student);
@@ -30,8 +32,10 @@ export function PayInstallmentsMain() {
         setStep('payment');
     };
 
-    const handlePaymentSuccess = (amount: number) => {
+    const handlePaymentSuccess = (amount: number, url?: string, number?: string) => {
         setPaidAmount(amount);
+        setReceiptUrl(url);
+        setReceiptNumber(number);
         setStep('success');
     };
 
@@ -43,6 +47,8 @@ export function PayInstallmentsMain() {
         setSelectedStudent(null);
         setSelectedDues([]);
         setPaidAmount(0);
+        setReceiptUrl(undefined);
+        setReceiptNumber(undefined);
         setStep('search');
     };
 
@@ -102,6 +108,8 @@ export function PayInstallmentsMain() {
                 <PaymentSuccessStep
                     studentName={selectedStudent.student_name}
                     amount={paidAmount}
+                    receiptUrl={receiptUrl}
+                    receiptNumber={receiptNumber}
                     onPayAnother={handleReset}
                 />
             )}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
@@ -49,7 +49,7 @@ export function PayInstallmentsMain() {
     const stepIndex = STEPS.findIndex((s) => s.key === step);
 
     return (
-        <div className="space-y-6">
+        <div className="flex flex-col gap-6 flex-1 min-h-0">
             {/* Step Indicator */}
             <div className="flex items-center gap-3 text-sm font-medium">
                 {STEPS.map((s, idx) => (

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PayInstallmentsMain.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { StudentFeePaymentRowDTO, StudentFeeDueDTO } from '@/types/manage-finances';
+import { AllocatePaymentResponse } from '@/services/manage-finances';
 import { StudentSearchStep } from './StudentSearchStep';
 import { InstallmentSelectionStep } from './InstallmentSelectionStep';
 import { PaymentDetailsStep } from './PaymentDetailsStep';
@@ -19,8 +20,7 @@ export function PayInstallmentsMain() {
     const [selectedStudent, setSelectedStudent] = useState<StudentFeePaymentRowDTO | null>(null);
     const [selectedDues, setSelectedDues] = useState<StudentFeeDueDTO[]>([]);
     const [paidAmount, setPaidAmount] = useState<number>(0);
-    const [receiptUrl, setReceiptUrl] = useState<string | undefined>();
-    const [receiptNumber, setReceiptNumber] = useState<string | undefined>();
+    const [receipt, setReceipt] = useState<AllocatePaymentResponse | undefined>();
 
     const handleSelectStudent = (student: StudentFeePaymentRowDTO) => {
         setSelectedStudent(student);
@@ -32,10 +32,9 @@ export function PayInstallmentsMain() {
         setStep('payment');
     };
 
-    const handlePaymentSuccess = (amount: number, url?: string, number?: string) => {
+    const handlePaymentSuccess = (amount: number, receiptData?: AllocatePaymentResponse) => {
         setPaidAmount(amount);
-        setReceiptUrl(url);
-        setReceiptNumber(number);
+        setReceipt(receiptData);
         setStep('success');
     };
 
@@ -47,8 +46,7 @@ export function PayInstallmentsMain() {
         setSelectedStudent(null);
         setSelectedDues([]);
         setPaidAmount(0);
-        setReceiptUrl(undefined);
-        setReceiptNumber(undefined);
+        setReceipt(undefined);
         setStep('search');
     };
 
@@ -107,9 +105,7 @@ export function PayInstallmentsMain() {
             {step === 'success' && selectedStudent && (
                 <PaymentSuccessStep
                     studentName={selectedStudent.student_name}
-                    amount={paidAmount}
-                    receiptUrl={receiptUrl}
-                    receiptNumber={receiptNumber}
+                    receipt={receipt}
                     onPayAnother={handleReset}
                 />
             )}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { StudentFeePaymentRowDTO, StudentFeeDueDTO } from '@/types/manage-finances';
-import { allocateSelectedPayment, getStudentDuesQueryKey } from '@/services/manage-finances';
+import { allocateSelectedPayment, AllocatePaymentResponse, getStudentDuesQueryKey } from '@/services/manage-finances';
 import { getInstituteId } from '@/constants/helper';
 import { ConfirmPaymentDialog } from './ConfirmPaymentDialog';
 
@@ -32,7 +32,7 @@ interface PaymentDetailsStepProps {
     student: StudentFeePaymentRowDTO;
     selectedDues: StudentFeeDueDTO[];
     onBack: () => void;
-    onSuccess: (amount: number) => void;
+    onSuccess: (amount: number, receiptUrl?: string, receiptNumber?: string) => void;
 }
 
 export function PaymentDetailsStep({
@@ -62,7 +62,7 @@ export function PaymentDetailsStep({
 
     const parsedAmount = parseFloat(amount) || 0;
 
-    const mutation = useMutation({
+    const mutation = useMutation<AllocatePaymentResponse, unknown>({
         mutationFn: () => {
             const instituteId = getInstituteId();
             if (!instituteId) throw new Error('Institute ID not found');
@@ -79,12 +79,12 @@ export function PaymentDetailsStep({
                 remarks: remarkParts.join(' | '),
             });
         },
-        onSuccess: () => {
+        onSuccess: (data) => {
             toast.success('Payment submitted successfully');
             queryClient.invalidateQueries({
                 queryKey: getStudentDuesQueryKey(student.student_id),
             });
-            onSuccess(parsedAmount);
+            onSuccess(parsedAmount, data?.download_url, data?.receipt_number);
         },
         onError: (err: any) => {
             toast.error(err?.response?.data?.ex || err?.message || 'Payment failed');

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
@@ -32,7 +32,7 @@ interface PaymentDetailsStepProps {
     student: StudentFeePaymentRowDTO;
     selectedDues: StudentFeeDueDTO[];
     onBack: () => void;
-    onSuccess: (amount: number, receiptUrl?: string, receiptNumber?: string) => void;
+    onSuccess: (amount: number, receipt?: AllocatePaymentResponse) => void;
 }
 
 export function PaymentDetailsStep({
@@ -84,7 +84,7 @@ export function PaymentDetailsStep({
             queryClient.invalidateQueries({
                 queryKey: getStudentDuesQueryKey(student.student_id),
             });
-            onSuccess(parsedAmount, data?.download_url, data?.receipt_number);
+            onSuccess(parsedAmount, data);
         },
         onError: (err: any) => {
             toast.error(err?.response?.data?.ex || err?.message || 'Payment failed');

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle } from '@phosphor-icons/react';
+import { CheckCircle, DownloadSimple } from '@phosphor-icons/react';
 
 const formatCurrency = (amount: number) =>
     new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
@@ -6,12 +6,16 @@ const formatCurrency = (amount: number) =>
 interface PaymentSuccessStepProps {
     studentName: string;
     amount: number;
+    receiptUrl?: string;
+    receiptNumber?: string;
     onPayAnother: () => void;
 }
 
 export function PaymentSuccessStep({
     studentName,
     amount,
+    receiptUrl,
+    receiptNumber,
     onPayAnother,
 }: PaymentSuccessStepProps) {
     return (
@@ -25,11 +29,29 @@ export function PaymentSuccessStep({
                 been recorded for{' '}
                 <span className="font-semibold text-gray-700">{studentName}</span>.
             </p>
-            <p className="mt-1 text-sm text-gray-400">
-                The receipt will be generated and sent automatically.
-            </p>
 
-            <div className="mt-8">
+            {receiptUrl ? (
+                <p className="mt-1 text-sm text-emerald-600 font-medium">
+                    Receipt {receiptNumber ? `#${receiptNumber} ` : ''}generated successfully.
+                </p>
+            ) : (
+                <p className="mt-1 text-sm text-gray-400">
+                    The receipt will be generated and sent automatically.
+                </p>
+            )}
+
+            <div className="mt-8 flex items-center justify-center gap-3">
+                {receiptUrl && (
+                    <a
+                        href={receiptUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 px-6 py-2.5 bg-emerald-600 text-white text-sm font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+                    >
+                        <DownloadSimple size={16} weight="bold" />
+                        Download Receipt
+                    </a>
+                )}
                 <button
                     onClick={onPayAnother}
                     className="px-6 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
@@ -1,60 +1,171 @@
 import { CheckCircle, DownloadSimple } from '@phosphor-icons/react';
+import dayjs from 'dayjs';
+import { AllocatePaymentResponse, ReceiptLineItem } from '@/services/manage-finances';
 
 const formatCurrency = (amount: number) =>
     new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
 
+const STATUS_STYLES: Record<string, { bg: string; text: string }> = {
+    PAID: { bg: 'bg-emerald-50', text: 'text-emerald-700' },
+    PARTIAL_PAID: { bg: 'bg-amber-50', text: 'text-amber-700' },
+    PENDING: { bg: 'bg-slate-100', text: 'text-slate-600' },
+    OVERDUE: { bg: 'bg-red-50', text: 'text-red-700' },
+};
+
 interface PaymentSuccessStepProps {
     studentName: string;
-    amount: number;
-    receiptUrl?: string;
-    receiptNumber?: string;
+    receipt?: AllocatePaymentResponse;
     onPayAnother: () => void;
 }
 
-export function PaymentSuccessStep({
-    studentName,
-    amount,
-    receiptUrl,
-    receiptNumber,
-    onPayAnother,
-}: PaymentSuccessStepProps) {
-    return (
-        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
-            <div className="flex justify-center mb-4">
-                <CheckCircle size={64} weight="duotone" className="text-emerald-500" />
-            </div>
-            <h2 className="text-xl font-bold text-gray-800">Payment Submitted</h2>
-            <p className="mt-2 text-gray-500">
-                <span className="font-semibold text-gray-700">{formatCurrency(amount)}</span> has
-                been recorded for{' '}
-                <span className="font-semibold text-gray-700">{studentName}</span>.
-            </p>
+export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: PaymentSuccessStepProps) {
+    const hasReceipt = receipt && receipt.invoice_id;
 
-            {receiptUrl ? (
-                <p className="mt-1 text-sm text-emerald-600 font-medium">
-                    Receipt {receiptNumber ? `#${receiptNumber} ` : ''}generated successfully.
+    return (
+        <div className="space-y-4">
+            {/* Success banner */}
+            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center">
+                <div className="flex justify-center mb-3">
+                    <CheckCircle size={56} weight="duotone" className="text-emerald-500" />
+                </div>
+                <h2 className="text-xl font-bold text-gray-800">Payment Submitted</h2>
+                <p className="mt-1 text-gray-500">
+                    Payment recorded for{' '}
+                    <span className="font-semibold text-gray-700">{studentName}</span>.
                 </p>
-            ) : (
-                <p className="mt-1 text-sm text-gray-400">
-                    The receipt will be generated and sent automatically.
-                </p>
+                {!hasReceipt && (
+                    <p className="mt-1 text-sm text-gray-400">
+                        The receipt will be generated and sent automatically.
+                    </p>
+                )}
+            </div>
+
+            {/* Receipt card */}
+            {hasReceipt && (
+                <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+                    {/* Receipt header */}
+                    <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/60 flex items-start justify-between">
+                        <div>
+                            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Receipt No</p>
+                            <p className="text-base font-bold text-gray-800 mt-0.5">{receipt.receipt_number}</p>
+                        </div>
+                        <div className="text-right">
+                            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Date</p>
+                            <p className="text-sm font-semibold text-gray-700 mt-0.5">
+                                {receipt.receipt_date ? dayjs(receipt.receipt_date).format('DD MMM YYYY') : '—'}
+                            </p>
+                        </div>
+                    </div>
+
+                    {/* Meta row */}
+                    <div className="px-6 py-3 border-b border-gray-100 flex flex-wrap gap-x-8 gap-y-1 text-sm">
+                        <div>
+                            <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Student: </span>
+                            <span className="font-semibold text-gray-700">{studentName}</span>
+                        </div>
+                        {receipt.payment_mode && (
+                            <div>
+                                <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Mode: </span>
+                                <span className="font-semibold text-gray-700">{receipt.payment_mode}</span>
+                            </div>
+                        )}
+                        {receipt.transaction_id && (
+                            <div>
+                                <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Txn ID: </span>
+                                <span className="font-semibold text-gray-700">{receipt.transaction_id}</span>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Line items table */}
+                    {receipt.line_items && receipt.line_items.length > 0 && (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-left border-collapse text-sm">
+                                <thead>
+                                    <tr className="border-b border-gray-100 bg-gray-50/80">
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">#</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Fee Type</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Due Date</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Expected</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Paid</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Balance</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-50">
+                                    {receipt.line_items.map((item: ReceiptLineItem, idx: number) => {
+                                        const style = STATUS_STYLES[item.status] || STATUS_STYLES['PENDING']!;
+                                        return (
+                                            <tr key={idx} className="hover:bg-gray-50/40">
+                                                <td className="py-2.5 px-4 text-gray-400 font-medium">{idx + 1}</td>
+                                                <td className="py-2.5 px-4">
+                                                    <p className="font-semibold text-gray-800">{item.fee_type_name || '—'}</p>
+                                                    {item.cpo_name && <p className="text-xs text-gray-400 mt-0.5">{item.cpo_name}</p>}
+                                                </td>
+                                                <td className="py-2.5 px-4 text-gray-600">
+                                                    {item.due_date ? dayjs(item.due_date).format('DD MMM YYYY') : '—'}
+                                                </td>
+                                                <td className="py-2.5 px-4 text-gray-700 text-right">{formatCurrency(item.amount_expected)}</td>
+                                                <td className="py-2.5 px-4 text-emerald-700 font-semibold text-right">{formatCurrency(item.amount_paid)}</td>
+                                                <td className="py-2.5 px-4 text-red-600 font-semibold text-right">
+                                                    {item.balance > 0 ? formatCurrency(item.balance) : '—'}
+                                                </td>
+                                                <td className="py-2.5 px-4">
+                                                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${style.bg} ${style.text}`}>
+                                                        {item.status.replace('_', ' ')}
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                                <tfoot>
+                                    <tr className="border-t-2 border-gray-200 bg-gray-50/60">
+                                        <td colSpan={3} />
+                                        <td className="py-3 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Expected</td>
+                                        <td className="py-3 px-4 text-sm font-bold text-gray-800 text-right">{formatCurrency(receipt.total_expected ?? 0)}</td>
+                                        <td className="py-3 px-4 text-sm font-bold text-gray-800 text-right">{formatCurrency(receipt.balance_due ?? 0)}</td>
+                                        <td />
+                                    </tr>
+                                    <tr className="bg-gray-50/60">
+                                        <td colSpan={3} />
+                                        <td className="py-1 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Paid</td>
+                                        <td className="py-1 px-4 text-sm font-bold text-emerald-700 text-right" colSpan={2}>{formatCurrency(receipt.total_paid ?? 0)}</td>
+                                        <td />
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    )}
+
+                    {/* Amount paid now highlight */}
+                    {receipt.amount_paid_now != null && (
+                        <div className="px-6 py-3 border-t border-gray-100 flex justify-end">
+                            <div className="text-right">
+                                <p className="text-xs text-gray-400 uppercase tracking-wide font-semibold">Amount Paid Now</p>
+                                <p className="text-xl font-extrabold text-emerald-600 mt-0.5">{formatCurrency(receipt.amount_paid_now)}</p>
+                            </div>
+                        </div>
+                    )}
+                </div>
             )}
 
-            <div className="mt-8 flex items-center justify-center gap-3">
-                {receiptUrl && (
+            {/* Actions */}
+            <div className="flex items-center justify-end gap-3">
+                {receipt?.download_url && (
                     <a
-                        href={receiptUrl}
+                        href={receipt.download_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 px-6 py-2.5 bg-emerald-600 text-white text-sm font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+                        className="inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-600 text-white text-sm font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
                     >
-                        <DownloadSimple size={16} weight="bold" />
+                        <DownloadSimple size={15} weight="bold" />
                         Download Receipt
                     </a>
                 )}
                 <button
                     onClick={onPayAnother}
-                    className="px-6 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+                    className="px-5 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"
                 >
                     Pay for Another Student
                 </button>

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle, DownloadSimple } from '@phosphor-icons/react';
 import dayjs from 'dayjs';
 import { AllocatePaymentResponse, ReceiptLineItem } from '@/services/manage-finances';
+import { useTheme } from '@/providers/theme/theme-provider';
 
 const formatCurrency = (amount: number) =>
     new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
@@ -19,6 +20,7 @@ interface PaymentSuccessStepProps {
 }
 
 export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: PaymentSuccessStepProps) {
+    const { getPrimaryColorCode } = useTheme();
     const hasReceipt = receipt && receipt.invoice_id;
 
     return (
@@ -157,7 +159,7 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                         href={receipt.download_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-600 text-white text-sm font-semibold rounded-lg hover:bg-emerald-700 transition-colors"
+                        className="inline-flex items-center gap-2 px-5 py-2.5 bg-black text-white text-sm font-semibold rounded-lg hover:bg-gray-800 transition-colors"
                     >
                         <DownloadSimple size={15} weight="bold" />
                         Download Receipt
@@ -165,7 +167,8 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                 )}
                 <button
                     onClick={onPayAnother}
-                    className="px-5 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+                    style={{ backgroundColor: getPrimaryColorCode() }}
+                    className="px-5 py-2.5 text-white text-sm font-semibold rounded-lg transition-colors"
                 >
                     Pay for Another Student
                 </button>

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
@@ -49,7 +49,7 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                     <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/60 flex items-start justify-between">
                         <div>
                             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Receipt No</p>
-                            <p className="text-base font-bold text-gray-800 mt-0.5">{receipt.receipt_number}</p>
+                            <p className="text-base font-normal text-gray-800 mt-0.5">{receipt.receipt_number}</p>
                         </div>
                         <div className="text-right">
                             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Date</p>
@@ -63,18 +63,18 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                     <div className="px-6 py-3 border-b border-gray-100 flex flex-wrap gap-x-8 gap-y-1 text-sm">
                         <div>
                             <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Student: </span>
-                            <span className="font-semibold text-gray-700">{studentName}</span>
+                            <span className="font-extrabold text-lg text-gray-800">{studentName}</span>
                         </div>
                         {receipt.payment_mode && (
                             <div>
                                 <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Mode: </span>
-                                <span className="font-semibold text-gray-700">{receipt.payment_mode}</span>
+                                <span className="font-extrabold text-lg text-gray-800">{receipt.payment_mode}</span>
                             </div>
                         )}
                         {receipt.transaction_id && (
                             <div>
                                 <span className="text-gray-400 text-xs uppercase tracking-wide font-semibold">Txn ID: </span>
-                                <span className="font-semibold text-gray-700">{receipt.transaction_id}</span>
+                                <span className="font-extrabold text-lg text-gray-800">{receipt.transaction_id}</span>
                             </div>
                         )}
                     </div>

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/index.lazy.tsx
@@ -25,7 +25,7 @@ function PayInstallmentsPage() {
             <Helmet>
                 <title>Pay Installments</title>
             </Helmet>
-            <div className="flex flex-col gap-6 p-6 animate-in fade-in duration-300 w-full max-w-[1400px] mx-auto">
+            <div className="flex flex-col gap-6 p-6 animate-in fade-in duration-300 w-full max-w-[1400px] mx-auto flex-1 min-h-0 h-full">
                 <PayInstallmentsMain />
             </div>
         </>

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -97,10 +97,28 @@ export const fetchStudentDues = async (userId: string): Promise<StudentFeeDueDTO
 
 // ─── Allocate Selected Payment ─────────────────────────────────────────────
 
+export interface ReceiptLineItem {
+    fee_type_name: string | null;
+    cpo_name: string | null;
+    due_date: string | null;
+    amount_expected: number;
+    amount_paid: number;
+    balance: number;
+    status: string;
+}
+
 export interface AllocatePaymentResponse {
     invoice_id?: string;
     receipt_number?: string;
+    receipt_date?: string;
     download_url?: string;
+    payment_mode?: string;
+    transaction_id?: string;
+    line_items?: ReceiptLineItem[];
+    total_expected?: number;
+    total_paid?: number;
+    balance_due?: number;
+    amount_paid_now?: number;
 }
 
 export const allocateSelectedPayment = async (

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -97,14 +97,21 @@ export const fetchStudentDues = async (userId: string): Promise<StudentFeeDueDTO
 
 // ─── Allocate Selected Payment ─────────────────────────────────────────────
 
+export interface AllocatePaymentResponse {
+    invoice_id?: string;
+    receipt_number?: string;
+    download_url?: string;
+}
+
 export const allocateSelectedPayment = async (
     userId: string,
     body: AllocateSelectedRequest
-): Promise<void> => {
-    await authenticatedAxiosInstance.post(
+): Promise<AllocatePaymentResponse> => {
+    const response = await authenticatedAxiosInstance.post<AllocatePaymentResponse>(
         `${BASE_URL}/admin-core-service/v1/admin/student-fee/${userId}/allocate-selected`,
         body
     );
+    return response.data;
 };
 
 // ─── Apply Manual Discount (per installment) ─────────────────────────────
@@ -153,6 +160,23 @@ export const generateInvoiceForInstallments = async (
         `${BASE_URL}/admin-core-service/v1/admin/student-fee/${userId}/generate-invoice`,
         { installment_ids: installmentIds },
         { params: { instituteId } }
+    );
+    return response.data;
+};
+
+// ─── Receipt URL for a specific paid installment ───────────────────────────
+
+export interface InstallmentReceiptResponse {
+    invoice_id: string;
+    receipt_number: string;
+    download_url: string;
+}
+
+export const getReceiptUrlForInstallment = async (
+    installmentId: string
+): Promise<InstallmentReceiptResponse> => {
+    const response = await authenticatedAxiosInstance.get<InstallmentReceiptResponse>(
+        `${BASE_URL}/admin-core-service/v1/admin/student-fee/installment/${installmentId}/receipt-url`
     );
     return response.data;
 };


### PR DESCRIPTION
## Summary of Changes

Improvements to the Pay Installments page in Fee Management: fixed the installment table height, made paid installments visible, added a full receipt details card on the payment success screen, and added per-installment receipt download buttons.

**Backend:**
- Removed the `PAID` status filter from `FeeTrackingService.getStudentDues()` so paid installments are returned alongside pending ones
- Made `SchoolFeeReceiptService.generateAndSendReceipt()` (allocation overload) synchronous and return the generated `invoiceId` instead of fire-and-forget void
- `FeeLedgerAllocationService.allocatePaymentForSelectedInstallments()` now returns the `invoiceId` from receipt generation
- Added `ReceiptDetailsDTO` with full receipt data: receipt number, date, payment mode, transaction ID, per-installment line items (fee type, CPO, due date, expected, paid, balance, post-payment status), and totals
- Added `FeeTrackingService.buildReceiptDetails(invoiceId)` — re-fetches fresh `StudentFeePayment` rows for post-payment amounts, reuses `buildFeeMetaMap` for fee type/CPO names, and parses payment mode + transaction ID from ledger remarks
- `POST /{userId}/allocate-selected` now returns the full `ReceiptDetailsDTO` (including S3 download URL) instead of 204
- Added `GET /installment/{installmentId}/receipt-url` endpoint — looks up `InvoiceLineItem.sourceId = installmentId`, finds the parent invoice, returns its S3 download URL
- Added `findBySourceId()` to `InvoiceLineItemRepository`

**Frontend:**
- Fixed flex height chain (`PayInstallmentsPage` → `PayInstallmentsMain` → `InstallmentSelectionStep`) so the installment table fills the full available viewport height instead of being constrained to ~1 row
- `PaymentSuccessStep` now renders a full receipt card mirroring the PDF: receipt number, date, student name, payment mode, transaction ID, line items table (fee type, CPO, due date, expected, paid, balance, status), totals, amount-paid-now highlight, and a Download Receipt button
- PAID rows in the installment table now have a download icon button that fetches and opens the receipt PDF on click, with a spinner while loading and a toast error if no receipt exists

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Selected unpaid installments, proceeded to pay — verified receipt card appears on success screen with correct fee type, amounts, status, and totals
- Verified payment mode (Cash/UPI/etc.) and transaction ID appear correctly on the receipt card
- Verified "Download Receipt" button on success screen opens the PDF in a new tab
- Clicked download icon on a PAID row in the installment table — verified receipt PDF opens in new tab
- Clicked download icon on a row with no receipt — verified toast error appears
- Verified paid installments now appear in the table (greyed out, non-selectable) alongside pending ones
- Verified the installment table fills the full page height on a standard laptop screen

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
