### PR TITLE
persist allowPhoneAuth in learner settings so phone OTP button renders

### DIFF
--- a/frontend-learner-dashboard-app/src/hooks/use-domain-routing.ts
+++ b/frontend-learner-dashboard-app/src/hooks/use-domain-routing.ts
@@ -138,6 +138,10 @@ export const useDomainRouting = () => {
           typeof data.allowUsernamePasswordAuth === "boolean"
             ? data.allowUsernamePasswordAuth
             : null,
+        allowPhoneAuth:
+          typeof data.allowPhoneAuth === "boolean"
+            ? data.allowPhoneAuth
+            : null,
         convertUsernamePasswordToLowercase:
           typeof data.convertUsernamePasswordToLowercase === "boolean"
             ? data.convertUsernamePasswordToLowercase


### PR DESCRIPTION
## Summary of Changes

The "use phone OTP instead" button on the login page was not showing on ReadOnRent (and any other institute with `allowPhoneAuth = true`). Root cause: the backend `/domain-routing/v1/resolve` endpoint correctly returned `allowPhoneAuth: true` as a JSON boolean, but the frontend hook `useDomainRouting` never copied this field into the `LEARNER_<instituteId>` Capacitor Preferences entry. The login form read `parsed?.allowPhoneAuth` from that cache, got `undefined`, and `undefined === true` evaluated to `false`, so the button was permanently hidden.

Fix: add `allowPhoneAuth` to the `learnerSettings` object that gets persisted to Preferences, using the same `typeof === "boolean" ? value : null` normalization pattern already used for the other auth flags.

**Backend:**
- No changes

**Frontend:**
- `frontend-learner-dashboard-app/src/hooks/use-domain-routing.ts`: include `allowPhoneAuth` when persisting learner settings to Capacitor Preferences

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Verified the `/resolve` response for readonrent.in returns `allowPhoneAuth: true`
- Loaded the login page on ReadOnRent and confirmed the "use phone OTP instead" toggle now renders
- Confirmed existing auth methods (Google, username/password, email OTP) still behave as before
- Confirmed institutes without `allowPhoneAuth` set continue to hide the phone button (null persists as null, falls through the `=== true` check)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
