### PR TITLE
Fix/pay installments table UI penalty logic

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeeAdjustmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeeAdjustmentService.java
@@ -75,7 +75,11 @@ public class StudentFeeAdjustmentService {
         bill.setAdjustmentAmount(amount);
         bill.setAdjustmentType(type.name());
         bill.setAdjustmentReason(reason);
-        bill.setAdjustmentStatus(AdjustmentStatus.PENDING_FOR_APPROVAL.name());
+        bill.setAdjustmentStatus(
+                type == AdjustmentType.PENALTY
+                        ? AdjustmentStatus.APPROVED.name()
+                        : AdjustmentStatus.PENDING_FOR_APPROVAL.name()
+        );
 
         StudentFeePayment saved = studentFeePaymentRepository.save(bill);
         log.info("Adjustment submitted: billId={}, userId={}, type={}, amount={}, status={}",

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/AdjustmentDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/AdjustmentDialog.tsx
@@ -57,7 +57,7 @@ export function AdjustmentDialog({
         onSuccess: () => {
             const msg =
                 selectedType === 'PENALTY'
-                    ? 'Penalty submitted for approval'
+                    ? 'Penalty applied'
                     : 'Concession submitted for approval';
             toast.success(msg);
             queryClient.invalidateQueries({ queryKey: getStudentDuesQueryKey(studentId) });
@@ -230,8 +230,8 @@ export function AdjustmentDialog({
                                 <div className="text-[11px] text-gray-500 mt-0.5">
                                     Increases due amount
                                 </div>
-                                <div className="text-[10px] text-amber-600 mt-1 font-medium">
-                                    Requires approval
+                                <div className="text-[10px] text-emerald-600 mt-1 font-medium">
+                                    Applied instantly
                                 </div>
                             </button>
                         </div>
@@ -281,7 +281,11 @@ export function AdjustmentDialog({
                                             : 'bg-red-600 hover:bg-red-700'
                                     )}
                                 >
-                                    {isPending ? 'Submitting...' : 'Submit for Approval'}
+                                    {isPending
+                                        ? 'Submitting...'
+                                        : selectedType === 'PENALTY'
+                                          ? 'Apply Penalty'
+                                          : 'Submit for Approval'}
                                 </button>
                             </div>
                         )}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/StudentSearchStep.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/StudentSearchStep.tsx
@@ -129,7 +129,7 @@ export function StudentSearchStep({ onSelectStudent }: StudentSearchStepProps) {
                         </div>
                     );
                 },
-                size: 180,
+                size: 260,
             },
             {
                 id: 'package',
@@ -144,14 +144,14 @@ export function StudentSearchStep({ onSelectStudent }: StudentSearchStepProps) {
                     const display = names.length > 0 ? names.join(', ') : '\u2014';
                     return (
                         <div
-                            className="text-sm text-gray-700 max-w-[200px] truncate"
+                            className="text-sm text-gray-700 truncate"
                             title={display}
                         >
                             {display}
                         </div>
                     );
                 },
-                size: 200,
+                size: 340,
             },
             {
                 id: 'dueAmount',
@@ -167,7 +167,7 @@ export function StudentSearchStep({ onSelectStudent }: StudentSearchStepProps) {
                         </div>
                     );
                 },
-                size: 120,
+                size: 180,
             },
             {
                 id: 'overdueAmount',
@@ -183,14 +183,14 @@ export function StudentSearchStep({ onSelectStudent }: StudentSearchStepProps) {
                         </div>
                     );
                 },
-                size: 120,
+                size: 180,
             },
             {
                 id: 'status',
                 header: 'Status',
                 accessorFn: (row) => row.status || '',
                 cell: ({ row }) => <StatusPill status={row.original.status} />,
-                size: 120,
+                size: 160,
             },
         ],
         [getPackageName]


### PR DESCRIPTION
## Summary of Changes

Two small fixes on the Pay Installments admin flow: the student search table wasn't filling its container horizontally, and penalty adjustments were going through the same approval queue as concessions even though the controller docstring already said penalty should be auto-approved.

**Backend:**
- `StudentFeeAdjustmentService.submitAdjustment` now sets `APPROVED` for `PENALTY` and `PENDING_FOR_APPROVAL` for `CONCESSION`, matching the controller contract. Existing pending records are untouched — behavior only applies to new submissions.

**Frontend:**
- Bumped column `size` values on the Pay Installments student search table so the sum exceeds container width and the table spans full width (`MyTable` pins the `<table>` width to `getCenterTotalSize()`, so columns need to total >= container).
- Updated `AdjustmentDialog` UX copy to reflect the new penalty behavior: "Applied instantly" replaces "Requires approval" on the penalty card, the submit button becomes "Apply Penalty" for penalty / "Submit for Approval" for concession, and the success toast says "Penalty applied" vs "Concession submitted for approval".

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Opened the Pay Installments page and verified the student search table now fills the full container width (no empty space on the right).
- Verified pagination still works on the student search table.
- Submitted a PENALTY adjustment on an installment — status came back as `APPROVED` immediately, dialog showed "Penalty applied" toast, and the due amount increased on the row.
- Submitted a CONCESSION adjustment — status came back as `PENDING_FOR_APPROVAL`, toast said "Concession submitted for approval", and due amount only decreased after a separate approve action.
- Retracted an approved penalty and verified adjustment fields reset to null.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
