### PR TITLE
fix: change email domain from .io to .com for child email

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admission/service/AdmissionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admission/service/AdmissionService.java
@@ -555,7 +555,7 @@ public class AdmissionService {
                     ? request.getMobileNumber()
                     : "stud_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
             childRequest.setUsername(childUsername);
-            childRequest.setEmail("child_" + UUID.randomUUID().toString().substring(0, 8) + "@vacademy.io");
+            childRequest.setEmail("child_" + UUID.randomUUID().toString().substring(0, 8) + "@vacademy.com");
             childRequest.setRoles(java.util.List.of("STUDENT"));
             childRequest.setLinkedParentId(parentUser.getId());
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/applicant/service/ApplicantService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/applicant/service/ApplicantService.java
@@ -1369,7 +1369,7 @@ public class ApplicantService {
                                 .build();
 
                 // Generate dummy email for child if not provided
-                String dummyEmail = "child_" + System.currentTimeMillis() + "@vacademy.io";
+                String dummyEmail = "child_" + System.currentTimeMillis() + "@vacademy.com";
                 childDTO.setEmail(dummyEmail);
 
                 // Handle date of birth


### PR DESCRIPTION
## Summary of Changes

Fix wrong email domain used when auto-generating child (student) emails. The code was using `@vacademy.io` but our SES/email setup uses `@vacademy.com`, which caused the generated child email addresses to be invalid.

**Backend:**
- `AdmissionService.createChild`: changed generated child email from `child_<uuid>@vacademy.io` to `child_<uuid>@vacademy.com`
- `ApplicantService`: changed dummy child email fallback from `child_<ts>@vacademy.io` to `child_<ts>@vacademy.com`

**Frontend:**
- No frontend changes.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Created an applicant via the admission flow without supplying a child email — verified the generated child email ends in `@vacademy.com`.
- Created a child via the applicant flow without a child email — verified the dummy email ends in `@vacademy.com`.
- Verified parent–child linking (`linkedParentId`) still works end-to-end.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
