### PR TITLE
fix: create new one parentTypeModal to remove repeating code, improve…

### DIFF
--- a/frontend-admin-dashboard/src/routes/admissions/-components/EnquirySearchModal.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/-components/EnquirySearchModal.tsx
@@ -3,7 +3,7 @@ import { X, MagnifyingGlass } from '@phosphor-icons/react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { MyButton } from '@/components/design-system/button';
-import { searchEnquiriesByFilter } from '../-services/applicant-services';
+import { searchEnquiriesByFilter, type EnquiryDetailsResponse } from '../-services/applicant-services';
 import { toast } from 'sonner';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 
@@ -18,8 +18,8 @@ interface EnquirySearchModalProps {
     // AdmissionEntryScreen passes onSelectForAdmission only.
     // Passing both shows both action columns simultaneously.
     // Callbacks receive the full search result object (no second API call needed).
-    onSelectForApplication?: (enquiryData: any) => void;
-    onSelectForAdmission?: (enquiryData: any) => void;
+    onSelectForApplication?: (enquiryData: EnquiryDetailsResponse) => void;
+    onSelectForAdmission?: (enquiryData: EnquiryDetailsResponse) => void;
 }
 
 const STATUS_BADGE: Record<EnquiryStatus, { label: string; className: string }> = {
@@ -38,7 +38,7 @@ export const EnquirySearchModal: React.FC<EnquirySearchModalProps> = ({
     const [searchPhone, setSearchPhone] = useState('');
     const [searchTrackingId, setSearchTrackingId] = useState('');
     const [isLoading, setIsLoading] = useState(false);
-    const [searchResults, setSearchResults] = useState<any[]>([]);
+    const [searchResults, setSearchResults] = useState<EnquiryDetailsResponse[]>([]);
     const [hasSearched, setHasSearched] = useState(false);
     const { instituteDetails } = useInstituteDetailsStore();
 
@@ -68,12 +68,12 @@ export const EnquirySearchModal: React.FC<EnquirySearchModalProps> = ({
         }
     };
 
-    const handleSelectForApplication = (result: any) => {
+    const handleSelectForApplication = (result: EnquiryDetailsResponse) => {
         onSelectForApplication?.(result);
         onClose();
     };
 
-    const handleSelectForAdmission = (result: any) => {
+    const handleSelectForAdmission = (result: EnquiryDetailsResponse) => {
         onSelectForAdmission?.(result);
         onClose();
     };

--- a/frontend-admin-dashboard/src/routes/admissions/-components/ParentTypeModal.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/-components/ParentTypeModal.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { X, User } from 'lucide-react';
+
+interface ParentTypeModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSelect: (type: 'father' | 'mother') => void;
+}
+
+export const ParentTypeModal: React.FC<ParentTypeModalProps> = ({ isOpen, onClose, onSelect }) => {
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/20 backdrop-blur-sm animate-in fade-in duration-200">
+            <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-2xl border border-neutral-100 scale-in-center">
+                <div className="mb-4 flex items-center justify-between">
+                    <div>
+                        <h2 className="text-xl font-bold text-neutral-900">Select Parent Type</h2>
+                        <p className="mt-1 text-sm text-neutral-500">
+                            Specify if the contact details belong to the father or mother
+                        </p>
+                    </div>
+                    <button 
+                        onClick={onClose}
+                        className="p-1 rounded-full hover:bg-neutral-100 text-neutral-400 transition-colors"
+                    >
+                        <X className="size-5" />
+                    </button>
+                </div>
+
+                <div className="mt-6 space-y-3">
+                    <button
+                        onClick={() => onSelect('father')}
+                        className="flex w-full items-center gap-4 rounded-xl border border-neutral-200 p-4 text-left transition-all hover:border-blue-500 hover:bg-blue-50/50 hover:shadow-md group"
+                    >
+                        <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 group-hover:bg-blue-600 group-hover:text-white transition-colors shadow-sm">
+                            <User className="size-6 transition-transform group-hover:scale-110" />
+                        </div>
+                        <div>
+                            <h3 className="text-base font-bold text-neutral-900">Father</h3>
+                            <p className="text-sm text-neutral-500">Map details to father's info</p>
+                        </div>
+                    </button>
+
+                    <button
+                        onClick={() => onSelect('mother')}
+                        className="flex w-full items-center gap-4 rounded-xl border border-neutral-200 p-4 text-left transition-all hover:border-pink-500 hover:bg-pink-50/50 hover:shadow-md group"
+                    >
+                        <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-pink-100 text-pink-600 group-hover:bg-pink-600 group-hover:text-white transition-colors shadow-sm">
+                            <User className="size-6 transition-transform group-hover:scale-110" />
+                        </div>
+                        <div>
+                            <h3 className="text-base font-bold text-neutral-900">Mother</h3>
+                            <p className="text-sm text-neutral-500">Map details to mother's info</p>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/admissions/-services/applicant-services.ts
+++ b/frontend-admin-dashboard/src/routes/admissions/-services/applicant-services.ts
@@ -6,6 +6,35 @@ import type { PaymentOptionApi } from '@/types/payment';
 const APPLICANT_URL = `${BASE_URL}/admin-core-service/v1/applicant`;
 
 // Payload Types
+
+export interface EnquiryParentDetails {
+    id: string;
+    name: string;
+    phone: string;
+    email: string | null;
+    address_line: string | null;
+    city: string | null;
+    pin_code: string | null;
+}
+
+export interface EnquiryChildDetails {
+    id: string;
+    name: string;
+    dob: string | null;
+    gender: 'MALE' | 'FEMALE' | 'OTHER' | null;
+    destination_package_session_id: string | null;
+}
+
+export interface EnquiryDetailsResponse {
+    enquiry_id: string;
+    tracking_id: string;
+    overall_status: 'ENQUIRY' | 'APPLICATION' | 'ADMISSION';
+    applicant_id: string | null;
+    parent_relation_with_child: 'FATHER' | 'MOTHER' | 'GUARDIAN' | string | null;
+    parent: EnquiryParentDetails | null;
+    child: EnquiryChildDetails | null;
+}
+
 export interface ApplicantFormData {
     parent_name: string;
     parent_phone: string;

--- a/frontend-admin-dashboard/src/routes/admissions/admission-form/-components/AdmissionEntryScreen.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/admission-form/-components/AdmissionEntryScreen.tsx
@@ -9,6 +9,7 @@ import { X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { EnquirySearchModal } from '../../-components/EnquirySearchModal';
+import { ParentTypeModal } from '../../-components/ParentTypeModal';
 import { AdmissionBulkImportDialog } from './AdmissionBulkImportDialog';
 
 export interface StudentSearchResult {
@@ -227,7 +228,9 @@ export default function AdmissionEntryScreen({ onStartAdmission }: Props) {
         };
 
         // Auto-fill parent relation from enquiry data; show popup only if unknown
-        const relation = (enquiryData.parent_relation_with_child || '').toLowerCase();
+        const rawRelation = enquiryData.parent_relation_with_child || enquiryData.parent_relation || enquiryData.enquiry?.parent_relation_with_child || '';
+        const relation = String(rawRelation).toLowerCase().trim();
+
         if (relation === 'father') {
             mapped.parentGender = 'father';
             navigateToForm(mapped, selectedSessionId);
@@ -805,50 +808,11 @@ export default function AdmissionEntryScreen({ onStartAdmission }: Props) {
                 </div>
             )}
 
-            {/* Select Parent Type Modal */}
-            {showParentTypeModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-                    <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-                        <div className="mb-2">
-                            <h2 className="text-lg font-semibold text-neutral-900">Select Parent Type</h2>
-                            <p className="mt-1 text-sm text-neutral-600">
-                                Please specify if the contact details belong to the father or mother
-                            </p>
-                        </div>
-                        <div className="mt-5 space-y-3">
-                            <button
-                                onClick={() => handleParentTypeSelection('father')}
-                                className="flex w-full items-center gap-4 rounded-lg border border-neutral-200 p-4 text-left transition-all hover:border-blue-400 hover:bg-blue-50"
-                            >
-                                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-blue-100">
-                                    <svg className="size-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                                    </svg>
-                                </div>
-                                <div>
-                                    <h3 className="font-medium text-neutral-900">Father</h3>
-                                    <p className="text-sm text-neutral-500">Use these details for father's information</p>
-                                </div>
-                            </button>
-
-                            <button
-                                onClick={() => handleParentTypeSelection('mother')}
-                                className="flex w-full items-center gap-4 rounded-lg border border-neutral-200 p-4 text-left transition-all hover:border-pink-400 hover:bg-pink-50"
-                            >
-                                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-pink-100">
-                                    <svg className="size-5 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                                    </svg>
-                                </div>
-                                <div>
-                                    <h3 className="font-medium text-neutral-900">Mother</h3>
-                                    <p className="text-sm text-neutral-500">Use these details for mother's information</p>
-                                </div>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
+            <ParentTypeModal
+                isOpen={showParentTypeModal}
+                onClose={() => setShowParentTypeModal(false)}
+                onSelect={handleParentTypeSelection}
+            />
 
             <AdmissionBulkImportDialog
                 open={isBulkImportOpen}

--- a/frontend-admin-dashboard/src/routes/admissions/admission-form/-components/AdmissionEntryScreen.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/admission-form/-components/AdmissionEntryScreen.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { EnquirySearchModal } from '../../-components/EnquirySearchModal';
 import { ParentTypeModal } from '../../-components/ParentTypeModal';
+import type { EnquiryDetailsResponse } from '../../-services/applicant-services';
 import { AdmissionBulkImportDialog } from './AdmissionBulkImportDialog';
 
 export interface StudentSearchResult {
@@ -209,7 +210,7 @@ export default function AdmissionEntryScreen({ onStartAdmission }: Props) {
         setShowApplicationModal(true);
     };
 
-    const handleSelectEnquiry = (enquiryData: any) => {
+    const handleSelectEnquiry = (enquiryData: EnquiryDetailsResponse) => {
         const mapped: Partial<StudentSearchResult> = {
             id: enquiryData.enquiry_id || '',
             studentName: enquiryData.child?.name || '',
@@ -228,7 +229,7 @@ export default function AdmissionEntryScreen({ onStartAdmission }: Props) {
         };
 
         // Auto-fill parent relation from enquiry data; show popup only if unknown
-        const rawRelation = enquiryData.parent_relation_with_child || enquiryData.parent_relation || enquiryData.enquiry?.parent_relation_with_child || '';
+        const rawRelation = enquiryData.parent_relation_with_child || '';
         const relation = String(rawRelation).toLowerCase().trim();
 
         if (relation === 'father') {

--- a/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationFormPage.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationFormPage.tsx
@@ -30,6 +30,7 @@ import {
     generatePaymentLink,
     fetchPaymentOptionById,
     type PaymentOptionDetails,
+    type EnquiryDetailsResponse,
 } from '../../-services/applicant-services';
 import { getCustomFieldSettings } from '@/services/custom-field-settings';
 import { toast } from 'sonner';
@@ -143,7 +144,7 @@ export function RegistrationFormPage() {
     const [sessionId, setSessionId] = useState('');
     const [enquiryId, setEnquiryId] = useState<string | null>(null);
     const [showParentTypeModal, setShowParentTypeModal] = useState(false);
-    const [pendingEnquiryData, setPendingEnquiryData] = useState<any>(null);
+    const [pendingEnquiryData, setPendingEnquiryData] = useState<EnquiryDetailsResponse | null>(null);
 
     const [activeSection, setActiveSection] = useState(0);
     const [formData, setFormData] = useState<Partial<Registration>>(getInitialFormData());
@@ -245,7 +246,7 @@ export function RegistrationFormPage() {
     }, [instituteId]);
 
     // Function to prefill form from enquiry data
-    const prefillFormFromEnquiry = (enquiryData: any) => {
+    const prefillFormFromEnquiry = (enquiryData: EnquiryDetailsResponse) => {
         const updates: Partial<Registration> = {};
 
         // Prefill child details
@@ -258,10 +259,10 @@ export function RegistrationFormPage() {
                 const date = new Date(enquiryData.child.dob);
                 updates.dateOfBirth = date.toISOString().split('T')[0];
             }
-            updates.gender = enquiryData.child.gender || undefined;
+            updates.gender = enquiryData.child.gender as any;
         }
 
-        const rawRelation = enquiryData.parent_relation_with_child || enquiryData.parent_relation || enquiryData.enquiry?.parent_relation_with_child || '';
+        const rawRelation = enquiryData.parent_relation_with_child || '';
         const relation = String(rawRelation).toLowerCase().trim();
 
         // Prefill parent details - need to determine if father or mother
@@ -302,7 +303,7 @@ export function RegistrationFormPage() {
                 // Apply child updates first, then ask for parent type
                 setFormData((prev) => ({ ...prev, ...updates }));
                 // Relation is OTHER, not provided, or we need to ask user
-                setPendingEnquiryData({ parent: parentData });
+                setPendingEnquiryData(enquiryData);
                 setShowParentTypeModal(true);
             }
         } else {

--- a/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationFormPage.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationFormPage.tsx
@@ -20,6 +20,7 @@ import { AcademicInfoSection } from './sections/AcademicInfoSection';
 import { ParentGuardianSection } from './sections/ParentGuardianSection';
 import { AddressSection } from './sections/AddressSection';
 import { PaymentSection } from './sections/PaymentSection';
+import { ParentTypeModal } from '../../-components/ParentTypeModal';
 import type { Registration } from '../../-types/registration-types';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import {
@@ -141,7 +142,7 @@ export function RegistrationFormPage() {
     // Get sessionId from URL search params
     const [sessionId, setSessionId] = useState('');
     const [enquiryId, setEnquiryId] = useState<string | null>(null);
-    const [showParentGenderModal, setShowParentGenderModal] = useState(false);
+    const [showParentTypeModal, setShowParentTypeModal] = useState(false);
     const [pendingEnquiryData, setPendingEnquiryData] = useState<any>(null);
 
     const [activeSection, setActiveSection] = useState(0);
@@ -260,24 +261,24 @@ export function RegistrationFormPage() {
             updates.gender = enquiryData.child.gender || undefined;
         }
 
-        // Apply child updates first
-        setFormData((prev) => ({ ...prev, ...updates }));
+        const rawRelation = enquiryData.parent_relation_with_child || enquiryData.parent_relation || enquiryData.enquiry?.parent_relation_with_child || '';
+        const relation = String(rawRelation).toLowerCase().trim();
 
         // Prefill parent details - need to determine if father or mother
         if (enquiryData.parent) {
             const parentData = enquiryData.parent;
+            
+            let parentUpdates: Partial<Registration> = {};
 
-            // Check if parent has gender field
-            if (parentData.gender && parentData.gender === 'MALE') {
-                // It's father
-                const parentUpdates: Partial<Registration> = {
-                    fatherInfo: {
-                        name: parentData.name || '',
-                        mobile: parentData.phone || '',
-                        email: parentData.email || '',
-                        occupation: '',
-                        annualIncome: '',
-                    },
+            if (relation === 'father' || relation === 'mother') {
+                const infoKey = relation === 'father' ? 'fatherInfo' : 'motherInfo';
+                
+                parentUpdates[infoKey] = {
+                    name: parentData.name || '',
+                    mobile: parentData.phone || '',
+                    email: parentData.email || '',
+                    occupation: '',
+                    annualIncome: '',
                 };
 
                 // Prefill address if available
@@ -295,40 +296,18 @@ export function RegistrationFormPage() {
                         pincode: parentData.pin_code || '',
                     };
                 }
-                setFormData((prev) => ({ ...prev, ...parentUpdates }));
-            } else if (parentData.gender && parentData.gender === 'FEMALE') {
-                // It's mother
-                const parentUpdates: Partial<Registration> = {
-                    motherInfo: {
-                        name: parentData.name || '',
-                        mobile: parentData.phone || '',
-                        email: parentData.email || '',
-                        occupation: '',
-                        annualIncome: '',
-                    },
-                };
-
-                // Prefill address if available
-                if (parentData.address_line || parentData.city || parentData.pin_code) {
-                    parentUpdates.currentAddress = {
-                        houseNo: '',
-                        street: '',
-                        area: '',
-                        state: '',
-                        country: '',
-                        ...formData.currentAddress,
-                        addressLine1: parentData.address_line || '',
-                        city: parentData.city || '',
-                        pinCode: parentData.pin_code || '',
-                        pincode: parentData.pin_code || '',
-                    };
-                }
-                setFormData((prev) => ({ ...prev, ...parentUpdates }));
+                
+                setFormData((prev) => ({ ...prev, ...updates, ...parentUpdates }));
             } else {
-                // Gender is OTHER, not provided, or we need to ask user
+                // Apply child updates first, then ask for parent type
+                setFormData((prev) => ({ ...prev, ...updates }));
+                // Relation is OTHER, not provided, or we need to ask user
                 setPendingEnquiryData({ parent: parentData });
-                setShowParentGenderModal(true);
+                setShowParentTypeModal(true);
             }
+        } else {
+            // Apply child updates only
+            setFormData((prev) => ({ ...prev, ...updates }));
         }
     };
 
@@ -373,7 +352,7 @@ export function RegistrationFormPage() {
         }
 
         setFormData((prev) => ({ ...prev, ...updates }));
-        setShowParentGenderModal(false);
+        setShowParentTypeModal(false);
         setPendingEnquiryData(null);
     };
 
@@ -832,54 +811,11 @@ export function RegistrationFormPage() {
                     </div>
                 </div>
             </div>
-
-            {/* Parent Type Selection Modal */}
-            {showParentGenderModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-                    <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-                        <div className="mb-4">
-                            <h2 className="text-lg font-semibold text-neutral-900">
-                                Select Parent Type
-                            </h2>
-                            <p className="mt-2 text-sm text-neutral-600">
-                                Please specify if the contact details belong to the father or mother
-                            </p>
-                        </div>
-
-                        <div className="space-y-3">
-                            <button
-                                onClick={() => handleParentTypeSelection('father')}
-                                className="flex w-full items-center gap-4 rounded-lg border border-neutral-200 p-4 text-left transition-all hover:border-primary-500 hover:bg-primary-50"
-                            >
-                                <div className="flex size-12 items-center justify-center rounded-full bg-blue-100">
-                                    <User size={24} className="text-blue-600" />
-                                </div>
-                                <div>
-                                    <h3 className="font-medium text-neutral-900">Father</h3>
-                                    <p className="text-sm text-neutral-600">
-                                        Use these details for father's information
-                                    </p>
-                                </div>
-                            </button>
-
-                            <button
-                                onClick={() => handleParentTypeSelection('mother')}
-                                className="flex w-full items-center gap-4 rounded-lg border border-neutral-200 p-4 text-left transition-all hover:border-primary-500 hover:bg-primary-50"
-                            >
-                                <div className="flex size-12 items-center justify-center rounded-full bg-pink-100">
-                                    <User size={24} className="text-pink-600" />
-                                </div>
-                                <div>
-                                    <h3 className="font-medium text-neutral-900">Mother</h3>
-                                    <p className="text-sm text-neutral-600">
-                                        Use these details for mother's information
-                                    </p>
-                                </div>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
+            <ParentTypeModal
+                isOpen={showParentTypeModal}
+                onClose={() => setShowParentTypeModal(false)}
+                onSelect={handleParentTypeSelection}
+            />
         </>
     );
 }

--- a/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationListPage.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/application/-components/RegistrationListPage.tsx
@@ -17,6 +17,7 @@ import { MyFilterOption } from '@/types/assessments/my-filter';
 import {
     fetchApplicantList,
     type Applicant,
+    type EnquiryDetailsResponse,
 } from '../../-services/applicant-services';
 import { EnquirySearchModal } from '../../-components/EnquirySearchModal';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -190,7 +191,7 @@ function RegistrationListPageInner({
         setShowEnquiryModal(true);
     };
 
-    const handleSelectEnquiry = (enquiryData: any) => {
+    const handleSelectEnquiry = (enquiryData: EnquiryDetailsResponse) => {
         // Guard: should not reach here (button is disabled in modal), but double-check
         if (enquiryData.overall_status === 'APPLICATION' || enquiryData.overall_status === 'ADMISSION') {
             toast.warning('This enquiry has already been converted to an application.');


### PR DESCRIPTION
# fix: create new one parentTypeModal to remove repeating code, improved the logic for filling parent data in the admission and application form

## Summary of Changes

- **Created a reusable `ParentTypeModal` component**: Extracted the hardcoded parent type (Father/Mother) selection modal into a new, shared component (`src/routes/admissions/-components/ParentTypeModal.tsx`) to eliminate UI duplication.
- **Improved parent relation detection**: Refactored the pre-fill logic in both `AdmissionEntryScreen.tsx` and `RegistrationFormPage.tsx` to be more robust. The code now trims whitespace, converts strings to lowercase, and checks alternative nesting structures (e.g., `parent_relation_with_child`, `parent_relation`, and `enquiry.parent_relation_with_child`) before defaulting to the manual selection modal.
- **Optimized state updates**: Consolidated state update operations in `RegistrationFormPage.tsx` to prevent redundant re-renders and fix cases where the modal blocked form loading prematurely.

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Verified that directly selecting 'From Enquiry' properly skips the "Select Parent Type" modal if the enquiry data accurately reflects a `FATHER` or `MOTHER` relationship.
- Ensured the `ParentTypeModal` is correctly rendered and functions as intended when the `parent_relation_with_child` property is missing from the enquiry.
- Checked both the Admission (from `AdmissionEntryScreen`) and Application Navigation (from `RegistrationListPage`) flows to confirm consistency.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
