### PR TITLE
Add receipt details to application fee payment response and show rece…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/applicant/service/ApplicantService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/applicant/service/ApplicantService.java
@@ -1543,17 +1543,14 @@ public class ApplicantService {
                 }
 
                 // SECURE FLAG FOR WEBHOOK: If payment is for application fees, flag it for
-                // Razorpay Webhook
-                if (paymentOptionId != null && (paymentOptionId.contains("application_fee")
-                                || paymentOptionId.contains("admission_fee"))) { // Handle both admission/application
-                                                                                 // fee formats
-                        requestDTO.setPaymentType(vacademy.io.common.payment.enums.PaymentType.APPLICATION_FEE);
-                } else {
-                        // Keep previous default behavior for other payments
-                        requestDTO.setPaymentType(vacademy.io.common.payment.enums.PaymentType.INITIAL); // Fallback
-                                                                                                         // for
-                                                                                                         // normal
-                                                                                                         // payments
+                // Razorpay Webhook. Respect frontend-provided paymentType if already set.
+                if (requestDTO.getPaymentType() == null) {
+                        if (paymentOptionId != null && (paymentOptionId.contains("application_fee")
+                                        || paymentOptionId.contains("admission_fee"))) {
+                                requestDTO.setPaymentType(vacademy.io.common.payment.enums.PaymentType.APPLICATION_FEE);
+                        } else {
+                                requestDTO.setPaymentType(vacademy.io.common.payment.enums.PaymentType.INITIAL);
+                        }
                 }
 
                 // Inject applicantId and optionId into Gateway Requests so PaymentService saves
@@ -1624,6 +1621,7 @@ public class ApplicantService {
                                         userPlan.getId());
 
                         // ---- INJECT APPLICATION FEE INVOICE GENERATION FOR MANUAL PAYMENTS ----
+                        java.util.Map<String, Object> receiptDetails = null;
                         try {
                                 if (vacademy.io.common.payment.enums.PaymentType.APPLICATION_FEE
                                                 .equals(requestDTO.getPaymentType())) {
@@ -1652,7 +1650,7 @@ public class ApplicantService {
                                                 }
                                         }
 
-                                        applicationFeeReceiptService.generateAndSendInvoice(
+                                        receiptDetails = applicationFeeReceiptService.generateAndSendInvoice(
                                                         applicantId, paymentOptionId, paymentLog.getId(), instituteId,
                                                         java.math.BigDecimal.valueOf(requestDTO.getAmount()),
                                                         transactionRef,
@@ -1673,6 +1671,9 @@ public class ApplicantService {
                         responseData.put("paymentStatus", "PAID");
                         responseData.put("paymentMode", "MANUAL");
                         responseData.put("transactionRef", transactionRef);
+                        if (receiptDetails != null) {
+                                responseData.put("receipt", receiptDetails);
+                        }
                         response.setResponseData(responseData);
 
                         logger.info("Manual payment recorded for applicant: {}, ref: {}", applicantId, transactionRef);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/ApplicationFeeReceiptService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/ApplicationFeeReceiptService.java
@@ -83,7 +83,7 @@ public class ApplicationFeeReceiptService {
      * @param recipientEmail  Email address to send invoice to
      * @param recipientName   Display name of recipient
      */
-    public void generateAndSendInvoice(
+    public Map<String, Object> generateAndSendInvoice(
             String applicantId,
             String paymentOptionId,
             String paymentLogId,
@@ -135,7 +135,15 @@ public class ApplicationFeeReceiptService {
 
             log.info("Application fee invoice saved: {}", receiptNumber);
 
-            // 9. Send email if recipient email is available
+            // 9. Get download URL for receipt PDF
+            String downloadUrl = null;
+            try {
+                downloadUrl = mediaService.getFileUrlById(pdfFileId);
+            } catch (Exception e) {
+                log.warn("Could not get download URL for receipt PDF fileId={}: {}", pdfFileId, e.getMessage());
+            }
+
+            // 10. Send email if recipient email is available
             if (StringUtils.hasText(recipientEmail)) {
                 try {
                     sendInvoiceEmail(invoice, instituteId, institute, pdfBytes, receiptNumber,
@@ -148,10 +156,23 @@ public class ApplicationFeeReceiptService {
                 log.warn("No recipient email available. Skipping email for receipt: {}", receiptNumber);
             }
 
+            // 11. Return receipt details for API response
+            Map<String, Object> receiptDetails = new HashMap<>();
+            receiptDetails.put("invoice_id", invoice.getId());
+            receiptDetails.put("receipt_number", receiptNumber);
+            receiptDetails.put("receipt_date", LocalDateTime.now().format(DISPLAY_DATE_FORMATTER));
+            receiptDetails.put("download_url", downloadUrl);
+            receiptDetails.put("payment_mode", paymentMode);
+            receiptDetails.put("transaction_id", transactionId);
+            receiptDetails.put("amount_paid", amountPaid);
+            receiptDetails.put("fee_description", paymentOptionName);
+            return receiptDetails;
+
         } catch (Exception e) {
             log.error("Error generating application fee invoice for applicantId={}, paymentLogId={}",
                     applicantId, paymentLogId, e);
             // Do NOT rethrow — invoice failure must never break the payment flow
+            return null;
         }
     }
 

--- a/frontend-admin-dashboard/src/routes/admissions/-services/applicant-services.ts
+++ b/frontend-admin-dashboard/src/routes/admissions/-services/applicant-services.ts
@@ -355,22 +355,35 @@ export interface InitiateManualPaymentRequest {
     amount: number;
     currency: string;
     email: string;
+    payment_type?: string;
     manual_request: {
         file_id?: string | null;
         transaction_id: string;
     };
 }
 
+export interface AppFeeReceiptData {
+    invoice_id?: string;
+    receipt_number?: string;
+    receipt_date?: string;
+    download_url?: string;
+    payment_mode?: string;
+    transaction_id?: string;
+    amount_paid?: number;
+    fee_description?: string;
+}
+
 export const initiateManualPayment = async (
     applicantId: string,
     paymentOptionId: string,
     request: InitiateManualPaymentRequest
-): Promise<void> => {
-    await authenticatedAxiosInstance.post(
+): Promise<AppFeeReceiptData | null> => {
+    const response = await authenticatedAxiosInstance.post(
         `${BASE_URL}/admin-core-service/v1/applicant/${applicantId}/payment/initiate`,
         request,
         { params: { paymentOptionId } }
     );
+    return response.data?.response_data?.receipt ?? null;
 };
 
 // Query keys for React Query

--- a/frontend-admin-dashboard/src/routes/admissions/application/-components/sections/PaymentSection.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/application/-components/sections/PaymentSection.tsx
@@ -308,7 +308,7 @@ export const PaymentSection: React.FC<SectionProps> = ({
                         <div className="flex items-center justify-between text-sm">
                             <span className="text-gray-500">Student</span>
                             <span className="font-extrabold text-lg text-gray-800">
-                                {formData.firstName} {formData.lastName}
+                                {formData.studentName || 'N/A'}
                             </span>
                         </div>
                         <div className="flex items-center justify-between text-sm">

--- a/frontend-admin-dashboard/src/routes/admissions/application/-components/sections/PaymentSection.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/application/-components/sections/PaymentSection.tsx
@@ -5,9 +5,10 @@ import { toast } from 'sonner';
 import type {
     PaymentOptionDetails,
     PaymentLinkMethod,
+    AppFeeReceiptData,
 } from '../../../-services/applicant-services';
 import { initiateManualPayment, generatePaymentLink } from '../../../-services/applicant-services';
-import { CardholderIcon, GlobeIcon, ArrowSquareOut, EnvelopeSimple, SpinnerGap } from '@phosphor-icons/react';
+import { CardholderIcon, GlobeIcon, ArrowSquareOut, EnvelopeSimple, SpinnerGap, DownloadSimple } from '@phosphor-icons/react';
 import { QRCodeSVG } from 'qrcode.react';
 import { getPublicUrl, UploadFileInS3 } from '@/services/upload_file';
 import { MyButton } from '@/components/design-system/button';
@@ -50,6 +51,9 @@ export const PaymentSection: React.FC<SectionProps> = ({
     const [isUploadingProof, setIsUploadingProof] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const proofInputRef = useRef<HTMLInputElement>(null);
+
+    // Receipt state (populated after successful manual payment)
+    const [receiptData, setReceiptData] = useState<AppFeeReceiptData | null>(null);
 
     // Email sending state
     const [showEmailInput, setShowEmailInput] = useState(false);
@@ -200,16 +204,20 @@ export const PaymentSection: React.FC<SectionProps> = ({
         setIsSubmitting(true);
         try {
             const email = formData.fatherInfo?.email || formData.motherInfo?.email || '';
-            await initiateManualPayment(applicantId, paymentOptionId, {
+            const receipt = await initiateManualPayment(applicantId, paymentOptionId, {
                 vendor: 'MANUAL',
                 amount: registrationFee,
                 currency: registrationFeeCurrency,
                 email,
+                payment_type: 'APPLICATION_FEE',
                 manual_request: {
                     file_id: proofFileId || null,
                     transaction_id: manualTxnId.trim(),
                 },
             });
+            if (receipt) {
+                setReceiptData(receipt);
+            }
             updateFormData({
                 feeStatus: 'PAID',
                 paymentMode: selectedPaymentMethod as string,
@@ -238,6 +246,7 @@ export const PaymentSection: React.FC<SectionProps> = ({
     if (isPaid) {
         return (
             <div className="space-y-6">
+                {/* Success banner */}
                 <div className="overflow-hidden rounded-xl border-2 border-green-200 bg-gradient-to-r from-green-50 to-emerald-50 shadow-sm">
                     <div className="flex items-center gap-4 p-5">
                         <div className="flex size-12 items-center justify-center rounded-full bg-green-100">
@@ -261,12 +270,94 @@ export const PaymentSection: React.FC<SectionProps> = ({
                     </div>
                     <div className="border-t border-green-200 px-5 py-3">
                         <button
-                            onClick={() => updateFormData({ feeStatus: 'PENDING' })}
+                            onClick={() => {
+                                setReceiptData(null);
+                                updateFormData({ feeStatus: 'PENDING' });
+                            }}
                             className="text-xs text-green-600 underline underline-offset-2 hover:text-green-700"
                         >
                             ↩ Undo — Mark as Unpaid
                         </button>
                     </div>
+                </div>
+
+                {/* Receipt card — always shown after payment */}
+                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+                    {/* Receipt header */}
+                    <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50/60 px-6 py-4">
+                        <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+                                Receipt No.
+                            </p>
+                            <p className="text-sm text-gray-800">
+                                {receiptData?.receipt_number ?? 'N/A'}
+                            </p>
+                        </div>
+                        <div className="text-right">
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+                                Date
+                            </p>
+                            <p className="text-sm text-gray-800">
+                                {receiptData?.receipt_date ?? formData.paymentDate ?? 'N/A'}
+                            </p>
+                        </div>
+                    </div>
+
+                    {/* Receipt details */}
+                    <div className="px-6 py-4 space-y-3">
+                        <div className="flex items-center justify-between text-sm">
+                            <span className="text-gray-500">Student</span>
+                            <span className="font-extrabold text-lg text-gray-800">
+                                {formData.firstName} {formData.lastName}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between text-sm">
+                            <span className="text-gray-500">Fee Description</span>
+                            <span className="font-medium text-gray-800">
+                                {receiptData?.fee_description ?? registrationFeeName}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between text-sm">
+                            <span className="text-gray-500">Payment Mode</span>
+                            <span className="font-medium text-gray-800">
+                                {receiptData?.payment_mode ?? formData.paymentMode ?? 'N/A'}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between text-sm">
+                            <span className="text-gray-500">Transaction ID</span>
+                            <span className="font-mono text-gray-800">
+                                {receiptData?.transaction_id ?? formData.transactionId ?? 'N/A'}
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Amount */}
+                    <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50/60 px-6 py-4">
+                        <span className="text-sm font-semibold text-gray-700">Amount Paid</span>
+                        <span className="text-xl font-extrabold text-emerald-700">
+                            {currencySymbol}{' '}
+                            {receiptData?.amount_paid != null
+                                ? typeof receiptData.amount_paid === 'number'
+                                    ? receiptData.amount_paid.toLocaleString('en-IN')
+                                    : receiptData.amount_paid
+                                : registrationFee.toLocaleString('en-IN')}
+                        </span>
+                    </div>
+
+                    {/* Download button */}
+                    {receiptData?.download_url && (
+                        <div className="border-t border-gray-100 px-6 py-4">
+                            <a
+                                href={receiptData.download_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-2 rounded-lg bg-black px-5 py-2.5 text-sm font-semibold text-white hover:bg-gray-800 transition-colors"
+                            >
+                                <DownloadSimple size={16} weight="bold" />
+                                Download Receipt
+                            </a>
+                        </div>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
## Summary of Changes

Return receipt details from the application fee manual payment API and display a receipt card in the Payment section of the admissions application page.

**Backend:**
- `ApplicationFeeReceiptService.generateAndSendInvoice` now returns `Map<String, Object>` with receipt metadata (receipt number, date, download URL, payment mode, transaction ID, amount, fee description) instead of `void`
- `ApplicantService.preparePayment` captures receipt details and includes them in the API response under `response_data.receipt`
- Fixed `paymentType` override bug — frontend-sent `APPLICATION_FEE` was being overwritten to `INITIAL` because the condition compared a UUID `paymentOptionId` against string literals like `"application_fee"`

**Frontend:**
- Added `AppFeeReceiptData` interface and updated `initiateManualPayment` to return receipt data from response
- Added `payment_type: 'APPLICATION_FEE'` to the manual payment request payload
- Receipt card always renders in PAID state with fallback values (`formData` or `"N/A"`) when backend receipt data is unavailable
- Download Receipt button (black) shown when download URL is available

## Related Issue



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Recorded a manual CASH payment on the Application page and verified the receipt card appears with receipt number, date, fee description, payment mode, transaction ID, and amount
- Verified Download Receipt button links to the generated PDF
- Verified "Undo — Mark as Unpaid" clears the receipt card and resets to payment form
- Verified receipt card shows fallback values when backend receipt data is missing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
