### PR TITLE
apply naming setting terminology to login form

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
@@ -43,6 +43,15 @@ import {
   isNativeOAuthRequired,
   openOAuthInSystemBrowser,
 } from "@/lib/auth/nativeOAuth";
+import {
+  getTerminology,
+  getTerminologyPlural,
+} from "@/components/common/layout-container/sidebar/utils";
+import {
+  ContentTerms,
+  RoleTerms,
+  SystemTerms,
+} from "@/types/naming-settings";
 
 export const getFromStorage = async (key: string) => {
   const result = await Preferences.get({ key });
@@ -746,7 +755,12 @@ export function LoginForm({
           try {
             await fetchAndStoreStudentDetails(instituteId, userId);
           } catch {
-            toast.error("Failed to fetch student details");
+            toast.error(
+              `Failed to fetch ${getTerminology(
+                RoleTerms.Learner,
+                SystemTerms.Learner
+              ).toLowerCase()} details`
+            );
           }
         } else {
           toast.error("Invalid user data received");
@@ -1097,7 +1111,11 @@ export function LoginForm({
                         navigate({ to: domainRouting.redirectPath as never })
                       }
                     >
-                      Explore Courses
+                      Explore{" "}
+                      {getTerminologyPlural(
+                        ContentTerms.Course,
+                        SystemTerms.Course
+                      )}
                     </Button>
                   </motion.div>
                 ) : null}


### PR DESCRIPTION
## Summary of Changes

Replace hardcoded role/content terms on the learner login page with `getTerminology` / `getTerminologyPlural` so institute naming settings (e.g. ReadOnRent calling Learners "Customers" and Courses "Books") are respected consistently.

**Backend:**
- No changes.

**Frontend:**
- `frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx`:
  - "Explore Courses" CTA now uses `getTerminologyPlural(ContentTerms.Course, SystemTerms.Course)`.
  - "Failed to fetch student details" toast now uses `getTerminology(RoleTerms.Learner, SystemTerms.Learner)`.
  - Added imports for `getTerminology`, `getTerminologyPlural`, `ContentTerms`, `RoleTerms`, `SystemTerms`.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Loaded the login page on an institute with default naming settings — verified CTA renders as "Explore Courses" and toast (on student details fetch failure) reads "Failed to fetch learner details".
- Loaded the login page on ReadOnRent — verified CTA renders using the customized plural (e.g. "Explore Books") and toast uses the customized learner term.
- Verified no TypeScript/lint warnings after adding the new imports.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
