### PR TITLE
feat(assessment): add result release types, manual upload exam, and r…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/InstituteService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/InstituteService.java
@@ -53,6 +53,7 @@ public class InstituteService {
         branding.put("institute_id", institute.getId());
         branding.put("institute_name", institute.getInstituteName());
         branding.put("logo_file_id", institute.getLogoFileId());
+        branding.put("institute_theme_code", institute.getInstituteThemeCode());
         return branding;
     }
 }

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/dto/create_assessment/BasicAssessmentDetailsDTO.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/dto/create_assessment/BasicAssessmentDetailsDTO.java
@@ -25,6 +25,7 @@ public class BasicAssessmentDetailsDTO {
     private Boolean raiseTimeIncreaseRequest;
     private Boolean hasOmrMode;
     private Integer defaultReattemptCount = 1;
+    private String resultType;
     private String source;
     private String sourceId;
 

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/entity/Assessment.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/entity/Assessment.java
@@ -36,6 +36,10 @@ public class Assessment {
     @JoinColumn(name = "instructions_id", referencedColumnName = "id", insertable = true, updatable = true)
     private AssessmentRichTextData instructions;
 
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "registration_instructions_id", referencedColumnName = "id", insertable = true, updatable = true)
+    private AssessmentRichTextData registrationInstructions;
+
     @Column(name = "play_mode", nullable = false)
     private String playMode;
 
@@ -95,6 +99,9 @@ public class Assessment {
 
     @Column(name = "omr_mode")
     private Boolean omrMode;
+
+    @Column(name = "result_type")
+    private String resultType;
 
     @Column(name = "reattempt_count")
     private Integer reattemptCount;

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/enums/ResultTypeEnum.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/enums/ResultTypeEnum.java
@@ -1,0 +1,7 @@
+package vacademy.io.assessment_service.features.assessment.enums;
+
+public enum ResultTypeEnum {
+    AUTO_AFTER_ASSESSMENT_END,
+    AUTO_AFTER_SUBMISSION,
+    MANUAL
+}

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/enums/creationSteps/AssessmentCreationEnum.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/enums/creationSteps/AssessmentCreationEnum.java
@@ -22,5 +22,6 @@ public enum AssessmentCreationEnum {
     ASSESSMENT_ID,
     ASSESSMENT_MODE,
     INSTRUCTIONS,
-    REATTEMPT_COUNT;
+    REATTEMPT_COUNT,
+    RESULT_TYPE;
 }

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/manager/AssessmentBasicDetailsManager.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/manager/AssessmentBasicDetailsManager.java
@@ -70,6 +70,7 @@ public class AssessmentBasicDetailsManager {
         }
         Optional.ofNullable(basicAssessmentDetailsDTO.getRaiseReattemptRequest()).ifPresent(assessment::setCanRequestReattempt);
         Optional.ofNullable(basicAssessmentDetailsDTO.getRaiseTimeIncreaseRequest()).ifPresent(assessment::setCanRequestTimeIncrease);
+        Optional.ofNullable(basicAssessmentDetailsDTO.getResultType()).ifPresent(assessment::setResultType);
         addOrUpdateTestCreationData(assessment, null, basicAssessmentDetailsDTO.getTestCreation());
         addOrUpdateBoundationData(assessment, null, basicAssessmentDetailsDTO.getTestBoundation());
 
@@ -104,6 +105,7 @@ public class AssessmentBasicDetailsManager {
         }
         Optional.ofNullable(basicAssessmentDetailsDTO.getRaiseReattemptRequest()).ifPresent(assessment::setCanRequestReattempt);
         Optional.ofNullable(basicAssessmentDetailsDTO.getRaiseTimeIncreaseRequest()).ifPresent(assessment::setCanRequestTimeIncrease);
+        Optional.ofNullable(basicAssessmentDetailsDTO.getResultType()).ifPresent(assessment::setResultType);
         addOrUpdateTestCreationData(assessment, assessmentInstituteMapping, basicAssessmentDetailsDTO.getTestCreation());
         addOrUpdateBoundationData(assessment, assessmentInstituteMapping, basicAssessmentDetailsDTO.getTestBoundation());
 

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/manager/AssessmentParticipantsManager.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/manager/AssessmentParticipantsManager.java
@@ -267,7 +267,7 @@ public class AssessmentParticipantsManager {
         }
 
         if (!ObjectUtils.isEmpty(openTestDetails.getInstructionsHtml())) {
-            assessment.setInstructions(
+            assessment.setRegistrationInstructions(
                     new AssessmentRichTextData(null, TextType.HTML.name(), openTestDetails.getInstructionsHtml()));
             assessmentRepository.save(assessment);
         }

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/AssessmentRepository.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/AssessmentRepository.java
@@ -214,13 +214,13 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
     @Query(value = "(SELECT DISTINCT a.id, a.name, a.play_mode, a.evaluation_type, a.submission_type, a.duration, " +
             "a.assessment_visibility, a.status, a.registration_close_date, a.registration_open_date, " +
             "a.expected_participants, a.cover_file_id, a.bound_start_time, a.bound_end_time, a.about_id, a.instructions_id, " +
-            "a.created_at, a.updated_at, recent_attempt.status AS recent_attempt_status, recent_attempt.start_time AS recent_attempt_start_time, a.reattempt_count, aur.reattempt_count, recent_attempt.total_attempts, a.preview_time, recent_attempt.id AS recent_attempt_id, aur.id AS assessment_user_registration_id, a.duration_distribution, a.can_switch_section, a.can_request_time_increase, a.can_request_reattempt, a.omr_mode " +
+            "a.created_at, a.updated_at, recent_attempt.status AS recent_attempt_status, recent_attempt.start_time AS recent_attempt_start_time, a.reattempt_count, aur.reattempt_count, recent_attempt.total_attempts, a.preview_time, recent_attempt.id AS recent_attempt_id, aur.id AS assessment_user_registration_id, a.duration_distribution, a.can_switch_section, a.can_request_time_increase, a.can_request_reattempt, a.omr_mode, a.result_type, recent_attempt.report_release_status " +
             "FROM public.assessment a " +
             "LEFT JOIN public.assessment_batch_registration abr ON a.id = abr.assessment_id " +
             "LEFT JOIN public.assessment_institute_mapping aim ON a.id = aim.assessment_id " +
             "LEFT JOIN public.assessment_user_registration aur ON a.id = aur.assessment_id AND aur.user_id IN :userIds " +
             "LEFT JOIN ( " +
-            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, " +
+            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, sa.report_release_status, " +
             "ROW_NUMBER() OVER (PARTITION BY sa.registration_id ORDER BY sa.start_time DESC) AS rn , COUNT(*) OVER (PARTITION BY sa.registration_id) AS total_attempts " +
             "FROM public.student_attempt sa " +
             ") AS recent_attempt ON aur.id = recent_attempt.registration_id AND recent_attempt.rn = 1 " +
@@ -229,7 +229,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
             "AND (:instituteIds IS NULL OR aim.institute_id IN :instituteIds) " +
             "AND (:assessmentStatuses IS NULL OR a.status IN :assessmentStatuses) " +
             "AND (:liveAssessments IS NULL OR :liveAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' BETWEEN a.bound_start_time AND a.bound_end_time)) " +
-            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time)) " +
+            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time AND (a.result_type IS NULL OR a.result_type != 'MANUAL' OR recent_attempt.report_release_status = 'RELEASED'))) " +
             "AND (:upcomingAssessments IS NULL OR :upcomingAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' < a.bound_start_time)) " +
             "AND (:assessmentTypes IS NULL OR a.assessment_type IN :assessmentTypes) " +
             "AND (:assessmentModes IS NULL OR a.play_mode IN :assessmentModes)) " +
@@ -237,12 +237,12 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
             "(SELECT DISTINCT a.id, a.name, a.play_mode, a.evaluation_type, a.submission_type, a.duration, " +
             "a.assessment_visibility, a.status, a.registration_close_date, a.registration_open_date, " +
             "a.expected_participants, a.cover_file_id, a.bound_start_time, a.bound_end_time, a.about_id, a.instructions_id, " +
-            "a.created_at, a.updated_at, recent_attempt.status AS recent_attempt_status, recent_attempt.start_time AS recent_attempt_start_time,  a.reattempt_count, aur.reattempt_count,  recent_attempt.total_attempts, a.preview_time, recent_attempt.id AS recent_attempt_id, aur.id AS assessment_user_registration_id, a.duration_distribution, a.can_switch_section, a.can_request_time_increase, a.can_request_reattempt, a.omr_mode " +
+            "a.created_at, a.updated_at, recent_attempt.status AS recent_attempt_status, recent_attempt.start_time AS recent_attempt_start_time, a.reattempt_count, aur.reattempt_count, recent_attempt.total_attempts, a.preview_time, recent_attempt.id AS recent_attempt_id, aur.id AS assessment_user_registration_id, a.duration_distribution, a.can_switch_section, a.can_request_time_increase, a.can_request_reattempt, a.omr_mode, a.result_type, recent_attempt.report_release_status " +
             "FROM public.assessment a " +
             "LEFT JOIN public.assessment_user_registration aur ON a.id = aur.assessment_id " +
             "LEFT JOIN public.assessment_institute_mapping aim ON a.id = aim.assessment_id " +
             "LEFT JOIN ( " +
-            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, " +
+            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, sa.report_release_status, " +
             "ROW_NUMBER() OVER (PARTITION BY sa.registration_id ORDER BY sa.start_time DESC) AS rn , COUNT(*) OVER (PARTITION BY sa.registration_id) AS total_attempts " +
             "FROM public.student_attempt sa " +
             ") AS recent_attempt ON aur.id = recent_attempt.registration_id AND recent_attempt.rn = 1 " +
@@ -251,7 +251,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
             "AND (:instituteIds IS NULL OR aim.institute_id IN :instituteIds) " +
             "AND (:assessmentStatuses IS NULL OR a.status IN :assessmentStatuses) " +
             "AND (:liveAssessments IS NULL OR :liveAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' BETWEEN a.bound_start_time AND a.bound_end_time)) " +
-            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time)) " +
+            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time AND (a.result_type IS NULL OR a.result_type != 'MANUAL' OR recent_attempt.report_release_status = 'RELEASED'))) " +
             "AND (:upcomingAssessments IS NULL OR :upcomingAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' < a.bound_start_time)) " +
             "AND (:assessmentTypes IS NULL OR a.assessment_type IN :assessmentTypes) " +
             "AND (:assessmentModes IS NULL OR a.play_mode IN :assessmentModes))",
@@ -262,7 +262,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
                             "LEFT JOIN public.assessment_institute_mapping aim ON a.id = aim.assessment_id " +
                             "LEFT JOIN public.assessment_user_registration aur ON a.id = aur.assessment_id AND aur.user_id IN :userIds " +
                             "LEFT JOIN ( " +
-                            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, " +
+                            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, sa.report_release_status, " +
                             "ROW_NUMBER() OVER (PARTITION BY sa.registration_id ORDER BY sa.start_time DESC) AS rn , COUNT(*) OVER (PARTITION BY sa.registration_id) AS total_attempts " +
                             "FROM public.student_attempt sa " +
                             ") AS recent_attempt ON aur.id = recent_attempt.registration_id AND recent_attempt.rn = 1 " +
@@ -271,7 +271,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
                             "AND (:instituteIds IS NULL OR aim.institute_id IN :instituteIds) " +
                             "AND (:assessmentStatuses IS NULL OR a.status IN :assessmentStatuses) " +
                             "AND (:liveAssessments IS NULL OR :liveAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' BETWEEN a.bound_start_time AND a.bound_end_time)) " +
-                            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time)) " +
+                            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time AND (a.result_type IS NULL OR a.result_type != 'MANUAL' OR recent_attempt.report_release_status = 'RELEASED'))) " +
                             "AND (:upcomingAssessments IS NULL OR :upcomingAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' < a.bound_start_time)) " +
                             "AND (:assessmentTypes IS NULL OR a.assessment_type IN :assessmentTypes) " +
                             "AND (:assessmentModes IS NULL OR a.play_mode IN :assessmentModes) " +
@@ -280,7 +280,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
                             "LEFT JOIN public.assessment_user_registration aur ON a.id = aur.assessment_id " +
                             "LEFT JOIN public.assessment_institute_mapping aim ON a.id = aim.assessment_id " +
                             "LEFT JOIN ( " +
-                            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, " +
+                            "SELECT sa.registration_id, sa.status, sa.start_time, sa.id, sa.report_release_status, " +
                             "ROW_NUMBER() OVER (PARTITION BY sa.registration_id ORDER BY sa.start_time DESC) AS rn , COUNT(*) OVER (PARTITION BY sa.registration_id) AS total_attempts " +
                             "FROM public.student_attempt sa " +
                             ") AS recent_attempt ON aur.id = recent_attempt.registration_id AND recent_attempt.rn = 1 " +
@@ -289,7 +289,7 @@ public interface AssessmentRepository extends CrudRepository<Assessment, String>
                             "AND (:instituteIds IS NULL OR aim.institute_id IN :instituteIds) " +
                             "AND (:assessmentStatuses IS NULL OR a.status IN :assessmentStatuses) " +
                             "AND (:liveAssessments IS NULL OR :liveAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' BETWEEN a.bound_start_time AND a.bound_end_time)) " +
-                            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time)) " +
+                            "AND (:passedAssessments IS NULL OR :passedAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time AND (a.result_type IS NULL OR a.result_type != 'MANUAL' OR recent_attempt.report_release_status = 'RELEASED'))) " +
                             "AND (:upcomingAssessments IS NULL OR :upcomingAssessments = 'false' OR (CURRENT_TIMESTAMP AT TIME ZONE 'UTC' < a.bound_start_time)) " +
                             "AND (:assessmentModes IS NULL OR a.play_mode IN :assessmentModes)" +
                             "AND (:assessmentTypes IS NULL OR a.assessment_type IN :assessmentTypes) " +

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/StudentAttemptRepository.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/StudentAttemptRepository.java
@@ -597,6 +597,18 @@ public interface StudentAttemptRepository extends CrudRepository<StudentAttempt,
     List<StudentAttempt> findByStatusNotIn(List<String> name);
 
     Optional<StudentAttempt> findTopByRegistrationOrderByCreatedAtDesc(vacademy.io.assessment_service.features.assessment.entity.AssessmentUserRegistration registration);
+
+    @Query(value = """
+            SELECT sa.* FROM student_attempt sa
+            JOIN assessment_user_registration aur ON aur.id = sa.registration_id
+            JOIN assessment a ON a.id = aur.assessment_id
+            WHERE a.result_type = 'AUTO_AFTER_ASSESSMENT_END'
+            AND CURRENT_TIMESTAMP AT TIME ZONE 'UTC' > a.bound_end_time
+            AND sa.status = 'ENDED'
+            AND sa.result_status = 'COMPLETED'
+            AND (sa.report_release_status IS NULL OR sa.report_release_status = 'PENDING')
+            """, nativeQuery = true)
+    List<StudentAttempt> findUnreleasedAttemptsForEndedAutoReleaseAssessments();
 }
 
 

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/service/StudentAttemptService.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/service/StudentAttemptService.java
@@ -17,6 +17,8 @@ import vacademy.io.assessment_service.features.assessment.entity.QuestionAssessm
 import vacademy.io.assessment_service.features.assessment.entity.Section;
 import vacademy.io.assessment_service.features.assessment.entity.StudentAttempt;
 import vacademy.io.assessment_service.features.assessment.enums.AttemptResultStatusEnum;
+import vacademy.io.assessment_service.features.assessment.enums.ReleaseResultStatusEnum;
+import vacademy.io.assessment_service.features.assessment.enums.ResultTypeEnum;
 import vacademy.io.assessment_service.features.assessment.repository.QuestionAssessmentSectionMappingRepository;
 import vacademy.io.assessment_service.features.assessment.repository.SectionRepository;
 import vacademy.io.assessment_service.features.assessment.repository.StudentAttemptRepository;
@@ -31,10 +33,7 @@ import vacademy.io.assessment_service.features.notification.service.AssessmentNo
 import vacademy.io.assessment_service.features.question_core.entity.Question;
 import vacademy.io.common.exceptions.VacademyException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.StreamSupport;
 
@@ -68,6 +67,19 @@ public class StudentAttemptService {
         return updateStudentAttempt(studentAttempt);
     }
 
+    public void releaseResultsForEndedAutoReleaseAssessments() {
+        List<StudentAttempt> unreleased = studentAttemptRepository.findUnreleasedAttemptsForEndedAutoReleaseAssessments();
+        Date now = new Date();
+        for (StudentAttempt attempt : unreleased) {
+            attempt.setReportReleaseStatus(ReleaseResultStatusEnum.RELEASED.name());
+            attempt.setReportLastReleaseDate(now);
+        }
+        if (!unreleased.isEmpty()) {
+            studentAttemptRepository.saveAll(unreleased);
+            log.info("[AUTO-RELEASE] Released results for {} attempts after assessment end", unreleased.size());
+        }
+    }
+
 
     @Async
     public CompletableFuture<StudentAttempt> updateStudentAttemptWithTotalAfterMarksCalculationAsync(Optional<StudentAttempt> studentAttemptOptional) {
@@ -98,6 +110,9 @@ public class StudentAttemptService {
             attempt.setStatus(AssessmentAttemptEnum.ENDED.name());
         }
 
+        // Auto-release result based on assessment's result_type
+        autoReleaseResultIfApplicable(attempt);
+
         return studentAttemptRepository.save(attempt);
     }
 
@@ -119,6 +134,27 @@ public class StudentAttemptService {
 
     }
 
+
+    private void autoReleaseResultIfApplicable(StudentAttempt attempt) {
+        try {
+            Assessment assessment = attempt.getRegistration().getAssessment();
+            String resultType = assessment.getResultType();
+            if (resultType == null) return;
+
+            if (ResultTypeEnum.AUTO_AFTER_SUBMISSION.name().equals(resultType)) {
+                attempt.setReportReleaseStatus(ReleaseResultStatusEnum.RELEASED.name());
+                attempt.setReportLastReleaseDate(new Date());
+            } else if (ResultTypeEnum.AUTO_AFTER_ASSESSMENT_END.name().equals(resultType)) {
+                Date now = new Date();
+                if (assessment.getBoundEndTime() != null && now.after(assessment.getBoundEndTime())) {
+                    attempt.setReportReleaseStatus(ReleaseResultStatusEnum.RELEASED.name());
+                    attempt.setReportLastReleaseDate(now);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to auto-release result for attempt {}: {}", attempt.getId(), e.getMessage());
+        }
+    }
 
     @Transactional
     public Double calculateTotalMarksForAttemptAndUpdateQuestionWiseMarks(Optional<StudentAttempt> studentAttemptOptional) {

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/service/creation/AssessmentBasicDetail.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/service/creation/AssessmentBasicDetail.java
@@ -7,6 +7,7 @@ import vacademy.io.assessment_service.features.assessment.enums.StepStatus;
 import vacademy.io.assessment_service.features.assessment.enums.creationSteps.AssessmentCreationEnum;
 import vacademy.io.assessment_service.features.assessment.service.IStep;
 import vacademy.io.assessment_service.features.assessment.service.StepOption;
+import vacademy.io.assessment_service.features.assessment.enums.ResultTypeEnum;
 import vacademy.io.assessment_service.features.question_core.enums.EvaluationTypes;
 import vacademy.io.assessment_service.features.question_core.enums.SubmissionTypes;
 
@@ -41,6 +42,7 @@ public class AssessmentBasicDetail extends IStep {
         savedData.put(AssessmentCreationEnum.SUBJECT_SELECTION.name().toLowerCase(), getSubjectIdByInstituteId(this.getInstituteId(), assessment.get()));
         savedData.put(AssessmentCreationEnum.BOUNDATION_START_DATE.name().toLowerCase(), assessment.get().getBoundStartTime());
         savedData.put(AssessmentCreationEnum.BOUNDATION_END_DATE.name().toLowerCase(), assessment.get().getBoundEndTime());
+        savedData.put(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), assessment.get().getResultType());
         setSavedData(savedData);
         updateStatusForStep();
     }
@@ -105,6 +107,11 @@ public class AssessmentBasicDetail extends IStep {
         this.getDefaultValues().put(AssessmentCreationEnum.ADD_TIME_CONSENT.name().toLowerCase(), new StepOption(AssessmentCreationEnum.ADD_TIME_CONSENT.name().toLowerCase(), "TRUE", null, false));
         this.getDefaultValues().put(AssessmentCreationEnum.REATTEMPT_CONSENT.name().toLowerCase(), new StepOption(AssessmentCreationEnum.REATTEMPT_CONSENT.name().toLowerCase(), "TRUE", null, false));
 
+        this.getFieldOptions().put(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), Arrays.stream(ResultTypeEnum.values()).map((option) ->
+                new StepOption(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), option.name(), null, false)
+        ).toList());
+        this.getDefaultValues().put(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), new StepOption(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), ResultTypeEnum.MANUAL.name(), null, false));
+
     }
 
     private List<Map<String, String>> getStepsForExam() {
@@ -119,7 +126,8 @@ public class AssessmentBasicDetail extends IStep {
                 Map.of(AssessmentCreationEnum.SUBMISSION_TYPE.name().toLowerCase(), "REQUIRED"),
                 Map.of(AssessmentCreationEnum.ASSESSMENT_PREVIEW.name().toLowerCase(), "REQUIRED"),
                 Map.of(AssessmentCreationEnum.ADD_TIME_CONSENT.name().toLowerCase(), "REQUIRED"),
-                Map.of(AssessmentCreationEnum.REATTEMPT_CONSENT.name().toLowerCase(), "REQUIRED"));
+                Map.of(AssessmentCreationEnum.REATTEMPT_CONSENT.name().toLowerCase(), "REQUIRED"),
+                Map.of(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), "REQUIRED"));
     }
 
     private List<Map<String, String>> getStepsForMock() {
@@ -163,7 +171,8 @@ public class AssessmentBasicDetail extends IStep {
                 Map.of(AssessmentCreationEnum.ASSESSMENT_VISIBILITY.name().toLowerCase(), "REQUIRED"),
                 Map.of(AssessmentCreationEnum.EXPECTED_PARTICIPANTS.name().toLowerCase(), "REQUIRED"),
                 Map.of(AssessmentCreationEnum.REATTEMPT_CONSENT.name().toLowerCase(), "REQUIRED"),
-                Map.of(AssessmentCreationEnum.REATTEMPT_COUNT.name().toLowerCase(), "REQUIRED"));
+                Map.of(AssessmentCreationEnum.REATTEMPT_COUNT.name().toLowerCase(), "REQUIRED"),
+                Map.of(AssessmentCreationEnum.RESULT_TYPE.name().toLowerCase(), "REQUIRED"));
 
     }
 

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/learner_assessment/dto/StudentAssessmentMapper.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/learner_assessment/dto/StudentAssessmentMapper.java
@@ -38,6 +38,8 @@ public class StudentAssessmentMapper {
                 .canIncreaseTime((Boolean) assessment[28])
                 .canAskForReattempt((Boolean) assessment[29])
                 .omrMode((Boolean) assessment[30])
+                .resultType((String) assessment[31])
+                .reportReleaseStatus((String) assessment[32])
                 .build();
 
         return dto;

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/learner_assessment/dto/StudentBasicAssessmentListItemDto.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/learner_assessment/dto/StudentBasicAssessmentListItemDto.java
@@ -46,4 +46,6 @@ public class StudentBasicAssessmentListItemDto {
     private Boolean canIncreaseTime;
     private Boolean canAskForReattempt;
     private Boolean omrMode;
+    private String resultType;
+    private String reportReleaseStatus;
 }

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/open_registration/dto/AssessmentPublicDto.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/open_registration/dto/AssessmentPublicDto.java
@@ -20,6 +20,8 @@ public class AssessmentPublicDto {
     private String assessmentId;
     private String assessmentName;
     private AssessmentRichTextDataDTO about;
+    private AssessmentRichTextDataDTO instructions;
+    private AssessmentRichTextDataDTO registrationInstructions;
     private String playMode;
     private String evaluationType;
     private String submissionType;
@@ -40,6 +42,12 @@ public class AssessmentPublicDto {
         this.assessmentId = assessment.getId();
         this.assessmentName = assessment.getName();
         this.about = new AssessmentRichTextDataDTO(assessment.getAbout());
+        this.instructions = assessment.getInstructions() != null
+                ? new AssessmentRichTextDataDTO(assessment.getInstructions())
+                : null;
+        this.registrationInstructions = assessment.getRegistrationInstructions() != null
+                ? new AssessmentRichTextDataDTO(assessment.getRegistrationInstructions())
+                : null;
         this.playMode = assessment.getPlayMode();
         this.evaluationType = assessment.getEvaluationType();
         this.submissionType = assessment.getSubmissionType();

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/scheduler/service/AssessmentAttemptEndTaskExecutor.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/scheduler/service/AssessmentAttemptEndTaskExecutor.java
@@ -49,6 +49,13 @@ public class AssessmentAttemptEndTaskExecutor implements TaskExecutor {
             }
         });
         createTaskExecutionAuditFromAttemptsAndUpdateAttemptStatus(activityLog, attempts, source);
+
+        // Auto-release results for ended assessments with result_type = AUTO_AFTER_ASSESSMENT_END
+        try {
+            studentAttemptService.releaseResultsForEndedAutoReleaseAssessments();
+        } catch (Exception e) {
+            log.error("[AUTO-RELEASE] Failed to release results for ended assessments: {}", e.getMessage());
+        }
     }
 
 

--- a/assessment_service/src/main/resources/db/migration/V8__add_result_type.sql
+++ b/assessment_service/src/main/resources/db/migration/V8__add_result_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment ADD COLUMN result_type VARCHAR(50) DEFAULT 'MANUAL';

--- a/assessment_service/src/main/resources/db/migration/V9__add_registration_instructions.sql
+++ b/assessment_service/src/main/resources/db/migration/V9__add_registration_instructions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment ADD COLUMN registration_instructions_id VARCHAR(255);

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/CreateAssessmentComponent.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/CreateAssessmentComponent.tsx
@@ -11,11 +11,14 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useInstituteQuery } from '@/services/student-list-section/getInstituteDetails';
 import { NoCourseDialog } from '@/components/common/students/no-course-dialog';
 // Define interfaces for props
+interface StepDef {
+    label: string;
+    description: string;
+    id: string;
+}
+
 interface CreateAssessmentSidebarProps {
-    steps: {
-        label: string;
-        id: string;
-    }[];
+    steps: StepDef[];
     currentStep: number;
     completedSteps: boolean[];
     onStepClick: (index: number) => void;
@@ -56,7 +59,14 @@ const CreateAssessmentSidebar: React.FC<CreateAssessmentSidebarProps> = ({
                             <span className="text-lg font-semibold">{index + 1}</span>
                         )}
                         {open && <span className="text-lg font-semibold">{index + 1}</span>}
-                        {open && <span className="font-thin">{step.label}</span>}
+                        {open && (
+                            <div className="flex flex-col">
+                                <span className="font-thin">{step.label}</span>
+                                <span className="text-[10px] leading-tight text-muted-foreground">
+                                    {step.description}
+                                </span>
+                            </div>
+                        )}
                     </div>
 
                     {completedSteps[index] && (
@@ -76,21 +86,33 @@ const CreateAssessmentComponent = () => {
     const { data: instituteDetails } = useSuspenseQuery(useInstituteQuery());
     const { SubjectFilterData } = useFilterDataForAssesment(instituteDetails);
 
-    const steps = [
+    const examTypeLabel: Record<string, string> = {
+        EXAM: 'Examination',
+        MOCK: 'Mock Assessment',
+        PRACTICE: 'Practice Assessment',
+        SURVEY: 'Survey',
+        MANUAL_UPLOAD_EXAM: 'Manual Upload Exam',
+    };
+
+    const steps: StepDef[] = [
         {
             label: 'Basic Info',
+            description: 'Name, schedule, and settings',
             id: 'basic-info',
         },
         {
-            label: 'Add Question',
+            label: 'Add Questions',
+            description: 'Upload or create questions',
             id: 'add-question',
         },
         {
             label: 'Add Participants',
+            description: 'Choose who can take this',
             id: 'add-participants',
         },
         {
             label: 'Access Control',
+            description: 'Permissions for managing',
             id: 'access-control',
         },
     ];
@@ -147,6 +169,14 @@ const CreateAssessmentComponent = () => {
                     content={examtype === 'SURVEY' ? 'This page is for creating a survey for students via admin.' : 'This page is for creating an assessment for students via admin.'}
                 />
             </Helmet>
+            <div className="mb-4 flex items-center gap-2">
+                <span className="rounded-md bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700">
+                    {examTypeLabel[examtype] || examtype}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                    Step {currentStep + 1} of {steps.length}
+                </span>
+            </div>
             <MainStepComponent
                 currentStep={currentStep}
                 handleCompleteCurrentStep={completeCurrentStep}

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step1BasicInfo.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step1BasicInfo.tsx
@@ -343,6 +343,10 @@ const DurationDistributionField = ({ control, form }: any) => {
                                     control={control}
                                     required
                                 />
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    Choose whether time limits apply to the whole test, per
+                                    section, or per question.
+                                </p>
                             </FormControl>
                         </FormItem>
                     )}
@@ -668,6 +672,7 @@ const Step1BasicInfo: React.FC<StepContentProps> = ({
             submissionType: savedData?.submission_type || '',
             durationDistribution: savedData?.duration_distribution || '',
             evaluationType: savedData?.evaluation_type || '',
+            resultType: savedData?.result_type || 'MANUAL',
             switchSections: savedData?.can_switch_section,
             raiseReattemptRequest: savedData?.reattempt_consent,
             raiseTimeIncreaseRequest: savedData?.add_time_consent,
@@ -687,7 +692,13 @@ const Step1BasicInfo: React.FC<StepContentProps> = ({
         <FormProvider {...form}>
             <form>
                 <div className="m-0 flex items-center justify-between p-0">
-                    <h1>Basic Information</h1>
+                    <div>
+                        <h1>Basic Information</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            Configure the basic details for your assessment including name,
+                            schedule, evaluation method, and result release preferences.
+                        </p>
+                    </div>
                     <MyButton
                         type="button"
                         scale="large"
@@ -729,31 +740,18 @@ const Step1BasicInfo: React.FC<StepContentProps> = ({
                             />
                         </div>
 
-                        {getStepKey({
-                            assessmentDetails,
-                            currentStep,
-                            key: 'subject_selection',
-                        }) && (
-                            <SelectField
-                                label={getTerminology(ContentTerms.Subjects, SystemTerms.Subjects)}
-                                name="testCreation.subject"
-                                labelStyle="font-thin"
-                                options={SubjectFilterData.map((option, index) => ({
-                                    value: option.name,
-                                    label: convertCapitalToTitleCase(option.name),
-                                    _id: index,
-                                }))}
-                                control={form.control}
-                                className="mt-[8px] w-56 font-thin"
-                                required={
-                                    getStepKey({
-                                        assessmentDetails,
-                                        currentStep,
-                                        key: 'subject_selection',
-                                    }) === 'REQUIRED'
-                                }
-                            />
-                        )}
+                        <SelectField
+                            label={getTerminology(ContentTerms.Subjects, SystemTerms.Subjects)}
+                            name="testCreation.subject"
+                            labelStyle="font-thin"
+                            options={SubjectFilterData.map((option, index) => ({
+                                value: option.name,
+                                label: convertCapitalToTitleCase(option.name),
+                                _id: index,
+                            }))}
+                            control={form.control}
+                            className="mt-[8px] w-56 font-thin"
+                        />
                     </div>
                     <div className="flex flex-col gap-6" id="assessment-instructions">
                         <h1 className="-mb-5 font-thin">{examType === 'SURVEY' ? 'Survey Instructions' : 'Assessment Instructions'}</h1>
@@ -895,66 +893,77 @@ const Step1BasicInfo: React.FC<StepContentProps> = ({
                         />
                     )}
                     <div className="flex flex-col gap-6" id="evaluation-type">
-                        {getStepKey({
-                            assessmentDetails,
-                            currentStep,
-                            key: 'evaluation_type',
-                        }) && (
+                        <div>
                             <SelectField
-                                label="Evaluation Type"
-                                name="evaluationType"
-                                options={
-                                    assessmentDetails[
-                                        currentStep
-                                    ]?.field_options?.evaluation_type?.map(
-                                        (distribution: any, index: number) => ({
-                                            value: distribution.value,
-                                            label: distribution.value,
-                                            _id: index,
-                                        })
-                                    ) || [] // Fallback to an empty array if undefined
-                                }
+                                label="Result & Evaluation Type"
+                                name="resultType"
+                                options={[
+                                    {
+                                        value: 'AUTO_AFTER_SUBMISSION',
+                                        label: 'Auto - Result After Submission',
+                                        _id: 0,
+                                    },
+                                    {
+                                        value: 'AUTO_AFTER_ASSESSMENT_END',
+                                        label: 'Auto - Results After Exam Ends',
+                                        _id: 1,
+                                    },
+                                    {
+                                        value: 'MANUAL',
+                                        label: 'Manual',
+                                        _id: 2,
+                                    },
+                                ]}
                                 control={form.control}
-                                className="w-56 font-thin"
-                                required={
-                                    getStepKey({
-                                        assessmentDetails,
-                                        currentStep,
-                                        key: 'evaluation_type',
-                                    }) === 'REQUIRED'
-                                }
+                                className="w-64 font-thin"
+                                required
                             />
-                        )}
-                        {watch('evaluationType') === 'MANUAL' &&
+                            <p className="mt-1 text-xs text-muted-foreground">
+                                {watch('resultType') === 'AUTO_AFTER_SUBMISSION'
+                                    ? 'System grades automatically. Results visible right after student submits.'
+                                    : watch('resultType') === 'AUTO_AFTER_ASSESSMENT_END'
+                                      ? 'System grades automatically. Results visible only after the assessment end time.'
+                                      : watch('resultType') === 'MANUAL'
+                                        ? 'Teacher grades by hand. Results hidden until admin releases them.'
+                                        : 'Choose how this assessment is evaluated and when results are shown.'}
+                            </p>
+                        </div>
+                        {watch('resultType') === 'MANUAL' &&
                             getStepKey({
                                 assessmentDetails,
                                 currentStep,
                                 key: 'submission_type',
                             }) && (
-                                <SelectField
-                                    label="Submission Type"
-                                    name="submissionType"
-                                    options={
-                                        assessmentDetails[
-                                            currentStep
-                                        ]?.field_options?.submission_type?.map(
-                                            (distribution: any, index: number) => ({
-                                                value: distribution.value,
-                                                label: distribution.value,
-                                                _id: index,
-                                            })
-                                        ) || [] // Fallback to an empty array if undefined
-                                    }
-                                    control={form.control}
-                                    className="w-56 font-thin"
-                                    required={
-                                        getStepKey({
-                                            assessmentDetails,
-                                            currentStep,
-                                            key: 'submission_type',
-                                        }) === 'REQUIRED'
-                                    }
-                                />
+                                <div>
+                                    <SelectField
+                                        label="Submission Type"
+                                        name="submissionType"
+                                        options={
+                                            assessmentDetails[
+                                                currentStep
+                                            ]?.field_options?.submission_type?.map(
+                                                (distribution: any, index: number) => ({
+                                                    value: distribution.value,
+                                                    label: distribution.value,
+                                                    _id: index,
+                                                })
+                                            ) || []
+                                        }
+                                        control={form.control}
+                                        className="w-56 font-thin"
+                                        required={
+                                            getStepKey({
+                                                assessmentDetails,
+                                                currentStep,
+                                                key: 'submission_type',
+                                            }) === 'REQUIRED'
+                                        }
+                                    />
+                                    <p className="mt-1 text-xs text-muted-foreground">
+                                        How students submit their answers (e.g., file upload,
+                                        PDF).
+                                    </p>
+                                </div>
                             )}
                     </div>
 

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step2AddingQuestions.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step2AddingQuestions.tsx
@@ -348,7 +348,13 @@ const Step2AddingQuestions: React.FC<StepContentProps> = ({
                 {allSections.length > 0 && (
                     <>
                         <div className="m-0 flex items-center justify-between p-0">
-                            <h1>Add Questions</h1>
+                            <div>
+                                <h1>Add Questions</h1>
+                                <p className="mt-1 text-sm text-muted-foreground">
+                                    Add sections and questions to your assessment. You can
+                                    upload a question paper or create questions manually.
+                                </p>
+                            </div>
                             <MyButton
                                 type="button"
                                 scale="large"

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step2SectionInfo.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step2SectionInfo.tsx
@@ -43,6 +43,8 @@ import sectionDetailsSchema from '../../-utils/section-details-schema';
 import { useSavedAssessmentStore } from '../../-utils/global-states';
 import { Route } from '../..';
 import { useQuestionsForSection } from '../../-hooks/getQuestionsDataForSection';
+import { getSubjectNameById } from '@/routes/assessment/question-papers/-utils/helper';
+import { useBasicInfoStore } from '../../-utils/zustand-global-states/step1-basic-info';
 import { calculateAveragePenalty } from '@/routes/assessment/assessment-list/assessment-details/$assessmentId/$examType/$assesssmentType/$assessmentTab/-utils/helper';
 import Step2GenerateQuestionsFromAI from './-components/Step2GenerateQuestionsFromAI';
 import { CriteriaStatusBadge } from './-components/CriteriaStatusBadge';
@@ -217,6 +219,16 @@ export const Step2SectionInfo = ({
             type: examtype,
         })
     );
+
+    // Get subject name from Step 1 context (Zustand store or saved assessment details)
+    const basicInfoStore = useBasicInfoStore();
+    const defaultSubject =
+        basicInfoStore.testCreation?.subject ||
+        getSubjectNameById(
+            instituteDetails?.subjects || [],
+            assessmentDetails?.[0]?.saved_data?.subject_selection ?? ''
+        ) ||
+        '';
 
     const adaptiveMarking = useQuestionsForSection(
         assessmentId,
@@ -587,7 +599,7 @@ export const Step2SectionInfo = ({
                     id="upload-question-paper"
                 >
                     <h3>Upload Question Paper</h3>
-                    <AlertDialog
+                    {/* <AlertDialog
                         open={isUploadFromDeviceDialogOpen}
                         onOpenChange={setIsUploadFromDeviceDialogOpen}
                     >
@@ -620,9 +632,10 @@ export const Step2SectionInfo = ({
                                 currentQuestionIndex={currentQuestionIndex}
                                 setCurrentQuestionIndex={setCurrentQuestionIndex}
                                 examType={examtype}
+                                defaultSubject={defaultSubject}
                             />
                         </AlertDialogContent>
-                    </AlertDialog>
+                    </AlertDialog> */}
                     <AlertDialog
                         open={isManualQuestionPaperDialogOpen}
                         onOpenChange={setIsManualQuestionPaperDialogOpen}
@@ -656,6 +669,7 @@ export const Step2SectionInfo = ({
                                 currentQuestionIndex={currentQuestionIndex}
                                 setCurrentQuestionIndex={setCurrentQuestionIndex}
                                 examType={examtype}
+                                defaultSubject={defaultSubject}
                             />
                         </AlertDialogContent>
                     </AlertDialog>
@@ -1150,13 +1164,6 @@ export const Step2SectionInfo = ({
                             <FormItem className="flex w-1/2 items-center justify-between">
                                 <FormLabel className="font-normal">
                                     Problem Randomization
-                                    {getStepKey({
-                                        assessmentDetails,
-                                        currentStep,
-                                        key: 'problem_randomization',
-                                    }) === 'REQUIRED' && (
-                                        <span className="text-subtitle text-danger-600">*</span>
-                                    )}
                                 </FormLabel>
                                 <FormControl>
                                     <Switch

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step3AddingParticipants.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step3AddingParticipants.tsx
@@ -551,7 +551,13 @@ const Step3AddingParticipants: React.FC<StepContentProps> = ({
         <FormProvider {...form}>
             <form>
                 <div className="m-0 flex items-center justify-between p-0">
-                    <h1>Add Participants</h1>
+                    <div>
+                        <h1>Add Participants</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            Define who can participate in this assessment. Add students from
+                            batches, individually, or via open registration.
+                        </p>
+                    </div>
                     <MyButton
                         type="button"
                         scale="large"

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step4AccessControl.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step4AccessControl.tsx
@@ -323,7 +323,13 @@ const Step4AccessControl: React.FC<StepContentProps> = ({
         <FormProvider {...form}>
             <form>
                 <div className="m-0 flex items-center justify-between p-0">
-                    <h1>Access Control</h1>
+                    <div>
+                        <h1>Access Control</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            Control who can manage, view results, and evaluate this
+                            assessment.
+                        </p>
+                    </div>
                     <div className="flex items-center gap-6">
                         <MyButton
                             type="button"

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-services/assessment-services.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-services/assessment-services.ts
@@ -154,8 +154,9 @@ export const handlePostStep1Data = async (
         default_reattempt_count:
             type === 'MOCK' || type === 'PRACTICE' ? 100000 : data.reattemptCount,
         switch_sections: data.switchSections,
-        evaluation_type: data.evaluationType,
+        evaluation_type: data.resultType === 'MANUAL' ? 'MANUAL' : 'AUTO',
         submission_type: data.submissionType,
+        result_type: data.resultType,
         raise_reattempt_request: data.raiseReattemptRequest,
         raise_time_increase_request: data.raiseTimeIncreaseRequest,
     };

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/basic-info-form-schema.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/basic-info-form-schema.ts
@@ -41,6 +41,7 @@ export const BasicInfoFormSchema = z.object({
     submissionType: z.string(),
     durationDistribution: z.string(),
     evaluationType: z.string(),
+    resultType: z.string().default('MANUAL'),
     switchSections: z.boolean(),
     raiseReattemptRequest: z.boolean(),
     raiseTimeIncreaseRequest: z.boolean(),

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/helper.ts
@@ -291,7 +291,12 @@ export const convertToUTC = (dateString: string) => {
 export const formatDateTimeLocal = (dateString: string | undefined) => {
     if (!dateString) return ''; // Handle empty or undefined values
     const date = new Date(dateString);
-    return date.toISOString().slice(0, 16); // Extract `YYYY-MM-DDTHH:mm`
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
 };
 
 export const getTimeLimitString = (time: number, timeLimit: string[]) => {
@@ -324,6 +329,7 @@ export const syncStep1DataWithStore = (form: UseFormReturn<BasicSectionFormType>
         reattemptCount: getValues('reattemptCount'),
         durationDistribution: getValues('durationDistribution'),
         evaluationType: getValues('evaluationType'),
+        resultType: getValues('resultType'),
         switchSections: getValues('switchSections'),
         raiseReattemptRequest: getValues('raiseReattemptRequest'),
         raiseTimeIncreaseRequest: getValues('raiseTimeIncreaseRequest'),

--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/zustand-global-states/step1-basic-info.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-utils/zustand-global-states/step1-basic-info.ts
@@ -8,6 +8,7 @@ interface BasicInfoState {
     reattemptCount?: string;
     durationDistribution?: string;
     evaluationType?: string;
+    resultType?: string;
     raiseReattemptRequest?: boolean;
     raiseTimeIncreaseRequest?: boolean;
     status?: string;
@@ -33,6 +34,7 @@ const initialState: Omit<BasicInfoState, 'setBasicInfo' | 'getBasicInfo' | 'rese
     reattemptCount: undefined,
     durationDistribution: undefined,
     evaluationType: undefined,
+    resultType: undefined,
     raiseReattemptRequest: undefined,
     raiseTimeIncreaseRequest: undefined,
     status: undefined,

--- a/frontend-admin-dashboard/src/routes/assessment/index.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/index.tsx
@@ -86,6 +86,19 @@ function AssessmentPage() {
                         A set of questions for feedback or opinions, with no right or wrong answers.
                     </p>
                 </div>
+                <div
+                    onClick={() => handleRedirectRoute('MANUAL_UPLOAD_EXAM')}
+                    className="flex cursor-pointer flex-col items-center rounded-xl border bg-neutral-50 p-4 transition-all hover:border-primary-200 hover:shadow-md active:scale-[0.98] sm:p-6 md:p-8"
+                >
+                    <Examination className="size-16 sm:size-auto" />
+                    <h1 className="mt-2 text-lg font-semibold sm:text-[1.4rem]">
+                        Manual Upload Exam
+                    </h1>
+                    <p className="mt-1 text-center text-xs text-neutral-500 sm:text-sm">
+                        Students download the question paper, solve offline, and upload answer
+                        sheets. Teachers check and assign marks manually.
+                    </p>
+                </div>
             </div>
         </>
     );

--- a/frontend-admin-dashboard/src/routes/assessment/question-papers/-components/QuestionPaperUpload.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/question-papers/-components/QuestionPaperUpload.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { uploadQuestionPaperFormSchema } from '../-utils/upload-question-paper-form-schema';
 import { z } from 'zod';
 import { FormProvider, useForm, UseFormReturn } from 'react-hook-form';
@@ -51,6 +51,7 @@ interface QuestionPaperUploadProps {
     currentQuestionIndex: number;
     setCurrentQuestionIndex: Dispatch<SetStateAction<number>>;
     examType?: string;
+    defaultSubject?: string;
 }
 
 // Helper hook for form management
@@ -239,10 +240,11 @@ const FileUploadSection = ({
 };
 
 // Helper component for basic form fields
-const BasicFormFields = ({ form, YearClassFilterData, SubjectFilterData }: {
+const BasicFormFields = ({ form, YearClassFilterData, SubjectFilterData, defaultSubject }: {
     form: any;
     YearClassFilterData: any[];
     SubjectFilterData: any[];
+    defaultSubject?: string;
 }) => {
     const { getTerminology } = useNamingSettings();
 
@@ -255,30 +257,32 @@ const BasicFormFields = ({ form, YearClassFilterData, SubjectFilterData }: {
                                 placeholder="Enter Title"
                                 required
                             />
-                            <div className="flex items-center gap-4">
-                                <SelectField
-                                    label={getTerminology('Level', 'Year/Class')}
-                                    name="yearClass"
-                                    options={YearClassFilterData.map((option, index) => ({
-                                        value: option.name,
-                                        label: convertCapitalToTitleCase(option.name),
-                                        _id: index,
-                                    }))}
-                                    control={form.control}
-                                    className="!w-full"
-                                />
-                                <SelectField
-                                    label={getTerminology('Subject', 'Subject')}
-                                    name="subject"
-                                    options={SubjectFilterData.map((option, index) => ({
-                                        value: option.name,
-                                        label: convertCapitalToTitleCase(option.name),
-                                        _id: index,
-                                    }))}
-                                    control={form.control}
-                                    className="!w-full"
-                                />
-                            </div>
+                            {!defaultSubject && (
+                                <div className="flex items-center gap-4">
+                                    <SelectField
+                                        label={getTerminology('Level', 'Year/Class')}
+                                        name="yearClass"
+                                        options={YearClassFilterData.map((option, index) => ({
+                                            value: option.name,
+                                            label: convertCapitalToTitleCase(option.name),
+                                            _id: index,
+                                        }))}
+                                        control={form.control}
+                                        className="!w-full"
+                                    />
+                                    <SelectField
+                                        label={getTerminology('Subject', 'Subject')}
+                                        name="subject"
+                                        options={SubjectFilterData.map((option, index) => ({
+                                            value: option.name,
+                                            label: convertCapitalToTitleCase(option.name),
+                                            _id: index,
+                                        }))}
+                                        control={form.control}
+                                        className="!w-full"
+                                    />
+                                </div>
+                            )}
         </>
     );
 };
@@ -405,6 +409,7 @@ export const QuestionPaperUpload = ({
     currentQuestionIndex,
     setCurrentQuestionIndex,
     examType = 'EXAM',
+    defaultSubject,
 }: QuestionPaperUploadProps) => {
     const queryClient = useQueryClient();
     const { instituteDetails } = useInstituteDetailsStore();
@@ -414,6 +419,14 @@ export const QuestionPaperUpload = ({
 
     const form = useQuestionPaperForm(examType);
     const { getValues, setValue, watch } = form;
+
+    // Auto-fill subject from parent assessment context
+    useEffect(() => {
+        if (defaultSubject) {
+            setValue('subject', defaultSubject);
+        }
+    }, [defaultSubject, setValue]);
+
     const formValidation = useFormValidation(form);
 
     const questionPaperId = getValues('questionPaperId') || 'default';
@@ -675,6 +688,7 @@ export const QuestionPaperUpload = ({
                                 form={form}
                                 YearClassFilterData={YearClassFilterData}
                                 SubjectFilterData={SubjectFilterData}
+                                defaultSubject={defaultSubject}
                             />
 
                             <ActionButtons

--- a/frontend-admin-dashboard/src/routes/homework-creation/create-assessment/$assessmentId/$examtype/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/homework-creation/create-assessment/$assessmentId/$examtype/-utils/helper.ts
@@ -14,12 +14,12 @@ import { useTestAccessStore } from './zustand-global-states/step3-adding-partici
 import { useAccessControlStore } from './zustand-global-states/step4-access-control';
 import {
     AccessControlFormValues,
-    BasicSectionFormType,
     SectionFormType,
     TestAccessFormType,
 } from '@/types/assessments/assessment-steps';
 import { z } from 'zod';
 import sectionDetailsSchema from './section-details-schema';
+import { BasicInfoFormSchema as HomeworkBasicInfoFormSchema } from './basic-info-form-schema';
 import { convertCustomFields } from '../-services/assessment-services';
 import testAccessSchema from './add-participants-schema';
 import { CourseWithSessionsType } from '@/stores/study-library/use-study-library-store';
@@ -291,7 +291,12 @@ export const convertToUTC = (dateString: string) => {
 export const formatDateTimeLocal = (dateString: string | undefined) => {
     if (!dateString) return ''; // Handle empty or undefined values
     const date = new Date(dateString);
-    return date.toISOString().slice(0, 16); // Extract `YYYY-MM-DDTHH:mm`
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
 };
 
 export const getTimeLimitString = (time: number, timeLimit: string[]) => {
@@ -313,7 +318,9 @@ export function calculateTotalMarks(questions: AdaptiveMarkingQuestion[]) {
     return String(totalMarks);
 }
 
-export const syncStep1DataWithStore = (form: UseFormReturn<BasicSectionFormType>) => {
+export const syncStep1DataWithStore = (
+    form: UseFormReturn<z.infer<typeof HomeworkBasicInfoFormSchema>>
+) => {
     const setBasicInfo = useBasicInfoStore.getState().setBasicInfo;
     const { getValues } = form;
     const basicInfoData = {

--- a/frontend-learner-dashboard-app/src/routes/assessment/examination/-components/AssessmentCard.tsx
+++ b/frontend-learner-dashboard-app/src/routes/assessment/examination/-components/AssessmentCard.tsx
@@ -61,6 +61,8 @@ const getPlayModeStyles = (mode: string) => {
       return "bg-blue-100 text-blue-700 border-blue-200 hover:bg-blue-200/80";
     case "SURVEY":
       return "bg-rose-100 text-rose-700 border-rose-200 hover:bg-rose-200/80";
+    case "MANUAL_UPLOAD_EXAM":
+      return "bg-amber-100 text-amber-700 border-amber-200 hover:bg-amber-200/80";
     default:
       return "bg-muted text-muted-foreground border-border hover:bg-muted/80";
   }
@@ -70,6 +72,8 @@ const getCardBorderColor = (mode: string) => {
   switch (mode) {
     case "EXAM":
       return "border-l-green-500";
+    case "MANUAL_UPLOAD_EXAM":
+      return "border-l-amber-500";
     case "MOCK":
       return "border-l-purple-500";
     case "PRACTICE":
@@ -363,7 +367,9 @@ export const AssessmentCard = ({
           )}
 
           {assessmentType === assessmentTypes.PAST &&
-            (assessmentInfo.created_attempts ?? 0) > 0 && (
+            (assessmentInfo.created_attempts ?? 0) > 0 &&
+            (assessmentInfo.result_type !== 'MANUAL' ||
+              assessmentInfo.report_release_status === 'RELEASED') && (
               <>
                 <Button
                   variant="outline"
@@ -402,6 +408,18 @@ export const AssessmentCard = ({
                   Show AI Report
                 </Button>
               </>
+            )}
+          {assessmentType === assessmentTypes.PAST &&
+            (assessmentInfo.created_attempts ?? 0) > 0 &&
+            assessmentInfo.result_type === 'MANUAL' &&
+            assessmentInfo.report_release_status !== 'RELEASED' && (
+              <Button
+                variant="outline"
+                className="w-full sm:w-auto min-w-[140px] cursor-not-allowed text-muted-foreground"
+                disabled
+              >
+                Results Pending
+              </Button>
             )}
         </CardFooter>
       </Card>

--- a/frontend-learner-dashboard-app/src/routes/assessment/examination/-utils.ts/useFetchAssessment.ts
+++ b/frontend-learner-dashboard-app/src/routes/assessment/examination/-utils.ts/useFetchAssessment.ts
@@ -166,7 +166,23 @@ export const fetchPreviewData = async (
 
 
     const sessions = await getAllSessionListFromStorage();
-    const batchIds = sessions?.map((session) => session.id) || [];
+    const batchIds = sessions?.map((session) => session.id).filter(Boolean) || [];
+
+    // Build the resolved batch_ids list, filtering out any null/undefined values
+    const resolvedBatchIds: string[] = (
+      batch_id
+        ? [batch_id]
+        : batchIds.length > 0
+          ? batchIds
+          : [student_details.package_session_id]
+    ).filter((id): id is string => Boolean(id));
+
+    if (resolvedBatchIds.length === 0) {
+      toast.error(
+        "No enrolled batch found for this student. Please contact your institute."
+      );
+      return;
+    }
 
     const requestBody = {
       username: student_details.username,
@@ -178,11 +194,7 @@ export const fetchPreviewData = async (
       guardian_email: student_details.parents_email,
       guardian_mobile_number: student_details.parents_mobile_number,
       reattempt_count: 3,
-      batch_ids: batch_id
-        ? [batch_id]
-        : batchIds.length > 0
-          ? batchIds
-          : [student_details.package_session_id],
+      batch_ids: resolvedBatchIds,
       institute_id: institute_id,
       assessment_id: assessment_id,
     };
@@ -194,11 +206,7 @@ export const fetchPreviewData = async (
       requestBody,
       {
         params: {
-          batch_ids: batch_id
-            ? batch_id
-            : batchIds.length > 0
-              ? batchIds.join(",")
-              : student_details.package_session_id,
+          batch_ids: resolvedBatchIds.join(","),
           instituteId: institute_id,
           assessment_id: assessment_id,
         },

--- a/frontend-learner-dashboard-app/src/routes/register/-component/AssessmentClosedExpiredComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/register/-component/AssessmentClosedExpiredComponent.tsx
@@ -1,23 +1,27 @@
-import { Separator } from "@/components/ui/separator";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import {
-  CloseRegistrationMobile,
-  CloseRegistrationWeb,
-} from "@/svgs";
-import { InstituteBrandingComponent, type InstituteBranding } from "@/components/common/institute-branding";
+  InstituteBrandingComponent,
+  type InstituteBranding,
+} from "@/components/common/institute-branding";
 import { useInstituteDetails } from "../live-class/-hooks/useInstituteDetails";
+import { Clock, Lock, XCircle } from "lucide-react";
+import { motion } from "framer-motion";
 
 const AssessmentClosedExpiredComponent = ({
   isExpired,
   assessmentName,
   isPrivate = false,
+  externalBranding,
 }: {
   isExpired: boolean;
   assessmentName: string;
   isPrivate?: boolean;
+  externalBranding?: InstituteBranding | null;
 }) => {
   const { data: instituteDetails } = useInstituteDetails();
-  
-  const branding: InstituteBranding = {
+
+  const branding: InstituteBranding = externalBranding || {
     instituteId: instituteDetails?.id || null,
     instituteName: instituteDetails?.institute_name || null,
     instituteLogoFileId: instituteDetails?.institute_logo_file_id || null,
@@ -25,41 +29,122 @@ const AssessmentClosedExpiredComponent = ({
     homeIconClickRoute: instituteDetails?.homeIconClickRoute ?? null,
   };
 
+  const config = isPrivate
+    ? {
+        Icon: Lock,
+        iconBg: "bg-amber-50",
+        iconColor: "text-amber-500",
+        ringColor: "ring-amber-100",
+        badgeVariant: "secondary" as const,
+        badgeClass: "bg-amber-50 text-amber-700 border-amber-200",
+        badgeText: "Access Denied",
+        title: "Assessment Access Denied",
+        description: "You are not registered for this assessment.",
+      }
+    : isExpired
+      ? {
+          Icon: XCircle,
+          iconBg: "bg-red-50",
+          iconColor: "text-red-500",
+          ringColor: "ring-red-100",
+          badgeVariant: "destructive" as const,
+          badgeClass: "bg-red-50 text-red-700 border-red-200",
+          badgeText: "Expired",
+          title: "Assessment Expired",
+          description:
+            "This assessment is no longer available. The window for taking this test has closed.",
+        }
+      : {
+          Icon: Clock,
+          iconBg: "bg-orange-50",
+          iconColor: "text-orange-500",
+          ringColor: "ring-orange-100",
+          badgeVariant: "secondary" as const,
+          badgeClass: "bg-orange-50 text-orange-700 border-orange-200",
+          badgeText: "Closed",
+          title: "Registration Closed",
+          description:
+            "Registration for this assessment has closed. Please contact your institute for more information.",
+        };
+
+  const { Icon } = config;
+
   return (
-    <div className="flex flex-col w-screen h-screen items-center justify-center gap-2 p-10 bg-background">
-      <InstituteBrandingComponent branding={branding} size="large" showName={false} />
-      <h1 className="text-sm sm:text-lg text-center">{assessmentName}</h1>
-      <Separator className="mt-2" />
-      <div className="block sm:hidden">
-        <CloseRegistrationMobile />
-      </div>
-      <div className="hidden sm:block">
-        <CloseRegistrationWeb />
-      </div>
-      {!isPrivate ? (
-        <>
-          <h1 className="-mt-4 text-sm sm:text-lg text-center">
-            {isExpired ? "Assessment Expired" : "Registration Closed"}
-          </h1>
-          <h1 className="mt-4 text-sm sm:text-lg text-center">
-            {isExpired
-              ? "This assessment is no longer available. "
-              : "Registration for this assessment has closed."}
-          </h1>
-        </>
-      ) : (
-        <>
-          <h1 className="-mt-4 text-sm sm:text-lg text-center">
-            Assessment Access Denied
-          </h1>
-          <h1 className="mt-4 text-sm sm:text-lg text-center">
-            You are not registered for this assessment.
-          </h1>
-        </>
-      )}
-      <h1 className="text-primary-500 text-sm sm:text-lg text-center">
-        Stay tuned for upcoming opportunities!
-      </h1>
+    <div className="min-h-screen w-full flex items-center justify-center bg-gradient-to-br from-slate-50 via-white to-slate-100 p-4 sm:p-6">
+      <motion.div
+        initial={{ opacity: 0, y: 20, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.4, ease: "easeOut" }}
+        className="w-full max-w-md"
+      >
+        <Card className="border-0 shadow-xl shadow-slate-200/60 overflow-hidden">
+          {/* Header strip */}
+          <div className="h-1.5 bg-gradient-to-r from-orange-400 via-red-400 to-pink-400" />
+
+          <CardContent className="p-8 sm:p-10">
+            {/* Branding */}
+            <div className="flex flex-col items-center gap-3 mb-6">
+              <InstituteBrandingComponent
+                branding={branding}
+                size="medium"
+                showName={false}
+              />
+              {branding.instituteName && (
+                <p className="text-xs font-medium text-slate-500 uppercase tracking-wider">
+                  {branding.instituteName}
+                </p>
+              )}
+            </div>
+
+            {/* Icon */}
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: 0.2, type: "spring", stiffness: 200 }}
+              className="flex justify-center mb-6"
+            >
+              <div
+                className={`relative w-20 h-20 rounded-full ${config.iconBg} flex items-center justify-center ring-8 ${config.ringColor}`}
+              >
+                <Icon
+                  className={`w-10 h-10 ${config.iconColor}`}
+                  strokeWidth={2}
+                />
+              </div>
+            </motion.div>
+
+            {/* Status badge */}
+            <div className="flex justify-center mb-4">
+              <Badge
+                variant={config.badgeVariant}
+                className={`${config.badgeClass} font-medium px-3 py-1`}
+              >
+                {config.badgeText}
+              </Badge>
+            </div>
+
+            {/* Title & description */}
+            <div className="text-center space-y-3 mb-6">
+              <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">
+                {config.title}
+              </h1>
+              <p className="text-sm text-slate-600 leading-relaxed">
+                {config.description}
+              </p>
+            </div>
+
+            {/* Assessment name */}
+            <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-3">
+              <p className="text-[11px] font-medium text-slate-500 uppercase tracking-wider mb-1">
+                Assessment
+              </p>
+              <p className="text-sm font-medium text-slate-900 truncate">
+                {assessmentName}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
     </div>
   );
 };

--- a/frontend-learner-dashboard-app/src/routes/register/-component/AssessmentRegistrationForm.tsx
+++ b/frontend-learner-dashboard-app/src/routes/register/-component/AssessmentRegistrationForm.tsx
@@ -1,10 +1,11 @@
 import { MyButton } from "@/components/design-system/button";
 import { MyInput } from "@/components/design-system/input";
 import { FormControl, FormField, FormItem } from "@/components/ui/form";
-import { Separator } from "@/components/ui/separator";
+import { Card, CardContent } from "@/components/ui/card";
+import { CalendarDays } from "lucide-react";
 import { InstituteBrandingComponent, type InstituteBranding } from "@/components/common/institute-branding";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -44,6 +45,9 @@ import AssessmentRegistrationCompleted from "./AssessmentRegistrationCompleted";
 import { useNavigate } from "@tanstack/react-router";
 import PhoneInputField from "@/components/design-system/phone-input-field";
 import { useInstituteDetails } from "../live-class/-hooks/useInstituteDetails";
+import axios from "axios";
+import { BASE_URL } from "@/constants/urls";
+import { useTheme } from "@/providers/theme/theme-provider";
 
 const case1 = (serverTime: number, startDate: string) => {
     const registrationStartDate: number = new Date(
@@ -73,18 +77,42 @@ const AssessmentRegistrationForm = () => {
     const [isAlreadyLoggedIn, setIsAlreadyLoggedIn] = useState(false);
     const [userAlreadyRegistered, setUserAlreadyRegistered] = useState(false);
     const { code } = Route.useSearch();
-    const { data: instituteDetails } = useInstituteDetails();
-    
-    const branding: InstituteBranding = {
-        instituteId: instituteDetails?.id || null,
-        instituteName: instituteDetails?.institute_name || null,
-        instituteLogoFileId: instituteDetails?.institute_logo_file_id || null,
-        instituteThemeCode: null,
-        homeIconClickRoute: instituteDetails?.homeIconClickRoute ?? null
-    };
+    const { data: localInstituteDetails } = useInstituteDetails();
     const { data, isLoading } = useSuspenseQuery(
         getOpenTestRegistrationDetails(code)
     );
+
+    const { data: instituteBranding } = useQuery({
+        queryKey: ["instituteBranding", data?.institute_id],
+        queryFn: async () => {
+            const res = await axios.get(
+                `${BASE_URL}/admin-core-service/public/institute/v1/branding/${data.institute_id}`
+            );
+            return res.data as {
+                institute_id: string;
+                institute_name: string;
+                logo_file_id: string | null;
+                institute_theme_code: string | null;
+            };
+        },
+        enabled: !!data?.institute_id,
+    });
+
+    const { setPrimaryColor } = useTheme();
+
+    useEffect(() => {
+        if (instituteBranding?.institute_theme_code) {
+            setPrimaryColor(instituteBranding.institute_theme_code);
+        }
+    }, [instituteBranding?.institute_theme_code, setPrimaryColor]);
+
+    const branding: InstituteBranding = {
+        instituteId: instituteBranding?.institute_id || localInstituteDetails?.id || null,
+        instituteName: instituteBranding?.institute_name || localInstituteDetails?.institute_name || null,
+        instituteLogoFileId: instituteBranding?.logo_file_id || localInstituteDetails?.institute_logo_file_id || null,
+        instituteThemeCode: instituteBranding?.institute_theme_code || null,
+        homeIconClickRoute: localInstituteDetails?.homeIconClickRoute ?? null
+    };
 
     const serverTime = useRef(
         new Date(Date.parse(data.server_time_in_gmt)).getTime()
@@ -128,7 +156,7 @@ const AssessmentRegistrationForm = () => {
     const [timeLeft, setTimeLeft] = useState(
         calculateTimeLeft(
             serverTime.current,
-            convertToLocalDateTime(data.assessment_public_dto.bound_start_time)
+            data.assessment_public_dto.bound_start_time
         )
     );
 
@@ -136,9 +164,7 @@ const AssessmentRegistrationForm = () => {
         useState(
             calculateTimeLeft(
                 serverTime.current,
-                convertToLocalDateTime(
-                    data.assessment_public_dto.registration_open_date
-                )
+                data.assessment_public_dto.registration_open_date
             )
         );
 
@@ -146,9 +172,7 @@ const AssessmentRegistrationForm = () => {
         useState(
             calculateTimeLeft(
                 serverTime.current,
-                convertToLocalDateTime(
-                    data.assessment_public_dto.registration_close_date
-                )
+                data.assessment_public_dto.registration_close_date
             )
         );
 
@@ -335,9 +359,7 @@ const AssessmentRegistrationForm = () => {
             setTimeLeft(
                 calculateTimeLeft(
                     serverTime.current,
-                    convertToLocalDateTime(
-                        data.assessment_public_dto.bound_start_time
-                    )
+                    data.assessment_public_dto.bound_start_time
                 )
             );
         }, 1000);
@@ -350,9 +372,7 @@ const AssessmentRegistrationForm = () => {
             setTimeLeftForRegistrationCase1(
                 calculateTimeLeft(
                     serverTime.current,
-                    convertToLocalDateTime(
-                        data.assessment_public_dto.registration_open_date
-                    )
+                    data.assessment_public_dto.registration_open_date
                 )
             );
         }, 1000);
@@ -365,9 +385,7 @@ const AssessmentRegistrationForm = () => {
             setTimeLeftForRegistrationCase2(
                 calculateTimeLeft(
                     serverTime.current,
-                    convertToLocalDateTime(
-                        data.assessment_public_dto.registration_close_date
-                    )
+                    data.assessment_public_dto.registration_close_date
                 )
             );
         }, 1000);
@@ -419,6 +437,40 @@ const AssessmentRegistrationForm = () => {
 
     if (isLoading) return <DashboardLoader />;
 
+    // Only show "expired" page when the assessment itself is deleted or its end time has truly passed
+    const assessmentEndTime = new Date(
+        Date.parse(data.assessment_public_dto.bound_end_time)
+    ).getTime();
+    const isAssessmentTrulyOver =
+        !!data.assessment_public_dto.bound_end_time &&
+        serverTime.current > assessmentEndTime;
+
+    if (
+        data.assessment_public_dto.status === 'DELETED' ||
+        isAssessmentTrulyOver
+    )
+        return (
+            <AssessmentClosedExpiredComponent
+                isExpired={true}
+                assessmentName={data.assessment_public_dto.assessment_name}
+                externalBranding={branding}
+            />
+        );
+
+    // Registration window has closed but assessment is still live
+    if (
+        !data.can_register &&
+        data.error_message === 'Assessment is closed' &&
+        !isAssessmentTrulyOver
+    )
+        return (
+            <AssessmentClosedExpiredComponent
+                isExpired={false}
+                assessmentName={data.assessment_public_dto.assessment_name}
+                externalBranding={branding}
+            />
+        );
+
     if (
         userAlreadyRegistered &&
         case3Status &&
@@ -431,6 +483,7 @@ const AssessmentRegistrationForm = () => {
             <AssessmentClosedExpiredComponent
                 isExpired={false}
                 assessmentName={data.assessment_public_dto.assessment_name}
+                externalBranding={branding}
             />
         );
 
@@ -446,6 +499,7 @@ const AssessmentRegistrationForm = () => {
             <AssessmentClosedExpiredComponent
                 isExpired={true}
                 assessmentName={data.assessment_public_dto.assessment_name}
+                externalBranding={branding}
             />
         );
 
@@ -462,76 +516,187 @@ const AssessmentRegistrationForm = () => {
             />
         );
 
-    return (
-        <>
-            {case1Status && (
-                <div className="flex justify-center items-center w-full mt-4">
-                    <div className="flex flex-col w-full sm:w-3/4 items-center justify-center gap-6">
-                        <InstituteBrandingComponent branding={branding} size="large" showName={false} />
-                        <h1 className="-mt-12 text-md sm:text-xl whitespace-normal sm:whitespace-nowrap p-4 sm:p-0 text-center">
-                            {data?.assessment_public_dto?.assessment_name}
-                        </h1>
-                        <div className="flex items-center gap-4 text-sm flex-col ">
-                            <span>Registration goes live in</span>
-                            <span className="font-thin">
-                                {timeLeftForRegistrationCase1.hours} hrs :{" "}
-                                {timeLeftForRegistrationCase1.minutes} min :{" "}
-                                {timeLeftForRegistrationCase1.seconds} sec
-                            </span>
+    const renderAssessmentInfoPanel = (
+        showCountdown: boolean,
+        constrained: boolean = true
+    ) => (
+        <div
+            className={`w-full ${
+                constrained ? "max-w-2xl mx-auto px-4 py-6 sm:py-10" : "py-2"
+            }`}
+        >
+            {/* Branding header */}
+            <div className="flex flex-col items-center text-center mb-6">
+                <InstituteBrandingComponent
+                    branding={branding}
+                    size="large"
+                    showName={false}
+                />
+                {branding.instituteName && (
+                    <p className="text-xs font-medium text-slate-500 uppercase tracking-wider mt-1">
+                        {branding.instituteName}
+                    </p>
+                )}
+                <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 tracking-tight mt-3">
+                    {data?.assessment_public_dto?.assessment_name}
+                </h1>
+            </div>
+
+            {/* Countdown card */}
+            {showCountdown && (
+                <Card className="mb-6 border-0 shadow-md shadow-slate-200/60 overflow-hidden">
+                    <div className="h-1 bg-gradient-to-r from-primary-300 to-primary-500" />
+                    <CardContent className="p-6 text-center">
+                        <p className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-3">
+                            Registration Goes Live In
+                        </p>
+                        <div className="flex items-center justify-center gap-3">
+                            {[
+                                {
+                                    value: timeLeftForRegistrationCase1.hours,
+                                    label: "Hours",
+                                },
+                                {
+                                    value: timeLeftForRegistrationCase1.minutes,
+                                    label: "Minutes",
+                                },
+                                {
+                                    value: timeLeftForRegistrationCase1.seconds,
+                                    label: "Seconds",
+                                },
+                            ].map((unit, idx) => (
+                                <div
+                                    key={idx}
+                                    className="flex flex-col items-center"
+                                >
+                                    <div className="bg-slate-50 border border-slate-200 rounded-lg px-4 py-3 min-w-[64px]">
+                                        <span className="text-2xl sm:text-3xl font-bold text-slate-900 tabular-nums">
+                                            {String(unit.value).padStart(2, "0")}
+                                        </span>
+                                    </div>
+                                    <span className="text-[10px] font-medium text-slate-500 uppercase tracking-wider mt-1">
+                                        {unit.label}
+                                    </span>
+                                </div>
+                            ))}
                         </div>
-                        <Separator />
-                        <h1 className="text-sm font-thin">
-                            Important Dates - Mark Your Calendar!
-                        </h1>
-                        <div className="text-sm flex flex-col gap-4 px-4">
-                            <div className="flex flex-col">
-                                <h1>Registration Window:</h1>
-                                <span className="font-thin">
-                                    Opens:{" "}
-                                    {convertToLocalDateTime(
-                                        data.assessment_public_dto
-                                            .registration_open_date
-                                    )}
-                                </span>
-                                <span className="font-thin">
-                                    Closes:{" "}
-                                    {convertToLocalDateTime(
-                                        data.assessment_public_dto
-                                            .registration_close_date
-                                    )}
-                                </span>
-                            </div>
-                            <div className="flex flex-col">
-                                <h1>Assessment Live Dates</h1>
-                                <span className="font-thin">
-                                    Starts:{" "}
-                                    {convertToLocalDateTime(
-                                        data.assessment_public_dto
-                                            .bound_start_time
-                                    )}
-                                </span>
-                                <span className="font-thin">
-                                    Ends:{" "}
-                                    {convertToLocalDateTime(
-                                        data.assessment_public_dto
-                                            .bound_end_time
-                                    )}
-                                </span>
-                            </div>
-                            {data.assessment_public_dto.about.content && (
-                                <div className="flex flex-col">
-                                    <h1>About Assessment</h1>
-                                    <span className="font-thin">
-                                        {parseHtmlToString(
-                                            data.assessment_public_dto.about
-                                                .content
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* Important Dates */}
+            <Card className="mb-6 border-0 shadow-md shadow-slate-200/60">
+                <CardContent className="p-6">
+                    <div className="flex items-center gap-2 mb-4">
+                        <CalendarDays className="w-4 h-4 text-primary-500" />
+                        <h2 className="text-sm font-semibold text-slate-900 uppercase tracking-wider">
+                            Important Dates
+                        </h2>
+                    </div>
+                    <div className="grid sm:grid-cols-2 gap-4">
+                        <div className="bg-slate-50 rounded-lg p-4 border border-slate-100">
+                            <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                                Registration Window
+                            </p>
+                            <div className="space-y-1.5">
+                                <div className="flex items-start gap-1.5">
+                                    <span className="text-xs font-medium text-slate-600">
+                                        Opens:
+                                    </span>
+                                    <span className="text-xs text-slate-700">
+                                        {convertToLocalDateTime(
+                                            data.assessment_public_dto
+                                                .registration_open_date
                                         )}
                                     </span>
                                 </div>
-                            )}
+                                <div className="flex items-start gap-1.5">
+                                    <span className="text-xs font-medium text-slate-600">
+                                        Closes:
+                                    </span>
+                                    <span className="text-xs text-slate-700">
+                                        {convertToLocalDateTime(
+                                            data.assessment_public_dto
+                                                .registration_close_date
+                                        )}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="bg-slate-50 rounded-lg p-4 border border-slate-100">
+                            <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                                Assessment Window
+                            </p>
+                            <div className="space-y-1.5">
+                                <div className="flex items-start gap-1.5">
+                                    <span className="text-xs font-medium text-slate-600">
+                                        Starts:
+                                    </span>
+                                    <span className="text-xs text-slate-700">
+                                        {convertToLocalDateTime(
+                                            data.assessment_public_dto
+                                                .bound_start_time
+                                        )}
+                                    </span>
+                                </div>
+                                <div className="flex items-start gap-1.5">
+                                    <span className="text-xs font-medium text-slate-600">
+                                        Ends:
+                                    </span>
+                                    <span className="text-xs text-slate-700">
+                                        {convertToLocalDateTime(
+                                            data.assessment_public_dto
+                                                .bound_end_time
+                                        )}
+                                    </span>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </CardContent>
+            </Card>
+
+            {/* About */}
+            {data.assessment_public_dto.about?.content && (
+                <Card className="mb-6 border-0 shadow-md shadow-slate-200/60">
+                    <CardContent className="p-6">
+                        <h2 className="text-sm font-semibold text-slate-900 uppercase tracking-wider mb-3">
+                            About Assessment
+                        </h2>
+                        <p className="text-sm text-slate-700 leading-relaxed">
+                            {parseHtmlToString(
+                                data.assessment_public_dto.about.content
+                            )}
+                        </p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* Registration Instructions */}
+            {data.assessment_public_dto.registration_instructions?.content && (
+                <Card className="mb-6 border-0 shadow-md shadow-slate-200/60">
+                    <CardContent className="p-6">
+                        <h2 className="text-sm font-semibold text-slate-900 uppercase tracking-wider mb-3">
+                            Registration Instructions
+                        </h2>
+                        <div
+                            className="text-sm text-slate-700 leading-relaxed prose prose-sm max-w-none prose-img:rounded-lg prose-img:my-3"
+                            dangerouslySetInnerHTML={{
+                                __html: data.assessment_public_dto
+                                    .registration_instructions.content,
+                            }}
+                        />
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+
+    return (
+        <div className="bg-gradient-to-br from-slate-50 via-white to-slate-100">
+            {/* Always show assessment info panel as background when not in active case2 form view */}
+            {!(!userHasAttemptCount && case2Status) && (
+                <>{renderAssessmentInfoPanel(case1Status)}</>
             )}
             {(case2Status ||
                 case3Status ||
@@ -553,93 +718,29 @@ const AssessmentRegistrationForm = () => {
                 <div className="flex w-full items-center justify-center bg-background gap-8 flex-col sm:flex-row">
                     <div className="flex justify-center items-center w-full mt-4">
                         <div className="flex flex-col w-full sm:w-3/4 items-center justify-center gap-6">
-                            <InstituteBrandingComponent branding={branding} size="large" showName={false} />
-                            <h1 className="-mt-12 text-md sm:text-xl whitespace-normal sm:whitespace-nowrap p-4 sm:p-0 text-center">
-                                {data?.assessment_public_dto?.assessment_name}
-                            </h1>
-                            <div className="flex items-center gap-4 text-sm flex-col sm:flex-row">
-                                <MyButton
-                                    type="button"
-                                    buttonType="primary"
-                                    scale="large"
-                                    layoutVariant="default"
-                                    className="block sm:hidden"
-                                    onClick={scrollToForm}
-                                >
-                                    Register Now!
-                                </MyButton>
-                                {(timeLeftForRegistrationCase2.hours > 0 ||
-                                    timeLeftForRegistrationCase2.minutes > 0 ||
-                                    timeLeftForRegistrationCase2.seconds >
-                                        0) && (
-                                    <span className="font-thin">
-                                        {timeLeftForRegistrationCase2.hours} hrs
-                                        : {timeLeftForRegistrationCase2.minutes}{" "}
-                                        min :{" "}
-                                        {timeLeftForRegistrationCase2.seconds}{" "}
-                                        sec
-                                    </span>
-                                )}
-                            </div>
-                            <Separator />
-                            <h1 className="text-sm font-thin">
-                                Important Dates - Mark Your Calendar!
-                            </h1>
-                            <div className="text-sm flex flex-col gap-4 px-4">
-                                <div className="flex flex-col">
-                                    <h1>Registration Window:</h1>
-                                    <span className="font-thin">
-                                        Opens:{" "}
-                                        {convertToLocalDateTime(
-                                            data.assessment_public_dto
-                                                .registration_open_date
-                                        )}
-                                    </span>
-                                    <span className="font-thin">
-                                        Closes:{" "}
-                                        {convertToLocalDateTime(
-                                            data.assessment_public_dto
-                                                .registration_close_date
-                                        )}
-                                    </span>
+                            {renderAssessmentInfoPanel(false, true)}
+                            {(timeLeftForRegistrationCase2.hours > 0 ||
+                                timeLeftForRegistrationCase2.minutes > 0 ||
+                                timeLeftForRegistrationCase2.seconds > 0) && (
+                                <div className="block sm:hidden">
+                                    <MyButton
+                                        type="button"
+                                        buttonType="primary"
+                                        scale="large"
+                                        layoutVariant="default"
+                                        onClick={scrollToForm}
+                                    >
+                                        Register Now!
+                                    </MyButton>
                                 </div>
-                                <div className="flex flex-col">
-                                    <h1>Assessment Live Dates</h1>
-                                    <span className="font-thin">
-                                        Starts:{" "}
-                                        {convertToLocalDateTime(
-                                            data.assessment_public_dto
-                                                .bound_start_time
-                                        )}
-                                    </span>
-                                    <span className="font-thin">
-                                        Ends:{" "}
-                                        {convertToLocalDateTime(
-                                            data.assessment_public_dto
-                                                .bound_end_time
-                                        )}
-                                    </span>
-                                </div>
-                                {data.assessment_public_dto.about.content && (
-                                    <div className="flex flex-col">
-                                        <h1>About Assessment</h1>
-                                        <span className="font-thin">
-                                            {parseHtmlToString(
-                                                data.assessment_public_dto.about
-                                                    .content
-                                            )}
-                                        </span>
-                                    </div>
-                                )}
-                            </div>
+                            )}
                         </div>
                     </div>
-                    <Separator className="block sm:hidden mx-4" />
                     <div
                         className="flex justify-center items-center w-full"
                         ref={formRef}
                     >
-                        <div className="flex justify-center items-start w-full  sm:w-3/4 flex-col bg-white rounded-xl p-4 shadow-md mx-4 mb-4">
+                        <div className="flex justify-center items-start w-full sm:w-3/4 flex-col bg-white rounded-xl p-4 shadow-md mx-4 mb-4">
                             <h1>Assessment Registration Form</h1>
                             <span className="text-sm text-neutral-500">
                                 Register for the assessment by completing the
@@ -768,7 +869,7 @@ const AssessmentRegistrationForm = () => {
                     </div>
                 </div>
             )}
-        </>
+        </div>
     );
 };
 

--- a/frontend-learner-dashboard-app/src/types/assessment-open-registration.ts
+++ b/frontend-learner-dashboard-app/src/types/assessment-open-registration.ts
@@ -8,6 +8,8 @@ export interface AssessmentPublicDto {
   assessment_id: string;
   assessment_name: string;
   about: About;
+  instructions?: About | null;
+  registration_instructions?: About | null;
   play_mode: string;
   evaluation_type: string;
   submission_type: string;

--- a/frontend-learner-dashboard-app/src/types/assessment.ts
+++ b/frontend-learner-dashboard-app/src/types/assessment.ts
@@ -26,6 +26,8 @@ export type Assessment = {
   last_attempt_id: string | null;
   assessment_user_registration_id: string | null;
   can_switch_section: boolean;
+  result_type: string | null;
+  report_release_status: string | null;
   batch_id?: string;
   package_session_id?: string;
 };


### PR DESCRIPTION
## Summary of Changes

- Add ResultTypeEnum (AUTO/MANUAL release) and wire through entity, DTOs, learner list query, and Step1 wizard
- Add Manual Upload Exam assessment type across creation wizard
- Separate registration_instructions from assessment instructions
- Expose institute branding (logo + theme) on public registration page
- Modernize assessment expired/closed state UI
- Fix registration countdown timer and batch_ids [null] 510 error
- Hide report buttons until manual results released; show "Results Pending" badge on past assessments



## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update


## Checklist

- [X] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
