### PR TITLE
fix: collection dashboard class-wise breakdown groups by package_sess…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/CollectionDashboardResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/CollectionDashboardResponseDTO.java
@@ -27,8 +27,8 @@ public class CollectionDashboardResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ClassWiseBreakdownDTO {
-        private String cpoId;
-        private String cpoName;
+        private String packageSessionId;
+        private String className;
         private BigDecimal projectedRevenue;
         private BigDecimal expectedToDate;
         private BigDecimal collectedToDate;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/CollectionDashboardRepositoryImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/CollectionDashboardRepositoryImpl.java
@@ -48,9 +48,21 @@ public class CollectionDashboardRepositoryImpl implements CollectionDashboardRep
             "    THEN (sfp.amount_expected - COALESCE(sfp.discount_amount,0)) - sfp.amount_paid " +
             "    ELSE 0 END),0) ";
 
+    // Class-wise breakdown resolves each student_fee_payment row to the actual
+    // package_session the learner is enrolled in (via SSIGM, anchored on
+    // user_plan_id, intersected with the CPO's psl mappings). LATERAL LIMIT 1
+    // prevents fan-out when a single user_plan spans multiple SSIGM rows.
+    // Bills with no resolvable package_session fall into an 'Unassigned' bucket
+    // so totals stay consistent with the summary cards.
     private static final String CLASS_WISE_SELECT =
             "SELECT " +
-            "  CAST(cpo.id AS VARCHAR), cpo.name, " +
+            "  COALESCE(CAST(ps.id AS VARCHAR), 'UNASSIGNED'), " +
+            "  COALESCE(" +
+            "    pkg.package_name || ' - ' || l.level_name" +
+            "      || COALESCE(' - ' || NULLIF(ps.name, ''), '')" +
+            "      || ' - ' || s.session_name," +
+            "    'Unassigned'" +
+            "  ), " +
             "  COALESCE(SUM(sfp.amount_expected - COALESCE(sfp.discount_amount,0)),0), " +
             "  COALESCE(SUM(CASE WHEN sfp.due_date <= CURRENT_DATE " +
             "    THEN (sfp.amount_expected - COALESCE(sfp.discount_amount,0)) ELSE 0 END),0), " +
@@ -62,8 +74,31 @@ public class CollectionDashboardRepositoryImpl implements CollectionDashboardRep
             "    THEN (sfp.amount_expected - COALESCE(sfp.discount_amount,0)) - sfp.amount_paid " +
             "    ELSE 0 END),0) ";
 
+    private static final String CLASS_WISE_FROM_WHERE =
+            "FROM student_fee_payment sfp " +
+            "JOIN complex_payment_option cpo ON sfp.cpo_id = cpo.id " +
+            "LEFT JOIN LATERAL ( " +
+            "  SELECT ssigm.package_session_id " +
+            "  FROM student_session_institute_group_mapping ssigm " +
+            "  JOIN package_session_learner_invitation_to_payment_option psl_r " +
+            "    ON psl_r.package_session_id = ssigm.package_session_id " +
+            "   AND psl_r.cpo_id = sfp.cpo_id " +
+            "   AND psl_r.status <> 'DELETED' " +
+            "  WHERE ssigm.user_plan_id = sfp.user_plan_id " +
+            "    AND ssigm.status = 'ACTIVE' " +
+            "  ORDER BY ssigm.created_at ASC " +
+            "  LIMIT 1 " +
+            ") resolved ON true " +
+            "LEFT JOIN package_session ps ON ps.id = resolved.package_session_id " +
+            "LEFT JOIN package pkg ON pkg.id = ps.package_id " +
+            "LEFT JOIN level l ON l.id = ps.level_id " +
+            "LEFT JOIN session s ON s.id = ps.session_id " +
+            "WHERE cpo.institute_id = :instituteId " +
+            "  AND sfp.status NOT IN ('CANCELLED','DROPPED') ";
+
     private static final String CLASS_WISE_GROUP =
-            "GROUP BY cpo.id, cpo.name ORDER BY cpo.name";
+            "GROUP BY ps.id, pkg.package_name, l.level_name, ps.name, s.session_name " +
+            "ORDER BY pkg.package_name NULLS LAST, l.level_name NULLS LAST, ps.name NULLS LAST";
 
     private static final String PAYMENT_MODE_SELECT =
             "SELECT pl.vendor, COALESCE(SUM(sal.amount_allocated),0) ";
@@ -108,7 +143,7 @@ public class CollectionDashboardRepositoryImpl implements CollectionDashboardRep
     @SuppressWarnings("unchecked")
     public List<Object[]> getClassWiseBreakdown(String instituteId, String sessionId,
                                                  boolean hasFeeTypes, List<String> feeTypeIds) {
-        String sql = CLASS_WISE_SELECT + BASE_WHERE
+        String sql = CLASS_WISE_SELECT + CLASS_WISE_FROM_WHERE
                 + buildOptionalClauses(sessionId, hasFeeTypes, feeTypeIds) + CLASS_WISE_GROUP;
         Query q = entityManager.createNativeQuery(sql);
         bindParams(q, instituteId, sessionId, hasFeeTypes, feeTypeIds);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
@@ -402,8 +402,8 @@ public class FeeTrackingService {
 
                 List<CollectionDashboardResponseDTO.ClassWiseBreakdownDTO> classWiseBreakdown = classRows.stream()
                                 .map(row -> CollectionDashboardResponseDTO.ClassWiseBreakdownDTO.builder()
-                                                .cpoId((String) row[0])
-                                                .cpoName((String) row[1])
+                                                .packageSessionId((String) row[0])
+                                                .className((String) row[1])
                                                 .projectedRevenue(toBD(row[2]))
                                                 .expectedToDate(toBD(row[3]))
                                                 .collectedToDate(toBD(row[4]))

--- a/frontend-admin-dashboard/src/routes/financial-management/collection-dashboard/-hooks/useCollectionDashboard.ts
+++ b/frontend-admin-dashboard/src/routes/financial-management/collection-dashboard/-hooks/useCollectionDashboard.ts
@@ -114,7 +114,7 @@ export const useCollectionDashboard = () => {
     const classWiseDetails = useMemo(() => {
         if (!dashboardData?.classWiseBreakdown) return [];
         return dashboardData.classWiseBreakdown.map(row => ({
-            className: row.cpoName,
+            className: row.className,
             projectedRevenue: row.projectedRevenue,
             expectedToDate: row.expectedToDate,
             collectedToDate: row.collectedToDate,

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -269,8 +269,8 @@ export interface DashboardCollectionResponse {
     collectedToDate: number;
     totalOverdue: number;
     classWiseBreakdown: Array<{
-        cpoId: string;
-        cpoName: string;
+        packageSessionId: string;
+        className: string;
         projectedRevenue: number;
         expectedToDate: number;
         collectedToDate: number;


### PR DESCRIPTION
## Summary of Changes

The "Class-wise Performance" table on the Collection Dashboard was grouping by `complex_payment_option` (fee plan) instead of by actual class/batch. The "Class Name" column was showing the CPO name — which is a fee template, not a class. This PR corrects the breakdown so rows represent real `package_session`s with labels matching the AdmissionDashboard format (`{package} - {level} - {batch?} - {session}`).

Since `student_fee_payment.cpo_id` cannot uniquely identify a class (one CPO can map to many package_sessions via `psl`), each fee payment is resolved to exactly one `package_session` by anchoring on `sfp.user_plan_id → ssigm.user_plan_id (ACTIVE)` and intersecting with the CPO's `psl` mappings. A `LATERAL LIMIT 1` guarantees no fan-out. Bills with no resolvable package_session (student lacks active enrollment, CPO unlinked, etc.) fall into a fallback `Unassigned` bucket via `LEFT JOIN`, ensuring totals in the table always reconcile with the top summary cards.

**Backend:**
- Rewrote `CollectionDashboardRepositoryImpl.getClassWiseBreakdown` SQL to resolve `student_fee_payment` → `package_session` via `SSIGM` (anchored on `user_plan_id`, intersected with `psl`), using `LATERAL LIMIT 1` for deterministic single-row attribution.
- Added `LEFT JOIN` fallback so unresolved bills aggregate under an `Unassigned` bucket — summary card totals stay consistent with the sum of table rows.
- Class label built as `{package_name} - {level_name}[ - {ps.name}] - {session_name}`, matching the AdmissionDashboard dropdown format.
- Renamed `ClassWiseBreakdownDTO.cpoId/cpoName` → `packageSessionId/className` to reflect actual semantics.
- Preserved existing `sessionId` and `feeTypeIds` filter clauses unchanged, so card/table filter behavior stays in sync.

**Frontend:**
- Updated `DashboardCollectionResponse.classWiseBreakdown` type (`cpoId/cpoName` → `packageSessionId/className`) in [manage-finances.ts](frontend-admin-dashboard/src/services/manage-finances.ts).
- Updated `useCollectionDashboard` hook to read `row.className` instead of `row.cpoName`.
- No UI/component changes — the existing `ClassWiseCollectionTable` already renders `className`.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Tested locally with the admin dashboard pointed at local backend (`localhost:8072`). Verified rows now show real class labels (e.g., `springboot course - Class 12 - Jan 26`) instead of CPO names.
- Verified sum of table rows (including `Unassigned`) matches the "Till Now Expected" and "Till Now Collected" summary card totals.
- Verified the session filter at the top still scopes both summary cards and the class-wise table consistently.
- Spot-checked a student with an active SSIGM to confirm their bills land under the correct package_session row.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
