### PR TITLE
add tag selector dialog to bulk create page

### DIFF
--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
@@ -30,6 +30,7 @@ import {
 } from '../-types/bulk-create-types';
 import { BatchSelectorDialog } from './batch-selector-dialog';
 import { CourseContentDialog } from './course-content-dialog';
+import { TagSelectorDialog } from './tag-selector-dialog';
 import { cn } from '@/lib/utils';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
@@ -70,8 +71,8 @@ export function BulkCreateTable({
 }: BulkCreateTableProps) {
     const [batchDialogOpen, setBatchDialogOpen] = useState(false);
     const [contentDialogOpen, setContentDialogOpen] = useState(false);
+    const [tagDialogOpen, setTagDialogOpen] = useState(false);
     const [activeCourseId, setActiveCourseId] = useState<string | null>(null);
-    const [tagInputs, setTagInputs] = useState<Record<string, string>>({});
 
     const handleOpenBatchDialog = (courseId: string) => {
         setActiveCourseId(courseId);
@@ -103,15 +104,9 @@ export function BulkCreateTable({
         }
     };
 
-    const handleAddTag = (courseId: string) => {
-        const tagInput = tagInputs[courseId]?.trim();
-        if (!tagInput) return;
-
-        const course = courses.find((c) => c.id === courseId);
-        if (course && !course.tags.includes(tagInput)) {
-            onUpdateCourse(courseId, { tags: [...course.tags, tagInput] });
-        }
-        setTagInputs((prev) => ({ ...prev, [courseId]: '' }));
+    const handleOpenTagDialog = (courseId: string) => {
+        setActiveCourseId(courseId);
+        setTagDialogOpen(true);
     };
 
     const handleRemoveTag = (courseId: string, tag: string) => {
@@ -337,7 +332,7 @@ export function BulkCreateTable({
                                                 <Badge
                                                     key={tag}
                                                     variant="outline"
-                                                    className="text-[10px]"
+                                                    className="rounded-full text-[10px]"
                                                 >
                                                     {tag}
                                                     <button
@@ -351,26 +346,22 @@ export function BulkCreateTable({
                                                 </Badge>
                                             ))}
                                             {course.tags.length > 2 && (
-                                                <Badge variant="outline" className="text-[10px]">
+                                                <Badge
+                                                    variant="outline"
+                                                    className="rounded-full text-[10px]"
+                                                >
                                                     +{course.tags.length - 2}
                                                 </Badge>
                                             )}
-                                            <div className="flex items-center">
-                                                <Input
-                                                    value={tagInputs[course.id] || ''}
-                                                    onChange={(e) =>
-                                                        setTagInputs((prev) => ({
-                                                            ...prev,
-                                                            [course.id]: e.target.value,
-                                                        }))
-                                                    }
-                                                    onKeyDown={(e) =>
-                                                        e.key === 'Enter' && handleAddTag(course.id)
-                                                    }
-                                                    placeholder="Tag"
-                                                    className="h-6 w-16 text-[10px]"
-                                                />
-                                            </div>
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                className="size-6 p-0"
+                                                onClick={() => handleOpenTagDialog(course.id)}
+                                                aria-label="Manage tags"
+                                            >
+                                                <Plus className="size-3" />
+                                            </Button>
                                         </div>
                                     </TableCell>
 
@@ -508,6 +499,18 @@ export function BulkCreateTable({
                     onSave={(data) => {
                         onUpdateCourse(activeCourse.id, data);
                     }}
+                />
+            )}
+
+            {/* Tag Selector Dialog */}
+            {activeCourse && (
+                <TagSelectorDialog
+                    open={tagDialogOpen}
+                    onOpenChange={setTagDialogOpen}
+                    selectedTags={activeCourse.tags}
+                    onConfirm={(tags) => onUpdateCourse(activeCourse.id, { tags })}
+                    title={`Tags for ${activeCourse.course_name || 'Untitled'}`}
+                    description="Pick existing tags or add your own."
                 />
             )}
         </div>

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
@@ -26,6 +26,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { BatchSelectorDialog } from './batch-selector-dialog';
+import { TagSelectorDialog } from './tag-selector-dialog';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
@@ -60,15 +61,8 @@ export function GlobalDefaultsSection({
     onAddLevel,
     onAddSession,
 }: GlobalDefaultsSectionProps) {
-    const [tagInput, setTagInput] = useState('');
     const [showBatchDialog, setShowBatchDialog] = useState(false);
-
-    const handleAddTag = () => {
-        if (tagInput.trim() && !globalDefaults.tags.includes(tagInput.trim())) {
-            onUpdate({ tags: [...globalDefaults.tags, tagInput.trim()] });
-            setTagInput('');
-        }
-    };
+    const [showTagDialog, setShowTagDialog] = useState(false);
 
     const handleRemoveTag = (tag: string) => {
         onUpdate({ tags: globalDefaults.tags.filter((t) => t !== tag) });
@@ -262,39 +256,34 @@ export function GlobalDefaultsSection({
                     {/* Default Tags */}
                     <div className="space-y-1.5 md:col-span-2 lg:col-span-3">
                         <Label className="text-xs text-neutral-600">Default Tags</Label>
-                        <div className="flex gap-2">
-                            <Input
-                                className="h-8 text-xs"
-                                placeholder="Add tag..."
-                                value={tagInput}
-                                onChange={(e) => setTagInput(e.target.value)}
-                                onKeyDown={(e) => e.key === 'Enter' && handleAddTag()}
-                            />
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-8"
-                                onClick={handleAddTag}
-                            >
-                                Add
-                            </Button>
-                        </div>
-                        <div className="flex flex-wrap gap-1.5 pt-1">
+                        <div className="flex flex-wrap items-center gap-1.5">
                             {globalDefaults.tags.map((tag) => (
                                 <Badge
                                     key={tag}
                                     variant="outline"
-                                    className="flex items-center gap-1 text-xs"
+                                    className="flex items-center gap-1 rounded-full text-xs"
                                 >
                                     {tag}
                                     <button
+                                        type="button"
                                         onClick={() => handleRemoveTag(tag)}
                                         className="hover:text-red-500"
+                                        aria-label={`Remove ${tag}`}
                                     >
                                         <X className="size-3" />
                                     </button>
                                 </Badge>
                             ))}
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-7"
+                                onClick={() => setShowTagDialog(true)}
+                            >
+                                <Plus className="mr-1 size-3.5" />
+                                {globalDefaults.tags.length === 0 ? 'Add Tags' : 'Manage Tags'}
+                            </Button>
                         </div>
                     </div>
                 </div>
@@ -311,6 +300,15 @@ export function GlobalDefaultsSection({
                     onUpdate({ batches: [...globalDefaults.batches, batch] });
                     setShowBatchDialog(false);
                 }}
+            />
+
+            <TagSelectorDialog
+                open={showTagDialog}
+                onOpenChange={setShowTagDialog}
+                selectedTags={globalDefaults.tags}
+                onConfirm={(tags) => onUpdate({ tags })}
+                title="Default Tags"
+                description="These tags will be applied to every new course/book by default."
             />
         </div>
     );

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/tag-selector-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/tag-selector-dialog.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { X, Plus } from '@phosphor-icons/react';
+import { useInstituteTags } from '../-hooks/useInstituteTags';
+
+interface TagSelectorDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    selectedTags: string[];
+    onConfirm: (tags: string[]) => void;
+    title?: string;
+    description?: string;
+}
+
+export function TagSelectorDialog({
+    open,
+    onOpenChange,
+    selectedTags,
+    onConfirm,
+    title = 'Select Tags',
+    description = 'Pick from existing tags or add your own.',
+}: TagSelectorDialogProps) {
+    const { tags: instituteTags, isLoading } = useInstituteTags();
+    const [draft, setDraft] = useState<string[]>(selectedTags);
+    const [newTag, setNewTag] = useState('');
+
+    useEffect(() => {
+        if (open) {
+            setDraft(selectedTags);
+            setNewTag('');
+        }
+    }, [open, selectedTags]);
+
+    const availableTags = useMemo(
+        () => instituteTags.filter((t) => !draft.includes(t)),
+        [instituteTags, draft]
+    );
+
+    const handleSelect = (tag: string) => {
+        if (!draft.includes(tag)) setDraft([...draft, tag]);
+    };
+
+    const handleRemove = (tag: string) => {
+        setDraft(draft.filter((t) => t !== tag));
+    };
+
+    const handleAddCustom = () => {
+        const trimmed = newTag.trim();
+        if (!trimmed) return;
+        if (!draft.includes(trimmed)) setDraft([...draft, trimmed]);
+        setNewTag('');
+    };
+
+    const handleConfirm = () => {
+        onConfirm(draft);
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-4">
+                    {/* Selected tags */}
+                    <div className="space-y-1.5">
+                        <Label className="text-xs text-neutral-600">
+                            Selected Tags ({draft.length})
+                        </Label>
+                        <div className="flex min-h-[44px] flex-wrap gap-1.5 rounded-md border border-neutral-200 bg-neutral-50 p-2">
+                            {draft.length === 0 ? (
+                                <span className="text-xs text-neutral-400">
+                                    No tags selected yet
+                                </span>
+                            ) : (
+                                draft.map((tag) => (
+                                    <Badge
+                                        key={tag}
+                                        variant="outline"
+                                        className="flex items-center gap-1 rounded-full border-primary-300 bg-primary-50 text-xs text-primary-700"
+                                    >
+                                        {tag}
+                                        <button
+                                            type="button"
+                                            onClick={() => handleRemove(tag)}
+                                            className="hover:text-red-500"
+                                            aria-label={`Remove ${tag}`}
+                                        >
+                                            <X className="size-3" />
+                                        </button>
+                                    </Badge>
+                                ))
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Add custom tag */}
+                    <div className="space-y-1.5">
+                        <Label className="text-xs text-neutral-600">Add a custom tag</Label>
+                        <div className="flex gap-2">
+                            <Input
+                                className="h-9 text-xs"
+                                placeholder="Type a tag and press Enter or click Add"
+                                value={newTag}
+                                onChange={(e) => setNewTag(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        handleAddCustom();
+                                    }
+                                }}
+                            />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-9"
+                                onClick={handleAddCustom}
+                                disabled={!newTag.trim()}
+                            >
+                                <Plus className="mr-1 size-3.5" />
+                                Add
+                            </Button>
+                        </div>
+                    </div>
+
+                    {/* Available tags from institute */}
+                    <div className="space-y-1.5">
+                        <Label className="text-xs text-neutral-600">
+                            Available Tags{' '}
+                            {!isLoading && (
+                                <span className="text-neutral-400">({availableTags.length})</span>
+                            )}
+                        </Label>
+                        <div className="max-h-48 overflow-y-auto rounded-md border border-neutral-200 p-2">
+                            {isLoading ? (
+                                <span className="text-xs text-neutral-400">Loading tags...</span>
+                            ) : availableTags.length === 0 ? (
+                                <span className="text-xs text-neutral-400">
+                                    {instituteTags.length === 0
+                                        ? 'No institute tags found'
+                                        : 'All available tags have been selected'}
+                                </span>
+                            ) : (
+                                <div className="flex flex-wrap gap-1.5">
+                                    {availableTags.map((tag) => (
+                                        <button
+                                            key={tag}
+                                            type="button"
+                                            onClick={() => handleSelect(tag)}
+                                            className="rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-xs text-neutral-700 transition-colors hover:border-primary-400 hover:bg-primary-50 hover:text-primary-700"
+                                        >
+                                            {tag}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleConfirm}>Done</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-hooks/useInstituteTags.ts
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-hooks/useInstituteTags.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { INIT_INSTITUTE_SETUP } from '@/constants/urls';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+
+const fetchInstituteTags = async (): Promise<string[]> => {
+    const instituteId = getCurrentInstituteId();
+    if (!instituteId) return [];
+    const response = await authenticatedAxiosInstance({
+        method: 'GET',
+        url: `${INIT_INSTITUTE_SETUP}/${instituteId}`,
+    });
+    const tags = response.data?.institute_info_dto?.tags;
+    return Array.isArray(tags) ? tags : [];
+};
+
+export const useInstituteTags = () => {
+    const { data: tags = [], isLoading } = useQuery({
+        queryKey: ['institute-tags'],
+        queryFn: fetchInstituteTags,
+        staleTime: 5 * 60 * 1000,
+    });
+    return { tags, isLoading };
+};


### PR DESCRIPTION
## Summary of Changes

Replaces the free-text tag input on the Bulk Create page with a reusable modal dialog. Admins can now pick from existing institute tags (populated from `GET /institute/v1/details`) as pill-shaped buttons, add custom tags inline, and see/remove their current selection — all from one place. Same dialog is used for Global Defaults and per-row tags.

**Frontend:**
- New `TagSelectorDialog` component (`bulk-create/-components/tag-selector-dialog.tsx`) — modal with three sections: Selected tags (removable pills), Add-custom input (Enter or Add button), and Available institute tags (clickable pills). Uses a draft state so Cancel discards changes.
- New `useInstituteTags` hook (`bulk-create/-hooks/useInstituteTags.ts`) — TanStack Query hook fetching institute tags via `INIT_INSTITUTE_SETUP/{instituteId}` with 5-minute stale time. Avoids the deprecated `useInstituteDetailsStore`.
- `global-defaults-section.tsx`: removed the text input + Add button for Default Tags; replaced with inline selected pills + a "Manage Tags" / "Add Tags" button that opens the dialog.
- `bulk-create-table.tsx`: removed the inline tag input from the Tags column; now shows up to 2 selected pills + `+N` truncation badge + `+` button that opens the dialog scoped to that row (matches the existing pattern used for the Batches column).

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Opened Bulk Create page → clicked "Add Tags" in Global Defaults → verified institute tags render as pills, clicking moves them to Selected, Done persists them to every new course row.
- Clicked `+` in a course row's Tags column → verified the dialog opens with that row's tags, supports add/remove, Cancel discards, Done saves only to that row.
- Added a custom tag via the input (Enter + Add button) → verified it appears in Selected and persists after Done.
- Verified truncation: with 3+ tags the row shows 2 pills + `+N` badge without breaking layout.
- TypeScript check clean on all modified files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
