### PR TITLE
feat: make new modal for showing search button and fetched packages t…

### DIFF
--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-page.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, Eye, ArrowClockwise, CheckCircle } from '@phosphor-icons/react';
+import { ArrowLeft, Eye, ArrowClockwise, CheckCircle, MagnifyingGlass } from '@phosphor-icons/react';
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
 import { useBulkCreate } from '../-hooks/useBulkCreate';
@@ -12,6 +12,7 @@ import { FileCsv } from '@phosphor-icons/react';
 import { PreviewDialog } from './preview-dialog';
 import { createLevel, createSession } from '../-services/bulk-create-service';
 import { LevelOption, SessionOption } from '../-types/bulk-create-types';
+import { SimilarPackagesDialog } from './similar-packages-dialog';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
@@ -23,6 +24,7 @@ export function BulkCreatePage() {
     const [localLevels, setLocalLevels] = useState<LevelOption[]>([]);
     const [localSessions, setLocalSessions] = useState<SessionOption[]>([]);
     const [showCsvImport, setShowCsvImport] = useState(false);
+    const [showSimilarPackages, setShowSimilarPackages] = useState(false);
 
     const {
         courses,
@@ -123,6 +125,15 @@ export function BulkCreatePage() {
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowSimilarPackages(true)}
+                        className="h-9"
+                    >
+                        <MagnifyingGlass className="mr-1 size-4" />
+                        Search already added {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package)}
+                    </Button>
                     <Button
                         variant="outline"
                         size="sm"
@@ -248,6 +259,11 @@ export function BulkCreatePage() {
                 levels={allLevels}
                 sessions={allSessions}
                 onImport={importCourses}
+            />
+
+            <SimilarPackagesDialog
+                open={showSimilarPackages}
+                onOpenChange={setShowSimilarPackages}
             />
         </section>
     );

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/similar-packages-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/similar-packages-dialog.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Search } from 'lucide-react';
+import { fetchPaginatedBatches } from '@/routes/manage-inventory/-services/inventory-service';
+import { PaginatedBatchItem } from '@/routes/manage-inventory/-types/inventory-types';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { DashboardLoader } from '@/components/core/dashboard-loader';
+
+interface SimilarPackagesDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function SimilarPackagesDialog({ open, onOpenChange }: SimilarPackagesDialogProps) {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [results, setResults] = useState<PaginatedBatchItem[]>([]);
+    const [hasSearched, setHasSearched] = useState(false);
+
+    const handleSearch = async () => {
+        if (!searchTerm.trim()) return;
+        setIsLoading(true);
+        setHasSearched(true);
+        try {
+            const response = await fetchPaginatedBatches({ search: searchTerm }, 0, 50);
+            setResults(response.content || []);
+        } catch (error) {
+            console.error('Error fetching packages:', error);
+            setResults([]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle>Search Already Added {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package)}</DialogTitle>
+                    <DialogDescription>
+                        Search to see if the {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package).toLowerCase()} you are trying to add already exist in the system.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex items-center gap-2 mb-4">
+                    <Input 
+                        placeholder="Search by name..." 
+                        value={searchTerm} 
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                    />
+                    <Button onClick={handleSearch} disabled={isLoading}>
+                        <Search className="mr-2 h-4 w-4" />
+                        Search
+                    </Button>
+                </div>
+
+                <div className="flex-1 overflow-auto border rounded-md">
+                    {isLoading ? (
+                        <div className="flex justify-center items-center h-32">
+                            <DashboardLoader />
+                        </div>
+                    ) : hasSearched && results.length === 0 ? (
+                        <div className="flex justify-center items-center h-32 text-neutral-500">
+                            No {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package).toLowerCase()} found for "{searchTerm}".
+                        </div>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Package Name</TableHead>
+                                    <TableHead>Level</TableHead>
+                                    <TableHead>Session</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {results.map((item) => (
+                                    <TableRow key={item.id}>
+                                        <TableCell className="font-medium">{item.package_dto?.package_name || 'N/A'}</TableCell>
+                                        <TableCell>{item.level?.level_name || 'N/A'}</TableCell>
+                                        <TableCell>{item.session?.session_name || 'N/A'}</TableCell>
+                                        <TableCell>{item.status || 'N/A'}</TableCell>
+                                    </TableRow>
+                                ))}
+                                {!hasSearched && results.length === 0 && (
+                                    <TableRow>
+                                        <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
+                                            Enter a search term and click Search to see results.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
## feat: make new modal for showing search button and fetched packages to check for duplicacy

## Summary of Changes

This PR introduces a new "Search already added packages" feature on the Bulk Create interface to help users prevent duplicate package creation. 

- **New Component**: Added `SimilarPackagesDialog`, a modal containing a search bar and a results table.
- **API Integration**: Linked the search to the existing `fetchPaginatedBatches` endpoint in the inventory service to query existing packages dynamically.
- **Dynamic Terminology**: Integrated the system's `getTerminologyPlural` function to ensure correct naming conventions (e.g., "Packages", "Books") across the new button and modal UI.
- **Data Display**: The search results table cleanly displays the found Package Name, Level, Session, and Status.
- **UI Updates**: Hooked up the new search button next to the "Import CSV" button in `BulkCreatePage`.

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Verified that clicking the "Search already added packages" button correctly opens the search modal.
- Ensured typing in the modal's search bar and pressing "Search" triggers the `fetchPaginatedBatches` API with the correct search parameters.
- Validated that the results table accurately lists matched packages and correctly handles empty states when no duplicates are found.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
