### PR TITLE
show concession and penalty separately on fee receipt and pay-install…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/ReceiptDetailsDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/ReceiptDetailsDTO.java
@@ -27,6 +27,8 @@ public class ReceiptDetailsDTO {
     private List<ReceiptLineItemDTO> lineItems;
     private BigDecimal totalExpected;
     private BigDecimal totalPaid;
+    private BigDecimal totalConcession;
+    private BigDecimal totalPenalty;
     private BigDecimal balanceDue;
     private BigDecimal amountPaidNow;
 
@@ -43,5 +45,8 @@ public class ReceiptDetailsDTO {
         private BigDecimal amountPaid;
         private BigDecimal balance;
         private String status;
+        private String adjustmentType;
+        private BigDecimal adjustmentAmount;
+        private String adjustmentStatus;
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
@@ -102,6 +102,18 @@ public class FeeTrackingService {
                 return BigDecimal.ZERO;
         }
 
+        private BigDecimal computeConcession(StudentFeePayment bill) {
+                if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
+                if (!"CONCESSION".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
+                return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+        }
+
+        private BigDecimal computePenalty(StudentFeePayment bill) {
+                if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
+                if (!"PENALTY".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
+                return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+        }
+
         private StudentFeeAllocationLedgerDTO mapToLedgerDTO(StudentFeeAllocationLedger entity) {
                 return StudentFeeAllocationLedgerDTO.builder()
                                 .id(entity.getId())
@@ -596,12 +608,14 @@ public class FeeTrackingService {
             BigDecimal totalPaid,
             BigDecimal balanceDue,
             BigDecimal totalDiscount,
-            BigDecimal totalExpected
+            BigDecimal totalExpected,
+            BigDecimal totalConcession,
+            BigDecimal totalPenalty
     ) {}
 
     private InvoiceDataFields extractInvoiceDataFields(String json) {
         if (json == null || json.isBlank()) {
-            return new InvoiceDataFields(null, null, null, null, null, null);
+            return new InvoiceDataFields(null, null, null, null, null, null, null, null);
         }
 
         return new InvoiceDataFields(
@@ -610,7 +624,9 @@ public class FeeTrackingService {
                 extractDecimalField(json, "totalPaid"),
                 extractDecimalField(json, "balanceDue"),
                 extractDecimalField(json, "totalDiscount"),
-                extractDecimalField(json, "totalExpected")
+                extractDecimalField(json, "totalExpected"),
+                extractDecimalField(json, "totalConcession"),
+                extractDecimalField(json, "totalPenalty")
         );
     }
 
@@ -749,6 +765,8 @@ public class FeeTrackingService {
 
             // Build line item DTOs with fresh post-payment amounts
             List<ReceiptDetailsDTO.ReceiptLineItemDTO> lineDTOs = new ArrayList<>();
+            BigDecimal computedConcession = BigDecimal.ZERO;
+            BigDecimal computedPenalty = BigDecimal.ZERO;
             for (String sourceId : sourceIds) {
                 StudentFeePayment sfp = paymentMap.get(sourceId);
                 if (sfp == null) continue;
@@ -757,6 +775,14 @@ public class FeeTrackingService {
                 BigDecimal paid = sfp.getAmountPaid() != null ? sfp.getAmountPaid() : BigDecimal.ZERO;
                 BigDecimal adjustmentEffect = computeAdjustmentEffect(sfp);
                 BigDecimal balance = expected.add(adjustmentEffect).subtract(paid).max(BigDecimal.ZERO);
+                boolean approvedAdjustment = "APPROVED".equals(sfp.getAdjustmentStatus());
+                String adjustmentType = approvedAdjustment ? sfp.getAdjustmentType() : null;
+                BigDecimal adjustmentAmount = approvedAdjustment && sfp.getAdjustmentAmount() != null
+                        ? sfp.getAdjustmentAmount()
+                        : BigDecimal.ZERO;
+                String adjustmentStatus = approvedAdjustment ? sfp.getAdjustmentStatus() : null;
+                computedConcession = computedConcession.add(computeConcession(sfp));
+                computedPenalty = computedPenalty.add(computePenalty(sfp));
                 lineDTOs.add(ReceiptDetailsDTO.ReceiptLineItemDTO.builder()
                         .feeTypeName(meta != null ? meta.feeTypeName() : null)
                         .cpoName(meta != null ? meta.cpoName() : null)
@@ -765,6 +791,9 @@ public class FeeTrackingService {
                         .amountPaid(paid)
                         .balance(balance)
                         .status(sfp.getStatus())
+                        .adjustmentType(adjustmentType)
+                        .adjustmentAmount(adjustmentAmount)
+                        .adjustmentStatus(adjustmentStatus)
                         .build());
             }
 
@@ -774,6 +803,12 @@ public class FeeTrackingService {
                     Comparator.nullsLast(Comparator.naturalOrder())));
 
             InvoiceDataFields dataFields = extractInvoiceDataFields(invoice.getInvoiceDataJson());
+            BigDecimal totalConcession = dataFields.totalConcession() != null
+                    ? dataFields.totalConcession()
+                    : computedConcession;
+            BigDecimal totalPenalty = dataFields.totalPenalty() != null
+                    ? dataFields.totalPenalty()
+                    : computedPenalty;
 
             return ReceiptDetailsDTO.builder()
                     .invoiceId(invoice.getId())
@@ -784,6 +819,8 @@ public class FeeTrackingService {
                     .lineItems(lineDTOs)
                     .totalExpected(dataFields.totalExpected())
                     .totalPaid(dataFields.totalPaid())
+                    .totalConcession(totalConcession)
+                    .totalPenalty(totalPenalty)
                     .balanceDue(dataFields.balanceDue())
                     .amountPaidNow(dataFields.amountPaidNow())
                     .build();

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
@@ -71,6 +71,18 @@ public class SchoolFeeReceiptService {
         return BigDecimal.ZERO;
     }
 
+    private BigDecimal computeConcession(StudentFeePayment bill) {
+        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
+        if (!"CONCESSION".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
+        return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+    }
+
+    private BigDecimal computePenalty(StudentFeePayment bill) {
+        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
+        if (!"PENALTY".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
+        return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+    }
+
     private static final String SCHOOL_FEE_RECEIPT_TEMPLATE_TYPE = "SCHOOL_FEE_RECEIPT";
     private static final String RECEIPT_PREFIX = "RCT";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -169,15 +181,17 @@ public class SchoolFeeReceiptService {
             // 4. Build receipt data
             BigDecimal totalExpected = BigDecimal.ZERO;
             BigDecimal totalPaid = BigDecimal.ZERO;
-            BigDecimal totalDiscount = BigDecimal.ZERO;
+            BigDecimal totalConcession = BigDecimal.ZERO;
+            BigDecimal totalPenalty = BigDecimal.ZERO;
 
             for (StudentFeePayment fp : feePayments) {
                 totalExpected = totalExpected
                         .add(fp.getAmountExpected() != null ? fp.getAmountExpected() : BigDecimal.ZERO);
                 totalPaid = totalPaid.add(fp.getAmountPaid() != null ? fp.getAmountPaid() : BigDecimal.ZERO);
-                totalDiscount = totalDiscount.add(computeAdjustmentEffect(fp).negate());
+                totalConcession = totalConcession.add(computeConcession(fp));
+                totalPenalty = totalPenalty.add(computePenalty(fp));
             }
-            BigDecimal balanceDue = totalExpected.subtract(totalPaid).subtract(totalDiscount);
+            BigDecimal balanceDue = totalExpected.add(totalPenalty).subtract(totalConcession).subtract(totalPaid);
 
             // 5. Generate receipt number
             String receiptNumber = generateReceiptNumber(instituteId);
@@ -188,7 +202,7 @@ public class SchoolFeeReceiptService {
             // 7. Replace placeholders (includes fee table HTML)
             String filledTemplate = replacePlaceholders(templateHtml, user, institute, feePayments,
                     receiptNumber, amountPaid, transactionId, paymentMode,
-                    totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                    totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
             // 8. Generate PDF
             byte[] pdfBytes = generatePdfFromHtml(filledTemplate);
@@ -198,7 +212,7 @@ public class SchoolFeeReceiptService {
 
             // 10. Save to invoice table
             Invoice invoice = saveReceipt(userId, instituteId, receiptNumber, pdfFileId,
-                    amountPaid, totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                    amountPaid, totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
             // 11. Save line items (one per installment)
             saveLineItems(invoice, feePayments, currency);
@@ -278,15 +292,17 @@ public class SchoolFeeReceiptService {
             // 4. Build receipt data (only for paid installments)
             BigDecimal totalExpected = BigDecimal.ZERO;
             BigDecimal totalPaid = BigDecimal.ZERO;
-            BigDecimal totalDiscount = BigDecimal.ZERO;
+            BigDecimal totalConcession = BigDecimal.ZERO;
+            BigDecimal totalPenalty = BigDecimal.ZERO;
 
             for (StudentFeePayment fp : feePayments) {
                 totalExpected = totalExpected
                         .add(fp.getAmountExpected() != null ? fp.getAmountExpected() : BigDecimal.ZERO);
                 totalPaid = totalPaid.add(fp.getAmountPaid() != null ? fp.getAmountPaid() : BigDecimal.ZERO);
-                totalDiscount = totalDiscount.add(computeAdjustmentEffect(fp).negate());
+                totalConcession = totalConcession.add(computeConcession(fp));
+                totalPenalty = totalPenalty.add(computePenalty(fp));
             }
-            BigDecimal balanceDue = totalExpected.subtract(totalPaid).subtract(totalDiscount);
+            BigDecimal balanceDue = totalExpected.add(totalPenalty).subtract(totalConcession).subtract(totalPaid);
 
             // 5. Generate receipt number
             String receiptNumber = generateReceiptNumber(instituteId);
@@ -297,7 +313,7 @@ public class SchoolFeeReceiptService {
             // 7. Replace placeholders (includes fee table HTML)
             String filledTemplate = replacePlaceholders(templateHtml, user, institute, feePayments,
                     receiptNumber, amountPaid, transactionId, paymentMode,
-                    totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                    totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
             // 8. Generate PDF
             byte[] pdfBytes = generatePdfFromHtml(filledTemplate);
@@ -307,7 +323,7 @@ public class SchoolFeeReceiptService {
 
             // 10. Save to invoice table
             Invoice invoice = saveReceipt(userId, instituteId, receiptNumber, pdfFileId,
-                    amountPaid, totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                    amountPaid, totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
             // 11. Save line items (only for paid installments)
             saveLineItems(invoice, feePayments, currency);
@@ -366,29 +382,31 @@ public class SchoolFeeReceiptService {
 
         BigDecimal totalExpected = BigDecimal.ZERO;
         BigDecimal totalPaid = BigDecimal.ZERO;
-        BigDecimal totalDiscount = BigDecimal.ZERO;
+        BigDecimal totalConcession = BigDecimal.ZERO;
+        BigDecimal totalPenalty = BigDecimal.ZERO;
 
         for (StudentFeePayment fp : feePayments) {
             totalExpected = totalExpected
                     .add(fp.getAmountExpected() != null ? fp.getAmountExpected() : BigDecimal.ZERO);
             totalPaid = totalPaid.add(fp.getAmountPaid() != null ? fp.getAmountPaid() : BigDecimal.ZERO);
-            totalDiscount = totalDiscount.add(computeAdjustmentEffect(fp).negate());
+            totalConcession = totalConcession.add(computeConcession(fp));
+            totalPenalty = totalPenalty.add(computePenalty(fp));
         }
-        BigDecimal balanceDue = totalExpected.subtract(totalPaid).subtract(totalDiscount);
+        BigDecimal balanceDue = totalExpected.add(totalPenalty).subtract(totalConcession).subtract(totalPaid);
 
         String receiptNumber = generateReceiptNumber(instituteId);
         String templateHtml = loadSchoolFeeReceiptTemplate(instituteId);
 
         String filledTemplate = replacePlaceholders(templateHtml, user, institute, feePayments,
                 receiptNumber, totalPaid, receiptNumber, "STATEMENT",
-                totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
         byte[] pdfBytes = generatePdfFromHtml(filledTemplate);
         String pdfFileId = uploadReceiptToS3(pdfBytes, receiptNumber, instituteId);
 
         // Save invoice record
         saveReceipt(userId, instituteId, receiptNumber, pdfFileId,
-                totalPaid, totalExpected, totalPaid, totalDiscount, balanceDue, currency);
+                totalPaid, totalExpected, totalPaid, totalConcession, totalPenalty, balanceDue, currency);
 
         return pdfFileId;
     }
@@ -553,14 +571,18 @@ public class SchoolFeeReceiptService {
                         </div>
                         <div class="totals-row" style="{{TOTAL_CONCESSION_ROW_STYLE}}">
                             <span class="totals-label">Concession:</span>
-                            <span class="totals-value">- {{currency_symbol}} {{total_discount}}</span>
+                            <span class="totals-value">- {{currency_symbol}} {{total_concession}}</span>
+                        </div>
+                        <div class="totals-row" style="{{TOTAL_PENALTY_ROW_STYLE}}">
+                            <span class="totals-label">Penalty:</span>
+                            <span class="totals-value">+ {{currency_symbol}} {{total_penalty}}</span>
                         </div>
                         <div class="totals-row">
                             <span class="totals-label">Total Paid:</span>
                             <span class="totals-value">{{currency_symbol}} {{total_paid}}</span>
                         </div>
                         <div class="totals-row grand-total">
-                            <span class="totals-label">Balance Due:</span>
+                            <span class="totals-label">Outstanding:</span>
                             <span class="totals-value">{{currency_symbol}} {{balance_due}}</span>
                         </div>
                     </div>
@@ -585,7 +607,8 @@ public class SchoolFeeReceiptService {
     private String replacePlaceholders(String template, UserDTO user, Institute institute,
             List<StudentFeePayment> feePayments, String receiptNumber,
             BigDecimal amountPaid, String transactionId, String paymentMode,
-            BigDecimal totalExpected, BigDecimal totalPaid, BigDecimal totalDiscount,
+            BigDecimal totalExpected, BigDecimal totalPaid,
+            BigDecimal totalConcession, BigDecimal totalPenalty,
             BigDecimal balanceDue, String currency) {
 
         String currencySymbol = getCurrencySymbol(currency);
@@ -595,8 +618,10 @@ public class SchoolFeeReceiptService {
         String instituteAddress = buildInstituteAddress(institute);
         String logoHtml = buildInstituteLogoHtml(institute);
         String logoUrl = buildInstituteLogoUrl(institute);
-        boolean showConcession = totalDiscount != null && totalDiscount.signum() > 0;
-        String feeTableHtml = buildFeeTableHtml(feePayments, currency, showConcession);
+        boolean showConcession = totalConcession != null && totalConcession.signum() > 0;
+        boolean showPenalty = totalPenalty != null && totalPenalty.signum() > 0;
+        boolean showAdjustmentColumn = showConcession || showPenalty;
+        String feeTableHtml = buildFeeTableHtml(feePayments, currency, showAdjustmentColumn);
         ReceiptEnrichment enrichment = enrichReceiptFromEnrollment(user.getId(), institute.getId());
         String safeTransactionId = transactionId != null ? transactionId : "N/A";
         String safePaymentMode = paymentMode != null ? paymentMode : "OFFLINE";
@@ -619,7 +644,9 @@ public class SchoolFeeReceiptService {
                 .replace("{{fee_table}}", feeTableHtml)
                 .replace("{{total_expected}}", totalExpected.toPlainString())
                 .replace("{{total_paid}}", totalPaid.toPlainString())
-                .replace("{{total_discount}}", totalDiscount.toPlainString())
+                .replace("{{total_concession}}", totalConcession.toPlainString())
+                .replace("{{total_penalty}}", totalPenalty.toPlainString())
+                .replace("{{total_discount}}", totalConcession.toPlainString())
                 .replace("{{balance_due}}", balanceDue.toPlainString())
                 .replace("{{amount_paid_now}}", amountPaid.toPlainString())
                 .replace("{{transaction_id}}", safeTransactionId)
@@ -647,10 +674,14 @@ public class SchoolFeeReceiptService {
                 .replace("{{REMARKS}}", "Paid")
                 .replace("{{FEE_TABLE}}", feeTableHtml)
                 .replace("{{TOTAL_EXPECTED_FEE}}", currencySymbol + " " + totalExpected.toPlainString())
-                .replace("{{TOTAL_DISCOUNT}}", currencySymbol + " " + totalDiscount.toPlainString())
+                .replace("{{TOTAL_CONCESSION}}", currencySymbol + " " + totalConcession.toPlainString())
+                .replace("{{TOTAL_PENALTY}}", currencySymbol + " " + totalPenalty.toPlainString())
+                .replace("{{TOTAL_DISCOUNT}}", currencySymbol + " " + totalConcession.toPlainString())
                 .replace("{{TOTAL_CONCESSION_ROW_STYLE}}", showConcession ? "" : "display: none;")
+                .replace("{{TOTAL_PENALTY_ROW_STYLE}}", showPenalty ? "" : "display: none;")
                 .replace("{{TOTAL_PAID_ALL_TIME}}", currencySymbol + " " + totalPaid.toPlainString())
                 .replace("{{CURRENT_BALANCE_DUE}}", currencySymbol + " " + balanceDue.toPlainString())
+                .replace("{{OUTSTANDING}}", currencySymbol + " " + balanceDue.toPlainString())
                 .replace("{{AMOUNT_PAID_NOW}}", currencySymbol + " " + amountPaid.toPlainString());
 
         return applyIndexedFeeRowPlaceholders(replaced, feePayments, currencySymbol);
@@ -812,10 +843,20 @@ public class SchoolFeeReceiptService {
             BigDecimal paid = fp.getAmountPaid() != null ? fp.getAmountPaid() : BigDecimal.ZERO;
             BigDecimal adjustmentEffect = computeAdjustmentEffect(fp);
             BigDecimal balance = expected.add(adjustmentEffect).subtract(paid);
-            // For template display: show concession as positive amount
-            BigDecimal discount = "APPROVED".equals(fp.getAdjustmentStatus()) && "CONCESSION".equals(fp.getAdjustmentType())
-                    ? (fp.getAdjustmentAmount() != null ? fp.getAdjustmentAmount() : BigDecimal.ZERO)
-                    : BigDecimal.ZERO;
+            BigDecimal concession = computeConcession(fp);
+            BigDecimal penalty = computePenalty(fp);
+            String adjustmentDisplay;
+            String adjustmentTypeLabel;
+            if (concession.signum() > 0) {
+                adjustmentDisplay = "- " + currencySymbol + " " + concession.toPlainString() + " (Concession)";
+                adjustmentTypeLabel = "Concession";
+            } else if (penalty.signum() > 0) {
+                adjustmentDisplay = "+ " + currencySymbol + " " + penalty.toPlainString() + " (Penalty)";
+                adjustmentTypeLabel = "Penalty";
+            } else {
+                adjustmentDisplay = "";
+                adjustmentTypeLabel = "";
+            }
             String status = fp.getStatus() != null ? fp.getStatus() : "PENDING";
             String statusLabel = status.replace("_", " ");
             String statusClass = switch (status) {
@@ -833,10 +874,14 @@ public class SchoolFeeReceiptService {
                     .replace("{{FEE_TYPE_" + index + "}}", feeType)
                     .replace("{{FEE_DUE_DATE_" + index + "}}", dueDate)
                     .replace("{{FEE_AMOUNT_EXPECTED_" + index + "}}", currencySymbol + " " + expected.toPlainString())
-                    .replace("{{FEE_DISCOUNT_" + index + "}}", currencySymbol + " " + discount.toPlainString())
-                    .replace("{{FEE_CONCESSION_" + index + "}}", currencySymbol + " " + discount.toPlainString())
+                    .replace("{{FEE_DISCOUNT_" + index + "}}", currencySymbol + " " + concession.toPlainString())
+                    .replace("{{FEE_CONCESSION_" + index + "}}", currencySymbol + " " + concession.toPlainString())
+                    .replace("{{FEE_PENALTY_" + index + "}}", currencySymbol + " " + penalty.toPlainString())
+                    .replace("{{FEE_ADJUSTMENT_" + index + "}}", adjustmentDisplay)
+                    .replace("{{FEE_ADJUSTMENT_TYPE_" + index + "}}", adjustmentTypeLabel)
                     .replace("{{FEE_AMOUNT_PAID_" + index + "}}", currencySymbol + " " + paid.toPlainString())
                     .replace("{{FEE_BALANCE_" + index + "}}", currencySymbol + " " + balance.toPlainString())
+                    .replace("{{FEE_OUTSTANDING_" + index + "}}", currencySymbol + " " + balance.toPlainString())
                     .replace("{{FEE_STATUS_CLASS_" + index + "}}", statusClass)
                     .replace("{{FEE_STATUS_LABEL_" + index + "}}", statusLabel);
             index++;
@@ -865,10 +910,10 @@ public class SchoolFeeReceiptService {
     // ─── Fee Table HTML ──────────────────────────────────────────────────────
 
     /**
-     * @param showConcessionColumn when false, no concession column is rendered (all amounts are zero).
+     * @param showAdjustmentColumn when false, no adjustment column is rendered (no approved concession or penalty exists).
      */
     private String buildFeeTableHtml(List<StudentFeePayment> feePayments, String currency,
-            boolean showConcessionColumn) {
+            boolean showAdjustmentColumn) {
         String currencySymbol = getCurrencySymbol(currency);
         StringBuilder sb = new StringBuilder();
         sb.append("<table>");
@@ -877,11 +922,11 @@ public class SchoolFeeReceiptService {
                 .append("<th>Fee Type</th>")
                 .append("<th>Due Date</th>")
                 .append("<th>Amount Expected</th>");
-        if (showConcessionColumn) {
-            sb.append("<th>Concession</th>");
+        if (showAdjustmentColumn) {
+            sb.append("<th>Adjustment</th>");
         }
         sb.append("<th>Amount Paid</th>")
-                .append("<th>Balance</th>")
+                .append("<th>Outstanding</th>")
                 .append("<th>Status</th>")
                 .append("</tr>");
 
@@ -891,9 +936,18 @@ public class SchoolFeeReceiptService {
             BigDecimal paid = fp.getAmountPaid() != null ? fp.getAmountPaid() : BigDecimal.ZERO;
             BigDecimal adjustmentEffect = computeAdjustmentEffect(fp);
             BigDecimal balance = expected.add(adjustmentEffect).subtract(paid);
-            BigDecimal discount = "APPROVED".equals(fp.getAdjustmentStatus()) && "CONCESSION".equals(fp.getAdjustmentType())
-                    ? (fp.getAdjustmentAmount() != null ? fp.getAdjustmentAmount() : BigDecimal.ZERO)
-                    : BigDecimal.ZERO;
+            BigDecimal concession = computeConcession(fp);
+            BigDecimal penalty = computePenalty(fp);
+            String adjustmentCell;
+            if (concession.signum() > 0) {
+                adjustmentCell = "<span style=\"color:#047857;\">- " + currencySymbol + " "
+                        + concession.toPlainString() + " (Concession)</span>";
+            } else if (penalty.signum() > 0) {
+                adjustmentCell = "<span style=\"color:#b91c1c;\">+ " + currencySymbol + " "
+                        + penalty.toPlainString() + " (Penalty)</span>";
+            } else {
+                adjustmentCell = "-";
+            }
             String status = fp.getStatus() != null ? fp.getStatus() : "PENDING";
             String dueDate = fp.getDueDate() != null
                     ? new java.text.SimpleDateFormat("dd MMM yyyy").format(fp.getDueDate())
@@ -919,8 +973,8 @@ public class SchoolFeeReceiptService {
                     .append("<td>").append(feeTypeName).append("</td>")
                     .append("<td>").append(dueDate).append("</td>")
                     .append("<td>").append(currencySymbol).append(" ").append(expected.toPlainString()).append("</td>");
-            if (showConcessionColumn) {
-                sb.append("<td>").append(currencySymbol).append(" ").append(discount.toPlainString()).append("</td>");
+            if (showAdjustmentColumn) {
+                sb.append("<td>").append(adjustmentCell).append("</td>");
             }
             sb.append("<td>").append(currencySymbol).append(" ").append(paid.toPlainString()).append("</td>")
                     .append("<td>").append(currencySymbol).append(" ").append(balance.toPlainString()).append("</td>")
@@ -1015,7 +1069,8 @@ public class SchoolFeeReceiptService {
     private Invoice saveReceipt(String userId, String instituteId, String receiptNumber,
             String pdfFileId, BigDecimal amountPaid,
             BigDecimal totalExpected, BigDecimal totalPaid,
-            BigDecimal totalDiscount, BigDecimal balanceDue, String currency) {
+            BigDecimal totalConcession, BigDecimal totalPenalty,
+            BigDecimal balanceDue, String currency) {
         Invoice invoice = new Invoice();
         invoice.setInvoiceNumber(receiptNumber);
         invoice.setUserId(userId);
@@ -1023,7 +1078,7 @@ public class SchoolFeeReceiptService {
         invoice.setInvoiceDate(LocalDateTime.now());
         invoice.setDueDate(LocalDateTime.now());
         invoice.setSubtotal(totalExpected);
-        invoice.setDiscountAmount(totalDiscount);
+        invoice.setDiscountAmount(totalConcession);
         invoice.setTaxAmount(BigDecimal.ZERO);
         invoice.setTotalAmount(amountPaid);
         invoice.setCurrency(currency);
@@ -1037,7 +1092,8 @@ public class SchoolFeeReceiptService {
             receiptData.put("type", "SCHOOL_FEE_RECEIPT");
             receiptData.put("totalExpected", totalExpected);
             receiptData.put("totalPaid", totalPaid);
-            receiptData.put("totalDiscount", totalDiscount);
+            receiptData.put("totalConcession", totalConcession);
+            receiptData.put("totalPenalty", totalPenalty);
             receiptData.put("balanceDue", balanceDue);
             receiptData.put("amountPaidNow", amountPaid);
             ObjectMapper objectMapper = new ObjectMapper();

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentDetailsStep.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { StudentFeePaymentRowDTO, StudentFeeDueDTO } from '@/types/manage-finances';
 import { allocateSelectedPayment, AllocatePaymentResponse, getStudentDuesQueryKey } from '@/services/manage-finances';
 import { getInstituteId } from '@/constants/helper';
+import { cn } from '@/lib/utils';
 import { ConfirmPaymentDialog } from './ConfirmPaymentDialog';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -53,6 +54,20 @@ export function PaymentDetailsStep({
         () => selectedDues.reduce((sum, d) => sum + d.amount_due, 0),
         [selectedDues]
     );
+
+    const { totalConcession, totalPenalty, showAdjustmentColumn } = useMemo(() => {
+        let concession = 0;
+        let penalty = 0;
+        let hasAdjustment = false;
+        for (const d of selectedDues) {
+            if (d.adjustment_status === 'APPROVED') {
+                hasAdjustment = true;
+                if (d.adjustment_type === 'CONCESSION') concession += d.adjustment_amount || 0;
+                else if (d.adjustment_type === 'PENALTY') penalty += d.adjustment_amount || 0;
+            }
+        }
+        return { totalConcession: concession, totalPenalty: penalty, showAdjustmentColumn: hasAdjustment };
+    }, [selectedDues]);
 
     const handleAmountChange = (value: string) => {
         if (value === '' || /^\d*\.?\d*$/.test(value)) {
@@ -142,11 +157,16 @@ export function PaymentDetailsStep({
                                     <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">
                                         Expected
                                     </th>
+                                    {showAdjustmentColumn && (
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">
+                                            Adjustment
+                                        </th>
+                                    )}
                                     <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">
                                         Paid
                                     </th>
                                     <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">
-                                        Due
+                                        Outstanding
                                     </th>
                                     <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
                                         Due Date
@@ -157,7 +177,11 @@ export function PaymentDetailsStep({
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-gray-100 text-sm font-medium">
-                                {selectedDues.map((inst) => (
+                                {selectedDues.map((inst) => {
+                                    const approvedAdj = inst.adjustment_status === 'APPROVED';
+                                    const isConcession = approvedAdj && inst.adjustment_type === 'CONCESSION';
+                                    const isPenalty = approvedAdj && inst.adjustment_type === 'PENALTY';
+                                    return (
                                     <tr key={inst.id} className="hover:bg-gray-50/40">
                                         <td className="py-2.5 px-4 text-gray-800 font-semibold">
                                             {inst.fee_type_name}
@@ -168,6 +192,21 @@ export function PaymentDetailsStep({
                                         <td className="py-2.5 px-4 text-gray-700 text-right">
                                             {formatCurrency(inst.amount_expected)}
                                         </td>
+                                        {showAdjustmentColumn && (
+                                            <td className="py-2.5 px-4 text-right">
+                                                {isConcession ? (
+                                                    <span className={cn('text-xs font-semibold text-emerald-600')}>
+                                                        - {formatCurrency(inst.adjustment_amount || 0)} <span className="font-normal">(Concession)</span>
+                                                    </span>
+                                                ) : isPenalty ? (
+                                                    <span className={cn('text-xs font-semibold text-red-600')}>
+                                                        + {formatCurrency(inst.adjustment_amount || 0)} <span className="font-normal">(Penalty)</span>
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-gray-400">{'\u2014'}</span>
+                                                )}
+                                            </td>
+                                        )}
                                         <td className="py-2.5 px-4 text-emerald-700 font-semibold text-right">
                                             {formatCurrency(inst.amount_paid)}
                                         </td>
@@ -193,15 +232,38 @@ export function PaymentDetailsStep({
                                             )}
                                         </td>
                                     </tr>
-                                ))}
+                                    );
+                                })}
                             </tbody>
                             <tfoot>
+                                {showAdjustmentColumn && totalConcession > 0 && (
+                                    <tr className="bg-gray-50/40">
+                                        <td colSpan={3} className="py-1.5 px-4 text-xs font-semibold text-gray-500 text-right uppercase tracking-wide">
+                                            Total Concession
+                                        </td>
+                                        <td className="py-1.5 px-4 text-sm font-semibold text-emerald-600 text-right">
+                                            - {formatCurrency(totalConcession)}
+                                        </td>
+                                        <td colSpan={4} />
+                                    </tr>
+                                )}
+                                {showAdjustmentColumn && totalPenalty > 0 && (
+                                    <tr className="bg-gray-50/40">
+                                        <td colSpan={3} className="py-1.5 px-4 text-xs font-semibold text-gray-500 text-right uppercase tracking-wide">
+                                            Total Penalty
+                                        </td>
+                                        <td className="py-1.5 px-4 text-sm font-semibold text-red-600 text-right">
+                                            + {formatCurrency(totalPenalty)}
+                                        </td>
+                                        <td colSpan={4} />
+                                    </tr>
+                                )}
                                 <tr className="border-t-2 border-gray-200 bg-gray-50/60">
                                     <td
-                                        colSpan={4}
+                                        colSpan={showAdjustmentColumn ? 5 : 4}
                                         className="py-3 px-4 text-sm font-bold text-gray-700 text-right"
                                     >
-                                        Total Due:
+                                        Total Outstanding:
                                     </td>
                                     <td className="py-3 px-4 text-base font-extrabold text-red-600 text-right">
                                         {formatCurrency(totalDue)}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/PaymentSuccessStep.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, DownloadSimple } from '@phosphor-icons/react';
 import dayjs from 'dayjs';
 import { AllocatePaymentResponse, ReceiptLineItem } from '@/services/manage-finances';
 import { useTheme } from '@/providers/theme/theme-provider';
+import { cn } from '@/lib/utils';
 
 const formatCurrency = (amount: number) =>
     new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
@@ -22,6 +23,11 @@ interface PaymentSuccessStepProps {
 export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: PaymentSuccessStepProps) {
     const { getPrimaryColorCode } = useTheme();
     const hasReceipt = receipt && receipt.invoice_id;
+    const totalConcession = receipt?.total_concession ?? 0;
+    const totalPenalty = receipt?.total_penalty ?? 0;
+    const hasAnyAdjustment = (receipt?.line_items ?? []).some(
+        (item) => item.adjustment_status === 'APPROVED'
+    ) || totalConcession > 0 || totalPenalty > 0;
 
     return (
         <div className="space-y-4">
@@ -89,14 +95,20 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                                         <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Fee Type</th>
                                         <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Due Date</th>
                                         <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Expected</th>
+                                        {hasAnyAdjustment && (
+                                            <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Adjustment</th>
+                                        )}
                                         <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Paid</th>
-                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Balance</th>
+                                        <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Outstanding</th>
                                         <th className="py-2.5 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Status</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-gray-50">
                                     {receipt.line_items.map((item: ReceiptLineItem, idx: number) => {
                                         const style = STATUS_STYLES[item.status] || STATUS_STYLES['PENDING']!;
+                                        const isApprovedAdj = item.adjustment_status === 'APPROVED';
+                                        const isConcession = isApprovedAdj && item.adjustment_type === 'CONCESSION';
+                                        const isPenalty = isApprovedAdj && item.adjustment_type === 'PENALTY';
                                         return (
                                             <tr key={idx} className="hover:bg-gray-50/40">
                                                 <td className="py-2.5 px-4 text-gray-400 font-medium">{idx + 1}</td>
@@ -108,6 +120,21 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                                                     {item.due_date ? dayjs(item.due_date).format('DD MMM YYYY') : '—'}
                                                 </td>
                                                 <td className="py-2.5 px-4 text-gray-700 text-right">{formatCurrency(item.amount_expected)}</td>
+                                                {hasAnyAdjustment && (
+                                                    <td className="py-2.5 px-4 text-right">
+                                                        {isConcession ? (
+                                                            <span className={cn('text-xs font-semibold text-emerald-600')}>
+                                                                - {formatCurrency(item.adjustment_amount || 0)} <span className="font-normal">(Concession)</span>
+                                                            </span>
+                                                        ) : isPenalty ? (
+                                                            <span className={cn('text-xs font-semibold text-red-600')}>
+                                                                + {formatCurrency(item.adjustment_amount || 0)} <span className="font-normal">(Penalty)</span>
+                                                            </span>
+                                                        ) : (
+                                                            <span className="text-gray-400">—</span>
+                                                        )}
+                                                    </td>
+                                                )}
                                                 <td className="py-2.5 px-4 text-emerald-700 font-semibold text-right">{formatCurrency(item.amount_paid)}</td>
                                                 <td className="py-2.5 px-4 text-red-600 font-semibold text-right">
                                                     {item.balance > 0 ? formatCurrency(item.balance) : '—'}
@@ -125,6 +152,7 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                                     <tr className="border-t-2 border-gray-200 bg-gray-50/60">
                                         <td colSpan={3} />
                                         <td className="py-3 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Expected</td>
+                                        {hasAnyAdjustment && <td />}
                                         <td className="py-3 px-4 text-sm font-bold text-gray-800 text-right">{formatCurrency(receipt.total_expected ?? 0)}</td>
                                         <td className="py-3 px-4 text-sm font-bold text-gray-800 text-right">{formatCurrency(receipt.balance_due ?? 0)}</td>
                                         <td />
@@ -132,9 +160,28 @@ export function PaymentSuccessStep({ studentName, receipt, onPayAnother }: Payme
                                     <tr className="bg-gray-50/60">
                                         <td colSpan={3} />
                                         <td className="py-1 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Paid</td>
+                                        {hasAnyAdjustment && <td />}
                                         <td className="py-1 px-4 text-sm font-bold text-emerald-700 text-right" colSpan={2}>{formatCurrency(receipt.total_paid ?? 0)}</td>
                                         <td />
                                     </tr>
+                                    {totalConcession > 0 && (
+                                        <tr className="bg-gray-50/60">
+                                            <td colSpan={3} />
+                                            <td className="py-1 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Concession</td>
+                                            {hasAnyAdjustment && <td />}
+                                            <td className="py-1 px-4 text-sm font-bold text-emerald-600 text-right" colSpan={2}>- {formatCurrency(totalConcession)}</td>
+                                            <td />
+                                        </tr>
+                                    )}
+                                    {totalPenalty > 0 && (
+                                        <tr className="bg-gray-50/60">
+                                            <td colSpan={3} />
+                                            <td className="py-1 px-4 text-xs font-bold text-gray-500 text-right uppercase tracking-wide">Total Penalty</td>
+                                            {hasAnyAdjustment && <td />}
+                                            <td className="py-1 px-4 text-sm font-bold text-red-600 text-right" colSpan={2}>+ {formatCurrency(totalPenalty)}</td>
+                                            <td />
+                                        </tr>
+                                    )}
                                 </tfoot>
                             </table>
                         </div>

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -105,6 +105,9 @@ export interface ReceiptLineItem {
     amount_paid: number;
     balance: number;
     status: string;
+    adjustment_type?: string | null;
+    adjustment_amount?: number | null;
+    adjustment_status?: string | null;
 }
 
 export interface AllocatePaymentResponse {
@@ -117,6 +120,8 @@ export interface AllocatePaymentResponse {
     line_items?: ReceiptLineItem[];
     total_expected?: number;
     total_paid?: number;
+    total_concession?: number;
+    total_penalty?: number;
     balance_due?: number;
     amount_paid_now?: number;
 }


### PR DESCRIPTION
## Summary of Changes

Approved concession and penalty adjustments were not surfaced on the Payment Success screen, and the PDF receipt treated penalty silently — the penalty amount got baked into the balance with no explicit row or column, and per-line adjustment display was concession-only. This change makes concession and penalty first-class citizens across the pay-installments wizard and the receipt PDF, and renames the ambiguous "Balance" / "Total Due" labels to "Outstanding" for clarity.

**Backend:**
- `ReceiptDetailsDTO`: added `totalConcession` + `totalPenalty` on the receipt; added `adjustmentType`, `adjustmentAmount`, `adjustmentStatus` on each line item.
- `SchoolFeeReceiptService`: tracks `totalConcession` and `totalPenalty` separately across all three receipt flows (immediate, post-allocation, statement). Default HTML template shows Concession and Penalty as independent rows (each hidden when 0) and labels the grand-total as "Outstanding". `buildFeeTableHtml` renders a single "Adjustment" column per line — `- ₹X (Concession)` in green or `+ ₹X (Penalty)` in red.
- New placeholders exposed: `{{total_concession}}`, `{{total_penalty}}`, `{{TOTAL_CONCESSION}}`, `{{TOTAL_PENALTY}}`, `{{TOTAL_PENALTY_ROW_STYLE}}`, `{{FEE_ADJUSTMENT_N}}`, `{{FEE_PENALTY_N}}`, `{{FEE_OUTSTANDING_N}}`, `{{OUTSTANDING}}`. Legacy `{{total_discount}}` / `{{FEE_CONCESSION_N}}` placeholders still populated with the concession value for DB-template backward compatibility.
- Invoice JSON persists `totalConcession` + `totalPenalty` separately.
- `FeeTrackingService.buildReceiptDetails`: populates adjustment fields on line items + totals. Falls back to live computation for legacy invoices whose JSON lacks the new fields.

**Frontend:**
- `manage-finances.ts`: mirrored the new fields on `ReceiptLineItem` and `AllocatePaymentResponse`.
- `PaymentDetailsStep`: added an Adjustment column (hidden when no row has an approved adjustment) with colour-coded concession/penalty badges; footer shows Total Concession / Total Penalty rows when non-zero; "Total Due" renamed to "Total Outstanding".
- `PaymentSuccessStep`: same Adjustment column + footer rows; "Balance" column renamed to "Outstanding".

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Paid an installment carrying an approved concession — Payment Success screen shows `- ₹X (Concession)` in the Adjustment column and a "Total Concession" footer row.
- Paid an installment carrying an approved penalty — shows `+ ₹X (Penalty)` and a "Total Penalty" footer row.
- Paid mixed installments (concession + penalty + none) — column + both footer rows appear, totals add up correctly.
- Paid installments with no adjustments — Adjustment column is hidden.
- Downloaded the generated PDF receipt — Adjustment column and separate Concession/Penalty total rows render; "Outstanding" label appears in the default template.
- Generated a standalone invoice via the Generate Invoice flow (no payment) — same layout.
- Regression: legacy invoices (pre-change `invoice_data_json`) open correctly; totals fall back to live recomputation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
