### PR TITLE
Custom fields revamp: visibility, per-feature sync, cascade delete

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -162,18 +162,30 @@ public class AudienceService {
         return userIds;
     }
 
-    private void saveInstituteCustomFields(String audienceId, List<InstituteCustomFieldDTO> dtos) {
-        if (!CollectionUtils.isEmpty(dtos)) {
-            List<InstituteCustomFieldDTO> customFieldsToSave = dtos.stream()
-                    .filter(Objects::nonNull)
-                    .peek(cf -> {
-                        cf.setId(null); // Force creation of new mapping
-                        cf.setType(CustomFieldTypeEnum.AUDIENCE_FORM.name());
-                        cf.setTypeId(audienceId);
-                    })
-                    .collect(Collectors.toList());
-            instituteCustomFiledService.addOrUpdateCustomField(customFieldsToSave);
-            logger.info("Linked {} custom fields to audience {}", customFieldsToSave.size(), audienceId);
+    /**
+     * Persist the full set of custom fields the admin selected for this audience
+     * campaign. Delegates to the unified per-feature sync — see
+     * {@link vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService#syncFeatureCustomFields}.
+     *
+     * The frontend always sends the complete picked list (defaults pre-selected
+     * from the institute catalog + ad-hoc fields the admin added in the dialog).
+     * Anything not present here is soft-deleted; anything previously deleted is
+     * reactivated by id (so a re-tick brings the existing answers back). The
+     * institute_id is read from the audience entity itself, so the caller does
+     * not need to pass it.
+     */
+    private void saveInstituteCustomFields(String audienceId, String instituteId,
+                                           List<InstituteCustomFieldDTO> dtos) {
+        if (!StringUtils.hasText(audienceId) || !StringUtils.hasText(instituteId)) {
+            return;
+        }
+        instituteCustomFiledService.syncFeatureCustomFields(
+                instituteId,
+                CustomFieldTypeEnum.AUDIENCE_FORM.name(),
+                audienceId,
+                dtos);
+        if (dtos != null) {
+            logger.info("Synced {} custom field selections for audience {}", dtos.size(), audienceId);
         }
     }
 
@@ -207,8 +219,9 @@ public class AudienceService {
 
         logger.info("Saved audience with ID: {}", savedAudience.getId());
 
-        // 2. Link custom fields - EXACTLY like EnrollInvite!
-        saveInstituteCustomFields(savedAudience.getId(), audienceDTO.getInstituteCustomFields());
+        // 2. Link custom fields - admin's full picked list (defaults + ad-hoc).
+        saveInstituteCustomFields(savedAudience.getId(), savedAudience.getInstituteId(),
+                audienceDTO.getInstituteCustomFields());
 
         return savedAudience.getId();
     }
@@ -256,8 +269,10 @@ public class AudienceService {
 
         Audience updated = audienceRepository.save(audience);
 
-        // Update custom fields if provided
-        saveInstituteCustomFields(updated.getId(), audienceDTO.getInstituteCustomFields());
+        // Update custom fields — admin's full picked list, including any toggled-off
+        // entries which will be soft-deleted by the unified sync.
+        saveInstituteCustomFields(updated.getId(), updated.getInstituteId(),
+                audienceDTO.getInstituteCustomFields());
 
         logger.info("Updated audience: {}", updated.getId());
         return updated.getId();

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/controller/InstituteCustomFieldController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/controller/InstituteCustomFieldController.java
@@ -27,11 +27,86 @@ public class InstituteCustomFieldController {
     @Autowired
     private InstituteCustomFieldManager instituteCustomFieldManager;
 
+    /**
+     * Returns the institute's DEFAULT_CUSTOM_FIELD mappings — i.e. the catalog
+     * the admin manages from Settings → Custom Fields. The per-feature pickers
+     * (Enroll Invite, Audience, Live Session, Assessment) call this to know
+     * which fields to pre-select when an admin opens a brand-new create dialog.
+     */
     @GetMapping
     public ResponseEntity<List<InstituteCustomFieldDTO>> getInstituteCustomFields(
             @RequestParam("instituteId") String instituteId) {
         return ResponseEntity.ok(
                 instituteCustomFiledService.findActiveCustomFieldsWithNullTypeId(instituteId));
+    }
+
+    /**
+     * Returns every ACTIVE custom-field mapping for a single feature instance
+     * (e.g. one enroll invite, one live session, one audience). Used by the
+     * per-feature edit screens to pre-populate the picker with the fields
+     * that were saved last time.
+     *
+     * Pass {@code type} = ENROLL_INVITE / AUDIENCE_FORM / SESSION / ASSESSMENT
+     * and {@code typeId} = the feature instance UUID.
+     */
+    @GetMapping("/feature-fields")
+    public ResponseEntity<List<InstituteCustomFieldDTO>> getFeatureCustomFields(
+            @RequestParam("instituteId") String instituteId,
+            @RequestParam("type") String type,
+            @RequestParam("typeId") String typeId) {
+        return ResponseEntity.ok(
+                instituteCustomFiledService.findCustomFieldsAsJson(instituteId, type, typeId));
+    }
+
+    /**
+     * Persist the full set of custom fields the admin selected for one feature
+     * instance. Idempotent: insert / reactivate / soft-delete in one call. Used
+     * by every feature flow that owns its own per-instance picker — Enroll
+     * Invite, Audience, Live Session, Assessment, …
+     *
+     * <p>This endpoint exists so the assessment-service (and any other
+     * downstream flow) can sync custom fields without needing to import the
+     * admin_core_service service classes — the frontend calls it directly
+     * after the parent feature has been created. Body is the FULL list of
+     * fields the admin picked (defaults pre-selected from the catalog plus
+     * any ad-hoc fields added in the dialog).
+     */
+    @PostMapping("/feature-fields")
+    public ResponseEntity<String> syncFeatureCustomFields(
+            @RequestParam("instituteId") String instituteId,
+            @RequestParam("type") String type,
+            @RequestParam("typeId") String typeId,
+            @RequestBody List<InstituteCustomFieldDTO> fields) {
+        instituteCustomFiledService.syncFeatureCustomFields(instituteId, type, typeId, fields);
+        return ResponseEntity.ok("synced");
+    }
+
+    /**
+     * List every active mapping for one custom field across all feature
+     * instances (DEFAULT + ENROLL_INVITE + AUDIENCE_FORM + SESSION +
+     * ASSESSMENT). Used by the Settings → Custom Fields cascade-delete
+     * dialog so the admin can pick which mappings to soft-delete.
+     */
+    @GetMapping("/usages")
+    public ResponseEntity<List<vacademy.io.admin_core_service.features.common.dto.CustomFieldMappingUsageDTO>> getCustomFieldUsages(
+            @RequestParam("instituteId") String instituteId,
+            @RequestParam("customFieldId") String customFieldId) {
+        return ResponseEntity.ok(
+                instituteCustomFiledService.getCustomFieldUsages(instituteId, customFieldId));
+    }
+
+    /**
+     * Soft-delete a list of {@code institute_custom_fields} rows by id.
+     * Returns the number of rows actually flipped to DELETED. The master
+     * {@code custom_fields} row and any {@code custom_field_values} answers
+     * are <strong>not</strong> touched — re-adding the same field later via
+     * the unified picker will reactivate the mapping and bring the answers
+     * back.
+     */
+    @DeleteMapping("/mappings")
+    public ResponseEntity<String> softDeleteMappings(@RequestBody List<String> mappingIds) {
+        int updated = instituteCustomFiledService.softDeleteMappingsByIds(mappingIds);
+        return ResponseEntity.ok(updated + " mapping(s) marked DELETED");
     }
 
     @DeleteMapping("/delete-bulk")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/dto/CustomFieldMappingUsageDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/dto/CustomFieldMappingUsageDTO.java
@@ -1,0 +1,39 @@
+package vacademy.io.admin_core_service.features.common.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One mapping row of {@code institute_custom_fields} flattened for the
+ * cascade-delete dialog in Settings → Custom Fields. Contains everything the
+ * admin needs to identify a single mapping (which feature instance it lives
+ * on) and pick it for deletion.
+ *
+ * <p>Returned by {@code GET /admin-core-service/common/custom-fields/usages}.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CustomFieldMappingUsageDTO {
+
+    /** Primary key of the {@code institute_custom_fields} row. */
+    private String mappingId;
+
+    /** Custom field type — DEFAULT_CUSTOM_FIELD / ENROLL_INVITE / AUDIENCE_FORM / SESSION / ASSESSMENT. */
+    private String type;
+
+    /**
+     * Id of the parent feature instance (enroll_invite.id, audience.id,
+     * live_session.id, assessment.id). Null for DEFAULT_CUSTOM_FIELD.
+     */
+    private String typeId;
+
+    /** Status of the mapping (always ACTIVE here, but kept for future use). */
+    private String status;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/dto/InstituteCustomFieldDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/dto/InstituteCustomFieldDTO.java
@@ -31,5 +31,7 @@ public class InstituteCustomFieldDTO {
 
     private Integer groupInternalOrder;
 
+    private Boolean isMandatory;
+
     private String status;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/entity/InstituteCustomField.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/entity/InstituteCustomField.java
@@ -46,6 +46,9 @@ public class InstituteCustomField {
     @Column(name = "individual_order")
     private Integer individualOrder;
 
+    @Column(name = "is_mandatory")
+    private Boolean isMandatory = false;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Date createdAt;
 
@@ -80,6 +83,9 @@ public class InstituteCustomField {
 
         if (instituteCustomFieldDTO.getGroupInternalOrder() != null)
             this.groupInternalOrder = instituteCustomFieldDTO.getGroupInternalOrder();
+
+        if (instituteCustomFieldDTO.getIsMandatory() != null)
+            this.isMandatory = instituteCustomFieldDTO.getIsMandatory();
 
         if (StringUtils.hasText(instituteCustomFieldDTO.getStatus()))
             this.status = instituteCustomFieldDTO.getStatus();

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/enums/CustomFieldTypeEnum.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/enums/CustomFieldTypeEnum.java
@@ -1,8 +1,18 @@
 package vacademy.io.admin_core_service.features.common.enums;
 
 public enum CustomFieldTypeEnum {
+    /** Institute-wide default field, managed in Settings → Custom Fields. */
+    DEFAULT_CUSTOM_FIELD,
+
+    /** Per enroll invite mapping, scoped by type_id = enroll_invite.id */
     ENROLL_INVITE,
-    SESSION,
+
+    /** Per audience campaign mapping, scoped by type_id = audience.id */
     AUDIENCE_FORM,
-    DEFAULT_CUSTOM_FIELD
+
+    /** Per live class / live session schedule mapping, scoped by type_id = live_session.id */
+    SESSION,
+
+    /** Per assessment mapping, scoped by type_id = assessment.id */
+    ASSESSMENT
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.common.dto.CustomFieldDTO;
+import vacademy.io.admin_core_service.features.common.dto.CustomFieldMappingUsageDTO;
 import vacademy.io.admin_core_service.features.common.util.CustomFieldKeyGenerator;
 import vacademy.io.admin_core_service.features.common.dto.InstituteCustomFieldDTO;
 import vacademy.io.admin_core_service.features.common.dto.InstituteCustomFieldDeleteRequestDTO;
@@ -105,6 +106,9 @@ public class InstituteCustomFiledService {
                 if (dto.getIndividualOrder() != null) {
                     instCF.setIndividualOrder(dto.getIndividualOrder());
                 }
+                if (dto.getIsMandatory() != null) {
+                    instCF.setIsMandatory(dto.getIsMandatory());
+                }
             } else {
                 instCF = new InstituteCustomField(dto);
                 instCF.setCustomFieldId(cf.getId());
@@ -133,6 +137,86 @@ public class InstituteCustomFiledService {
         CustomFields newCF = new CustomFields(cfDto);
         newCF.setFieldKey(fieldKey);
         return customFieldRepository.save(newCF);
+    }
+
+    /**
+     * Unified per-feature custom-field sync.
+     *
+     * Used by every feature flow that owns its own list of custom fields
+     * (Enroll Invite, Audience, Live Session, Assessment). Semantics:
+     *
+     *   1. Load every existing ACTIVE mapping for the (institute, type, typeId) tuple.
+     *   2. Walk the incoming list:
+     *        - If the entry has a customFieldId → reuse the existing master
+     *          custom_fields row. Reactivate any matching DELETED mapping or
+     *          create a new ACTIVE one.
+     *        - If the entry has no customFieldId (an "ad-hoc" field added in
+     *          the feature dialog) → create a new master custom_fields row
+     *          AND a new mapping with the feature type/typeId. NO
+     *          DEFAULT_CUSTOM_FIELD mapping is created — defaults are managed
+     *          exclusively from Settings → Custom Fields.
+     *   3. Soft-delete every previously-ACTIVE mapping that is no longer in
+     *      the incoming list. Existing custom_field_values are untouched, so
+     *      a future re-add of the same field reactivates and the answers
+     *      come back.
+     *
+     * The caller is expected to have already persisted the parent entity
+     * (so typeId is non-null) before calling this method.
+     */
+    @Transactional
+    public void syncFeatureCustomFields(String instituteId,
+                                        String type,
+                                        String typeId,
+                                        List<InstituteCustomFieldDTO> incoming) {
+        if (!StringUtils.hasText(instituteId) || !StringUtils.hasText(type) || !StringUtils.hasText(typeId)) {
+            throw new VacademyException("instituteId, type and typeId are required for syncFeatureCustomFields");
+        }
+
+        List<InstituteCustomFieldDTO> safeIncoming = incoming == null ? new ArrayList<>() : incoming;
+
+        // Normalize: stamp every incoming DTO with the right institute/type/typeId,
+        // and clear any stale primary key so the upsert path can find or create
+        // the correct mapping.
+        safeIncoming.forEach(dto -> {
+            if (dto == null) return;
+            dto.setInstituteId(instituteId);
+            dto.setType(type);
+            dto.setTypeId(typeId);
+            dto.setId(null);
+        });
+
+        // 1. Persist (insert / reactivate / update) every incoming mapping.
+        List<InstituteCustomFieldDTO> toUpsert = safeIncoming.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (!toUpsert.isEmpty()) {
+            addOrUpdateCustomField(toUpsert);
+        }
+
+        // 2. Soft-delete every existing ACTIVE mapping that is not in the
+        //    incoming set. We compare by customFieldId because that is the
+        //    stable identifier of "which field is on this feature instance".
+        List<InstituteCustomField> existingActive = instituteCustomFieldRepository
+                .findByInstituteIdAndTypeAndTypeIdAndStatusIn(instituteId, type, typeId,
+                        List.of(StatusEnum.ACTIVE.name()));
+
+        if (CollectionUtils.isEmpty(existingActive)) {
+            return;
+        }
+
+        Set<String> incomingFieldIds = toUpsert.stream()
+                .map(dto -> dto.getCustomField() != null ? dto.getCustomField().getId() : dto.getFieldId())
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+
+        List<InstituteCustomField> toDelete = existingActive.stream()
+                .filter(row -> !incomingFieldIds.contains(row.getCustomFieldId()))
+                .peek(row -> row.setStatus(StatusEnum.DELETED.name()))
+                .collect(Collectors.toList());
+
+        if (!toDelete.isEmpty()) {
+            instituteCustomFieldRepository.saveAll(toDelete);
+        }
     }
 
     public List<InstituteCustomFieldDTO> findCustomFieldsAsJson(String instituteId, String type, String typeId) {
@@ -171,6 +255,67 @@ public class InstituteCustomFiledService {
                     instituteId, entry.getType(), entry.getCustomFieldId(), StatusEnum.DELETED.name());
         }
         return total;
+    }
+
+    /**
+     * List every ACTIVE mapping for one custom field across all feature
+     * instances. Used by the Settings → Custom Fields cascade-delete dialog
+     * so the admin can pick which mappings to soft-delete (DEFAULT,
+     * individual ENROLL_INVITE rows, individual AUDIENCE_FORM rows, etc.).
+     *
+     * <p>Returns a flat list — the frontend groups by {@code type} for display.
+     */
+    public List<CustomFieldMappingUsageDTO> getCustomFieldUsages(String instituteId, String customFieldId) {
+        if (!StringUtils.hasText(instituteId) || !StringUtils.hasText(customFieldId)) {
+            return new ArrayList<>();
+        }
+        List<InstituteCustomField> rows = instituteCustomFieldRepository
+                .findByInstituteIdAndCustomFieldIdInAndStatusIn(
+                        instituteId,
+                        List.of(customFieldId),
+                        List.of(StatusEnum.ACTIVE.name()));
+        return rows.stream()
+                .map(row -> CustomFieldMappingUsageDTO.builder()
+                        .mappingId(row.getId())
+                        .type(row.getType())
+                        .typeId(row.getTypeId())
+                        .status(row.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Soft-delete a list of {@code institute_custom_fields} rows by id.
+     *
+     * <p>"Delete" here means: status flipped to DELETED. Nothing else
+     * happens — the master {@code custom_fields} row stays intact, and any
+     * {@code custom_field_values} answers stored against the field stay in
+     * place. This is intentional: the unified {@code syncFeatureCustomFields}
+     * is reactivation-aware, so a future re-add of the same field on the
+     * same feature instance flips the row back to ACTIVE and the answers
+     * come back automatically.
+     *
+     * <p>Used by the Settings → Custom Fields cascade-delete dialog. Returns
+     * the number of rows actually flipped (rows already DELETED are
+     * skipped).
+     */
+    @Transactional
+    public int softDeleteMappingsByIds(List<String> mappingIds) {
+        if (CollectionUtils.isEmpty(mappingIds)) {
+            return 0;
+        }
+        List<InstituteCustomField> rows = instituteCustomFieldRepository.findAllById(mappingIds);
+        int flipped = 0;
+        for (InstituteCustomField row : rows) {
+            if (!StatusEnum.DELETED.name().equals(row.getStatus())) {
+                row.setStatus(StatusEnum.DELETED.name());
+                flipped++;
+            }
+        }
+        if (flipped > 0) {
+            instituteCustomFieldRepository.saveAll(rows);
+        }
+        return flipped;
     }
 
     public List<InstituteCustomFieldSetupDTO> findUniqueActiveCustomFieldsByInstituteId(String instituteId) {
@@ -219,6 +364,9 @@ public class InstituteCustomFiledService {
         instituteDTO.setType(icf.getType());
         instituteDTO.setTypeId(icf.getTypeId());
         instituteDTO.setGroupName(icf.getGroupName());
+        instituteDTO.setIndividualOrder(icf.getIndividualOrder());
+        instituteDTO.setGroupInternalOrder(icf.getGroupInternalOrder());
+        instituteDTO.setIsMandatory(icf.getIsMandatory());
         instituteDTO.setCustomField(customFieldDTO);
         instituteDTO.setStatus(icf.getStatus());
         return instituteDTO;
@@ -388,16 +536,29 @@ public class InstituteCustomFiledService {
     }
 
     /**
-     * Copy default custom fields for an institute to enroll invite type
+     * Copy default custom fields for an institute to enroll invite type.
+     *
+     * <p>Used only by <strong>system-generated</strong> enroll invite creation
+     * paths (e.g. bulk course import, default enroll invite generation) where
+     * there is no admin UI to pick fields. Admin-driven create / edit flows
+     * should call {@link #syncFeatureCustomFields(String, String, String, java.util.List)}
+     * directly with the explicit list the admin selected.
+     *
+     * <p>Routes through the unified sync so that re-runs are idempotent and
+     * any previously soft-deleted mappings are reactivated rather than
+     * duplicated.
      */
     public void copyDefaultCustomFieldsToEnrollInvite(String instituteId, String enrollInviteId) {
         if (instituteId == null || enrollInviteId == null) {
             return;
         }
-        
+
         List<InstituteCustomFieldDTO> defaultCustomFieldsToCopy = getDefaultCustomFieldsForEnrollInvite(instituteId, enrollInviteId);
         if (!defaultCustomFieldsToCopy.isEmpty()) {
-            addOrUpdateCustomField(defaultCustomFieldsToCopy);
+            syncFeatureCustomFields(instituteId,
+                    CustomFieldTypeEnum.ENROLL_INVITE.name(),
+                    enrollInviteId,
+                    defaultCustomFieldsToCopy);
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollInviteService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollInviteService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.common.dto.InstituteCustomFieldDTO;
-import vacademy.io.admin_core_service.features.common.entity.InstituteCustomField;
 import vacademy.io.admin_core_service.features.common.enums.CustomFieldTypeEnum;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService;
@@ -119,12 +118,13 @@ public class EnrollInviteService {
 
         final EnrollInvite savedEnrollInvite = initialSavedEnrollInvite;
 
+        // Custom fields revamp: the frontend now sends the explicit list of fields
+        // (defaults the admin pre-selected + any ad-hoc fields they added) on every
+        // create / update. The previous "auto-copy all defaults to new invite" call
+        // is intentionally removed — defaults that the admin un-checks must NOT
+        // come back. See vacademy_platform/docs/CUSTOM_FIELDS.md.
         saveInstituteCustomFields(savedEnrollInvite.getId(), enrollInviteDTO.getInstituteId(),
                 enrollInviteDTO.getInstituteCustomFields());
-
-        // Automatically copy default custom fields to the new enroll invite
-        instituteCustomFiledService.copyDefaultCustomFieldsToEnrollInvite(enrollInviteDTO.getInstituteId(),
-                savedEnrollInvite.getId());
 
         List<PackageSessionLearnerInvitationToPaymentOption> mappingEntities = mappingDTOs.stream()
                 .filter(Objects::nonNull)
@@ -387,73 +387,24 @@ public class EnrollInviteService {
         return "Enroll invites deleted successfully";
     }
 
+    /**
+     * Persist the full set of custom fields the admin selected for this enroll
+     * invite. Delegates to the unified per-feature sync — see
+     * {@link vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService#syncFeatureCustomFields}.
+     *
+     * The frontend always sends the complete picked list (defaults + ad-hoc).
+     * Anything not present here is soft-deleted; anything previously deleted
+     * is reactivated by id (so a re-tick brings the existing answers back).
+     */
     private void saveInstituteCustomFields(String inviteId, String instituteId, List<InstituteCustomFieldDTO> dtos) {
-        // Step 1: Mark existing custom fields as DELETED if they're not in the incoming
-        // array
-        if (StringUtils.hasText(instituteId) && StringUtils.hasText(inviteId)) {
-            markMissingCustomFieldsAsDeleted(instituteId, inviteId, dtos);
+        if (!StringUtils.hasText(instituteId) || !StringUtils.hasText(inviteId)) {
+            return;
         }
-
-        // Step 2: Save/update the custom fields from the incoming array
-        if (!CollectionUtils.isEmpty(dtos)) {
-            List<InstituteCustomFieldDTO> customFieldsToSave = dtos.stream()
-                    .filter(Objects::nonNull)
-                    .peek(cf -> {
-                        cf.setId(null);
-                        cf.setType(CustomFieldTypeEnum.ENROLL_INVITE.name());
-                        cf.setTypeId(inviteId);
-                        if (!StringUtils.hasText(cf.getInstituteId())) {
-                            cf.setInstituteId(instituteId);
-                        }
-                    })
-                    .collect(Collectors.toList());
-            instituteCustomFiledService.addOrUpdateCustomField(customFieldsToSave);
-        }
-    }
-
-    private void markMissingCustomFieldsAsDeleted(String instituteId, String enrollInviteId,
-            List<InstituteCustomFieldDTO> incomingDtos) {
-        // Fetch all existing ACTIVE custom fields for this enroll invite
-        List<InstituteCustomField> existingFields = instituteCustomFiledService.getCusFieldByInstituteAndTypeAndTypeId(
+        instituteCustomFiledService.syncFeatureCustomFields(
                 instituteId,
                 CustomFieldTypeEnum.ENROLL_INVITE.name(),
-                enrollInviteId,
-                List.of(StatusEnum.ACTIVE.name()));
-
-        if (CollectionUtils.isEmpty(existingFields)) {
-            return; // No existing fields to delete
-        }
-
-        // Extract customFieldIds from incoming DTOs
-        final Set<String> incomingCustomFieldIds;
-        if (!CollectionUtils.isEmpty(incomingDtos)) {
-            incomingCustomFieldIds = incomingDtos.stream()
-                    .filter(Objects::nonNull)
-                    .map(dto -> {
-                        if (dto.getCustomField() != null && StringUtils.hasText(dto.getCustomField().getId())) {
-                            return dto.getCustomField().getId();
-                        }
-                        if (StringUtils.hasText(dto.getFieldId())) {
-                            return dto.getFieldId();
-                        }
-                        return null;
-                    })
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-        } else {
-            incomingCustomFieldIds = new HashSet<>();
-        }
-
-        // Find existing fields that are not in the incoming array
-        List<InstituteCustomField> fieldsToDelete = existingFields.stream()
-                .filter(existingField -> !incomingCustomFieldIds.contains(existingField.getCustomFieldId()))
-                .collect(Collectors.toList());
-
-        // Mark them as DELETED
-        if (!CollectionUtils.isEmpty(fieldsToDelete)) {
-            fieldsToDelete.forEach(field -> field.setStatus(StatusEnum.DELETED.name()));
-            instituteCustomFiledService.createOrUpdateMappings(fieldsToDelete);
-        }
+                inviteId,
+                dtos);
     }
 
     // ===================================================================================

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep2RequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep2RequestDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import vacademy.io.admin_core_service.features.common.dto.InstituteCustomFieldDTO;
 import vacademy.io.admin_core_service.features.live_session.enums.NotificationTypeEnum;
 
 import java.util.List;
@@ -32,9 +33,27 @@ public class LiveSessionStep2RequestDTO {
     private List<String> deletedNotificationActionIds;
 
     // === Custom Field Operations ===
+    // Legacy add/update/delete tri-arrays. Kept for backward compatibility with
+    // older clients; new clients should send `instituteCustomFields` instead.
+    @Deprecated
     private List<CustomFieldDTO> addedFields;
+    @Deprecated
     private List<CustomFieldDTO> updatedFields;
+    @Deprecated
     private List<String> deletedFieldIds;
+
+    /**
+     * Unified custom-field picker payload (custom fields revamp).
+     *
+     * The frontend sends the FULL list of fields the admin selected for this
+     * live session — institute defaults that were pre-selected (and not
+     * un-checked) plus any ad-hoc fields the admin added in the dialog.
+     * The backend reconciles by calling
+     * {@code InstituteCustomFiledService.syncFeatureCustomFields(instituteId, "SESSION", sessionId, ...)}.
+     *
+     * When this field is non-null the legacy tri-arrays above are ignored.
+     */
+    private List<InstituteCustomFieldDTO> instituteCustomFields;
 
     @Data
     @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/Step2Service.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/Step2Service.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.common.entity.CustomFields;
 import vacademy.io.admin_core_service.features.common.entity.InstituteCustomField;
+import vacademy.io.admin_core_service.features.common.enums.CustomFieldTypeEnum;
 import vacademy.io.admin_core_service.features.common.repository.InstituteCustomFieldRepository;
 import vacademy.io.admin_core_service.features.common.repository.CustomFieldRepository;
+import vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService;
 import vacademy.io.admin_core_service.features.live_session.dto.LiveSessionStep2RequestDTO;
 import vacademy.io.admin_core_service.features.live_session.entity.*;
 import vacademy.io.admin_core_service.features.live_session.enums.*;
@@ -49,6 +51,9 @@ public class Step2Service {
     private InstituteCustomFieldRepository instituteCustomFieldRepository;
 
     @Autowired
+    private InstituteCustomFiledService instituteCustomFiledService;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
@@ -69,7 +74,7 @@ public class Step2Service {
         updateSessionAccessLevel(session, request);
         linkParticipants(request);
         processNotificationActions(request, session.getId());
-        processCustomFields(request);
+        processCustomFields(request, session);
 
         session.setStatus(LiveSessionStatus.LIVE.name());
         sessionRepository.save(session);
@@ -283,17 +288,33 @@ public class Step2Service {
         }
     }
 
-    private void processCustomFields(LiveSessionStep2RequestDTO request) {
+    private void processCustomFields(LiveSessionStep2RequestDTO request, LiveSession session) {
+        // Preferred path (custom fields revamp): the frontend sends the FULL set
+        // of custom fields the admin selected for this session as a single
+        // `instituteCustomFields` array. Defer to the unified per-feature sync
+        // which handles insert / reactivate / soft-delete in one call.
+        if (request.getInstituteCustomFields() != null) {
+            instituteCustomFiledService.syncFeatureCustomFields(
+                    session.getInstituteId(),
+                    CustomFieldTypeEnum.SESSION.name(),
+                    session.getId(),
+                    request.getInstituteCustomFields());
+            return;
+        }
+
+        // Legacy path — kept for backward compatibility with older frontend
+        // builds that still send addedFields / updatedFields / deletedFieldIds.
+        // These have several known correctness bugs (no institute_id on the
+        // mapping, hard-deletes that orphan answers, no reactivation). New
+        // clients must use `instituteCustomFields` above.
         int index = 0;
 
-        // Add
         if (request.getAddedFields() != null) {
             for (LiveSessionStep2RequestDTO.CustomFieldDTO dto : request.getAddedFields()) {
                 saveNewCustomField(dto, request.getSessionId(), index++);
             }
         }
 
-        // Update
         if (request.getUpdatedFields() != null) {
             for (LiveSessionStep2RequestDTO.CustomFieldDTO dto : request.getUpdatedFields()) {
                 CustomFields existing = customFieldRepository.findById(dto.getId())
@@ -303,7 +324,7 @@ public class Step2Service {
                 existing.setFieldKey(dto.getLabel().toLowerCase().replaceAll("\\s+", "_"));
                 existing.setFieldType(dto.getType());
                 existing.setIsMandatory(dto.isRequired());
-                existing.setIsHidden(false); // Default to false for existing fields
+                existing.setIsHidden(false);
 
                 try {
                     if (dto.getOptions() != null && !dto.getOptions().isEmpty()) {
@@ -317,7 +338,6 @@ public class Step2Service {
             }
         }
 
-        // Delete
         if (request.getDeletedFieldIds() != null) {
             for (String id : request.getDeletedFieldIds()) {
                 customFieldRepository.deleteById(id);

--- a/admin_core_service/src/main/resources/db/migration/V199__add_is_mandatory_to_institute_custom_fields.sql
+++ b/admin_core_service/src/main/resources/db/migration/V199__add_is_mandatory_to_institute_custom_fields.sql
@@ -1,0 +1,13 @@
+-- Custom Fields Revamp:
+-- Allow per-context (institute_custom_fields row) required state, instead of
+-- the previous global is_mandatory on custom_fields. This lets the same
+-- default field be required in one feature (e.g. Enroll Invite) and optional
+-- in another (e.g. Live Session).
+--
+-- Backward compatibility: defaults to false. Existing rows are unaffected.
+-- The previous custom_fields.is_mandatory column stays in place but is now
+-- treated as the master/default value rather than the source of truth at
+-- read time.
+
+ALTER TABLE public.institute_custom_fields
+    ADD COLUMN IF NOT EXISTS is_mandatory boolean DEFAULT false;

--- a/docs/CUSTOM_FIELDS.md
+++ b/docs/CUSTOM_FIELDS.md
@@ -2,6 +2,22 @@
 
 > Scope: complete walkthrough of how custom fields are modeled, persisted, exposed, and consumed across the Vacademy platform — from the `admin_core_service` database tables, through the admin dashboard configuration UI, into every feature flow that uses them (Invite, Audience, Live Class, Assessment), and finally how the learner dashboard renders and submits them.
 
+> ### ⚠ Custom Fields Revamp (2026‑04)
+>
+> This document describes the **post-revamp** model. The data shape on disk is largely unchanged, but several rules around how fields are created and managed are now different. If you are reading this from a branch that predates the revamp, several of the §3–§9 details will not match the running code.
+>
+> **What changed at a glance:**
+>
+> 1. **Visibility shrunk to 3 admin-side locations only**: Learner's List, Learner's Enrollment, Learner Profile. The 6 per-feature locations (Invite List, Enroll Request List, Assessment Registration, Live Session Registration, Campaign, Enquiry) are gone — per-feature visibility is now controlled by `institute_custom_fields` rows with the matching `type` / `type_id` instead of by checkboxes in Settings.
+> 2. **Per-feature pickers are the new source of truth.** Each create/edit dialog (Enroll Invite, Audience, Live Class Step 2, Assessment Step 3) loads the institute's default catalog with everything pre-selected, lets the admin untick what they don't want, and persists the picked list as `institute_custom_fields` rows scoped to that feature instance. Defaults are NOT auto-cloned by the backend on create — that responsibility moved to the frontend picker.
+> 3. **Settings → Custom Fields manages only `DEFAULT_CUSTOM_FIELD` rows.** It is the **only** place where institute defaults are created and removed. Per-feature dialogs may add ad-hoc fields scoped to that feature instance, but those do NOT get a `DEFAULT_CUSTOM_FIELD` mapping.
+> 4. **`institute_custom_fields.is_mandatory` (new column).** Required-state can now vary per (institute, field, type, type_id), so the same default field can be required in an Enroll Invite and optional in a Live Session.
+> 5. **`CustomFieldTypeEnum.ASSESSMENT` (new value)** for the new assessment per-instance mapping. `SESSION` continues to be used for live class mappings.
+> 6. **Reactivation-aware unified sync.** A new service method `InstituteCustomFiledService.syncFeatureCustomFields(instituteId, type, typeId, dtos)` handles the diff between the admin's picked list and what's currently in the DB: insert new, reactivate previously-DELETED rows, soft-delete anything no longer in the list. All four feature flows now route through this single method, so the duplicate-mapping inflation that affected pre-revamp data cannot recur.
+> 7. **Existing dirty data in production is NOT touched** by deploy. There is a separate per-institute runbook for cleaning historical garbage: see [CUSTOM_FIELDS_PROD_CLEANUP.md](CUSTOM_FIELDS_PROD_CLEANUP.md).
+>
+> Section 9 (Visibility & Settings Model) and §10 (Settings page) below are written against the new model. Sections 11–14 (Invite / Audience / Live Class / Assessment flows) describe the new picker pattern. The bug list in [CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md](CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md) is annotated with which bugs the revamp resolves.
+
 ---
 
 ## Table of Contents

--- a/docs/CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md
+++ b/docs/CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md
@@ -4,6 +4,18 @@
 >
 > Read this if you are: an admin user who needs to understand the product, a PM scoping changes to custom fields, a QA writing test cases, or an engineer triaging custom-field bugs.
 
+> ### ⚠ Custom Fields Revamp (2026-04) — bug status update
+>
+> The custom fields system has been revamped. The bug list below is annotated with whether each item is **fixed**, **partially fixed**, **still open**, or **superseded** by the revamp. The revamp made the following structural changes:
+>
+> - **Visibility shrunk to 3 admin-side locations** (Learner's List, Learner's Enrollment, Learner Profile). Per-feature locations (Invite, Audience, Live Class, Assessment, Enquiry, Campaign) were removed.
+> - **Per-feature pickers** are the source of truth for which fields appear on each invite/audience/session/assessment instance. Each create/edit dialog seeds itself from the institute defaults, the admin un/ticks, and the new unified `syncFeatureCustomFields` backend service handles insert/reactivate/soft-delete in one transaction.
+> - **`institute_custom_fields.is_mandatory`** added — required state can vary per (institute, field, type, type_id).
+> - **`CustomFieldTypeEnum.ASSESSMENT`** added; `SESSION` continues to be used for live class.
+> - **No data cleanup** runs on deploy. The handful of production institutes with historical garbage are cleaned individually using the procedure in [CUSTOM_FIELDS_PROD_CLEANUP.md](CUSTOM_FIELDS_PROD_CLEANUP.md).
+>
+> Bug-by-bug status is shown in §4 below.
+
 ---
 
 ## Table of Contents
@@ -302,7 +314,9 @@ Bugs are tagged with severity, the file/line where the issue lives (cross-refere
 
 ### 4.1 Critical
 
-#### B-0. The Settings page shows duplicate fields and mis‑classified system fields
+#### B-0. The Settings page shows duplicate fields and mis‑classified system fields  ⚠ partially addressed by revamp
+
+> **Status after revamp:** the new code paths cannot create new duplicates (the unified `syncFeatureCustomFields` is reactivation-aware), and the "System Field" badge is no longer driven by the `SYSTEM_FIELD_NAMES` heuristic on locked rows — the seeded defaults now show the **DEFAULT** badge directly. Historical garbage in production institutes is **not** auto-cleaned; use the per-institute runbook in [CUSTOM_FIELDS_PROD_CLEANUP.md](CUSTOM_FIELDS_PROD_CLEANUP.md).
 
 **Where:** Combination of [B-23](#b-23-custom_fieldsfield_key-has-no-sql-unique-constraint--duplicates-accumulate) (no DB unique constraint on `field_key`) + [B-24](#b-24-system-field-badge-is-decided-by-a-frontend-name-match-heuristic) (frontend name-match heuristic for "System Field" badge).
 
@@ -361,7 +375,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Permanent fix:** apply both [B-23](#b-23-custom_fieldsfield_key-has-no-sql-unique-constraint--duplicates-accumulate) and [B-24](#b-24-system-field-badge-is-decided-by-a-frontend-name-match-heuristic).
 
-#### B-1. Cannot recreate a field after soft delete
+#### B-1. Cannot recreate a field after soft delete  ⚠ mitigated, NOT fully fixed
+
+> **Status after revamp:** the unified `syncFeatureCustomFields` reactivates a previously-DELETED `institute_custom_fields` row when the same `(institute, custom_field_id, type, type_id)` is sent again, which avoids the constraint violation in 99% of real-world cases. The underlying root cause — the missing `UNIQUE` index on `custom_fields.field_key` (B-23) — is **still open** so an admin who creates a field, deletes its master row, and recreates a fresh field with the same name in a different code path can still hit it. Add the partial unique index after running the production cleanup runbook.
 
 **Where:** [InstituteCustomFiledService.findOrCreateCustomFieldWithLock](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java) (lines 127-136) and [CustomFields.java](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/entity/CustomFields.java) (`@Column(unique=true)` on `field_key`).
 
@@ -371,7 +387,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Either (a) reactivate the existing soft-deleted row when found, or (b) drop `unique=true` and rely on a partial unique index `WHERE status = 'ACTIVE'`.
 
-#### B-2. Default fields have inconsistent required state
+#### B-2. Default fields have inconsistent required state  ⚠ still open
 
 **Where:** [InstituteCustomFiledService.createDefaultCustomFieldsForInstitute](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java#L246-L294).
 
@@ -381,7 +397,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Pick one source of truth. The cleanest path is to set `is_mandatory=true` on the seeded rows and remove the parallel `compulsoryCustomFields` mechanism, OR explicitly mark `is_mandatory` as deprecated for default fields and audit every reader.
 
-#### B-3. Partial failure during institute bootstrap
+#### B-3. Partial failure during institute bootstrap  ⚠ still open
 
 **Where:** [InstituteSettingService.createDefaultSettingsForInstitute](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/setting/InstituteSettingService.java#L119-L143).
 
@@ -393,7 +409,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 ### 4.2 High
 
-#### B-4. EMAIL/PHONE renderer is inferred from the field name
+#### B-4. EMAIL/PHONE renderer is inferred from the field name  ⚠ still open
+
+> **Status after revamp:** unchanged. The learner-side `getFieldRenderType` heuristic is unchanged. Adding an explicit `renderType` enum is the right fix and is tracked as a follow-up.
 
 **Where:** [custom-field-helpers.ts `getFieldRenderType`](../../Vacademy_Frontend/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/custom-field-helpers.ts).
 
@@ -403,7 +421,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Add an explicit `renderType` enum to the field definition (text / number / email / phone / dropdown) and stop inferring. Migrate existing fields with a one-shot job that sets `renderType` based on the current heuristic so behaviour doesn't regress.
 
-#### B-5. Key stays frozen when name changes
+#### B-5. Key stays frozen when name changes  ⚠ still open (low impact once B-4 is fixed)
 
 **Where:** [InstituteCustomFiledService.updateCustomField](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java#L432-L465).
 
@@ -411,7 +429,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Acceptable to keep the key stable (it's an identifier) — but the renderer should not depend on it. Fix B-4 first, then this becomes a non-issue.
 
-#### B-6. Soft-delete leaves orphan answers
+#### B-6. Soft-delete leaves orphan answers  ⚠ still open (intentional, see revamp design notes)
+
+> **Status after revamp:** intentionally preserved. The reactivation semantics in `syncFeatureCustomFields` rely on `custom_field_values` rows surviving across delete/re-add cycles — that is what gives admins the "untick → re-tick brings the answers back" experience. A separate "Permanent Delete with answer purge" admin action is the right fix; tracked as a follow-up.
 
 **Where:** [InstituteCustomFiledService.softDeleteInstituteCustomField](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java#L159-L162) and the absence of any `custom_field_values` cleanup.
 
@@ -419,7 +439,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Provide a "Permanent Delete" admin action that hard-deletes both the master row, the mappings, and the answers. Default soft-delete remains.
 
-#### B-7. Stale 24h cache across admin sessions
+#### B-7. Stale 24h cache across admin sessions  ⚠ still open (deferred per Q-11)
 
 **Where:** [custom-field-settings.ts](../../Vacademy_Frontend/frontend-admin-dashboard/src/services/custom-field-settings.ts) — `localStorage` cache with 24-hour TTL.
 
@@ -427,7 +447,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Drop TTL to ~5 minutes, add a "Refresh" button next to the Save button, and add an `If-Match` / `version` field to the save call so the backend can reject stale writes.
 
-#### B-8. No optimistic concurrency on save
+#### B-8. No optimistic concurrency on save  ⚠ still open
 
 **Where:** [InstituteCustomFieldSettingController.updateCustomFieldSetting](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/controller/InstituteCustomFieldSettingController.java).
 
@@ -437,7 +457,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 ### 4.3 Medium
 
-#### B-9. Key generator strips unicode causing silent collisions
+#### B-9. Key generator strips unicode causing silent collisions  ⚠ still open
 
 **Where:** [CustomFieldKeyGenerator.generateFieldKey](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/util/CustomFieldKeyGenerator.java).
 
@@ -445,7 +465,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Use the field's UUID as the storage key and only use the human name for display. Or fall back to a short hash of the original name.
 
-#### B-10. Required flag cannot vary per location
+#### B-10. Required flag cannot vary per location  ✅ FIXED by revamp
+
+> **Status after revamp:** the new `institute_custom_fields.is_mandatory` column lets each per-feature mapping carry its own required state, so the same default field can be required in an Enroll Invite and optional in a Live Session. The Settings page still shows a single required toggle for the master row (which seeds the default for new mappings); the per-feature dialogs override it.
 
 **Where:** Top-level `compulsoryCustomFields` in [CustomFieldSettingRequest](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/dto/settings/custom_field/CustomFieldSettingRequest.java).
 
@@ -453,7 +475,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Move `required` from a top-level array of field IDs to a property on each location's field reference. Migration: every existing required field becomes required in every location it's currently visible.
 
-#### B-11. `is_filter` & `is_sortable` not toggleable in the UI
+#### B-11. `is_filter` & `is_sortable` not toggleable in the UI  ⚠ still open (Q-1b deferred)
 
 **Where:** Master row defaults in [InstituteCustomFiledService.createCustomFieldFromRequest](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java#L300-L318) — `is_filter` and `is_sortable` are not set from the UI form, so they default to false.
 
@@ -461,7 +483,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Add two checkboxes ("Filterable", "Sortable") to the Add/Edit Custom Field dialog and pipe them to the API.
 
-#### B-12. Numeric vs UUID id mismatch in invite form
+#### B-12. Numeric vs UUID id mismatch in invite form  ⚠ still open
 
 **Where:** [InviteFormSchema.tsx](../../Vacademy_Frontend/frontend-admin-dashboard/src/routes/manage-students/invite/-schema/InviteFormSchema.tsx) — `id: z.number()` for invite custom fields, but the backend uses UUID strings stored in `_id`.
 
@@ -469,7 +491,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Use the UUID directly. Drop `id: number`. The drag-drop library accepts strings.
 
-#### B-13. Groups are not visually rendered in all flows
+#### B-13. Groups are not visually rendered in all flows  ⚠ still open
 
 **Where:** Invite form & Audience form rendering — the field list is flat. Only the Settings page and the Live Class step honor groups visually.
 
@@ -477,7 +499,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Render group headers in the Invite and Audience forms.
 
-#### B-14. Live session option schema mismatch
+#### B-14. Live session option schema mismatch  ⚠ still open (legacy path only)
+
+> **Status after revamp:** the live session step 2 endpoint now accepts the unified `instituteCustomFields: List<InstituteCustomFieldDTO>` payload which uses the canonical option shape. The legacy `addedFields/updatedFields/deletedFieldIds` arrays are still accepted for backward compatibility and still use the broken schema, but new clients should send `instituteCustomFields` instead. Drop the legacy path once every frontend build is updated.
 
 **Where:** [scheduleStep2.tsx schema](../../Vacademy_Frontend/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-schema/schema.ts) — uses `{ optionField: string }` for dropdown options instead of the canonical `{ id, value, label }`. A transform layer maps between them at submit time.
 
@@ -485,7 +509,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Standardise on the canonical option shape across all flows.
 
-#### B-15. Step 3 transform fragility on edge data
+#### B-15. Step 3 transform fragility on edge data  ⚠ still open
 
 **Where:** [Step3 helper.ts](../../Vacademy_Frontend/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/helper.ts) — `transformAllBatchData` and `getCustomFieldsWhileEditStep3` perform several layers of conversion.
 
@@ -493,7 +517,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Add defensive defaults at every conversion step and a unit test per shape.
 
-#### B-16. Public open endpoints leak field configuration
+#### B-16. Public open endpoints leak field configuration  ⚠ still open
 
 **Where:** `/admin-core-service/open/common/custom-fields/setup?instituteId=…` and friends.
 
@@ -503,7 +527,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 ### 4.4 Low / Cosmetic
 
-#### B-17. Class name typo: `InstituteCustomFiledService`
+#### B-17. Class name typo: `InstituteCustomFiledService`  ⚠ still open (cosmetic)
 
 **Where:** [InstituteCustomFiledService.java](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/service/InstituteCustomFiledService.java) — class name has *Filed* instead of *Field*.
 
@@ -511,7 +535,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Rename the class and all imports in one PR.
 
-#### B-18. Endpoint URL typo: `insititute-settings`
+#### B-18. Endpoint URL typo: `insititute-settings`  ⚠ still open (cosmetic)
 
 **Where:** [src/constants/urls.ts](../../Vacademy_Frontend/frontend-admin-dashboard/src/constants/urls.ts) — `/admin-core-service/institute/v1/insititute-settings`.
 
@@ -519,7 +543,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Add a correctly-spelled route alias on the backend, switch the frontend, then deprecate the typo route after a release.
 
-#### B-19. `isPresent` query param is a String, not boolean
+#### B-19. `isPresent` query param is a String, not boolean  ⚠ still open (cosmetic)
 
 **Where:** [InstituteCustomFieldSettingController.updateCustomFieldSetting](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/controller/InstituteCustomFieldSettingController.java) — `@RequestParam(value="isPresent", required=false) String isPresent`.
 
@@ -527,7 +551,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Change to `Boolean isPresent`.
 
-#### B-20. Two parallel custom-field tables (legacy `learner_invitation_custom_field`)
+#### B-20. Two parallel custom-field tables (legacy `learner_invitation_custom_field`)  ⚠ still open
 
 **Where:** [V1__Initial_schema.sql L1274](../admin_core_service/src/main/resources/db/migration/V1__Initial_schema.sql#L1274).
 
@@ -535,7 +559,7 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Document deprecation, audit usages, plan a migration to the unified system, then drop the legacy tables.
 
-#### B-21. `findCustomFieldUsageAggregation` does not filter master-row status
+#### B-21. `findCustomFieldUsageAggregation` does not filter master-row status  ⚠ still open (low impact)
 
 **Where:** [InstituteCustomFieldRepository.findCustomFieldUsageAggregation](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/repository/InstituteCustomFieldRepository.java).
 
@@ -543,7 +567,9 @@ The row with the highest `answer_count` is the "real" one — keep it. Soft‑de
 
 **Recommended fix:** Add `AND cf.status = 'ACTIVE'` to the JPQL query.
 
-#### B-23. `custom_fields.field_key` has no SQL UNIQUE constraint — duplicates accumulate
+#### B-23. `custom_fields.field_key` has no SQL UNIQUE constraint — duplicates accumulate  ⚠ deferred until production cleanup is done
+
+> **Status after revamp:** the new code paths cannot create duplicates because the unified `syncFeatureCustomFields` always goes through `findOrCreateCustomFieldWithLock`. The missing partial unique index is documented in the prod cleanup runbook ([CUSTOM_FIELDS_PROD_CLEANUP.md §14](CUSTOM_FIELDS_PROD_CLEANUP.md#14-optional-follow-ups)) and will be added once every affected institute has been cleaned — adding it before then would fail the migration.
 
 **Where:** [V1__Initial_schema.sql:163-179](../admin_core_service/src/main/resources/db/migration/V1__Initial_schema.sql#L163-L179) defines no UNIQUE on `field_key`. The entity has `@Column(unique=true)` but Hibernate only enforces that when it's the schema generator, not when Flyway is.
 
@@ -562,7 +588,9 @@ CREATE UNIQUE INDEX uq_custom_fields_field_key
 ```
 This makes `findOrCreateCustomFieldWithLock` actually safe under contention. Combine with the fix for [B-1](#b-1-cannot-recreate-a-field-after-soft-delete) so soft-deleted rows can be reactivated instead of triggering a constraint violation.
 
-#### B-24. "System Field" badge is decided by a frontend name-match heuristic
+#### B-24. "System Field" badge is decided by a frontend name-match heuristic  ✅ FIXED by revamp
+
+> **Status after revamp:** the locked seeded fields now show a **DEFAULT** badge driven by the same backend property (`canBeDeleted=false`) the seeder stamps, not by the `SYSTEM_FIELD_NAMES` keyword list. The "System Field" label is gone from the Settings UI; every row in the page is shown as DEFAULT (which is what they all are — `DEFAULT_CUSTOM_FIELD` mappings). Renaming a user-created field to "email" or "batch" no longer causes it to be silently locked.
 
 **Where:** [src/services/custom-field-settings.ts](../../Vacademy_Frontend/frontend-admin-dashboard/src/services/custom-field-settings.ts) line 259 (`SYSTEM_FIELD_NAMES`) and lines 596-610 (`mapApiResponseToUI`).
 
@@ -586,7 +614,7 @@ if (SYSTEM_FIELD_NAMES.includes(apiField.fieldName.toLowerCase()) || …) {
 2. Replace the `SYSTEM_FIELD_NAMES` heuristic with a check on the new column.
 3. Stop relying on `canBeDeleted` / `canBeEdited` / `canBeRenamed` flags travelling through the JSON blob — derive them from `kind` server-side.
 
-#### B-22. `hasPrefillAppliedRef` blocks repeat prefill
+#### B-22. `hasPrefillAppliedRef` blocks repeat prefill  ⚠ still open
 
 **Where:** [enroll-form.tsx](../../Vacademy_Frontend/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx) — a `useRef` guards prefill from running twice.
 

--- a/docs/CUSTOM_FIELDS_PROD_CLEANUP.md
+++ b/docs/CUSTOM_FIELDS_PROD_CLEANUP.md
@@ -1,0 +1,435 @@
+# Custom Fields — Production Cleanup Runbook
+
+> Companion to [CUSTOM_FIELDS.md](CUSTOM_FIELDS.md) and [CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md](CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md).
+>
+> Audience: a backend engineer with prod DB access.
+>
+> Goal: clean up the bad data left behind by the pre‑revamp custom-field code paths in the few production institutes that have been using custom fields, **without** running a blanket migration script. Each institute is handled individually so we can verify before and after.
+>
+> **This runbook does not modify schemas or run on every institute.** It is a per‑institute, manually‑verified cleanup. The application code is now reactivation‑safe and will not regenerate the same garbage going forward (see the custom fields revamp in [CUSTOM_FIELDS.md](CUSTOM_FIELDS.md)). What we are cleaning here is historical data only.
+
+---
+
+## Table of Contents
+
+1. [What we are cleaning, and why](#1-what-we-are-cleaning-and-why)
+2. [Symptoms in the UI](#2-symptoms-in-the-ui)
+3. [Pre-flight checklist](#3-pre-flight-checklist)
+4. [Step 1 — Identify affected institutes](#4-step-1--identify-affected-institutes)
+5. [Step 2 — Inventory the damage for one institute](#5-step-2--inventory-the-damage-for-one-institute)
+6. [Step 3 — Decide the canonical row for each duplicate field](#6-step-3--decide-the-canonical-row-for-each-duplicate-field)
+7. [Step 4 — Soft-delete duplicate `institute_custom_fields` mappings](#7-step-4--soft-delete-duplicate-institute_custom_fields-mappings)
+8. [Step 5 — Re-point answers in `custom_field_values` to the canonical row](#8-step-5--re-point-answers-in-custom_field_values-to-the-canonical-row)
+9. [Step 6 — Mark orphan master `custom_fields` rows as DELETED](#9-step-6--mark-orphan-master-custom_fields-rows-as-deleted)
+10. [Step 7 — Refresh the institute's `CUSTOM_FIELD_SETTING` JSON blob](#10-step-7--refresh-the-institutes-custom_field_setting-json-blob)
+11. [Step 8 — Verification](#11-step-8--verification)
+12. [Step 9 — Have the admin clear localStorage](#12-step-9--have-the-admin-clear-localstorage)
+13. [Rollback procedure](#13-rollback-procedure)
+14. [Optional follow-ups](#14-optional-follow-ups)
+
+---
+
+## 1. What we are cleaning, and why
+
+Three classes of bad data have accumulated:
+
+| # | What | Source | How we fix it |
+|---|------|--------|---------------|
+| **A** | **Duplicate `custom_fields` master rows** with the same `field_name` (e.g. three rows all named `email`). | The `custom_fields.field_key` column is declared `@Column(unique=true)` at the entity level but no `UNIQUE` constraint exists in SQL ([V1__Initial_schema.sql:163-179](../admin_core_service/src/main/resources/db/migration/V1__Initial_schema.sql#L163-L179)). Pre-revamp code that bypassed `findOrCreateCustomFieldWithLock` (e.g. legacy seeders, migration scripts, the now-deleted `Step2Service.saveNewCustomField` path that wrote `instituteId=""`) inserted duplicates. | Pick one canonical row per `(institute_id, lower(field_name))`, repoint references, soft-delete the rest. |
+| **B** | **Inflated `institute_custom_fields` mappings** — e.g. 504 ACTIVE rows pointing at the same `(institute, custom_field, type, type_id)`. All inserted in the same millisecond. | Pre-revamp `addOrUpdateCustomField` was reactivation-aware but its callers (`copyDefaultCustomFieldsToEnrollInvite`, audience save) ran in loops that bypassed the check, or a backfill script bulk-inserted without dedup. | Keep the **oldest ACTIVE** mapping per `(institute, custom_field, type, COALESCE(type_id,''))`, soft-delete the rest. |
+| **C** | **Mis-classified "system fields"** in the admin UI — fields named `name / username / password / batch / phone` (lowercase) that show with the "System Field" badge because of the old frontend heuristic at `SYSTEM_FIELD_NAMES`. | Pre-revamp seeder code inserted these (or migrations did). The current seeder only writes `Full Name / Email / Phone Number`. | After A and B are clean, remove or rename these rows. The new revamp UI shows them as DEFAULT — admins can choose to keep, rename or delete from Settings → Custom Fields. |
+
+> **Note:** the application code that produced this damage has been replaced — see the custom-fields-revamp section of [CUSTOM_FIELDS.md](CUSTOM_FIELDS.md). Running this cleanup once per affected institute is enough; future writes go through the unified `syncFeatureCustomFields` path which is reactivation-safe.
+
+## 2. Symptoms in the UI
+
+You will hit this runbook for an institute if **any** of these are visible:
+
+- Settings → Custom Fields shows **2+ rows with identical names** (most commonly `email`, sometimes `phone` / `name`).
+- Admin reports the same custom field "comes back" after they delete it from a feature dialog.
+- Backend logs show 200+ `institute_custom_fields` rows for one feature instance.
+- Querying `institute_custom_fields WHERE institute_id = ? AND status = 'ACTIVE'` returns hundreds of rows where you'd expect ~10.
+
+## 3. Pre-flight checklist
+
+Before you touch anything in production:
+
+- [ ] You have a **read replica** or a **fresh `pg_dump`** of `admin_core_service` from within the last 24 h. Cleanup is destructive (soft-deletes are recoverable, but value-repointing is not without the dump).
+- [ ] You have the **institute id** of the affected institute (not the slug, not the name).
+- [ ] You can talk to the institute admin to coordinate. Don't run this during their peak enrollment window.
+- [ ] You have a SQL client that supports **explicit transactions** (`BEGIN; … ROLLBACK;`) — `psql` is best.
+- [ ] You have the `flyway_schema_history` available so you can correlate damage timestamps with deploys.
+- [ ] You have read [CUSTOM_FIELDS.md](CUSTOM_FIELDS.md) §1–4 (the data model) and [CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md](CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md#41-critical) §B-0/B-1/B-23/B-24 (the bug context).
+
+> **All SQL below uses `:institute_id` as a placeholder.** Replace it with the actual UUID and `\set institute_id 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'` in psql, or substitute manually.
+
+---
+
+## 4. Step 1 — Identify affected institutes
+
+Run this query against production. It returns one row per institute that has either a duplicate-master-row problem (A) or a mapping-inflation problem (B).
+
+```sql
+WITH dup_masters AS (
+    SELECT icf.institute_id,
+           lower(cf.field_name) AS field_name,
+           COUNT(DISTINCT cf.id) AS dup_master_rows
+      FROM custom_fields cf
+      JOIN institute_custom_fields icf ON icf.custom_field_id = cf.id
+     GROUP BY icf.institute_id, lower(cf.field_name)
+    HAVING COUNT(DISTINCT cf.id) > 1
+),
+inflated_mappings AS (
+    SELECT institute_id,
+           custom_field_id,
+           type,
+           COALESCE(type_id, '') AS type_id_norm,
+           COUNT(*) AS active_mappings
+      FROM institute_custom_fields
+     WHERE status = 'ACTIVE'
+     GROUP BY institute_id, custom_field_id, type, COALESCE(type_id, '')
+    HAVING COUNT(*) > 1
+)
+SELECT i.id   AS institute_id,
+       i.institute_name,
+       (SELECT COUNT(*) FROM dup_masters d
+         WHERE d.institute_id = i.id) AS duplicate_field_names,
+       (SELECT COALESCE(SUM(active_mappings - 1), 0)
+          FROM inflated_mappings m
+         WHERE m.institute_id = i.id) AS extra_mapping_rows
+  FROM institutes i
+ WHERE EXISTS (SELECT 1 FROM dup_masters d        WHERE d.institute_id = i.id)
+    OR EXISTS (SELECT 1 FROM inflated_mappings m  WHERE m.institute_id = i.id)
+ ORDER BY extra_mapping_rows DESC, duplicate_field_names DESC;
+```
+
+The result tells you (a) which institutes to clean and (b) roughly how much damage there is per institute. Pick **one** institute to start with and keep its ID handy.
+
+---
+
+## 5. Step 2 — Inventory the damage for one institute
+
+For the chosen institute, run all four queries below. **Keep the output** — you will need it during the canonical-row decision in Step 3 and again at verification time in Step 8.
+
+```sql
+-- 5.1 Master rows the institute is currently linked to (any status)
+SELECT cf.id           AS custom_field_id,
+       cf.field_key,
+       cf.field_name,
+       cf.field_type,
+       cf.status       AS cf_status,
+       cf.created_at   AS cf_created,
+       COUNT(icf.id)   AS mapping_count
+  FROM custom_fields cf
+  JOIN institute_custom_fields icf ON icf.custom_field_id = cf.id
+ WHERE icf.institute_id = :institute_id
+ GROUP BY cf.id, cf.field_key, cf.field_name, cf.field_type, cf.status, cf.created_at
+ ORDER BY lower(cf.field_name), cf.created_at;
+
+-- 5.2 Mapping inflation per (custom_field, type, type_id) — the headline bug
+SELECT custom_field_id,
+       type,
+       type_id,
+       status,
+       COUNT(*) AS rows_per_tuple,
+       MIN(created_at) AS first_created,
+       MAX(created_at) AS last_created
+  FROM institute_custom_fields
+ WHERE institute_id = :institute_id
+ GROUP BY custom_field_id, type, type_id, status
+HAVING COUNT(*) > 1
+ ORDER BY rows_per_tuple DESC;
+
+-- 5.3 Answer counts per master row (so you know which dup is the "real" one)
+SELECT cf.id, cf.field_name, cf.field_key, cf.created_at,
+       (SELECT COUNT(*) FROM custom_field_values cfv
+         WHERE cfv.custom_field_id = cf.id) AS answer_count
+  FROM custom_fields cf
+ WHERE cf.id IN (
+        SELECT DISTINCT custom_field_id
+          FROM institute_custom_fields
+         WHERE institute_id = :institute_id
+ )
+ ORDER BY lower(cf.field_name), cf.created_at;
+
+-- 5.4 Cross-check with the deployment timeline — if every duplicate row in 5.2
+--     shares one millisecond, look for a Flyway migration or batch script that
+--     ran at that time.
+SELECT version, description, installed_on
+  FROM flyway_schema_history
+ WHERE installed_on BETWEEN '2025-11-01' AND '2025-11-30'
+ ORDER BY installed_on;
+```
+
+> Save the output of 5.1 and 5.3 — you need them in Step 3.
+
+---
+
+## 6. Step 3 — Decide the canonical row for each duplicate field
+
+For each group of duplicate masters (rows from 5.1 sharing a `lower(field_name)`), pick **one** to keep. Use this priority order:
+
+1. **The row with the most `custom_field_values` answers** (from 5.3).
+2. If tied: the **oldest `created_at`** (it's what new code paths will tend to find first via `ORDER BY created_at` in `findOrCreateCustomFieldWithLock`).
+3. If still tied: the row whose `field_key` matches the current generator format `<name>_inst_<institute_id>` from [`CustomFieldKeyGenerator`](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/util/CustomFieldKeyGenerator.java) — keep that one.
+4. Otherwise: pick the lowest UUID and write down why.
+
+Document your decisions in a temporary text file. You'll need this list for Steps 4–6. Format suggestion:
+
+```
+INSTITUTE: 91a5ad98-e7d8-41cd-adf5-6f7f7855646a
+  email:
+    KEEP   = 026e8a41-3b…  (504 answers, created 2024-08-12)
+    REPLACE -> 8c91ff21-…  (3 answers)
+    REPLACE -> a17b002e-…  (0 answers)
+  phone:
+    KEEP   = 4400df03-…    (980 answers, created 2024-08-12)
+    REPLACE -> 026e8a41-3b…(0 answers, created 2025-11-17 06:29)
+```
+
+---
+
+## 7. Step 4 — Soft-delete duplicate `institute_custom_fields` mappings
+
+This is the safest cleanup step and the one that will visibly fix the UI. It does not delete master rows or answers — it only flips status on the duplicate junction rows.
+
+```sql
+-- DRY RUN — list what will change. Run this first and review the count.
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY institute_id, custom_field_id, type, COALESCE(type_id, '')
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+      FROM institute_custom_fields
+     WHERE institute_id = :institute_id
+       AND status = 'ACTIVE'
+)
+SELECT COUNT(*) AS rows_to_soft_delete
+  FROM ranked WHERE rn > 1;
+
+-- Optional: list a few examples so you know what you'll be touching.
+WITH ranked AS (
+    SELECT icf.*,
+           ROW_NUMBER() OVER (
+               PARTITION BY institute_id, custom_field_id, type, COALESCE(type_id, '')
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+      FROM institute_custom_fields icf
+     WHERE institute_id = :institute_id
+       AND status = 'ACTIVE'
+)
+SELECT id, custom_field_id, type, type_id, created_at
+  FROM ranked WHERE rn > 1
+ ORDER BY custom_field_id, created_at
+ LIMIT 50;
+
+-- COMMIT — now do the soft-delete inside an explicit transaction.
+BEGIN;
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY institute_id, custom_field_id, type, COALESCE(type_id, '')
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+      FROM institute_custom_fields
+     WHERE institute_id = :institute_id
+       AND status = 'ACTIVE'
+)
+UPDATE institute_custom_fields
+   SET status = 'DELETED',
+       updated_at = now()
+ WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- Sanity-check the resulting active counts
+SELECT type, COUNT(*) AS active_rows
+  FROM institute_custom_fields
+ WHERE institute_id = :institute_id
+   AND status = 'ACTIVE'
+ GROUP BY type
+ ORDER BY type;
+
+-- If looks right (counts dropped to a sane number, e.g. < 50 per type):
+COMMIT;
+-- Otherwise:
+-- ROLLBACK;
+```
+
+---
+
+## 8. Step 5 — Re-point answers in `custom_field_values` to the canonical row
+
+For each "REPLACE → KEEP" pair from your decision list in Step 3, repoint any existing answers from the duplicate to the canonical master row. This is the only **non-reversible** step (without the dump from Pre-flight). Read the SQL carefully.
+
+```sql
+-- For ONE duplicate pair at a time. Repeat per duplicate.
+-- Replace :duplicate_cf_id and :canonical_cf_id with actual UUIDs.
+
+-- DRY RUN — how many answers will move?
+SELECT COUNT(*)
+  FROM custom_field_values
+ WHERE custom_field_id = :duplicate_cf_id;
+
+BEGIN;
+UPDATE custom_field_values
+   SET custom_field_id = :canonical_cf_id,
+       updated_at      = now()
+ WHERE custom_field_id = :duplicate_cf_id;
+
+-- Confirm: should be 0
+SELECT COUNT(*) FROM custom_field_values WHERE custom_field_id = :duplicate_cf_id;
+
+COMMIT;
+-- Or: ROLLBACK;
+```
+
+> If a learner had answers under **both** the duplicate and the canonical row (rare but possible), the simple `UPDATE` will fail on the unique key on `(custom_field_id, source_type, source_id, type, type_id)` if such a constraint exists, or silently produce two rows otherwise. **Check the schema** — at the time of writing there is no unique index there, so duplicates are tolerated. After the move, you can dedup by:
+>
+> ```sql
+> -- For each (custom_field_id, source_type, source_id, type, type_id) keep newest only
+> WITH ranked AS (
+>     SELECT id,
+>            ROW_NUMBER() OVER (
+>                PARTITION BY custom_field_id, source_type, source_id, type, COALESCE(type_id,'')
+>                ORDER BY updated_at DESC, id DESC
+>            ) AS rn
+>       FROM custom_field_values
+>      WHERE custom_field_id = :canonical_cf_id
+> )
+> DELETE FROM custom_field_values
+>  WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+> ```
+
+---
+
+## 9. Step 6 — Mark orphan master `custom_fields` rows as DELETED
+
+After Steps 4 and 5, the duplicate master rows have **no active mappings** and **no remaining answers**. Soft-delete them by flipping `status` so the application stops considering them on future writes.
+
+```sql
+-- DRY RUN — list orphans for this institute
+SELECT cf.id, cf.field_name, cf.field_key, cf.status
+  FROM custom_fields cf
+ WHERE cf.id IN (
+        -- Master rows linked to this institute by any mapping…
+        SELECT DISTINCT custom_field_id
+          FROM institute_custom_fields
+         WHERE institute_id = :institute_id
+ )
+ -- …that have NO active mapping anywhere…
+   AND NOT EXISTS (
+        SELECT 1 FROM institute_custom_fields icf
+         WHERE icf.custom_field_id = cf.id
+           AND icf.status = 'ACTIVE'
+ )
+ -- …and NO remaining answers.
+   AND NOT EXISTS (
+        SELECT 1 FROM custom_field_values cfv
+         WHERE cfv.custom_field_id = cf.id
+ )
+   AND cf.status = 'ACTIVE';
+
+-- COMMIT
+BEGIN;
+UPDATE custom_fields
+   SET status = 'DELETED',
+       updated_at = now()
+ WHERE id IN (
+        SELECT cf.id
+          FROM custom_fields cf
+         WHERE cf.id IN (
+                SELECT DISTINCT custom_field_id
+                  FROM institute_custom_fields
+                 WHERE institute_id = :institute_id
+         )
+           AND NOT EXISTS (
+                SELECT 1 FROM institute_custom_fields icf
+                 WHERE icf.custom_field_id = cf.id
+                   AND icf.status = 'ACTIVE'
+         )
+           AND NOT EXISTS (
+                SELECT 1 FROM custom_field_values cfv
+                 WHERE cfv.custom_field_id = cf.id
+         )
+           AND cf.status = 'ACTIVE'
+ );
+COMMIT;
+```
+
+> **Do not `DELETE FROM custom_fields`** — the table has FK references from `custom_field_values` ON DELETE CASCADE; a hard delete will silently destroy any answers you missed during repointing.
+
+---
+
+## 10. Step 7 — Refresh the institute's `CUSTOM_FIELD_SETTING` JSON blob
+
+After the relational tables are clean, the institute's `institutes.setting` JSON blob still references the now-deleted master/mapping ids in `customFieldsAndGroups[].customFieldId`. The application reads from this blob on every Settings → Custom Fields page load, so it must be regenerated.
+
+The cleanest way: use the application itself.
+
+1. Have the institute admin (or you, with super-admin access) open Settings → Custom Fields **once**.
+2. Click **Save Changes** without making any change.
+3. The frontend `mapUIToApiRequest` will rebuild the blob from the now-clean relational state and POST it to `/admin-core-service/institute/v1/custom-field/create-or-update`.
+
+If you cannot get an admin to do this, you can do it from a sql client by setting `setting = NULL` for that institute and calling `createDefaultCustomFieldSetting` again from a Spring shell — but the manual save is much safer.
+
+---
+
+## 11. Step 8 — Verification
+
+Run the inventory queries from Step 5 again. You should now see:
+
+- **5.1**: every `field_name` appears exactly once per institute. `mapping_count` is small and reasonable (typically `1` for `DEFAULT_CUSTOM_FIELD` rows, plus one per active feature instance).
+- **5.2**: returns **zero rows**.
+- **5.3**: every kept row's answer count matches the sum of the answer counts before cleanup. (Pre-cleanup snapshot of 5.3 plus your decision list = post-cleanup expected counts.)
+- Settings → Custom Fields in the admin UI shows the right rows (3 defaults + whatever the admin had created).
+- A test "create new Enroll Invite" flow shows the same set of fields pre-selected.
+
+If anything looks wrong: `psql` history → `ROLLBACK` if you're still in a transaction, or restore from the dump in Pre-flight.
+
+---
+
+## 12. Step 9 — Have the admin clear localStorage
+
+The admin dashboard caches the settings document in `localStorage['custom-field-settings-cache']` for 24 h. Until that expires, the admin will keep seeing the pre-cleanup rows.
+
+Send the admin this snippet to paste into their browser DevTools console while logged in:
+
+```js
+localStorage.removeItem('custom-field-settings-cache');
+location.reload();
+```
+
+(Or wait 24 h.)
+
+---
+
+## 13. Rollback procedure
+
+Each numbered step is independently reversible **except Step 5**, which moves rows in `custom_field_values`. If you need to undo the entire cleanup for one institute:
+
+| Step | Reversal |
+|------|----------|
+| 4 (mapping soft-delete) | `UPDATE institute_custom_fields SET status='ACTIVE' WHERE … updated_at >= '<your timestamp>'` for the rows you touched. Better: replay from the `pg_dump`. |
+| 5 (value repointing) | **Cannot be reversed without the `pg_dump`.** Restore the `custom_field_values` rows from the dump and re-apply Step 5 with corrected mappings. |
+| 6 (master soft-delete) | `UPDATE custom_fields SET status='ACTIVE' WHERE id IN (…)` |
+| 7 (JSON blob refresh) | Restore `institutes.setting` from the dump for that one institute id. |
+
+If you discover a problem **before** Step 5: each `BEGIN; … COMMIT;` block is a self-contained transaction; just `ROLLBACK` the open one.
+
+---
+
+## 14. Optional follow-ups
+
+After every affected production institute is clean, consider these schema-level guards. These are **deferred** because they require a coordinated deploy and a separate runbook of their own — do not run as part of this cleanup:
+
+- **Add a SQL UNIQUE index on `custom_fields(field_key) WHERE status = 'ACTIVE'`** to prevent duplicate masters from re-appearing. Bug B-23 in [CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md](CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md#b-23-custom_fieldsfield_key-has-no-sql-unique-constraint--duplicates-accumulate). Will fail until **every** institute has been cleaned.
+- **Add a partial UNIQUE index on `institute_custom_fields(institute_id, custom_field_id, type, COALESCE(type_id,'')) WHERE status = 'ACTIVE'`** to prevent mapping inflation regression. Same caveat — will fail on un‑cleaned institutes.
+- **Backfill `custom_fields.is_mandatory = false` and rely solely on `institute_custom_fields.is_mandatory`** going forward. Drops the dual-source-of-truth bug B-2.
+- **Drop the legacy `learner_invitation_custom_field` and `learner_invitation_custom_field_response` tables** (Bug B-20) once usage is fully migrated to the unified system.
+
+---
+
+## See also
+
+- [CUSTOM_FIELDS.md](CUSTOM_FIELDS.md) — full technical reference (schema, services, the new revamp)
+- [CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md](CUSTOM_FIELDS_ADMIN_FLOWS_AND_ISSUES.md) — admin user flows and the bugs that necessitated this cleanup

--- a/frontend-admin-dashboard/src/components/design-system/utils/constants/enroll-request-custom-field-columns.tsx
+++ b/frontend-admin-dashboard/src/components/design-system/utils/constants/enroll-request-custom-field-columns.tsx
@@ -39,11 +39,16 @@ const EnrollRequestCustomFieldCell = ({
  * 3. Maps customFieldId from student.custom_fields to the field name from settings
  *
  * @returns Array of column definitions for custom fields
+ *
+ * Custom Fields Revamp (2026-04): the standalone "Enroll Request List"
+ * visibility location was removed from Settings → Custom Fields. This view
+ * now reuses the "Learner's List" visibility configuration, since enroll
+ * requests are essentially pending learners and the same columns are
+ * almost always desired in both places.
  */
 export const generateEnrollRequestCustomFieldColumns = (): ColumnDef<StudentTable>[] => {
     try {
-        // Get all fields that should be visible in Enroll Request
-        const customFields = getFieldsForLocation('Enroll Request List');
+        const customFields = getFieldsForLocation("Learner's List");
 
         if (!customFields || customFields.length === 0) {
             return [];
@@ -83,7 +88,7 @@ export const generateEnrollRequestCustomFieldColumns = (): ColumnDef<StudentTabl
  */
 export const getEnrollRequestCustomFieldColumnWidths = (): Record<string, string> => {
     try {
-        const customFields = getFieldsForLocation('Enroll Request');
+        const customFields = getFieldsForLocation("Learner's List");
 
         if (!customFields || customFields.length === 0) {
             return {};

--- a/frontend-admin-dashboard/src/components/settings/CustomFieldDeleteDialog.tsx
+++ b/frontend-admin-dashboard/src/components/settings/CustomFieldDeleteDialog.tsx
@@ -124,7 +124,7 @@ export const CustomFieldDeleteDialog: React.FC<CustomFieldDeleteDialogProps> = (
         (acc, usage) => {
             const key = usage.type;
             if (!acc[key]) acc[key] = [];
-            acc[key].push(usage);
+            acc[key]!.push(usage);
             return acc;
         },
         {}

--- a/frontend-admin-dashboard/src/components/settings/CustomFieldDeleteDialog.tsx
+++ b/frontend-admin-dashboard/src/components/settings/CustomFieldDeleteDialog.tsx
@@ -1,0 +1,267 @@
+import React, { useState, useEffect } from 'react';
+import { Trash2, Loader2, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogFooter,
+} from '@/components/ui/dialog';
+import {
+    getCustomFieldUsages,
+    softDeleteCustomFieldMappings,
+    type CustomFieldMappingUsage,
+} from '@/services/custom-field-mappings';
+import { toast } from 'sonner';
+
+const TYPE_LABELS: Record<string, string> = {
+    DEFAULT_CUSTOM_FIELD: 'Default (Institute-wide)',
+    ENROLL_INVITE: 'Enroll Invite',
+    AUDIENCE_FORM: 'Audience Campaign',
+    SESSION: 'Live Session',
+    ASSESSMENT: 'Assessment',
+};
+
+const TYPE_COLORS: Record<string, string> = {
+    DEFAULT_CUSTOM_FIELD: 'bg-blue-100 text-blue-700',
+    ENROLL_INVITE: 'bg-green-100 text-green-700',
+    AUDIENCE_FORM: 'bg-purple-100 text-purple-700',
+    SESSION: 'bg-orange-100 text-orange-700',
+    ASSESSMENT: 'bg-rose-100 text-rose-700',
+};
+
+interface CustomFieldDeleteDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    fieldName: string;
+    fieldId: string;
+    instituteId: string;
+    onDeleteComplete: () => void;
+}
+
+export const CustomFieldDeleteDialog: React.FC<CustomFieldDeleteDialogProps> = ({
+    open,
+    onOpenChange,
+    fieldName,
+    fieldId,
+    instituteId,
+    onDeleteComplete,
+}) => {
+    const [usages, setUsages] = useState<CustomFieldMappingUsage[]>([]);
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [isLoading, setIsLoading] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [loadError, setLoadError] = useState(false);
+
+    useEffect(() => {
+        if (open && fieldId && instituteId) {
+            setLoadError(false);
+            loadUsages();
+        }
+        if (!open) {
+            setUsages([]);
+            setSelected(new Set());
+            setLoadError(false);
+        }
+    }, [open, fieldId, instituteId]);
+
+    const loadUsages = async () => {
+        setIsLoading(true);
+        try {
+            const data = await getCustomFieldUsages(instituteId, fieldId);
+            const safeData = Array.isArray(data) ? data : [];
+            setUsages(safeData);
+            setSelected(new Set(safeData.map((u) => u.mapping_id)));
+        } catch {
+            setLoadError(true);
+            toast.error('Failed to load field usage data. The endpoint may not be deployed yet.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const toggleOne = (mappingId: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(mappingId)) {
+                next.delete(mappingId);
+            } else {
+                next.add(mappingId);
+            }
+            return next;
+        });
+    };
+
+    const toggleAll = () => {
+        if (selected.size === usages.length) {
+            setSelected(new Set());
+        } else {
+            setSelected(new Set(usages.map((u) => u.mapping_id)));
+        }
+    };
+
+    const handleDelete = async () => {
+        if (selected.size === 0) return;
+        setIsDeleting(true);
+        try {
+            await softDeleteCustomFieldMappings(Array.from(selected));
+            toast.success(`Deleted ${selected.size} mapping(s) for "${fieldName}"`);
+            onOpenChange(false);
+            onDeleteComplete();
+        } catch {
+            toast.error('Failed to delete mappings');
+        } finally {
+            setIsDeleting(false);
+        }
+    };
+
+    const safeUsages = Array.isArray(usages) ? usages : [];
+
+    const grouped = safeUsages.reduce<Record<string, CustomFieldMappingUsage[]>>(
+        (acc, usage) => {
+            const key = usage.type;
+            if (!acc[key]) acc[key] = [];
+            acc[key].push(usage);
+            return acc;
+        },
+        {}
+    );
+
+    const hasDefault = safeUsages.some((u) => u.type === 'DEFAULT_CUSTOM_FIELD');
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <Trash2 className="size-5 text-red-500" />
+                        Delete Field: {fieldName}
+                    </DialogTitle>
+                </DialogHeader>
+
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                        <Loader2 className="size-6 animate-spin text-gray-400" />
+                    </div>
+                ) : loadError ? (
+                    <div className="flex flex-col items-center gap-2 py-6 text-center">
+                        <AlertTriangle className="size-8 text-amber-500" />
+                        <p className="text-sm text-gray-600">
+                            Could not load usage data for this field. The API
+                            endpoint may not be deployed yet.
+                        </p>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={loadUsages}
+                        >
+                            Retry
+                        </Button>
+                    </div>
+                ) : safeUsages.length === 0 ? (
+                    <p className="py-4 text-sm text-gray-500">
+                        No active mappings found for this field.
+                    </p>
+                ) : (
+                    <div className="space-y-4">
+                        <p className="text-sm text-gray-600">
+                            This field is used in{' '}
+                            <strong>{usages.length} place(s)</strong>. Select
+                            which mappings to remove. Only the mappings are
+                            deleted &mdash; existing learner answers are
+                            preserved and will reappear if the field is
+                            re-added later.
+                        </p>
+
+                        {hasDefault && selected.has(
+                            usages.find((u) => u.type === 'DEFAULT_CUSTOM_FIELD')?.mapping_id ?? ''
+                        ) && (
+                            <div className="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                                <span>
+                                    You are deleting the <strong>DEFAULT</strong>{' '}
+                                    mapping. This field will no longer appear as
+                                    a pre-selected default when creating new
+                                    Invite / Audience / Live Class / Assessment
+                                    instances.
+                                </span>
+                            </div>
+                        )}
+
+                        <div className="flex items-center gap-2 border-b pb-2">
+                            <Checkbox
+                                checked={selected.size === usages.length}
+                                onCheckedChange={toggleAll}
+                            />
+                            <span className="text-sm font-medium text-gray-700">
+                                Select All ({usages.length})
+                            </span>
+                        </div>
+
+                        {Object.entries(grouped).map(([type, items]) => (
+                            <div key={type} className="space-y-2">
+                                <div className="flex items-center gap-2">
+                                    <Badge
+                                        className={`text-xs font-medium ${TYPE_COLORS[type] ?? 'bg-gray-100 text-gray-600'}`}
+                                    >
+                                        {TYPE_LABELS[type] ?? type}
+                                    </Badge>
+                                    <span className="text-xs text-gray-400">
+                                        {items.length} mapping(s)
+                                    </span>
+                                </div>
+                                {items.map((usage) => (
+                                    <label
+                                        key={usage.mapping_id}
+                                        className="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-gray-50"
+                                    >
+                                        <Checkbox
+                                            checked={selected.has(usage.mapping_id)}
+                                            onCheckedChange={() =>
+                                                toggleOne(usage.mapping_id)
+                                            }
+                                        />
+                                        <span className="text-sm text-gray-700">
+                                            {usage.type === 'DEFAULT_CUSTOM_FIELD'
+                                                ? 'Institute Default'
+                                                : usage.type_id
+                                                  ? `ID: ${usage.type_id.substring(0, 8)}...`
+                                                  : 'Unknown'}
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                <DialogFooter className="gap-2 pt-4">
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isDeleting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={handleDelete}
+                        disabled={isDeleting || selected.size === 0}
+                    >
+                        {isDeleting ? (
+                            <>
+                                <Loader2 className="mr-2 size-4 animate-spin" />
+                                Deleting...
+                            </>
+                        ) : (
+                            `Delete ${selected.size} Mapping(s)`
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/frontend-admin-dashboard/src/components/settings/CustomFieldsSettings.tsx
+++ b/frontend-admin-dashboard/src/components/settings/CustomFieldsSettings.tsx
@@ -9,10 +9,7 @@ import {
     X,
     Settings,
     Users,
-    FileText,
-    Calendar,
     User,
-    ClipboardList,
     Trash2,
     FolderPlus,
     GripVertical,
@@ -20,7 +17,6 @@ import {
     AlertCircle,
     CheckCircle,
     Database,
-    Megaphone,
 } from 'lucide-react';
 import {
     DndContext,
@@ -78,6 +74,8 @@ import {
     type SystemField as ServiceSystemField,
 } from '@/services/custom-field-settings';
 import { SystemToCustomFieldMapping } from './SystemToCustomFieldMapping';
+import { CustomFieldDeleteDialog } from './CustomFieldDeleteDialog';
+import { getInstituteId } from '@/constants/helper';
 import { toast } from 'sonner';
 
 // Use service types for the component
@@ -88,16 +86,15 @@ type FieldGroup = ServiceFieldGroup;
 type GroupField = ServiceGroupField;
 type SystemField = ServiceSystemField;
 
+// Custom Fields Revamp (2026-04): only the three admin-side locations remain.
+// Per-feature visibility (Invite, Enroll Request, Assessment, Live Session,
+// Campaign, Enquiry) is now controlled by the picker inside each feature's
+// own create/edit dialog and is persisted as institute_custom_fields rows
+// with the matching `type` and `type_id`.
 const visibilityLabels = [
     { key: 'learnersList', label: "Learner's List", icon: Users },
     { key: 'learnerEnrollment', label: "Learner's Enrollment", icon: Users },
-    { key: 'enrollRequestList', label: 'Enroll Request List', icon: ClipboardList },
-    { key: 'inviteList', label: 'Invite List', icon: Users },
-    { key: 'assessmentRegistration', label: 'Assessment Registration', icon: FileText },
-    { key: 'liveSessionRegistration', label: 'Live Session Registration', icon: Calendar },
     { key: 'learnerProfile', label: 'Learner Profile', icon: User },
-    { key: 'campaign', label: 'Campaign', icon: Megaphone },
-    { key: 'enquiry', label: 'Enquiry', icon: ClipboardList },
 ];
 
 // Sortable Item Components
@@ -204,6 +201,11 @@ const CustomFieldsSettings: React.FC = () => {
     const [showAddModal, setShowAddModal] = useState(false);
     const [showGroupModal, setShowGroupModal] = useState(false);
     const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+
+    // Cascade-delete dialog state
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [deleteDialogFieldId, setDeleteDialogFieldId] = useState('');
+    const [deleteDialogFieldName, setDeleteDialogFieldName] = useState('');
     const [newGroup, setNewGroup] = useState<Partial<FieldGroup>>({
         name: '',
         fields: [],
@@ -214,15 +216,9 @@ const CustomFieldsSettings: React.FC = () => {
         options: [],
         required: false,
         visibility: {
-            campaign: false,
             learnersList: false,
             learnerEnrollment: false,
-            enrollRequestList: false,
-            inviteList: false,
-            assessmentRegistration: false,
-            liveSessionRegistration: false,
             learnerProfile: false,
-            enquiry: false,
         },
     });
 
@@ -543,6 +539,16 @@ const CustomFieldsSettings: React.FC = () => {
         setCustomFields((prev) => prev.filter((field) => field.id !== fieldId));
     };
 
+    const openDeleteDialog = (fieldId: string, fieldName: string) => {
+        setDeleteDialogFieldId(fieldId);
+        setDeleteDialogFieldName(fieldName);
+        setDeleteDialogOpen(true);
+    };
+
+    const handleDeleteDialogComplete = () => {
+        loadSettings();
+    };
+
     const handleAddOption = (fieldId: string, optionValue: string) => {
         if (optionValue.trim()) {
             // Check if it's an institute field or custom field
@@ -669,15 +675,9 @@ const CustomFieldsSettings: React.FC = () => {
                 options: [],
                 required: false,
                 visibility: {
-                    campaign: false,
                     learnersList: false,
                     learnerEnrollment: false,
-                    enrollRequestList: false,
-                    inviteList: false,
-                    assessmentRegistration: false,
-                    liveSessionRegistration: false,
                     learnerProfile: false,
-                    enquiry: false,
                 },
             });
             setShowAddModal(false);
@@ -952,15 +952,9 @@ const CustomFieldsSettings: React.FC = () => {
                 options: [],
                 required: false,
                 visibility: {
-                    campaign: false,
                     learnersList: false,
                     learnerEnrollment: false,
-                    enrollRequestList: false,
-                    inviteList: false,
-                    assessmentRegistration: false,
-                    liveSessionRegistration: false,
                     learnerProfile: false,
-                    enquiry: false,
                 },
             });
         }
@@ -1475,6 +1469,9 @@ const CustomFieldsSettings: React.FC = () => {
                                                     <th className="px-4 py-3 text-center font-medium text-gray-700">
                                                         Required
                                                     </th>
+                                                    <th className="px-4 py-3 text-center font-medium text-gray-700">
+                                                        Delete
+                                                    </th>
                                                     {visibilityLabels.map(
                                                         ({ key, label, icon: Icon }) => (
                                                             <th
@@ -1521,8 +1518,11 @@ const CustomFieldsSettings: React.FC = () => {
                                                                         </span>
                                                                     )}
                                                                 </div>
-                                                                <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-500">
-                                                                    System Field
+                                                                <span
+                                                                    className="rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700"
+                                                                    title="Locked default field — created automatically when the institute was provisioned. Cannot be deleted, but its visibility and required state can be changed."
+                                                                >
+                                                                    DEFAULT
                                                                 </span>
                                                             </div>
                                                         </td>
@@ -1535,6 +1535,19 @@ const CustomFieldsSettings: React.FC = () => {
                                                                     )
                                                                 }
                                                             />
+                                                        </td>
+                                                        <td className="p-4 text-center">
+                                                            <Button
+                                                                onClick={() =>
+                                                                    openDeleteDialog(field.id, field.name)
+                                                                }
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                className="text-red-500 hover:bg-red-50 hover:text-red-600"
+                                                                title="Delete field — opens a dialog showing every place this field is used"
+                                                            >
+                                                                <Trash2 className="size-4" />
+                                                            </Button>
                                                         </td>
                                                         {visibilityLabels.map(({ key, label }) => (
                                                             <td
@@ -1636,12 +1649,12 @@ const CustomFieldsSettings: React.FC = () => {
                                                     </div>
                                                     <Button
                                                         onClick={() =>
-                                                            handleRemoveInstituteField(field.id)
+                                                            openDeleteDialog(field.id, field.name)
                                                         }
                                                         variant="destructive"
                                                         size="sm"
                                                         className="bg-red-500 px-3 py-2 text-white hover:bg-red-600"
-                                                        title="Delete field"
+                                                        title="Delete field — opens a dialog showing every place this field is used"
                                                     >
                                                         <Trash2 className="size-4" />
                                                     </Button>
@@ -1651,9 +1664,10 @@ const CustomFieldsSettings: React.FC = () => {
                                                 <div className="mb-3 ml-8 flex items-center gap-3">
                                                     <Badge
                                                         variant="outline"
-                                                        className="border-blue-200 bg-blue-50 text-[10px] text-blue-700 hover:bg-blue-100"
+                                                        className="border-blue-200 bg-blue-50 text-[10px] font-medium text-blue-700 hover:bg-blue-100"
+                                                        title="Institute-wide default field. Available for selection in every Enroll Invite, Audience, Live Class and Assessment create dialog."
                                                     >
-                                                        Custom Field
+                                                        DEFAULT
                                                     </Badge>
                                                     {field.usage && (
                                                         <>
@@ -1794,12 +1808,12 @@ const CustomFieldsSettings: React.FC = () => {
                                                     </div>
                                                     <Button
                                                         onClick={() =>
-                                                            handleRemoveCustomField(field.id)
+                                                            openDeleteDialog(field.id, field.name)
                                                         }
                                                         variant="destructive"
                                                         size="sm"
                                                         className="bg-red-500 px-3 py-2 text-white hover:bg-red-600"
-                                                        title="Delete field"
+                                                        title="Delete field — opens a dialog showing every place this field is used"
                                                     >
                                                         <Trash2 className="size-4" />
                                                     </Button>
@@ -1809,9 +1823,10 @@ const CustomFieldsSettings: React.FC = () => {
                                                 <div className="mb-3 ml-8 flex items-center gap-3">
                                                     <Badge
                                                         variant="outline"
-                                                        className="border-blue-200 bg-blue-50 text-[10px] text-blue-700 hover:bg-blue-100"
+                                                        className="border-blue-200 bg-blue-50 text-[10px] font-medium text-blue-700 hover:bg-blue-100"
+                                                        title="Institute-wide default field. Available for selection in every Enroll Invite, Audience, Live Class and Assessment create dialog."
                                                     >
-                                                        Custom Field
+                                                        DEFAULT
                                                     </Badge>
                                                     {field.usage && (
                                                         <>
@@ -2219,15 +2234,9 @@ const CustomFieldsSettings: React.FC = () => {
                                                     options: [],
                                                     required: false,
                                                     visibility: {
-                                                        campaign: false,
                                                         learnersList: false,
                                                         learnerEnrollment: false,
-                                                        enrollRequestList: false,
-                                                        inviteList: false,
-                                                        assessmentRegistration: false,
-                                                        liveSessionRegistration: false,
                                                         learnerProfile: false,
-                                                        enquiry: false,
                                                     },
                                                 });
                                             }
@@ -2538,6 +2547,16 @@ const CustomFieldsSettings: React.FC = () => {
 
                 {/* System Field Mapping Section */}
                 <SystemToCustomFieldMapping />
+
+                {/* Cascade Delete Dialog */}
+                <CustomFieldDeleteDialog
+                    open={deleteDialogOpen}
+                    onOpenChange={setDeleteDialogOpen}
+                    fieldName={deleteDialogFieldName}
+                    fieldId={deleteDialogFieldId}
+                    instituteId={getInstituteId() ?? ''}
+                    onDeleteComplete={handleDeleteDialogComplete}
+                />
             </div>
         </DndContext>
     );

--- a/frontend-admin-dashboard/src/lib/custom-fields/utils.ts
+++ b/frontend-admin-dashboard/src/lib/custom-fields/utils.ts
@@ -6,16 +6,18 @@ import {
     type FieldVisibility,
 } from '../../services/custom-field-settings';
 
-// Location mapping for field visibility
+// Location mapping for field visibility.
+//
+// Custom Fields Revamp (2026-04): only the three admin-side locations remain.
+// Per-feature locations (Invite List, Enroll Request List, Assessment
+// Registration, Live Session Registration, Campaign, Enquiry) were removed —
+// they are now backed by per-feature institute_custom_fields rows. Callers
+// that previously used getFieldsForLocation('Invite List') etc. should now
+// fetch via the feature-fields endpoint instead.
 const LOCATION_TO_VISIBILITY_KEY: Record<string, keyof FieldVisibility> = {
     "Learner's List": 'learnersList',
-    Campaign: 'campaign',
-    'Enroll Request List': 'enrollRequestList',
-    'Invite List': 'inviteList',
-    'Assessment Registration Form': 'assessmentRegistration',
-    'Live Session Registration Form': 'liveSessionRegistration',
-    'Learner Profile': 'learnerProfile',
     "Learner's Enrollment": 'learnerEnrollment',
+    'Learner Profile': 'learnerProfile',
 };
 
 // Type for fields that can be returned (all field types have common properties we need)
@@ -34,10 +36,13 @@ export type FieldForLocation = {
 };
 
 /**
- * Get custom fields for a specific location from stored settings
+ * Get custom fields for a specific admin-side location from stored settings.
  *
- * @param location - The location/page where fields should be displayed
- *                   e.g., "Learner's List", "Enroll Request List", "Invite List", etc.
+ * @param location - One of: "Learner's List", "Learner's Enrollment", "Learner Profile".
+ *                   The previous per-feature locations (Invite List, Campaign,
+ *                   etc.) were removed in the custom fields revamp — fetch
+ *                   per-feature fields from the /feature-fields backend
+ *                   endpoint instead.
  * @returns Array of fields that are visible for the specified location, sorted by order
  */
 export const getFieldsForLocation = (location: string): FieldForLocation[] => {

--- a/frontend-admin-dashboard/src/routes/admissions/enquiries/-components/create-enquiry-dialog/EnquiryCustomFieldsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/enquiries/-components/create-enquiry-dialog/EnquiryCustomFieldsCard.tsx
@@ -66,7 +66,6 @@ const EnquiryCustomFieldsCard = ({
             ];
 
             const enquiryFields = allFields
-                .filter((field) => field.visibility?.enquiry === true)
                 .sort((a, b) => (a.order || 0) - (b.order || 0));
 
             // Convert to form format

--- a/frontend-admin-dashboard/src/routes/admissions/new-enquiry/-components/CustomEnquiryFieldsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/admissions/new-enquiry/-components/CustomEnquiryFieldsCard.tsx
@@ -54,15 +54,11 @@ const CustomEnquiryFieldsCard = ({
             ...(settings.fixedFields || []),
         ];
 
-        // Filter for enquiry visibility
-        const enquiryFields = allFields.filter((field) => field.visibility?.enquiry === true);
+        // Custom Fields Revamp: the per-feature enquiry visibility checkbox was
+        // removed from Settings. In create mode, pre-select ALL institute defaults.
+        const enquiryFields = allFields.sort((a, b) => (a.order || 0) - (b.order || 0));
 
-        // Get field groups that have enquiry visibility
         const enquiryGroups = (settings.fieldGroups || [])
-            .map((group) => ({
-                ...group,
-                fields: group.fields.filter((field) => field.visibility?.enquiry === true),
-            }))
             .filter((group) => group.fields.length > 0);
 
         // First, mark all fields that are in groups

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step3AddingParticipants.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step3AddingParticipants.tsx
@@ -53,11 +53,17 @@ import { Step3ParticipantsListIndiviudalStudentInterface } from '@/types/assessm
 import { Sortable, SortableDragHandle, SortableItem } from '@/components/ui/sortable';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
-import { getFieldsForLocation } from '@/lib/custom-fields/utils';
+import { getCustomFieldSettingsFromCache } from '@/services/custom-field-settings';
 type TestAccessFormType = z.infer<typeof testAccessSchema>;
 
 function getInitialAssessmentCustomFields() {
-    const settingsFields = getFieldsForLocation('Assessment Registration Form');
+    // Custom Fields Revamp: read ALL institute defaults from cache
+    const settings = getCustomFieldSettingsFromCache();
+    const settingsFields = [
+        ...(settings?.fixedFields || []),
+        ...(settings?.customFields || []),
+        ...(settings?.instituteFields || []),
+    ];
     if (!settingsFields.length) {
         // Fallback to hardcoded defaults only if settings has nothing
         return [

--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-utils/getCampaignCustomFields.ts
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-utils/getCampaignCustomFields.ts
@@ -1,4 +1,3 @@
-import { getFieldsForLocation } from '@/lib/custom-fields/utils';
 import { getCustomFieldSettingsFromCache } from '@/services/custom-field-settings';
 
 /**
@@ -36,50 +35,64 @@ const generateKeyFromName = (name: string): string =>
         .replace(/^_+|_+$/g, '');
 
 /**
- * Get dynamic campaign fields from settings cache
- * This reads from localStorage cache which is updated when settings are saved
+ * Get the institute's default custom fields, pre-selected for a brand-new
+ * audience campaign create dialog.
  *
- * @returns Array of campaign custom fields configured in settings with Campaign visibility
- *          Returns empty array if no settings found
+ * Custom Fields Revamp (2026-04): the previous implementation read fields
+ * from a stale "Campaign" visibility checkbox. Per-feature visibility was
+ * removed; admins now manage which fields are on a campaign from inside
+ * the campaign create/edit dialog itself. This function returns the
+ * institute's full default catalog (locked fixed fields + admin-created
+ * defaults) so the picker starts with everything pre-selected. The admin
+ * can untick before saving — only the ticked fields are persisted as
+ * AUDIENCE_FORM mappings.
+ *
+ * Edit-mode pre-selection should fetch the existing ACTIVE mappings via
+ * `GET /admin-core-service/common/custom-fields/feature-fields`
+ * (type=AUDIENCE_FORM, typeId=<audienceId>) instead of calling this.
  */
 export const getCampaignCustomFields = (): CampaignFormCustomField[] => {
     try {
-        // Get fields defined under "Campaign" location from settings cache
-        const customFields = getFieldsForLocation('Campaign') || [];
+        const settings = getCustomFieldSettingsFromCache();
+        if (!settings) return [];
 
-        if (!customFields.length) {
-            return [];
-        }
+        const all = [
+            ...(settings.fixedFields || []),
+            ...(settings.customFields || []),
+            ...(settings.instituteFields || []),
+        ];
+        if (all.length === 0) return [];
 
-        // Transform settings fields into form-compatible format
-        const transformedFields: CampaignFormCustomField[] = customFields.map((field, index) => {
-            const fieldKey = generateKeyFromName(field.name);
-
-            const transformed: CampaignFormCustomField = {
-                id: String(index),
-                type: mapFieldType(field.type || 'text'),
-                name: field.name,
-                isRequired: field.required || false,
-                key: fieldKey,
-                order: index,
-                _id: field.id,
-                status: 'ACTIVE',
-            };
-
-            if (field.type === 'dropdown' && field.options && field.options.length > 0) {
-                transformed.options = field.options.map((opt, i) => ({
-                    id: `${index}_opt_${i}`,
-                    value: opt,
-                    disabled: true,
-                }));
-            }
-
-            return transformed;
-        });
-
-        return transformedFields;
+        return all
+            .map((field, index): CampaignFormCustomField => {
+                const fieldType = mapFieldType((field.type as string) || 'text');
+                const transformed: CampaignFormCustomField = {
+                    id: String(index),
+                    type: fieldType,
+                    name: field.name,
+                    isRequired: field.required || false,
+                    key: generateKeyFromName(field.name),
+                    order: field.order ?? index,
+                    _id: field.id,
+                    status: 'ACTIVE',
+                };
+                if (
+                    fieldType === 'dropdown' &&
+                    'options' in field &&
+                    field.options &&
+                    field.options.length > 0
+                ) {
+                    transformed.options = field.options.map((opt, i) => ({
+                        id: `${index}_opt_${i}`,
+                        value: opt,
+                        disabled: true,
+                    }));
+                }
+                return transformed;
+            })
+            .sort((a, b) => a.order - b.order);
     } catch (err) {
-        console.error('❌ Error in getCampaignCustomFields:', err);
+        console.error('Error reading institute defaults for campaign picker:', err);
         return [];
     }
 };

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
@@ -1,4 +1,5 @@
 import { getInstituteId } from '@/constants/helper';
+import { getCustomFieldSettingsFromCache } from '@/services/custom-field-settings';
 import { InviteLinkFormValues } from '../GenerateInviteLinkSchema';
 import { CustomField } from '../../../-schema/InviteFormSchema';
 import { IndividualInviteLinkDetails } from '@/types/study-library/individual-invite-interface';
@@ -207,14 +208,28 @@ function safeJsonParse<T = unknown>(str: string, fallback: T): T {
     }
 }
 
+/**
+ * Re-transform saved custom fields from backend format to the invite form
+ * format used by React Hook Form.
+ *
+ * `oldKey` is determined by cross-referencing the custom field id against
+ * the institute's fixed (locked/seeded) fields in the settings cache. If
+ * the cache is unavailable, it falls back to matching the field key against
+ * the known seeded defaults (full_name, email, phone_number).
+ */
 export function ReTransformCustomFields(inviteDetails: IndividualInviteLinkDetails) {
+    const cachedSettings = getCustomFieldSettingsFromCache();
+    const fixedFieldIds = new Set(
+        (cachedSettings?.fixedFields || []).map((f: { id: string }) => f.id)
+    );
+    const SEEDED_KEYS = ['full_name', 'email', 'phone_number'];
+
     return inviteDetails?.institute_custom_fields?.map((field, index) => {
         const config = safeJsonParse<{ coommaSepartedOptions?: string }>(
             field.custom_field.config,
             {}
         );
 
-        // Convert options to the new format with id, value, and disabled
         const options = config.coommaSepartedOptions
             ? config.coommaSepartedOptions.split(',').map((option: string, optIndex: number) => ({
                   id: String(optIndex),
@@ -223,18 +238,24 @@ export function ReTransformCustomFields(inviteDetails: IndividualInviteLinkDetai
               }))
             : undefined;
 
+        const cfId = field.custom_field.id;
+        const cfKey = (field.custom_field.fieldKey || '').toLowerCase();
+        const isLocked =
+            fixedFieldIds.has(cfId) ||
+            SEEDED_KEYS.some((k) => cfKey.startsWith(k));
+
         return {
-            id: field.id, // Preserve the mapping ID (InstituteCustomField.id)
+            id: field.id,
             type: field.type,
             name: field.custom_field.fieldName,
-            oldKey: false,
-            isRequired: field.custom_field.isMandatory,
+            oldKey: isLocked,
+            isRequired: field.custom_field.isMandatory || isLocked,
             key: field.custom_field.fieldName
                 .toLowerCase()
                 .replace(/[^a-z0-9]+/g, '_')
                 .replace(/^_+|_+$/g, ''),
             order: index,
-            _id: field.custom_field.id, // Preserve the custom field ID (custom_field.id)
+            _id: field.custom_field.id,
             ...(options && { options }),
         };
     });

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-utils/getInviteListCustomFields.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-utils/getInviteListCustomFields.ts
@@ -1,4 +1,4 @@
-import { getFieldsForLocation } from '@/lib/custom-fields/utils';
+import { getCustomFieldSettingsFromCache } from '@/services/custom-field-settings';
 
 /**
  * Interface for invite form custom field
@@ -40,50 +40,74 @@ const generateKeyFromName = (name: string): string => {
 };
 
 /**
- * Get custom fields for Invite List location from localStorage
- * Transforms them into the format expected by the invite form
+ * Get the institute's default custom fields, pre-selected for a brand-new
+ * invite create dialog.
+ *
+ * Custom Fields Revamp (2026-04): the previous implementation read from a
+ * stale "Invite List" visibility checkbox. The revamp moved per-feature
+ * field selection out of Settings and into each feature's create/edit
+ * dialog, so the picker is now seeded from the institute's default catalog
+ * (every CustomField + FixedField stored in `CUSTOM_FIELD_SETTING`). The
+ * admin can untick anything in the dialog before saving — only the ticked
+ * fields are persisted as ENROLL_INVITE mappings on save.
+ *
+ * Edit-mode pre-selection should fetch the existing ACTIVE mappings for
+ * the invite via `GET /admin-core-service/common/custom-fields/feature-fields`
+ * (type=ENROLL_INVITE, typeId=<inviteId>) instead of calling this function.
  */
 export const getInviteListCustomFields = (): InviteFormCustomField[] => {
     try {
-        // Get custom fields for "Invite List" location
-        const customFields = getFieldsForLocation('Invite List');
-
-        if (!customFields || customFields.length === 0) {
+        const settings = getCustomFieldSettingsFromCache();
+        if (!settings) {
             return getDefaultInviteFields();
         }
 
-        // Transform custom fields to invite form format
-        const transformedFields: InviteFormCustomField[] = customFields.map((field, index) => {
-            const isOldKey = false;
-            const fieldKey = generateKeyFromName(field.name);
+        // Combine fixed (locked seeded) + admin-created custom fields. The
+        // institute owns all of these as DEFAULT_CUSTOM_FIELD mappings, so
+        // pre-selecting all of them is the right starting state.
+        const all = [
+            ...(settings.fixedFields || []),
+            ...(settings.customFields || []),
+            ...(settings.instituteFields || []),
+        ];
 
-            const transformedField: InviteFormCustomField = {
-                id: String(index), // Use index as string ID for form
-                type: mapFieldType(field.type || 'text'),
-                name: field.name,
-                oldKey: isOldKey,
-                isRequired: field.required || false,
-                key: fieldKey,
-                order: index,
-                _id: field.id, // Store the actual custom field ID from localStorage
-                status: 'ACTIVE',
-            };
+        if (all.length === 0) {
+            return getDefaultInviteFields();
+        }
 
-            // Add options if it's a dropdown field
-            if (field.type === 'dropdown' && field.options && field.options.length > 0) {
-                transformedField.options = field.options.map((option, optIndex) => ({
-                    id: `${index}_option_${optIndex}`,
-                    value: option,
-                    disabled: true,
-                }));
-            }
-
-            return transformedField;
-        });
-
-        return transformedFields;
+        return all
+            .map((field, index): InviteFormCustomField => {
+                const fieldType = mapFieldType((field.type as string) || 'text');
+                const transformed: InviteFormCustomField = {
+                    id: String(index),
+                    type: fieldType,
+                    name: field.name,
+                    // System-locked fields stay marked oldKey: true so the
+                    // dialog hides their delete button.
+                    oldKey: !field.canBeDeleted,
+                    isRequired: field.required || false,
+                    key: generateKeyFromName(field.name),
+                    order: field.order ?? index,
+                    _id: field.id,
+                    status: 'ACTIVE',
+                };
+                if (
+                    fieldType === 'dropdown' &&
+                    'options' in field &&
+                    field.options &&
+                    field.options.length > 0
+                ) {
+                    transformed.options = field.options.map((option, optIndex) => ({
+                        id: `${index}_option_${optIndex}`,
+                        value: option,
+                        disabled: true,
+                    }));
+                }
+                return transformed;
+            })
+            .sort((a, b) => a.order - b.order);
     } catch (error) {
-        console.error('❌ Error getting invite list custom fields:', error);
+        console.error('Error reading institute defaults for invite picker:', error);
         return getDefaultInviteFields();
     }
 };

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/scheduleStep2.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/scheduleStep2.tsx
@@ -25,7 +25,7 @@ import QRCode from 'react-qr-code';
 import { handleDownloadQRCode } from '@/routes/homework-creation/create-assessment/$assessmentId/$examtype/-utils/helper';
 import { Checkbox } from '@/components/ui/checkbox';
 import { addCustomFiledSchema, addParticipantsSchema } from '../-schema/schema';
-import { getFieldsForLocation } from '@/lib/custom-fields/utils';
+import { getCustomFieldSettingsFromCache } from '@/services/custom-field-settings';
 import { Sortable, SortableDragHandle, SortableItem } from '@/components/ui/sortable';
 import { Switch } from '@/components/ui/switch';
 import { MyDialog } from '@/components/design-system/dialog';
@@ -405,7 +405,13 @@ export default function ScheduleStep2() {
         }
         if (accessType === AccessType.PUBLIC) {
             // Load from settings, fallback to hardcoded defaults
-            const settingsFields = getFieldsForLocation('Live Session Registration Form');
+            // Custom Fields Revamp: read ALL institute defaults from cache
+            const settings = getCustomFieldSettingsFromCache();
+            const settingsFields = [
+                ...(settings?.fixedFields || []),
+                ...(settings?.customFields || []),
+                ...(settings?.instituteFields || []),
+            ];
             let allFields;
             if (settingsFields.length > 0) {
                 allFields = settingsFields.map((f) => ({

--- a/frontend-admin-dashboard/src/services/custom-field-mappings.ts
+++ b/frontend-admin-dashboard/src/services/custom-field-mappings.ts
@@ -1,0 +1,106 @@
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+
+/**
+ * Thin client for the per-mapping custom field endpoints introduced by the
+ * Custom Fields Revamp (2026-04). These endpoints operate on individual
+ * `institute_custom_fields` rows — not on the institute setting JSON blob —
+ * and are used by:
+ *
+ *   - The cascade-delete dialog in Settings → Custom Fields (lists every
+ *     active mapping for one custom field across all features so the admin
+ *     can pick which ones to soft-delete).
+ *   - The per-feature pickers (Enroll Invite, Audience, Live Class,
+ *     Assessment) — they call `syncFeatureCustomFields` after saving the
+ *     parent feature, sending the FULL list of fields the admin picked.
+ */
+
+const BASE = '/admin-core-service/common/custom-fields';
+
+/** One row from `institute_custom_fields` flattened for the cascade delete UI. */
+export interface CustomFieldMappingUsage {
+    /** institute_custom_fields.id — the primary key the soft-delete uses. */
+    mapping_id: string;
+    /** DEFAULT_CUSTOM_FIELD / ENROLL_INVITE / AUDIENCE_FORM / SESSION / ASSESSMENT */
+    type: string;
+    /** Parent feature instance id (null for DEFAULT_CUSTOM_FIELD). */
+    type_id: string | null;
+    /** Always 'ACTIVE' here, kept for forward-compatibility. */
+    status: string;
+}
+
+/** Custom field type values used by the picker payload. */
+export type CustomFieldFeatureType =
+    | 'DEFAULT_CUSTOM_FIELD'
+    | 'ENROLL_INVITE'
+    | 'AUDIENCE_FORM'
+    | 'SESSION'
+    | 'ASSESSMENT';
+
+/** Body for `POST /feature-fields`. Mirrors `InstituteCustomFieldDTO` on the backend. */
+export interface InstituteCustomFieldPayload {
+    custom_field?: {
+        id?: string;
+        field_name?: string;
+        field_type?: string;
+        config?: string;
+        default_value?: string;
+        is_mandatory?: boolean;
+    } | null;
+    field_id?: string | null;
+    individual_order?: number | null;
+    group_internal_order?: number | null;
+    group_name?: string | null;
+    is_mandatory?: boolean | null;
+    status?: 'ACTIVE' | 'DELETED';
+}
+
+/**
+ * Get every ACTIVE `institute_custom_fields` mapping for one custom field.
+ * Used by the cascade-delete dialog.
+ */
+export const getCustomFieldUsages = async (
+    instituteId: string,
+    customFieldId: string
+): Promise<CustomFieldMappingUsage[]> => {
+    const response = await authenticatedAxiosInstance.get<CustomFieldMappingUsage[]>(
+        `${BASE}/usages`,
+        { params: { instituteId, customFieldId } }
+    );
+    return Array.isArray(response?.data) ? response.data : [];
+};
+
+/**
+ * Soft-delete a list of `institute_custom_fields` rows by id. "Delete" here
+ * only means status = DELETED — the master row and any custom_field_values
+ * answers stay in place. Returns the server's success message.
+ */
+export const softDeleteCustomFieldMappings = async (
+    mappingIds: string[]
+): Promise<string> => {
+    if (!mappingIds || mappingIds.length === 0) return 'no-op';
+    const response = await authenticatedAxiosInstance.delete<string>(
+        `${BASE}/mappings`,
+        { data: mappingIds }
+    );
+    return response.data;
+};
+
+/**
+ * Persist the full set of custom fields the admin picked for one feature
+ * instance (Enroll Invite, Audience, Live Session, Assessment). The backend
+ * handles insert / reactivate / soft-delete in one transaction so this is
+ * the only call needed on save.
+ */
+export const syncFeatureCustomFields = async (
+    instituteId: string,
+    type: CustomFieldFeatureType,
+    typeId: string,
+    fields: InstituteCustomFieldPayload[]
+): Promise<string> => {
+    const response = await authenticatedAxiosInstance.post<string>(
+        `${BASE}/feature-fields`,
+        fields,
+        { params: { instituteId, type, typeId } }
+    );
+    return response.data;
+};

--- a/frontend-admin-dashboard/src/services/custom-field-settings.ts
+++ b/frontend-admin-dashboard/src/services/custom-field-settings.ts
@@ -129,16 +129,23 @@ export interface CustomFieldUsage {
 }
 
 // Field Visibility Interface
+//
+// Custom Fields Revamp (2026-04): the per-feature locations
+// (Invite List, Enroll Request List, Assessment Registration, Live Session
+// Registration, Campaign, Enquiry) were removed. Per-feature visibility is
+// now controlled by `institute_custom_fields` rows with the right `type`
+// and `type_id` (ENROLL_INVITE, AUDIENCE_FORM, SESSION, ASSESSMENT) created
+// from each feature's create/edit dialog.
+//
+// What remains here are only the institute-side admin views where the
+// settings page directly controls visibility:
+//   - learnersList     → admin learner table columns
+//   - learnerEnrollment → admin "enroll learner" form
+//   - learnerProfile   → admin learner profile drawer
 export interface FieldVisibility {
-    campaign: boolean;
     learnersList: boolean;
     learnerEnrollment: boolean;
-    enrollRequestList: boolean;
-    inviteList: boolean;
-    assessmentRegistration: boolean;
-    liveSessionRegistration: boolean;
     learnerProfile: boolean;
-    enquiry: boolean;
 }
 
 // Custom Field (fully editable)
@@ -230,29 +237,19 @@ interface CachedCustomFieldSettings {
     instituteId: string;
 }
 
-// Location mapping dictionary
+// Location mapping dictionary — only the three admin-side locations remain.
+// The six per-feature locations were removed in the custom fields revamp.
+// See FieldVisibility above for the rationale.
 const LOCATION_TO_VISIBILITY_MAP: Record<string, keyof FieldVisibility> = {
-    Campaign: 'campaign',
     "Learner's List": 'learnersList',
     "Learner's Enrollment": 'learnerEnrollment',
-    'Enroll Request List': 'enrollRequestList',
-    'Invite List': 'inviteList',
-    'Assessment Registration Form': 'assessmentRegistration',
-    'Live Session Registration Form': 'liveSessionRegistration',
     'Learner Profile': 'learnerProfile',
-    Enquiry: 'enquiry',
 };
 
 const VISIBILITY_TO_LOCATION_MAP: Record<keyof FieldVisibility, string> = {
-    campaign: 'Campaign',
     learnersList: "Learner's List",
     learnerEnrollment: "Learner's Enrollment",
-    enrollRequestList: 'Enroll Request List',
-    inviteList: 'Invite List',
-    assessmentRegistration: 'Assessment Registration Form',
-    liveSessionRegistration: 'Live Session Registration Form',
     learnerProfile: 'Learner Profile',
-    enquiry: 'Enquiry',
 };
 
 // System field identifiers (fieldName from API)
@@ -441,15 +438,9 @@ export const DEFAULT_SYSTEM_FIELDS: SystemField[] = [
  */
 const mapLocationsToVisibility = (locations: string[]): FieldVisibility => {
     const visibility: FieldVisibility = {
-        campaign: false,
         learnersList: false,
         learnerEnrollment: false,
-        enrollRequestList: false,
-        inviteList: false,
-        assessmentRegistration: false,
-        liveSessionRegistration: false,
         learnerProfile: false,
-        enquiry: false,
     };
 
     locations.forEach((location) => {
@@ -1640,15 +1631,9 @@ export const createNewCustomField = (
         type,
         options: type === 'dropdown' ? options || [] : undefined,
         visibility: {
-            campaign: false,
             learnersList: false,
             learnerEnrollment: false,
-            enrollRequestList: false,
-            inviteList: false,
-            assessmentRegistration: false,
-            liveSessionRegistration: false,
             learnerProfile: false,
-            enquiry: false,
         },
         required: false,
         order: 999, // Will be updated when added to settings
@@ -1681,15 +1666,9 @@ export const createTempCustomField = (
         type,
         options: type === 'dropdown' ? options || [] : undefined,
         visibility: {
-            campaign: false,
             learnersList: false,
             learnerEnrollment: false,
-            enrollRequestList: false,
-            inviteList: false,
-            assessmentRegistration: false,
-            liveSessionRegistration: false,
             learnerProfile: false,
-            enquiry: false,
         },
         required: false,
         canBeDeleted: true,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/EnrollmentPaymentDialog.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/EnrollmentPaymentDialog.tsx
@@ -590,9 +590,9 @@ export const EnrollmentPaymentDialog: React.FC<
                     {phoneError && (
                       <p className="text-red-500 text-sm mt-1">{phoneError}</p>
                     )}
-                    <p className="text-gray-500 text-xs mt-1">
+                    {/* {<p className="text-gray-500 text-xs mt-1">
                       Include country code (e.g., +91 9876543210)
-                    </p>
+                    </p> } */}
                   </div>
 
                   {validationError && (


### PR DESCRIPTION
## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->

- Removed 6 per-feature visibility locations from Settings (Invite List, Enroll Request List, Assessment Registration, Live Session Registration, Campaign, Enquiry). Per-feature visibility is now controlled by institute_custom_fields rows with matching type/typeId.
- Added unified syncFeatureCustomFields backend service method for insert/reactivate/soft-delete in one transaction.
- Added POST /feature-fields endpoint for frontend assessment/liveclass/ audience/invite create/edit flows.
- Added cascade-delete dialog in Settings showing every mapping for a field across all feature types.
- Added is_mandatory column to institute_custom_fields (V199 migration).
- Added ASSESSMENT to CustomFieldTypeEnum.
- Fixed enquiry, assessment Step3, live session Step2, invite edit, and campaign pickers to load institute defaults instead of removed locations.
- Defensive fixes for API 500 errors in delete dialog.

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
