### PR TITLE
Feat/fee adjustment approval history

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/constants/AuthServiceRoutes.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/constants/AuthServiceRoutes.java
@@ -19,4 +19,5 @@ public class AuthServiceRoutes {
     public static final String GET_USERS_WITH_CHILDREN = "/auth-service/v1/user/internal/users-with-children";
     public static final String GET_USER_BY_MOBILE = "/auth-service/v1/user/internal/user-by-mobile";
     public static final String UPDATE_INSTITUTE_SETTINGS = "/auth-service/internal/institute-settings";
+    public static final String AUTOSUGGEST_USERS = "/auth-service/internal/user/autosuggest-users";
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
@@ -304,6 +304,37 @@ public class AuthService {
      * @param mobileNumber User's phone number in any format
      * @return UserDTO if found, null if not found
      */
+    /**
+     * Search users in auth_service by free-text query (name/email/mobile),
+     * scoped to an institute. Backed by the autosuggest-users endpoint.
+     * Returns up to 10 matches.
+     */
+    public List<UserDTO> autosuggestUsers(String instituteId, String query) {
+        if (instituteId == null || instituteId.isBlank() || query == null || query.isBlank()) {
+            return List.of();
+        }
+        try {
+            String endpoint = AuthServiceRoutes.AUTOSUGGEST_USERS
+                    + "?instituteId=" + java.net.URLEncoder.encode(instituteId, java.nio.charset.StandardCharsets.UTF_8)
+                    + "&query=" + java.net.URLEncoder.encode(query, java.nio.charset.StandardCharsets.UTF_8);
+
+            ResponseEntity<String> response = hmacClientUtils.makeHmacRequest(
+                    clientName,
+                    HttpMethod.GET.name(),
+                    authServerBaseUrl,
+                    endpoint,
+                    null);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.readValue(response.getBody(), new TypeReference<List<UserDTO>>() {});
+            }
+            return List.of();
+        } catch (Exception e) {
+            throw new VacademyException("Failed to autosuggest users: " + e.getMessage());
+        }
+    }
+
     public UserDTO getUserByMobileNumber(String mobileNumber) {
         if (mobileNumber == null || mobileNumber.isBlank()) {
             return null;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
@@ -337,6 +337,23 @@ public class FeeTrackingAdminController {
     }
 
     /**
+     * Institute-wide adjustment history. Powers the Adjustment Approvals page
+     * with tabs (Pending / Approved / Rejected / All) plus optional filters
+     * (actor, date range, adjustment types, student search).
+     *
+     * Filter is in the request body (POST) so multi-valued fields stay clean.
+     * Pagination is DB-level via Spring {@code Pageable} (default 20/page).
+     */
+    @PostMapping("/adjustment/history")
+    public ResponseEntity<Page<vacademy.io.admin_core_service.features.fee_management.dto.EnrichedAdjustmentHistoryDTO>> getInstituteAdjustmentHistory(
+            @RequestBody(required = false) vacademy.io.admin_core_service.features.fee_management.dto.InstituteAdjustmentHistoryFilterDTO filter,
+            @RequestParam("instituteId") String instituteId,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity.ok(
+                adjustmentHistoryQueryService.getInstituteHistory(instituteId, filter));
+    }
+
+    /**
      * Get all installments with pending adjustment approvals for an institute.
      */
     @PostMapping("/adjustment/pending")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeTrackingAdminController.java
@@ -74,6 +74,9 @@ public class FeeTrackingAdminController {
     @Autowired
     private StudentFeeAdjustmentService studentFeeAdjustmentService;
 
+    @Autowired
+    private vacademy.io.admin_core_service.features.fee_management.service.AdjustmentHistoryQueryService adjustmentHistoryQueryService;
+
     @PostMapping("/{userId}/dues")
     public ResponseEntity<StudentDuesPageResponse> getStudentDues(
             @PathVariable("userId") String userId,
@@ -261,16 +264,17 @@ public class FeeTrackingAdminController {
     ) {
         AdjustmentType type = AdjustmentType.valueOf(request.getAdjustmentType().toUpperCase());
 
-        StudentFeePayment updated = studentFeeAdjustmentService.submitAdjustment(
+        StudentFeeAdjustmentService.AdjustmentResult result = studentFeeAdjustmentService.submitAdjustment(
                 request.getStudentFeePaymentId(),
                 request.getUserId(),
                 request.getAdjustmentAmount(),
                 type,
                 request.getAdjustmentReason(),
-                instituteId
+                instituteId,
+                adminUser
         );
 
-        return ResponseEntity.ok(buildAdjustmentResponse(updated));
+        return ResponseEntity.ok(buildAdjustmentResponse(result.bill(), result.event()));
     }
 
     /**
@@ -285,19 +289,20 @@ public class FeeTrackingAdminController {
     ) {
         AdjustmentStatus action = AdjustmentStatus.valueOf(request.getAction().toUpperCase());
 
-        StudentFeePayment updated = studentFeeAdjustmentService.reviewAdjustment(
+        StudentFeeAdjustmentService.AdjustmentResult result = studentFeeAdjustmentService.reviewAdjustment(
                 request.getStudentFeePaymentId(),
                 action,
                 instituteId,
                 adminUser
         );
 
-        return ResponseEntity.ok(buildAdjustmentResponse(updated));
+        return ResponseEntity.ok(buildAdjustmentResponse(result.bill(), result.event()));
     }
 
     /**
      * Retract an adjustment (pending, rejected, or approved).
-     * Resets all adjustment fields to null.
+     * Appends a RETRACTED event to the history; the installment's FK still
+     * points to the RETRACTED row so the audit trail remains intact.
      */
     @PatchMapping("/adjustment/retract")
     public ResponseEntity<?> retractAdjustment(
@@ -305,12 +310,30 @@ public class FeeTrackingAdminController {
             @RequestParam("instituteId") String instituteId,
             @RequestAttribute("user") CustomUserDetails adminUser
     ) {
-        StudentFeePayment updated = studentFeeAdjustmentService.retractAdjustment(
+        StudentFeeAdjustmentService.AdjustmentResult result = studentFeeAdjustmentService.retractAdjustment(
                 request.getStudentFeePaymentId(),
-                instituteId
+                instituteId,
+                adminUser
         );
 
-        return ResponseEntity.ok(buildAdjustmentResponse(updated));
+        return ResponseEntity.ok(buildAdjustmentResponse(result.bill(), result.event()));
+    }
+
+    /**
+     * Paginated adjustment history for a single installment. Powers the
+     * "History" section in the AdjustmentDialog on the Pay Installments page.
+     * DB-level pagination — default 20 per page.
+     */
+    @GetMapping("/installment/{installmentId}/adjustment-history")
+    public ResponseEntity<Page<vacademy.io.admin_core_service.features.fee_management.dto.AdjustmentHistoryDTO>> getAdjustmentHistory(
+            @PathVariable("installmentId") String installmentId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size,
+            @RequestAttribute("user") CustomUserDetails user) {
+        if (size <= 0 || size > 100) size = 20;
+        if (page < 0) page = 0;
+        return ResponseEntity.ok(
+                adjustmentHistoryQueryService.getHistoryForInstallment(installmentId, page, size));
     }
 
     /**
@@ -325,16 +348,27 @@ public class FeeTrackingAdminController {
         return ResponseEntity.ok(pending);
     }
 
-    private Map<String, Object> buildAdjustmentResponse(StudentFeePayment bill) {
+    private Map<String, Object> buildAdjustmentResponse(
+            StudentFeePayment bill,
+            vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory event
+    ) {
         BigDecimal amountExpected = bill.getAmountExpected() != null ? bill.getAmountExpected() : BigDecimal.ZERO;
         BigDecimal amountPaid = bill.getAmountPaid() != null ? bill.getAmountPaid() : BigDecimal.ZERO;
-        BigDecimal adjustmentAmount = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+
+        String eventType = event != null ? event.getEventType() : null;
+        String resultingStatus = event != null ? event.getResultingStatus() : null;
+        String adjustmentType = event != null ? event.getAdjustmentType() : null;
+        BigDecimal adjustmentAmount = (event != null && event.getAmount() != null)
+                ? event.getAmount() : BigDecimal.ZERO;
+
+        // A RETRACTED event means "no effective adjustment" — callers expect null fields.
+        boolean isRetracted = "RETRACTED".equals(eventType);
 
         BigDecimal amountDue = amountExpected.subtract(amountPaid);
-        if ("APPROVED".equals(bill.getAdjustmentStatus())) {
-            if ("PENALTY".equals(bill.getAdjustmentType())) {
+        if (!isRetracted && "APPROVED".equals(resultingStatus)) {
+            if ("PENALTY".equals(adjustmentType)) {
                 amountDue = amountDue.add(adjustmentAmount);
-            } else if ("CONCESSION".equals(bill.getAdjustmentType())) {
+            } else if ("CONCESSION".equals(adjustmentType)) {
                 amountDue = amountDue.subtract(adjustmentAmount);
             }
         }
@@ -342,10 +376,10 @@ public class FeeTrackingAdminController {
         Map<String, Object> resp = new java.util.HashMap<>();
         resp.put("student_fee_payment_id", bill.getId());
         resp.put("user_id", bill.getUserId());
-        resp.put("adjustment_amount", adjustmentAmount);
-        resp.put("adjustment_type", bill.getAdjustmentType());
-        resp.put("adjustment_status", bill.getAdjustmentStatus());
-        resp.put("adjustment_reason", bill.getAdjustmentReason());
+        resp.put("adjustment_amount", isRetracted ? BigDecimal.ZERO : adjustmentAmount);
+        resp.put("adjustment_type", isRetracted ? null : adjustmentType);
+        resp.put("adjustment_status", isRetracted ? null : resultingStatus);
+        resp.put("adjustment_reason", isRetracted || event == null ? null : event.getReason());
         resp.put("status", bill.getStatus());
         resp.put("amount_due", amountDue);
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/AdjustmentHistoryDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/AdjustmentHistoryDTO.java
@@ -1,0 +1,32 @@
+package vacademy.io.admin_core_service.features.fee_management.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AdjustmentHistoryDTO {
+    private String id;
+    private String studentFeePaymentId;
+    private String eventType;
+    private String adjustmentType;
+    private BigDecimal amount;
+    private String reason;
+    private String resultingStatus;
+    private String actorUserId;
+    private String actorName;
+    private String actorRole;
+    private String previousEventId;
+    private String metadata;
+    private LocalDateTime createdAt;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/EnrichedAdjustmentHistoryDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/EnrichedAdjustmentHistoryDTO.java
@@ -1,0 +1,46 @@
+package vacademy.io.admin_core_service.features.fee_management.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+/**
+ * Adjustment history row enriched with student + fee-type context.
+ * Used by the institute-wide Adjustment Approvals history view so the admin can
+ * see who the adjustment was for and against which fee without extra lookups.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EnrichedAdjustmentHistoryDTO {
+    private String id;
+    private String studentFeePaymentId;
+    private String eventType;
+    private String adjustmentType;
+    private BigDecimal amount;
+    private String reason;
+    private String resultingStatus;
+    private String actorUserId;
+    private String actorName;
+    private String actorRole;
+    private String previousEventId;
+    private String metadata;
+    private LocalDateTime createdAt;
+
+    // Enrichment fields
+    private String studentUserId;
+    private String studentName;
+    private String studentPhone;
+    private String feeTypeName;
+    private String cpoName;
+    private Date installmentDueDate;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/InstituteAdjustmentHistoryFilterDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/dto/InstituteAdjustmentHistoryFilterDTO.java
@@ -1,0 +1,39 @@
+package vacademy.io.admin_core_service.features.fee_management.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Filter body for the institute-wide adjustment history endpoint.
+ * Posted as request body so multi-valued filters (event types, adjustment types)
+ * are easy to express and the URL stays clean.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class InstituteAdjustmentHistoryFilterDTO {
+
+    private Integer page;         // 0-indexed; defaults to 0
+    private Integer size;         // defaults to 20, max 100
+
+    private List<String> eventTypes;       // SUBMITTED, APPROVED, REJECTED, RETRACTED
+    private List<String> adjustmentTypes;  // CONCESSION, PENALTY
+    private List<String> resultingStatuses; // optional: PENDING_FOR_APPROVAL, APPROVED, REJECTED, RETRACTED
+
+    private String actorUserId;   // filter by specific FD/admin who took the action
+    private LocalDate startDate;  // filter created_at >= startDate
+    private LocalDate endDate;    // filter created_at <= endDate
+
+    private String studentSearch; // partial name/phone/username — matched against student roster
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeeAdjustmentHistory.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeeAdjustmentHistory.java
@@ -1,0 +1,72 @@
+package vacademy.io.admin_core_service.features.fee_management.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+@Entity
+@Table(name = "student_fee_adjustment_history")
+public class StudentFeeAdjustmentHistory {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(name = "student_fee_payment_id", nullable = false)
+    private String studentFeePaymentId;
+
+    @Column(name = "institute_id", nullable = false)
+    private String instituteId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "adjustment_type", nullable = false)
+    private String adjustmentType;
+
+    @Column(name = "amount", nullable = false)
+    private BigDecimal amount;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "resulting_status", nullable = false)
+    private String resultingStatus;
+
+    @Column(name = "actor_user_id", nullable = false)
+    private String actorUserId;
+
+    @Column(name = "actor_role")
+    private String actorRole;
+
+    @Column(name = "previous_event_id")
+    private String previousEventId;
+
+    @Column(name = "metadata", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String metadata;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeePayment.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeePayment.java
@@ -50,17 +50,8 @@ public class StudentFeePayment {
     @Column(name = "amount_expected", nullable = false)
     private BigDecimal amountExpected;
 
-    @Column(name = "adjustment_amount")
-    private BigDecimal adjustmentAmount;
-
-    @Column(name = "adjustment_reason")
-    private String adjustmentReason;
-
-    @Column(name = "adjustment_type")
-    private String adjustmentType; // CONCESSION or PENALTY
-
-    @Column(name = "adjustment_status")
-    private String adjustmentStatus; // PENDING_FOR_APPROVAL, APPROVED, REJECTED
+    @Column(name = "current_adjustment_history_id")
+    private String currentAdjustmentHistoryId;
 
     @Column(name = "amount_paid")
     private BigDecimal amountPaid = BigDecimal.ZERO;
@@ -102,9 +93,6 @@ public class StudentFeePayment {
         }
         if (amountPaid == null) {
             amountPaid = BigDecimal.ZERO;
-        }
-        if (adjustmentAmount == null) {
-            adjustmentAmount = BigDecimal.ZERO;
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/enums/AdjustmentEventType.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/enums/AdjustmentEventType.java
@@ -1,0 +1,8 @@
+package vacademy.io.admin_core_service.features.fee_management.enums;
+
+public enum AdjustmentEventType {
+    SUBMITTED,
+    APPROVED,
+    REJECTED,
+    RETRACTED
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/CollectionDashboardRepositoryImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/CollectionDashboardRepositoryImpl.java
@@ -29,23 +29,42 @@ public class CollectionDashboardRepositoryImpl implements CollectionDashboardRep
         return clause.append(")) ").toString();
     }
 
+    // Reusable JOIN to the current adjustment history row. A RETRACTED event counts
+    // as "no effective adjustment" — the CASE expressions below gate on event_type.
+    private static final String ADJUSTMENT_JOIN =
+            "LEFT JOIN student_fee_adjustment_history h " +
+            "       ON h.id = sfp.current_adjustment_history_id ";
+
+    // Signed delta to apply on top of amount_expected for an approved adjustment.
+    private static final String ADJUSTMENT_DELTA =
+            "(CASE " +
+            "   WHEN h.event_type <> 'RETRACTED' AND h.resulting_status = 'APPROVED' AND h.adjustment_type = 'PENALTY' " +
+            "     THEN COALESCE(h.amount, 0) " +
+            "   WHEN h.event_type <> 'RETRACTED' AND h.resulting_status = 'APPROVED' AND h.adjustment_type = 'CONCESSION' " +
+            "     THEN -1 * COALESCE(h.amount, 0) " +
+            "   ELSE 0 " +
+            " END)";
+
+    private static final String NET_EXPECTED = "(sfp.amount_expected + " + ADJUSTMENT_DELTA + ")";
+
     private static final String BASE_WHERE =
             "FROM student_fee_payment sfp " +
             "JOIN complex_payment_option cpo ON sfp.cpo_id = cpo.id " +
+            ADJUSTMENT_JOIN +
             "WHERE cpo.institute_id = :instituteId " +
             "  AND sfp.status NOT IN ('CANCELLED','DROPPED') ";
 
     private static final String SUMMARY_SELECT =
             "SELECT " +
-            "  COALESCE(SUM(sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)),0), " +
+            "  COALESCE(SUM(" + NET_EXPECTED + "),0), " +
             "  COALESCE(SUM(CASE WHEN sfp.due_date <= CURRENT_DATE " +
-            "    THEN (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) ELSE 0 END),0), " +
+            "    THEN " + NET_EXPECTED + " ELSE 0 END),0), " +
             "  COALESCE(SUM(sfp.amount_paid),0), " +
             "  COALESCE(SUM(CASE " +
             "    WHEN sfp.due_date <= CURRENT_DATE " +
             "      AND sfp.status NOT IN ('WAIVED') " +
-            "      AND sfp.amount_paid < (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) " +
-            "    THEN (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) - sfp.amount_paid " +
+            "      AND sfp.amount_paid < " + NET_EXPECTED + " " +
+            "    THEN " + NET_EXPECTED + " - sfp.amount_paid " +
             "    ELSE 0 END),0) ";
 
     // Class-wise breakdown resolves each student_fee_payment row to the actual
@@ -63,20 +82,21 @@ public class CollectionDashboardRepositoryImpl implements CollectionDashboardRep
             "      || ' - ' || s.session_name," +
             "    'Unassigned'" +
             "  ), " +
-            "  COALESCE(SUM(sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)),0), " +
+            "  COALESCE(SUM(" + NET_EXPECTED + "),0), " +
             "  COALESCE(SUM(CASE WHEN sfp.due_date <= CURRENT_DATE " +
-            "    THEN (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) ELSE 0 END),0), " +
+            "    THEN " + NET_EXPECTED + " ELSE 0 END),0), " +
             "  COALESCE(SUM(sfp.amount_paid),0), " +
             "  COALESCE(SUM(CASE " +
             "    WHEN sfp.due_date <= CURRENT_DATE " +
             "      AND sfp.status NOT IN ('WAIVED') " +
-            "      AND sfp.amount_paid < (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) " +
-            "    THEN (sfp.amount_expected + (CASE WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'PENALTY' THEN COALESCE(sfp.adjustment_amount,0) WHEN sfp.adjustment_status = 'APPROVED' AND sfp.adjustment_type = 'CONCESSION' THEN -1 * COALESCE(sfp.adjustment_amount,0) ELSE 0 END)) - sfp.amount_paid " +
+            "      AND sfp.amount_paid < " + NET_EXPECTED + " " +
+            "    THEN " + NET_EXPECTED + " - sfp.amount_paid " +
             "    ELSE 0 END),0) ";
 
     private static final String CLASS_WISE_FROM_WHERE =
             "FROM student_fee_payment sfp " +
             "JOIN complex_payment_option cpo ON sfp.cpo_id = cpo.id " +
+            ADJUSTMENT_JOIN +
             "LEFT JOIN LATERAL ( " +
             "  SELECT ssigm.package_session_id " +
             "  FROM student_session_institute_group_mapping ssigm " +

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistoryRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistoryRepository.java
@@ -1,0 +1,19 @@
+package vacademy.io.admin_core_service.features.fee_management.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
+
+import java.util.List;
+
+@Repository
+public interface StudentFeeAdjustmentHistoryRepository
+        extends JpaRepository<StudentFeeAdjustmentHistory, String> {
+
+    Page<StudentFeeAdjustmentHistory> findByStudentFeePaymentIdOrderByCreatedAtDesc(
+            String studentFeePaymentId, Pageable pageable);
+
+    List<StudentFeeAdjustmentHistory> findByIdIn(List<String> ids);
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistoryRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistoryRepository.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.fee_management.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
 
@@ -10,7 +11,8 @@ import java.util.List;
 
 @Repository
 public interface StudentFeeAdjustmentHistoryRepository
-        extends JpaRepository<StudentFeeAdjustmentHistory, String> {
+        extends JpaRepository<StudentFeeAdjustmentHistory, String>,
+                JpaSpecificationExecutor<StudentFeeAdjustmentHistory> {
 
     Page<StudentFeeAdjustmentHistory> findByStudentFeePaymentIdOrderByCreatedAtDesc(
             String studentFeePaymentId, Pageable pageable);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistorySpecification.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeeAdjustmentHistorySpecification.java
@@ -1,0 +1,66 @@
+package vacademy.io.admin_core_service.features.fee_management.repository;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Dynamic filter builder for institute-wide adjustment history queries.
+ * Any null/empty filter is skipped — no WHERE clause noise.
+ */
+public class StudentFeeAdjustmentHistorySpecification {
+
+    public static Specification<StudentFeeAdjustmentHistory> withFilters(
+            String instituteId,
+            Collection<String> eventTypes,
+            Collection<String> adjustmentTypes,
+            Collection<String> resultingStatuses,
+            String actorUserId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Collection<String> studentFeePaymentIds  // pre-resolved from student search
+    ) {
+        return (root, query, cb) -> {
+            List<Predicate> preds = new ArrayList<>();
+
+            preds.add(cb.equal(root.get("instituteId"), instituteId));
+
+            if (eventTypes != null && !eventTypes.isEmpty()) {
+                preds.add(root.get("eventType").in(eventTypes));
+            }
+            if (adjustmentTypes != null && !adjustmentTypes.isEmpty()) {
+                preds.add(root.get("adjustmentType").in(adjustmentTypes));
+            }
+            if (resultingStatuses != null && !resultingStatuses.isEmpty()) {
+                preds.add(root.get("resultingStatus").in(resultingStatuses));
+            }
+            if (actorUserId != null && !actorUserId.isBlank()) {
+                preds.add(cb.equal(root.get("actorUserId"), actorUserId));
+            }
+            if (startDate != null) {
+                preds.add(cb.greaterThanOrEqualTo(
+                        root.get("createdAt"), startDate.atStartOfDay()));
+            }
+            if (endDate != null) {
+                preds.add(cb.lessThan(
+                        root.get("createdAt"), endDate.plusDays(1).atStartOfDay()));
+            }
+            if (studentFeePaymentIds != null) {
+                if (studentFeePaymentIds.isEmpty()) {
+                    // Caller signalled "no matches" for studentSearch → force zero rows
+                    preds.add(cb.disjunction());
+                } else {
+                    preds.add(root.get("studentFeePaymentId").in(studentFeePaymentIds));
+                }
+            }
+
+            return cb.and(preds.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeePaymentRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/repository/StudentFeePaymentRepository.java
@@ -54,6 +54,19 @@ public interface StudentFeePaymentRepository extends JpaRepository<StudentFeePay
             @Param("windowEnd") Date windowEnd
     );
 
-    List<StudentFeePayment> findByInstituteIdAndAdjustmentStatus(String instituteId, String adjustmentStatus);
+    /**
+     * Return bills whose current adjustment event has the given resulting_status.
+     * Uses a join with student_fee_adjustment_history via the FK
+     * current_adjustment_history_id (replaces the removed adjustment_status column).
+     */
+    @Query(value = "SELECT sfp.* FROM student_fee_payment sfp " +
+                   "JOIN student_fee_adjustment_history h " +
+                   "  ON h.id = sfp.current_adjustment_history_id " +
+                   "WHERE sfp.institute_id = :instituteId " +
+                   "  AND h.resulting_status = :resultingStatus",
+           nativeQuery = true)
+    List<StudentFeePayment> findBillsWithCurrentResultingStatus(
+            @Param("instituteId") String instituteId,
+            @Param("resultingStatus") String resultingStatus);
 }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentHistoryQueryService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentHistoryQueryService.java
@@ -1,0 +1,88 @@
+package vacademy.io.admin_core_service.features.fee_management.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.fee_management.dto.AdjustmentHistoryDTO;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
+import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeeAdjustmentHistoryRepository;
+import vacademy.io.common.auth.dto.UserDTO;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read-side service for adjustment history — powers the "History" tab in the
+ * AdjustmentDialog. DB-level pagination so installments with thousands of
+ * events don't load the whole list at once.
+ */
+@Service
+public class AdjustmentHistoryQueryService {
+
+    @Autowired
+    private StudentFeeAdjustmentHistoryRepository adjustmentHistoryRepository;
+
+    @Autowired
+    private AuthService authService;
+
+    @Transactional(readOnly = true)
+    public Page<AdjustmentHistoryDTO> getHistoryForInstallment(
+            String studentFeePaymentId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<StudentFeeAdjustmentHistory> eventsPage = adjustmentHistoryRepository
+                .findByStudentFeePaymentIdOrderByCreatedAtDesc(studentFeePaymentId, pageable);
+
+        if (eventsPage.isEmpty()) {
+            return eventsPage.map(e -> toDTO(e, null));
+        }
+
+        List<String> actorIds = eventsPage.getContent().stream()
+                .map(StudentFeeAdjustmentHistory::getActorUserId)
+                .filter(id -> id != null && !id.isBlank() && !"MIGRATION".equals(id))
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<String, UserDTO> userMap;
+        try {
+            userMap = actorIds.isEmpty()
+                    ? Map.of()
+                    : authService.getUsersFromAuthServiceByUserIds(actorIds).stream()
+                            .collect(Collectors.toMap(UserDTO::getId, Function.identity(), (a, b) -> a));
+        } catch (Exception e) {
+            userMap = Map.of();
+        }
+
+        final Map<String, UserDTO> resolved = userMap;
+        return eventsPage.map(event -> {
+            UserDTO actor = resolved.get(event.getActorUserId());
+            String actorName = actor != null
+                    ? actor.getFullName()
+                    : ("MIGRATION".equals(event.getActorUserId()) ? "System (migration)" : null);
+            return toDTO(event, actorName);
+        });
+    }
+
+    private AdjustmentHistoryDTO toDTO(StudentFeeAdjustmentHistory e, String actorName) {
+        return AdjustmentHistoryDTO.builder()
+                .id(e.getId())
+                .studentFeePaymentId(e.getStudentFeePaymentId())
+                .eventType(e.getEventType())
+                .adjustmentType(e.getAdjustmentType())
+                .amount(e.getAmount())
+                .reason(e.getReason())
+                .resultingStatus(e.getResultingStatus())
+                .actorUserId(e.getActorUserId())
+                .actorName(actorName)
+                .actorRole(e.getActorRole())
+                .previousEventId(e.getPreviousEventId())
+                .metadata(e.getMetadata())
+                .createdAt(e.getCreatedAt())
+                .build();
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentHistoryQueryService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentHistoryQueryService.java
@@ -1,35 +1,82 @@
 package vacademy.io.admin_core_service.features.fee_management.service;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
 import vacademy.io.admin_core_service.features.fee_management.dto.AdjustmentHistoryDTO;
+import vacademy.io.admin_core_service.features.fee_management.dto.EnrichedAdjustmentHistoryDTO;
+import vacademy.io.admin_core_service.features.fee_management.dto.InstituteAdjustmentHistoryFilterDTO;
+import vacademy.io.admin_core_service.features.fee_management.entity.AssignedFeeValue;
+import vacademy.io.admin_core_service.features.fee_management.entity.ComplexPaymentOption;
+import vacademy.io.admin_core_service.features.fee_management.entity.FeeType;
 import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeePayment;
+import vacademy.io.admin_core_service.features.fee_management.repository.AssignedFeeValueRepository;
+import vacademy.io.admin_core_service.features.fee_management.repository.ComplexPaymentOptionRepository;
+import vacademy.io.admin_core_service.features.fee_management.repository.FeeTypeRepository;
 import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeeAdjustmentHistoryRepository;
+import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeeAdjustmentHistorySpecification;
+import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeePaymentRepository;
 import vacademy.io.common.auth.dto.UserDTO;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Read-side service for adjustment history — powers the "History" tab in the
- * AdjustmentDialog. DB-level pagination so installments with thousands of
- * events don't load the whole list at once.
+ * Read-side service for adjustment history.
+ * - Per-installment history: powers the "History" section in the AdjustmentDialog.
+ * - Institute-wide history: powers the tabbed Adjustment Approvals page
+ *   (Pending / Approved / Rejected / All).
+ *
+ * Pagination is always DB-level via Spring {@link Pageable}.
  */
 @Service
+@Slf4j
 public class AdjustmentHistoryQueryService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+    private static final int DEFAULT_PAGE_SIZE = 20;
 
     @Autowired
     private StudentFeeAdjustmentHistoryRepository adjustmentHistoryRepository;
 
     @Autowired
+    private StudentFeePaymentRepository studentFeePaymentRepository;
+
+    @Autowired
+    private AssignedFeeValueRepository assignedFeeValueRepository;
+
+    @Autowired
+    private FeeTypeRepository feeTypeRepository;
+
+    @Autowired
+    private ComplexPaymentOptionRepository complexPaymentOptionRepository;
+
+    @Autowired
     private AuthService authService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    // ─────────────────────────────────────────────────────────────
+    //  Per-installment history (AdjustmentDialog History section)
+    // ─────────────────────────────────────────────────────────────
 
     @Transactional(readOnly = true)
     public Page<AdjustmentHistoryDTO> getHistoryForInstallment(
@@ -39,36 +86,126 @@ public class AdjustmentHistoryQueryService {
                 .findByStudentFeePaymentIdOrderByCreatedAtDesc(studentFeePaymentId, pageable);
 
         if (eventsPage.isEmpty()) {
-            return eventsPage.map(e -> toDTO(e, null));
+            return eventsPage.map(e -> toBaseDTO(e, null));
         }
 
-        List<String> actorIds = eventsPage.getContent().stream()
+        Map<String, UserDTO> userMap = resolveActors(eventsPage.getContent());
+        return eventsPage.map(event -> toBaseDTO(event, actorName(event, userMap)));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  Institute-wide history (Adjustment Approvals page)
+    // ─────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public Page<EnrichedAdjustmentHistoryDTO> getInstituteHistory(
+            String instituteId, InstituteAdjustmentHistoryFilterDTO filter) {
+
+        int page = filter != null && filter.getPage() != null && filter.getPage() >= 0
+                ? filter.getPage() : 0;
+        int size = filter != null && filter.getSize() != null
+                && filter.getSize() > 0 && filter.getSize() <= MAX_PAGE_SIZE
+                ? filter.getSize() : DEFAULT_PAGE_SIZE;
+
+        // Resolve studentSearch → set of student_fee_payment_ids. Null = no filter.
+        Collection<String> billIdFilter = resolveStudentSearchToBillIds(
+                instituteId,
+                filter != null ? filter.getStudentSearch() : null);
+
+        Specification<StudentFeeAdjustmentHistory> spec =
+                StudentFeeAdjustmentHistorySpecification.withFilters(
+                        instituteId,
+                        filter != null ? filter.getEventTypes() : null,
+                        filter != null ? filter.getAdjustmentTypes() : null,
+                        filter != null ? filter.getResultingStatuses() : null,
+                        filter != null ? filter.getActorUserId() : null,
+                        filter != null ? filter.getStartDate() : null,
+                        filter != null ? filter.getEndDate() : null,
+                        billIdFilter);
+
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<StudentFeeAdjustmentHistory> eventsPage =
+                adjustmentHistoryRepository.findAll(spec, pageable);
+
+        if (eventsPage.isEmpty()) {
+            return eventsPage.map(e -> toEnrichedDTO(e, null, null, null));
+        }
+
+        Map<String, UserDTO> userMap = resolveActors(eventsPage.getContent());
+        EnrichmentContext ctx = buildEnrichmentContext(eventsPage.getContent());
+
+        return eventsPage.map(event -> toEnrichedDTO(event, actorName(event, userMap), ctx,
+                userMap));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  Helpers
+    // ─────────────────────────────────────────────────────────────
+
+    private Collection<String> resolveStudentSearchToBillIds(String instituteId, String studentSearch) {
+        if (!StringUtils.hasText(studentSearch)) return null;
+        // The `users` table lives in the auth_service database — we can't query it
+        // directly from admin_core_service. Delegate name/email/mobile search to
+        // auth_service via HTTP (HMAC-signed). It returns up to 10 matches.
+        List<UserDTO> matchedUsers;
+        try {
+            matchedUsers = authService.autosuggestUsers(instituteId, studentSearch.trim());
+        } catch (Exception e) {
+            log.warn("autosuggestUsers failed for query='{}': {}", studentSearch, e.getMessage());
+            matchedUsers = List.of();
+        }
+        log.info("Adjustment history student-search: query='{}' matched {} users",
+                studentSearch, matchedUsers.size());
+
+        if (matchedUsers.isEmpty()) {
+            return Collections.emptyList(); // signals "force zero rows" to the spec
+        }
+
+        List<String> matchedUserIds = matchedUsers.stream()
+                .map(UserDTO::getId)
+                .filter(StringUtils::hasText)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<String> billIds = entityManager.createQuery(
+                        "SELECT sfp.id FROM StudentFeePayment sfp " +
+                        "WHERE sfp.instituteId = :instituteId " +
+                        "  AND sfp.userId IN :userIds",
+                        String.class)
+                .setParameter("instituteId", instituteId)
+                .setParameter("userIds", matchedUserIds)
+                .getResultList();
+
+        log.info("Adjustment history student-search: userIds={}, billIds={}",
+                matchedUserIds.size(), billIds.size());
+
+        return billIds.isEmpty() ? Collections.emptyList() : billIds;
+    }
+
+    private Map<String, UserDTO> resolveActors(List<StudentFeeAdjustmentHistory> events) {
+        List<String> actorIds = events.stream()
                 .map(StudentFeeAdjustmentHistory::getActorUserId)
                 .filter(id -> id != null && !id.isBlank() && !"MIGRATION".equals(id))
                 .distinct()
                 .collect(Collectors.toList());
-
-        Map<String, UserDTO> userMap;
+        if (actorIds.isEmpty()) return Map.of();
         try {
-            userMap = actorIds.isEmpty()
-                    ? Map.of()
-                    : authService.getUsersFromAuthServiceByUserIds(actorIds).stream()
-                            .collect(Collectors.toMap(UserDTO::getId, Function.identity(), (a, b) -> a));
+            return authService.getUsersFromAuthServiceByUserIds(actorIds).stream()
+                    .collect(Collectors.toMap(UserDTO::getId, Function.identity(), (a, b) -> a));
         } catch (Exception e) {
-            userMap = Map.of();
+            return Map.of();
         }
-
-        final Map<String, UserDTO> resolved = userMap;
-        return eventsPage.map(event -> {
-            UserDTO actor = resolved.get(event.getActorUserId());
-            String actorName = actor != null
-                    ? actor.getFullName()
-                    : ("MIGRATION".equals(event.getActorUserId()) ? "System (migration)" : null);
-            return toDTO(event, actorName);
-        });
     }
 
-    private AdjustmentHistoryDTO toDTO(StudentFeeAdjustmentHistory e, String actorName) {
+    private String actorName(StudentFeeAdjustmentHistory event, Map<String, UserDTO> userMap) {
+        UserDTO user = userMap.get(event.getActorUserId());
+        if (user != null) return user.getFullName();
+        return "MIGRATION".equals(event.getActorUserId()) ? "System (migration)" : null;
+    }
+
+    private AdjustmentHistoryDTO toBaseDTO(StudentFeeAdjustmentHistory e, String actorName) {
         return AdjustmentHistoryDTO.builder()
                 .id(e.getId())
                 .studentFeePaymentId(e.getStudentFeePaymentId())
@@ -85,4 +222,112 @@ public class AdjustmentHistoryQueryService {
                 .createdAt(e.getCreatedAt())
                 .build();
     }
+
+    // Fetch all the referenced bills + their fee meta + the student users, in batch.
+    private EnrichmentContext buildEnrichmentContext(List<StudentFeeAdjustmentHistory> events) {
+        Set<String> billIds = events.stream()
+                .map(StudentFeeAdjustmentHistory::getStudentFeePaymentId)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+
+        Map<String, StudentFeePayment> billMap = billIds.isEmpty()
+                ? Map.of()
+                : studentFeePaymentRepository.findAllById(billIds).stream()
+                        .collect(Collectors.toMap(StudentFeePayment::getId, Function.identity(),
+                                (a, b) -> a));
+
+        Set<String> cpoIds = new HashSet<>();
+        Set<String> asvIds = new HashSet<>();
+        Set<String> studentUserIds = new HashSet<>();
+        for (StudentFeePayment bill : billMap.values()) {
+            if (StringUtils.hasText(bill.getCpoId())) cpoIds.add(bill.getCpoId());
+            if (StringUtils.hasText(bill.getAsvId())) asvIds.add(bill.getAsvId());
+            if (StringUtils.hasText(bill.getUserId())) studentUserIds.add(bill.getUserId());
+        }
+
+        Map<String, String> cpoIdToName = cpoIds.isEmpty() ? Map.of()
+                : complexPaymentOptionRepository.findAllById(cpoIds).stream()
+                        .collect(Collectors.toMap(ComplexPaymentOption::getId,
+                                ComplexPaymentOption::getName, (a, b) -> a));
+
+        Map<String, String> asvIdToFeeTypeId = asvIds.isEmpty() ? Map.of()
+                : assignedFeeValueRepository.findAllById(asvIds).stream()
+                        .collect(Collectors.toMap(AssignedFeeValue::getId,
+                                AssignedFeeValue::getFeeTypeId, (a, b) -> a));
+
+        Set<String> feeTypeIds = new HashSet<>(asvIdToFeeTypeId.values());
+        feeTypeIds.remove(null);
+        Map<String, String> feeTypeIdToName = feeTypeIds.isEmpty() ? Map.of()
+                : feeTypeRepository.findAllById(feeTypeIds).stream()
+                        .collect(Collectors.toMap(FeeType::getId, FeeType::getName, (a, b) -> a));
+
+        Map<String, UserDTO> studentUserMap = Map.of();
+        if (!studentUserIds.isEmpty()) {
+            try {
+                studentUserMap = authService.getUsersFromAuthServiceByUserIds(
+                                new java.util.ArrayList<>(studentUserIds)).stream()
+                        .collect(Collectors.toMap(UserDTO::getId, Function.identity(), (a, b) -> a));
+            } catch (Exception ignored) {
+            }
+        }
+
+        return new EnrichmentContext(billMap, cpoIdToName, asvIdToFeeTypeId, feeTypeIdToName,
+                studentUserMap);
+    }
+
+    private EnrichedAdjustmentHistoryDTO toEnrichedDTO(
+            StudentFeeAdjustmentHistory e,
+            String actorName,
+            EnrichmentContext ctx,
+            Map<String, UserDTO> actorMap) {
+
+        EnrichedAdjustmentHistoryDTO.EnrichedAdjustmentHistoryDTOBuilder b =
+                EnrichedAdjustmentHistoryDTO.builder()
+                        .id(e.getId())
+                        .studentFeePaymentId(e.getStudentFeePaymentId())
+                        .eventType(e.getEventType())
+                        .adjustmentType(e.getAdjustmentType())
+                        .amount(e.getAmount())
+                        .reason(e.getReason())
+                        .resultingStatus(e.getResultingStatus())
+                        .actorUserId(e.getActorUserId())
+                        .actorName(actorName)
+                        .actorRole(e.getActorRole())
+                        .previousEventId(e.getPreviousEventId())
+                        .metadata(e.getMetadata())
+                        .createdAt(e.getCreatedAt());
+
+        if (ctx == null) return b.build();
+
+        StudentFeePayment bill = ctx.billMap.get(e.getStudentFeePaymentId());
+        if (bill != null) {
+            b.installmentDueDate(bill.getDueDate());
+            b.studentUserId(bill.getUserId());
+
+            UserDTO student = ctx.studentUserMap.get(bill.getUserId());
+            if (student != null) {
+                b.studentName(student.getFullName());
+                b.studentPhone(student.getMobileNumber());
+            }
+
+            if (StringUtils.hasText(bill.getCpoId())) {
+                b.cpoName(ctx.cpoIdToName.get(bill.getCpoId()));
+            }
+            String feeTypeId = StringUtils.hasText(bill.getAsvId())
+                    ? ctx.asvIdToFeeTypeId.get(bill.getAsvId()) : null;
+            if (StringUtils.hasText(feeTypeId)) {
+                b.feeTypeName(ctx.feeTypeIdToName.get(feeTypeId));
+            }
+        }
+
+        return b.build();
+    }
+
+    private record EnrichmentContext(
+            Map<String, StudentFeePayment> billMap,
+            Map<String, String> cpoIdToName,
+            Map<String, String> asvIdToFeeTypeId,
+            Map<String, String> feeTypeIdToName,
+            Map<String, UserDTO> studentUserMap
+    ) {}
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/AdjustmentResolver.java
@@ -1,0 +1,112 @@
+package vacademy.io.admin_core_service.features.fee_management.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeePayment;
+import vacademy.io.admin_core_service.features.fee_management.enums.AdjustmentEventType;
+import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeeAdjustmentHistoryRepository;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Central resolver for a bill's current effective adjustment.
+ * Replaces the removed adjustment_* columns on student_fee_payment with a
+ * lookup into student_fee_adjustment_history via current_adjustment_history_id.
+ *
+ * A RETRACTED event counts as "no active adjustment" for compute purposes,
+ * so downstream services see the same effective state they did before the
+ * schema refactor.
+ */
+@Service
+public class AdjustmentResolver {
+
+    @Autowired
+    private StudentFeeAdjustmentHistoryRepository adjustmentHistoryRepository;
+
+    public StudentFeeAdjustmentHistory getCurrentEvent(StudentFeePayment bill) {
+        if (bill == null || !StringUtils.hasText(bill.getCurrentAdjustmentHistoryId())) {
+            return null;
+        }
+        return adjustmentHistoryRepository.findById(bill.getCurrentAdjustmentHistoryId())
+                .orElse(null);
+    }
+
+    public Map<String, StudentFeeAdjustmentHistory> loadCurrentEventsForBills(
+            Collection<StudentFeePayment> bills) {
+        if (bills == null || bills.isEmpty()) return Collections.emptyMap();
+        List<String> ids = bills.stream()
+                .map(StudentFeePayment::getCurrentAdjustmentHistoryId)
+                .filter(StringUtils::hasText)
+                .distinct()
+                .collect(Collectors.toList());
+        if (ids.isEmpty()) return Collections.emptyMap();
+        return adjustmentHistoryRepository.findByIdIn(ids).stream()
+                .collect(Collectors.toMap(StudentFeeAdjustmentHistory::getId, Function.identity()));
+    }
+
+    public StudentFeeAdjustmentHistory lookup(
+            StudentFeePayment bill,
+            Map<String, StudentFeeAdjustmentHistory> eventMap) {
+        if (bill == null || !StringUtils.hasText(bill.getCurrentAdjustmentHistoryId())) {
+            return null;
+        }
+        return eventMap.get(bill.getCurrentAdjustmentHistoryId());
+    }
+
+    /** Returns null if the current event is a RETRACTED one (no active adjustment). */
+    public StudentFeeAdjustmentHistory effectiveOrNull(StudentFeeAdjustmentHistory event) {
+        if (event == null) return null;
+        if (AdjustmentEventType.RETRACTED.name().equals(event.getEventType())) return null;
+        return event;
+    }
+
+    // ───── Compute helpers (accept the current event, possibly null) ─────
+
+    public BigDecimal computeAdjustmentEffect(StudentFeeAdjustmentHistory event) {
+        StudentFeeAdjustmentHistory effective = effectiveOrNull(event);
+        if (effective == null) return BigDecimal.ZERO;
+        if (!"APPROVED".equals(effective.getResultingStatus())) return BigDecimal.ZERO;
+        BigDecimal amt = effective.getAmount() != null ? effective.getAmount() : BigDecimal.ZERO;
+        if ("PENALTY".equals(effective.getAdjustmentType())) return amt;
+        if ("CONCESSION".equals(effective.getAdjustmentType())) return amt.negate();
+        return BigDecimal.ZERO;
+    }
+
+    public BigDecimal computeConcession(StudentFeeAdjustmentHistory event) {
+        StudentFeeAdjustmentHistory effective = effectiveOrNull(event);
+        if (effective == null) return BigDecimal.ZERO;
+        if (!"APPROVED".equals(effective.getResultingStatus())) return BigDecimal.ZERO;
+        if (!"CONCESSION".equals(effective.getAdjustmentType())) return BigDecimal.ZERO;
+        return effective.getAmount() != null ? effective.getAmount() : BigDecimal.ZERO;
+    }
+
+    public BigDecimal computePenalty(StudentFeeAdjustmentHistory event) {
+        StudentFeeAdjustmentHistory effective = effectiveOrNull(event);
+        if (effective == null) return BigDecimal.ZERO;
+        if (!"APPROVED".equals(effective.getResultingStatus())) return BigDecimal.ZERO;
+        if (!"PENALTY".equals(effective.getAdjustmentType())) return BigDecimal.ZERO;
+        return effective.getAmount() != null ? effective.getAmount() : BigDecimal.ZERO;
+    }
+
+    // ───── Single-bill convenience (does a DB lookup each call — avoid in loops) ─────
+
+    public BigDecimal computeAdjustmentEffect(StudentFeePayment bill) {
+        return computeAdjustmentEffect(getCurrentEvent(bill));
+    }
+
+    public BigDecimal computeConcession(StudentFeePayment bill) {
+        return computeConcession(getCurrentEvent(bill));
+    }
+
+    public BigDecimal computePenalty(StudentFeePayment bill) {
+        return computePenalty(getCurrentEvent(bill));
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeAllocationEngine.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeAllocationEngine.java
@@ -39,6 +39,9 @@ public class FeeAllocationEngine {
     @Autowired
     private InstituteFeeTypePriorityRepository priorityRepository;
 
+    @Autowired
+    private AdjustmentResolver adjustmentResolver;
+
     /**
      * Core allocation entry point.
      *
@@ -204,15 +207,7 @@ public class FeeAllocationEngine {
     private BigDecimal computeAmountDue(StudentFeePayment bill) {
         BigDecimal expected = bill.getAmountExpected() != null ? bill.getAmountExpected() : BigDecimal.ZERO;
         BigDecimal paid = bill.getAmountPaid() != null ? bill.getAmountPaid() : BigDecimal.ZERO;
-        BigDecimal adjustment = BigDecimal.ZERO;
-        if ("APPROVED".equals(bill.getAdjustmentStatus())) {
-            BigDecimal amt = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-            if ("PENALTY".equals(bill.getAdjustmentType())) {
-                adjustment = amt;
-            } else if ("CONCESSION".equals(bill.getAdjustmentType())) {
-                adjustment = amt.negate();
-            }
-        }
+        BigDecimal adjustment = adjustmentResolver.computeAdjustmentEffect(bill);
         return expected.add(adjustment).subtract(paid);
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeLedgerAllocationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeLedgerAllocationService.java
@@ -39,18 +39,13 @@ public class FeeLedgerAllocationService {
     @Lazy
     private SchoolFeeReceiptService schoolFeeReceiptService;
 
+    @Autowired
+    private AdjustmentResolver adjustmentResolver;
+
     private BigDecimal computeAmountDue(StudentFeePayment bill) {
         BigDecimal expected = bill.getAmountExpected() != null ? bill.getAmountExpected() : BigDecimal.ZERO;
         BigDecimal paid = bill.getAmountPaid() != null ? bill.getAmountPaid() : BigDecimal.ZERO;
-        BigDecimal adjustment = BigDecimal.ZERO;
-        if ("APPROVED".equals(bill.getAdjustmentStatus())) {
-            BigDecimal amt = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-            if ("PENALTY".equals(bill.getAdjustmentType())) {
-                adjustment = amt;
-            } else if ("CONCESSION".equals(bill.getAdjustmentType())) {
-                adjustment = amt.negate();
-            }
-        }
+        BigDecimal adjustment = adjustmentResolver.computeAdjustmentEffect(bill);
         return expected.add(adjustment).subtract(paid);
     }
 
@@ -60,10 +55,8 @@ public class FeeLedgerAllocationService {
      * - and remaining due <= 0
      */
     private boolean isAdjustmentSettled(StudentFeePayment bill) {
-        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return false;
-        if (!"CONCESSION".equals(bill.getAdjustmentType())) return false;
-        BigDecimal amt = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-        if (amt.compareTo(BigDecimal.ZERO) <= 0) return false;
+        BigDecimal concession = adjustmentResolver.computeConcession(bill);
+        if (concession.compareTo(BigDecimal.ZERO) <= 0) return false;
         return computeAmountDue(bill).compareTo(BigDecimal.ZERO) <= 0;
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/FeeTrackingService.java
@@ -23,6 +23,7 @@ import vacademy.io.admin_core_service.features.fee_management.entity.AftInstallm
 import vacademy.io.admin_core_service.features.fee_management.entity.AssignedFeeValue;
 import vacademy.io.admin_core_service.features.fee_management.entity.ComplexPaymentOption;
 import vacademy.io.admin_core_service.features.fee_management.entity.FeeType;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
 import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAllocationLedger;
 import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeePayment;
 import vacademy.io.admin_core_service.features.fee_management.repository.*;
@@ -75,44 +76,12 @@ public class FeeTrackingService {
         @Autowired
         private PackageSessionLearnerInvitationToPaymentOptionRepository packageSessionInviteRepo;
 
+        @Autowired
+        private AdjustmentResolver adjustmentResolver;
+
         @PersistenceContext
         private EntityManager entityManager;
 
-        private StudentFeePaymentDTO mapToPaymentDTO(StudentFeePayment entity) {
-                return StudentFeePaymentDTO.builder()
-                                .id(entity.getId())
-                                .userPlanId(entity.getUserPlanId())
-                                .cpoId(entity.getCpoId())
-                                .amountExpected(entity.getAmountExpected())
-                                .adjustmentAmount(entity.getAdjustmentAmount())
-                                .adjustmentReason(entity.getAdjustmentReason())
-                                .adjustmentType(entity.getAdjustmentType())
-                                .adjustmentStatus(entity.getAdjustmentStatus())
-                                .amountPaid(entity.getAmountPaid())
-                                .dueDate(entity.getDueDate())
-                                .status(entity.getStatus())
-                                .build();
-        }
-
-        private BigDecimal computeAdjustmentEffect(StudentFeePayment bill) {
-                if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-                BigDecimal amt = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-                if ("PENALTY".equals(bill.getAdjustmentType())) return amt;
-                if ("CONCESSION".equals(bill.getAdjustmentType())) return amt.negate();
-                return BigDecimal.ZERO;
-        }
-
-        private BigDecimal computeConcession(StudentFeePayment bill) {
-                if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-                if (!"CONCESSION".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
-                return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-        }
-
-        private BigDecimal computePenalty(StudentFeePayment bill) {
-                if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-                if (!"PENALTY".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
-                return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-        }
 
         private StudentFeeAllocationLedgerDTO mapToLedgerDTO(StudentFeeAllocationLedger entity) {
                 return StudentFeeAllocationLedgerDTO.builder()
@@ -168,6 +137,10 @@ public class FeeTrackingService {
                 List<String> cpoIds = allPayments.stream().map(StudentFeePayment::getCpoId).filter(Objects::nonNull).distinct().collect(Collectors.toList());
                 Map<String, String> cpoNameMap = complexPaymentOptionRepository.findAllById(cpoIds).stream().collect(Collectors.toMap(ComplexPaymentOption::getId, ComplexPaymentOption::getName, (a, b) -> a));
 
+                // Batch-load current adjustment events to avoid N+1 in the aggregation loop
+                Map<String, StudentFeeAdjustmentHistory> adjustmentMap =
+                                adjustmentResolver.loadCurrentEventsForBills(allPayments);
+
                 // Step 4: Grouping by [userId, cpoId]
                 Map<String, List<StudentFeePayment>> groupedPayments = allPayments.stream()
                         .collect(Collectors.groupingBy(p -> p.getUserId() + "_" + p.getCpoId()));
@@ -189,7 +162,8 @@ public class FeeTrackingService {
                         BigDecimal expected = p.getAmountExpected() != null ? p.getAmountExpected() : BigDecimal.ZERO;
                         BigDecimal paid = p.getAmountPaid() != null ? p.getAmountPaid() : BigDecimal.ZERO;
 
-                        BigDecimal netExpected = expected.add(computeAdjustmentEffect(p));
+                        StudentFeeAdjustmentHistory pEvent = adjustmentResolver.lookup(p, adjustmentMap);
+                        BigDecimal netExpected = expected.add(adjustmentResolver.computeAdjustmentEffect(pEvent));
                         totalExpectedAmount = totalExpectedAmount.add(netExpected);
                         totalPaidAmount = totalPaidAmount.add(paid);
 
@@ -379,10 +353,15 @@ public class FeeTrackingService {
             List<String> installmentIds = payments.stream().map(StudentFeePayment::getIId).filter(Objects::nonNull).distinct().collect(Collectors.toList());
             Map<String, Integer> installmentNumberMap = fetchInstallmentNumberMap(installmentIds);
 
+            Map<String, StudentFeeAdjustmentHistory> adjustmentMap =
+                    adjustmentResolver.loadCurrentEventsForBills(payments);
+
             return payments.stream().map(p -> {
                 BigDecimal expected = p.getAmountExpected() != null ? p.getAmountExpected() : BigDecimal.ZERO;
                 BigDecimal paid = p.getAmountPaid() != null ? p.getAmountPaid() : BigDecimal.ZERO;
-                BigDecimal adjustmentEffect = computeAdjustmentEffect(p);
+                StudentFeeAdjustmentHistory event = adjustmentResolver.lookup(p, adjustmentMap);
+                StudentFeeAdjustmentHistory effective = adjustmentResolver.effectiveOrNull(event);
+                BigDecimal adjustmentEffect = adjustmentResolver.computeAdjustmentEffect(effective);
                 String name = feeTypeNameMap.getOrDefault(p.getAsvId(), "N/A");
                 Integer num = installmentNumberMap.getOrDefault(p.getIId(), null);
 
@@ -390,9 +369,9 @@ public class FeeTrackingService {
                         .feeTypeName(name)
                         .installmentNumber(num)
                         .amountExpected(expected)
-                        .adjustmentAmount(p.getAdjustmentAmount())
-                        .adjustmentType(p.getAdjustmentType())
-                        .adjustmentStatus(p.getAdjustmentStatus())
+                        .adjustmentAmount(effective != null ? effective.getAmount() : null)
+                        .adjustmentType(effective != null ? effective.getAdjustmentType() : null)
+                        .adjustmentStatus(effective != null ? effective.getResultingStatus() : null)
                         .amountPaid(paid)
                         .dueAmount(expected.add(adjustmentEffect).subtract(paid))
                         .dueDate(p.getDueDate())
@@ -470,10 +449,12 @@ public class FeeTrackingService {
         @Transactional(readOnly = true)
         public List<StudentFeePaymentDTO> getPendingAdjustments(String instituteId) {
                 List<StudentFeePayment> pending = studentFeePaymentRepository
-                        .findByInstituteIdAndAdjustmentStatus(instituteId, "PENDING_FOR_APPROVAL");
+                        .findBillsWithCurrentResultingStatus(instituteId, "PENDING_FOR_APPROVAL");
                 if (pending.isEmpty()) return Collections.emptyList();
 
                 Map<String, FeeMeta> metaMap = buildFeeMetaMap(pending);
+                Map<String, StudentFeeAdjustmentHistory> adjustmentMap =
+                                adjustmentResolver.loadCurrentEventsForBills(pending);
 
                 List<String> userIds = pending.stream()
                         .map(StudentFeePayment::getUserId)
@@ -483,7 +464,10 @@ public class FeeTrackingService {
 
                 return pending.stream()
                         .map(entity -> {
-                                StudentFeePaymentDTO dto = mapToPaymentDTO(entity, metaMap.getOrDefault(entity.getId(), null));
+                                StudentFeePaymentDTO dto = mapToPaymentDTO(
+                                                entity,
+                                                metaMap.getOrDefault(entity.getId(), null),
+                                                adjustmentResolver.lookup(entity, adjustmentMap));
                                 dto.setUserId(entity.getUserId());
                                 UserDTO user = userMap.get(entity.getUserId());
                                 dto.setStudentName(user != null ? user.getFullName() : entity.getUserId());
@@ -501,9 +485,14 @@ public class FeeTrackingService {
                 }
 
                 Map<String, FeeMeta> billIdToMeta = buildFeeMetaMap(allBills);
+                Map<String, StudentFeeAdjustmentHistory> adjustmentMap =
+                                adjustmentResolver.loadCurrentEventsForBills(allBills);
 
                 return allBills.stream()
-                                .map(bill -> mapToPaymentDTO(bill, billIdToMeta.get(bill.getId())))
+                                .map(bill -> mapToPaymentDTO(
+                                                bill,
+                                                billIdToMeta.get(bill.getId()),
+                                                adjustmentResolver.lookup(bill, adjustmentMap)))
                                 .collect(Collectors.toList());
         }
 
@@ -677,9 +666,17 @@ public class FeeTrackingService {
         }
 
         private StudentFeePaymentDTO mapToPaymentDTO(StudentFeePayment entity, FeeMeta meta) {
+                return mapToPaymentDTO(entity, meta, adjustmentResolver.getCurrentEvent(entity));
+        }
+
+        private StudentFeePaymentDTO mapToPaymentDTO(
+                        StudentFeePayment entity,
+                        FeeMeta meta,
+                        StudentFeeAdjustmentHistory event) {
+                StudentFeeAdjustmentHistory effective = adjustmentResolver.effectiveOrNull(event);
                 BigDecimal expected = entity.getAmountExpected() != null ? entity.getAmountExpected() : BigDecimal.ZERO;
                 BigDecimal paid = entity.getAmountPaid() != null ? entity.getAmountPaid() : BigDecimal.ZERO;
-                BigDecimal amountDue = expected.add(computeAdjustmentEffect(entity)).subtract(paid);
+                BigDecimal amountDue = expected.add(adjustmentResolver.computeAdjustmentEffect(effective)).subtract(paid);
 
                 Boolean isOverdue = false;
                 Long daysOverdue = null;
@@ -701,10 +698,10 @@ public class FeeTrackingService {
                                 .feeTypeCode(meta != null ? meta.feeTypeCode : null)
                                 .feeTypeDescription(meta != null ? meta.feeTypeDescription : null)
                                 .amountExpected(entity.getAmountExpected())
-                                .adjustmentAmount(entity.getAdjustmentAmount())
-                                .adjustmentReason(entity.getAdjustmentReason())
-                                .adjustmentType(entity.getAdjustmentType())
-                                .adjustmentStatus(entity.getAdjustmentStatus())
+                                .adjustmentAmount(effective != null ? effective.getAmount() : null)
+                                .adjustmentReason(effective != null ? effective.getReason() : null)
+                                .adjustmentType(effective != null ? effective.getAdjustmentType() : null)
+                                .adjustmentStatus(effective != null ? effective.getResultingStatus() : null)
                                 .amountPaid(entity.getAmountPaid())
                                 .dueDate(entity.getDueDate())
                                 .status(entity.getStatus())
@@ -763,6 +760,10 @@ public class FeeTrackingService {
                 }
             }
 
+            // Batch-load current adjustment events to avoid N+1
+            Map<String, StudentFeeAdjustmentHistory> adjustmentMap =
+                    adjustmentResolver.loadCurrentEventsForBills(bills);
+
             // Build line item DTOs with fresh post-payment amounts
             List<ReceiptDetailsDTO.ReceiptLineItemDTO> lineDTOs = new ArrayList<>();
             BigDecimal computedConcession = BigDecimal.ZERO;
@@ -773,16 +774,19 @@ public class FeeTrackingService {
                 FeeMeta meta = metaMap.get(sfp.getId());
                 BigDecimal expected = sfp.getAmountExpected() != null ? sfp.getAmountExpected() : BigDecimal.ZERO;
                 BigDecimal paid = sfp.getAmountPaid() != null ? sfp.getAmountPaid() : BigDecimal.ZERO;
-                BigDecimal adjustmentEffect = computeAdjustmentEffect(sfp);
+                StudentFeeAdjustmentHistory sfpEvent = adjustmentResolver.lookup(sfp, adjustmentMap);
+                StudentFeeAdjustmentHistory sfpEffective = adjustmentResolver.effectiveOrNull(sfpEvent);
+                BigDecimal adjustmentEffect = adjustmentResolver.computeAdjustmentEffect(sfpEffective);
                 BigDecimal balance = expected.add(adjustmentEffect).subtract(paid).max(BigDecimal.ZERO);
-                boolean approvedAdjustment = "APPROVED".equals(sfp.getAdjustmentStatus());
-                String adjustmentType = approvedAdjustment ? sfp.getAdjustmentType() : null;
-                BigDecimal adjustmentAmount = approvedAdjustment && sfp.getAdjustmentAmount() != null
-                        ? sfp.getAdjustmentAmount()
+                boolean approvedAdjustment = sfpEffective != null
+                        && "APPROVED".equals(sfpEffective.getResultingStatus());
+                String adjustmentType = approvedAdjustment ? sfpEffective.getAdjustmentType() : null;
+                BigDecimal adjustmentAmount = approvedAdjustment && sfpEffective.getAmount() != null
+                        ? sfpEffective.getAmount()
                         : BigDecimal.ZERO;
-                String adjustmentStatus = approvedAdjustment ? sfp.getAdjustmentStatus() : null;
-                computedConcession = computedConcession.add(computeConcession(sfp));
-                computedPenalty = computedPenalty.add(computePenalty(sfp));
+                String adjustmentStatus = approvedAdjustment ? sfpEffective.getResultingStatus() : null;
+                computedConcession = computedConcession.add(adjustmentResolver.computeConcession(sfpEffective));
+                computedPenalty = computedPenalty.add(adjustmentResolver.computePenalty(sfpEffective));
                 lineDTOs.add(ReceiptDetailsDTO.ReceiptLineItemDTO.builder()
                         .feeTypeName(meta != null ? meta.feeTypeName() : null)
                         .cpoName(meta != null ? meta.cpoName() : null)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/SchoolFeeReceiptService.java
@@ -63,24 +63,19 @@ import java.util.*;
 @Service
 public class SchoolFeeReceiptService {
 
+    @Autowired
+    private AdjustmentResolver adjustmentResolver;
+
     private BigDecimal computeAdjustmentEffect(StudentFeePayment bill) {
-        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-        BigDecimal amt = bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
-        if ("PENALTY".equals(bill.getAdjustmentType())) return amt;
-        if ("CONCESSION".equals(bill.getAdjustmentType())) return amt.negate();
-        return BigDecimal.ZERO;
+        return adjustmentResolver.computeAdjustmentEffect(bill);
     }
 
     private BigDecimal computeConcession(StudentFeePayment bill) {
-        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-        if (!"CONCESSION".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
-        return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+        return adjustmentResolver.computeConcession(bill);
     }
 
     private BigDecimal computePenalty(StudentFeePayment bill) {
-        if (!"APPROVED".equals(bill.getAdjustmentStatus())) return BigDecimal.ZERO;
-        if (!"PENALTY".equals(bill.getAdjustmentType())) return BigDecimal.ZERO;
-        return bill.getAdjustmentAmount() != null ? bill.getAdjustmentAmount() : BigDecimal.ZERO;
+        return adjustmentResolver.computePenalty(bill);
     }
 
     private static final String SCHOOL_FEE_RECEIPT_TEMPLATE_TYPE = "SCHOOL_FEE_RECEIPT";

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeeAdjustmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeeAdjustmentService.java
@@ -6,9 +6,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeeAdjustmentHistory;
 import vacademy.io.admin_core_service.features.fee_management.entity.StudentFeePayment;
+import vacademy.io.admin_core_service.features.fee_management.enums.AdjustmentEventType;
 import vacademy.io.admin_core_service.features.fee_management.enums.AdjustmentStatus;
 import vacademy.io.admin_core_service.features.fee_management.enums.AdjustmentType;
+import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeeAdjustmentHistoryRepository;
 import vacademy.io.admin_core_service.features.fee_management.repository.StudentFeePaymentRepository;
 import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
 import vacademy.io.common.auth.model.CustomUserDetails;
@@ -29,16 +32,22 @@ public class StudentFeeAdjustmentService {
     private StudentFeePaymentRepository studentFeePaymentRepository;
 
     @Autowired
+    private StudentFeeAdjustmentHistoryRepository adjustmentHistoryRepository;
+
+    @Autowired
     private InstituteSettingService instituteSettingService;
 
+    public record AdjustmentResult(StudentFeePayment bill, StudentFeeAdjustmentHistory event) {}
+
     @Transactional
-    public StudentFeePayment submitAdjustment(
+    public AdjustmentResult submitAdjustment(
             String studentFeePaymentId,
             String userId,
             BigDecimal amount,
             AdjustmentType type,
             String reason,
-            String instituteId
+            String instituteId,
+            CustomUserDetails actor
     ) {
         validateRequired(studentFeePaymentId, "studentFeePaymentId");
         validateRequired(userId, "userId");
@@ -52,43 +61,71 @@ public class StudentFeeAdjustmentService {
         StudentFeePayment bill = findBillOrThrow(studentFeePaymentId);
 
         if (!userId.equals(bill.getUserId())) {
-            throw new VacademyException("student_fee_payment " + studentFeePaymentId + " does not belong to user " + userId);
+            throw new VacademyException("student_fee_payment " + studentFeePaymentId
+                    + " does not belong to user " + userId);
         }
 
-        // Cannot submit if a concession is already pending
-        if (AdjustmentStatus.PENDING_FOR_APPROVAL.name().equals(bill.getAdjustmentStatus())) {
-            throw new VacademyException("An adjustment is already pending for approval. Retract it before submitting a new one.");
+        // Block submit if current adjustment is active (pending / approved / rejected).
+        // Admin must retract before submitting a new one. Matches UX behaviour.
+        StudentFeeAdjustmentHistory currentEvent = loadCurrentEvent(bill);
+        if (currentEvent != null) {
+            String status = currentEvent.getResultingStatus();
+            if (AdjustmentStatus.PENDING_FOR_APPROVAL.name().equals(status)
+                    || AdjustmentStatus.APPROVED.name().equals(status)
+                    || AdjustmentStatus.REJECTED.name().equals(status)) {
+                throw new VacademyException("An active adjustment already exists ("
+                        + status + "). Retract it before submitting a new one.");
+            }
         }
 
-        BigDecimal amountExpected = bill.getAmountExpected() != null ? bill.getAmountExpected() : BigDecimal.ZERO;
-
+        BigDecimal amountExpected = bill.getAmountExpected() != null
+                ? bill.getAmountExpected() : BigDecimal.ZERO;
         if (type == AdjustmentType.CONCESSION && amount.compareTo(amountExpected) > 0) {
             throw new VacademyException("Concession amount cannot exceed amount_expected ("
                     + amountExpected + ")");
         }
 
-        // Backfill institute_id if missing
-        if (bill.getInstituteId() == null && StringUtils.hasText(instituteId)) {
-            bill.setInstituteId(instituteId);
+        // Backfill institute_id on bill if missing (kept for backward compat)
+        String resolvedInstituteId = StringUtils.hasText(bill.getInstituteId())
+                ? bill.getInstituteId() : instituteId;
+        if (bill.getInstituteId() == null && StringUtils.hasText(resolvedInstituteId)) {
+            bill.setInstituteId(resolvedInstituteId);
+        }
+        if (!StringUtils.hasText(resolvedInstituteId)) {
+            throw new VacademyException("institute_id could not be resolved for bill "
+                    + studentFeePaymentId);
         }
 
-        bill.setAdjustmentAmount(amount);
-        bill.setAdjustmentType(type.name());
-        bill.setAdjustmentReason(reason);
-        bill.setAdjustmentStatus(
-                type == AdjustmentType.PENALTY
-                        ? AdjustmentStatus.APPROVED.name()
-                        : AdjustmentStatus.PENDING_FOR_APPROVAL.name()
-        );
+        boolean autoApproved = (type == AdjustmentType.PENALTY);
+        String resultingStatus = autoApproved
+                ? AdjustmentStatus.APPROVED.name()
+                : AdjustmentStatus.PENDING_FOR_APPROVAL.name();
 
-        StudentFeePayment saved = studentFeePaymentRepository.save(bill);
-        log.info("Adjustment submitted: billId={}, userId={}, type={}, amount={}, status={}",
-                studentFeePaymentId, userId, type, amount, saved.getAdjustmentStatus());
-        return saved;
+        StudentFeeAdjustmentHistory event = StudentFeeAdjustmentHistory.builder()
+                .studentFeePaymentId(studentFeePaymentId)
+                .instituteId(resolvedInstituteId)
+                .eventType(AdjustmentEventType.SUBMITTED.name())
+                .adjustmentType(type.name())
+                .amount(amount)
+                .reason(reason)
+                .resultingStatus(resultingStatus)
+                .actorUserId(actorUserIdOrThrow(actor))
+                .actorRole(resolveActorRole(actor))
+                .previousEventId(null)
+                .metadata(autoApproved ? "{\"auto_approved\": true}" : null)
+                .build();
+        event = adjustmentHistoryRepository.save(event);
+
+        bill.setCurrentAdjustmentHistoryId(event.getId());
+        StudentFeePayment savedBill = studentFeePaymentRepository.save(bill);
+
+        log.info("Adjustment submitted: billId={}, userId={}, type={}, amount={}, status={}, auto={}",
+                studentFeePaymentId, userId, type, amount, resultingStatus, autoApproved);
+        return new AdjustmentResult(savedBill, event);
     }
 
     @Transactional
-    public StudentFeePayment reviewAdjustment(
+    public AdjustmentResult reviewAdjustment(
             String studentFeePaymentId,
             AdjustmentStatus action,
             String instituteId,
@@ -101,54 +138,88 @@ public class StudentFeeAdjustmentService {
             throw new VacademyException("action must be APPROVED or REJECTED");
         }
 
-        // Check reviewer has an approval role
         if (!canApproveAdjustment(reviewer, instituteId)) {
-            throw new VacademyException("You do not have permission to approve/reject adjustments for this institute");
+            throw new VacademyException(
+                    "You do not have permission to approve/reject adjustments for this institute");
         }
 
         StudentFeePayment bill = findBillOrThrow(studentFeePaymentId);
-
-        if (!AdjustmentStatus.PENDING_FOR_APPROVAL.name().equals(bill.getAdjustmentStatus())) {
-            throw new VacademyException("Adjustment is not pending for approval. Current status: " + bill.getAdjustmentStatus());
+        StudentFeeAdjustmentHistory currentEvent = loadCurrentEvent(bill);
+        if (currentEvent == null
+                || !AdjustmentStatus.PENDING_FOR_APPROVAL.name()
+                        .equals(currentEvent.getResultingStatus())) {
+            String status = currentEvent == null ? "NONE" : currentEvent.getResultingStatus();
+            throw new VacademyException(
+                    "Adjustment is not pending for approval. Current status: " + status);
         }
 
-        bill.setAdjustmentStatus(action.name());
+        AdjustmentEventType eventType = (action == AdjustmentStatus.APPROVED)
+                ? AdjustmentEventType.APPROVED : AdjustmentEventType.REJECTED;
 
-        StudentFeePayment saved = studentFeePaymentRepository.save(bill);
+        StudentFeeAdjustmentHistory event = StudentFeeAdjustmentHistory.builder()
+                .studentFeePaymentId(studentFeePaymentId)
+                .instituteId(currentEvent.getInstituteId())
+                .eventType(eventType.name())
+                .adjustmentType(currentEvent.getAdjustmentType())
+                .amount(currentEvent.getAmount())
+                .reason(currentEvent.getReason())
+                .resultingStatus(action.name())
+                .actorUserId(actorUserIdOrThrow(reviewer))
+                .actorRole(resolveActorRole(reviewer))
+                .previousEventId(currentEvent.getId())
+                .build();
+        event = adjustmentHistoryRepository.save(event);
+
+        bill.setCurrentAdjustmentHistoryId(event.getId());
+        StudentFeePayment savedBill = studentFeePaymentRepository.save(bill);
+
         log.info("Adjustment reviewed: billId={}, action={}, reviewer={}",
                 studentFeePaymentId, action, reviewer.getUserId());
-        return saved;
+        return new AdjustmentResult(savedBill, event);
     }
 
     @Transactional
-    public StudentFeePayment retractAdjustment(
+    public AdjustmentResult retractAdjustment(
             String studentFeePaymentId,
-            String instituteId
+            String instituteId,
+            CustomUserDetails actor
     ) {
         validateRequired(studentFeePaymentId, "studentFeePaymentId");
 
         StudentFeePayment bill = findBillOrThrow(studentFeePaymentId);
-
-        String currentStatus = bill.getAdjustmentStatus();
-        if (currentStatus == null) {
+        StudentFeeAdjustmentHistory currentEvent = loadCurrentEvent(bill);
+        if (currentEvent == null) {
             throw new VacademyException("No adjustment exists to retract");
         }
+        if (AdjustmentEventType.RETRACTED.name().equals(currentEvent.getEventType())) {
+            throw new VacademyException("Adjustment is already retracted");
+        }
 
-        // Reset all adjustment fields
-        bill.setAdjustmentAmount(BigDecimal.ZERO);
-        bill.setAdjustmentReason(null);
-        bill.setAdjustmentType(null);
-        bill.setAdjustmentStatus(null);
+        StudentFeeAdjustmentHistory event = StudentFeeAdjustmentHistory.builder()
+                .studentFeePaymentId(studentFeePaymentId)
+                .instituteId(currentEvent.getInstituteId())
+                .eventType(AdjustmentEventType.RETRACTED.name())
+                .adjustmentType(currentEvent.getAdjustmentType())
+                .amount(currentEvent.getAmount())
+                .reason(currentEvent.getReason())
+                .resultingStatus(AdjustmentEventType.RETRACTED.name())
+                .actorUserId(actorUserIdOrThrow(actor))
+                .actorRole(resolveActorRole(actor))
+                .previousEventId(currentEvent.getId())
+                .build();
+        event = adjustmentHistoryRepository.save(event);
 
-        StudentFeePayment saved = studentFeePaymentRepository.save(bill);
-        log.info("Adjustment retracted: billId={}, previousStatus={}", studentFeePaymentId, currentStatus);
-        return saved;
+        bill.setCurrentAdjustmentHistoryId(event.getId());
+        StudentFeePayment savedBill = studentFeePaymentRepository.save(bill);
+
+        log.info("Adjustment retracted: billId={}, previousStatus={}",
+                studentFeePaymentId, currentEvent.getResultingStatus());
+        return new AdjustmentResult(savedBill, event);
     }
 
     public boolean canApproveAdjustment(CustomUserDetails user, String instituteId) {
         List<String> approvalRoles = getApprovalRoles(instituteId);
         if (approvalRoles.isEmpty()) {
-            // No roles configured — only root users can approve
             return user.isRootUser();
         }
         return approvalRoles.stream()
@@ -156,10 +227,19 @@ public class StudentFeeAdjustmentService {
                         .anyMatch(auth -> auth.getAuthority().equalsIgnoreCase(role)));
     }
 
+    private StudentFeeAdjustmentHistory loadCurrentEvent(StudentFeePayment bill) {
+        if (!StringUtils.hasText(bill.getCurrentAdjustmentHistoryId())) {
+            return null;
+        }
+        return adjustmentHistoryRepository.findById(bill.getCurrentAdjustmentHistoryId())
+                .orElse(null);
+    }
+
     @SuppressWarnings("unchecked")
     private List<String> getApprovalRoles(String instituteId) {
         try {
-            Object settingData = instituteSettingService.getSettingByInstituteIdAndKey(instituteId, SETTING_KEY);
+            Object settingData = instituteSettingService
+                    .getSettingByInstituteIdAndKey(instituteId, SETTING_KEY);
             if (settingData instanceof Map) {
                 Map<String, Object> settingMap = (Map<String, Object>) settingData;
                 Object roles = settingMap.get("approvalRoles");
@@ -168,7 +248,8 @@ public class StudentFeeAdjustmentService {
                 }
             }
         } catch (Exception e) {
-            log.warn("Could not read FEE_ADJUSTMENT_SETTINGS for institute {}: {}", instituteId, e.getMessage());
+            log.warn("Could not read FEE_ADJUSTMENT_SETTINGS for institute {}: {}",
+                    instituteId, e.getMessage());
         }
         return Collections.emptyList();
     }
@@ -182,5 +263,19 @@ public class StudentFeeAdjustmentService {
         if (!StringUtils.hasText(value)) {
             throw new VacademyException(fieldName + " is required");
         }
+    }
+
+    private String actorUserIdOrThrow(CustomUserDetails user) {
+        if (user == null || !StringUtils.hasText(user.getUserId())) {
+            throw new VacademyException("Unable to resolve acting user");
+        }
+        return user.getUserId();
+    }
+
+    private String resolveActorRole(CustomUserDetails user) {
+        if (user == null || user.getAuthorities() == null || user.getAuthorities().isEmpty()) {
+            return null;
+        }
+        return user.getAuthorities().iterator().next().getAuthority();
     }
 }

--- a/admin_core_service/src/main/resources/db/migration/V212__Add_student_fee_adjustment_history.sql
+++ b/admin_core_service/src/main/resources/db/migration/V212__Add_student_fee_adjustment_history.sql
@@ -1,0 +1,70 @@
+-- New table: append-only history of every adjustment event on an installment
+CREATE TABLE student_fee_adjustment_history (
+    id                      VARCHAR(36) PRIMARY KEY,
+    student_fee_payment_id  VARCHAR(36) NOT NULL REFERENCES student_fee_payment(id),
+    institute_id            VARCHAR(255) NOT NULL,
+    event_type              VARCHAR(40) NOT NULL,
+    adjustment_type         VARCHAR(40) NOT NULL,
+    amount                  NUMERIC(19, 4) NOT NULL,
+    reason                  TEXT,
+    resulting_status        VARCHAR(40) NOT NULL,
+    actor_user_id           VARCHAR(255) NOT NULL,
+    actor_role              VARCHAR(100),
+    previous_event_id       VARCHAR(36) REFERENCES student_fee_adjustment_history(id),
+    metadata                JSONB,
+    created_at              TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_sfah_bill_created
+    ON student_fee_adjustment_history (student_fee_payment_id, created_at DESC);
+
+CREATE INDEX idx_sfah_institute_event
+    ON student_fee_adjustment_history (institute_id, event_type, created_at DESC);
+
+CREATE INDEX idx_sfah_actor
+    ON student_fee_adjustment_history (actor_user_id);
+
+-- FK on student_fee_payment pointing to current effective history row
+ALTER TABLE student_fee_payment
+    ADD COLUMN current_adjustment_history_id VARCHAR(36)
+    REFERENCES student_fee_adjustment_history(id);
+
+-- Backfill: one seed history row per existing non-null adjustment.
+-- Actor set to synthetic 'MIGRATION' marker since original actor was never recorded.
+INSERT INTO student_fee_adjustment_history (
+    id, student_fee_payment_id, institute_id, event_type,
+    adjustment_type, amount, reason, resulting_status,
+    actor_user_id, metadata, created_at
+)
+SELECT
+    gen_random_uuid()::text,
+    sfp.id,
+    COALESCE(sfp.institute_id, 'UNKNOWN'),
+    CASE
+        WHEN sfp.adjustment_status = 'PENDING_FOR_APPROVAL' THEN 'SUBMITTED'
+        WHEN sfp.adjustment_status = 'APPROVED' THEN 'APPROVED'
+        WHEN sfp.adjustment_status = 'REJECTED' THEN 'REJECTED'
+    END,
+    sfp.adjustment_type,
+    COALESCE(sfp.adjustment_amount, 0),
+    sfp.adjustment_reason,
+    sfp.adjustment_status,
+    'MIGRATION',
+    '{"source": "V212_backfill"}'::jsonb,
+    COALESCE(sfp.updated_at, sfp.created_at, NOW())
+FROM student_fee_payment sfp
+WHERE sfp.adjustment_status IS NOT NULL
+  AND sfp.adjustment_type IS NOT NULL;
+
+-- Link each installment's FK to its seeded history row
+UPDATE student_fee_payment sfp
+SET current_adjustment_history_id = h.id
+FROM student_fee_adjustment_history h
+WHERE h.student_fee_payment_id = sfp.id
+  AND h.actor_user_id = 'MIGRATION';
+
+-- Drop the 4 legacy adjustment columns — replaced by FK lookup into history table
+ALTER TABLE student_fee_payment DROP COLUMN adjustment_amount;
+ALTER TABLE student_fee_payment DROP COLUMN adjustment_reason;
+ALTER TABLE student_fee_payment DROP COLUMN adjustment_type;
+ALTER TABLE student_fee_payment DROP COLUMN adjustment_status;

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/user/controller/UserInternalController.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/user/controller/UserInternalController.java
@@ -76,4 +76,18 @@ public class UserInternalController {
         return CsvUtil.convertUserListToCsv(users, "inactive_users.csv");
     }
 
+    /**
+     * Internal, HMAC-authenticated equivalent of the public autosuggest-users
+     * endpoint. Lets other services do a free-text user search against
+     * auth_service's DB (full_name / email / mobile_number) scoped to an
+     * institute. Returns up to 10 matches.
+     */
+    @GetMapping("/autosuggest-users")
+    public ResponseEntity<List<UserDTO>> autoSuggestUsersInternal(
+            @RequestParam("instituteId") String instituteId,
+            @RequestParam(value = "roles", required = false) List<String> roles,
+            @RequestParam("query") String query) {
+        return ResponseEntity.ok(userService.autoSuggestUsers(instituteId, roles, query));
+    }
+
 }

--- a/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/AdjustmentApprovalsMain.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/AdjustmentApprovalsMain.tsx
@@ -1,208 +1,46 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import dayjs from 'dayjs';
-import { Check, X } from '@phosphor-icons/react';
-import { DashboardLoader } from '@/components/core/dashboard-loader';
-import {
-    fetchPendingAdjustments,
-    getPendingAdjustmentsQueryKey,
-    reviewAdjustment,
-} from '@/services/manage-finances';
-import { StudentFeeDueDTO } from '@/types/manage-finances';
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
+import { PendingApprovalsTable } from './PendingApprovalsTable';
+import { AdjustmentHistoryList } from './AdjustmentHistoryList';
 
-const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
+type Tab = 'PENDING' | 'APPROVED' | 'REJECTED' | 'ALL';
+
+const TABS: { key: Tab; label: string }[] = [
+    { key: 'PENDING', label: 'Pending' },
+    { key: 'APPROVED', label: 'Approved' },
+    { key: 'REJECTED', label: 'Rejected' },
+    { key: 'ALL', label: 'All History' },
+];
 
 export function AdjustmentApprovalsMain() {
-    const queryClient = useQueryClient();
-
-    const { data: pending, isLoading, error } = useQuery({
-        queryKey: getPendingAdjustmentsQueryKey(),
-        queryFn: fetchPendingAdjustments,
-        refetchInterval: 30000,
-    });
-
-    const reviewMutation = useMutation({
-        mutationFn: (params: { id: string; action: 'APPROVED' | 'REJECTED' }) =>
-            reviewAdjustment({
-                student_fee_payment_id: params.id,
-                action: params.action,
-            }),
-        onSuccess: (_data, variables) => {
-            toast.success(
-                variables.action === 'APPROVED'
-                    ? 'Adjustment approved'
-                    : 'Adjustment rejected'
-            );
-            queryClient.invalidateQueries({ queryKey: getPendingAdjustmentsQueryKey() });
-        },
-        onError: (err: any) => {
-            toast.error(
-                err?.response?.data?.ex || err?.message || 'Failed to review adjustment'
-            );
-        },
-    });
-
-    if (isLoading) {
-        return (
-            <div className="flex h-48 items-center justify-center">
-                <DashboardLoader />
-            </div>
-        );
-    }
-
-    if (error) {
-        return (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-8 text-center">
-                <p className="font-semibold text-red-800">Unable to load pending approvals</p>
-                <p className="mt-2 text-sm text-red-600">
-                    {error instanceof Error ? error.message : 'Please try again.'}
-                </p>
-            </div>
-        );
-    }
-
-    if (!pending || pending.length === 0) {
-        return (
-            <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
-                <p className="text-lg font-semibold text-gray-600">No pending approvals</p>
-                <p className="mt-2 text-sm text-gray-400">
-                    All adjustment requests have been reviewed.
-                </p>
-            </div>
-        );
-    }
+    const [activeTab, setActiveTab] = useState<Tab>('PENDING');
 
     return (
-        <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-            <div className="overflow-auto">
-                <table className="w-full text-left border-collapse min-w-[800px]">
-                    <thead>
-                        <tr className="border-b-2 border-gray-200 bg-gray-50/95">
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Student
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Fee Type
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                CPO / Plan
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Type
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Expected
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Amount
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Reason
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Due Date
-                            </th>
-                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                                Actions
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100 text-sm font-medium">
-                        {pending.map((item: StudentFeeDueDTO) => {
-                            const isPenalty = item.adjustment_type === 'PENALTY';
-                            return (
-                            <tr
-                                key={item.id}
-                                className={cn(
-                                    'transition-colors border-l-4',
-                                    isPenalty
-                                        ? 'border-l-red-400 hover:bg-red-50/40'
-                                        : 'border-l-emerald-400 hover:bg-emerald-50/40'
-                                )}
-                            >
-                                <td className="py-3 px-4 text-gray-800 font-semibold">
-                                    {item.student_name || item.user_id}
-                                </td>
-                                <td className="py-3 px-4 text-gray-800 font-semibold">
-                                    {item.fee_type_name}
-                                </td>
-                                <td className="py-3 px-4 text-gray-600">
-                                    {item.cpo_name || '\u2014'}
-                                </td>
-                                <td className="py-3 px-4">
-                                    <span
-                                        className={cn(
-                                            'inline-flex rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
-                                            isPenalty
-                                                ? 'bg-red-100 text-red-800'
-                                                : 'bg-emerald-100 text-emerald-800'
-                                        )}
-                                    >
-                                        {isPenalty ? 'Penalty' : 'Concession'}
-                                    </span>
-                                </td>
-                                <td className="py-3 px-4 text-gray-700">
-                                    {formatCurrency(item.amount_expected)}
-                                </td>
-                                <td
-                                    className={cn(
-                                        'py-3 px-4 font-semibold',
-                                        isPenalty ? 'text-red-700' : 'text-emerald-700'
-                                    )}
-                                >
-                                    {isPenalty ? '+' : '-'}
-                                    {formatCurrency(item.adjustment_amount)}
-                                </td>
-                                <td className="py-3 px-4 text-gray-500 max-w-[200px] truncate" title={item.adjustment_reason ?? ''}>
-                                    {item.adjustment_reason || '\u2014'}
-                                </td>
-                                <td className="py-3 px-4 text-gray-600">
-                                    {item.due_date
-                                        ? dayjs(item.due_date).format('D MMM YYYY')
-                                        : '\u2014'}
-                                </td>
-                                <td className="py-3 px-4">
-                                    <div className="flex items-center gap-2">
-                                        <button
-                                            type="button"
-                                            title="Approve"
-                                            onClick={() =>
-                                                reviewMutation.mutate({
-                                                    id: item.id,
-                                                    action: 'APPROVED',
-                                                })
-                                            }
-                                            disabled={reviewMutation.isPending}
-                                            className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-lg bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 disabled:opacity-50 transition-colors"
-                                        >
-                                            <Check size={13} weight="bold" />
-                                            Approve
-                                        </button>
-                                        <button
-                                            type="button"
-                                            title="Reject"
-                                            onClick={() =>
-                                                reviewMutation.mutate({
-                                                    id: item.id,
-                                                    action: 'REJECTED',
-                                                })
-                                            }
-                                            disabled={reviewMutation.isPending}
-                                            className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-lg bg-red-50 text-red-700 border border-red-200 hover:bg-red-100 disabled:opacity-50 transition-colors"
-                                        >
-                                            <X size={13} weight="bold" />
-                                            Reject
-                                        </button>
-                                    </div>
-                                </td>
-                            </tr>
-                            );
-                        })}
-                    </tbody>
-                </table>
+        <div className="space-y-4">
+            {/* Tabs */}
+            <div className="flex items-center gap-1 border-b border-gray-200">
+                {TABS.map((t) => (
+                    <button
+                        key={t.key}
+                        type="button"
+                        onClick={() => setActiveTab(t.key)}
+                        className={cn(
+                            'px-4 py-2 text-sm font-semibold border-b-2 -mb-px transition-colors',
+                            activeTab === t.key
+                                ? 'border-blue-600 text-blue-700'
+                                : 'border-transparent text-gray-500 hover:text-gray-700'
+                        )}
+                    >
+                        {t.label}
+                    </button>
+                ))}
             </div>
+
+            {/* Content */}
+            {activeTab === 'PENDING' && <PendingApprovalsTable />}
+            {activeTab === 'APPROVED' && <AdjustmentHistoryList eventTypes={['APPROVED']} />}
+            {activeTab === 'REJECTED' && <AdjustmentHistoryList eventTypes={['REJECTED']} />}
+            {activeTab === 'ALL' && <AdjustmentHistoryList />}
         </div>
     );
 }

--- a/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/AdjustmentHistoryList.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/AdjustmentHistoryList.tsx
@@ -1,0 +1,355 @@
+import { useMemo, useState, useEffect, useRef } from 'react';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { CaretLeft, CaretRight, MagnifyingGlass, X } from '@phosphor-icons/react';
+import { DashboardLoader } from '@/components/core/dashboard-loader';
+import {
+    fetchInstituteAdjustmentHistory,
+    getInstituteAdjustmentHistoryQueryKey,
+} from '@/services/manage-finances';
+import {
+    EnrichedAdjustmentHistoryDTO,
+    InstituteAdjustmentHistoryFilter,
+} from '@/types/manage-finances';
+import { cn } from '@/lib/utils';
+
+const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
+
+const EVENT_STYLES: Record<string, { bg: string; text: string }> = {
+    SUBMITTED: { bg: 'bg-blue-100', text: 'text-blue-700' },
+    APPROVED: { bg: 'bg-emerald-100', text: 'text-emerald-700' },
+    REJECTED: { bg: 'bg-red-100', text: 'text-red-700' },
+    RETRACTED: { bg: 'bg-gray-200', text: 'text-gray-700' },
+};
+
+const PAGE_SIZE = 20;
+
+type AdjustmentTypeFilter = 'ALL' | 'CONCESSION' | 'PENALTY';
+
+interface AdjustmentHistoryListProps {
+    /**
+     * Pre-applied event type filter. Tabs pass e.g. ['APPROVED'] to scope the list
+     * to that status. 'All History' tab passes undefined for unfiltered.
+     */
+    eventTypes?: ('SUBMITTED' | 'APPROVED' | 'REJECTED' | 'RETRACTED')[];
+    /**
+     * Pre-applied resulting_status filter. The Pending-history view would pass
+     * ['PENDING_FOR_APPROVAL'] for example. Optional.
+     */
+    resultingStatuses?: ('PENDING_FOR_APPROVAL' | 'APPROVED' | 'REJECTED' | 'RETRACTED')[];
+}
+
+export function AdjustmentHistoryList({
+    eventTypes,
+    resultingStatuses,
+}: AdjustmentHistoryListProps) {
+    const [page, setPage] = useState(0);
+
+    const [studentSearchInput, setStudentSearchInput] = useState('');
+    const [studentSearch, setStudentSearch] = useState('');
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+    useEffect(() => {
+        debounceRef.current = setTimeout(() => {
+            setStudentSearch(studentSearchInput.trim());
+            setPage(0);
+        }, 300);
+        return () => clearTimeout(debounceRef.current);
+    }, [studentSearchInput]);
+
+    const [adjustmentTypeFilter, setAdjustmentTypeFilter] =
+        useState<AdjustmentTypeFilter>('ALL');
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+
+    // Reset to first page whenever an on-screen filter changes
+    useEffect(() => {
+        setPage(0);
+    }, [adjustmentTypeFilter, startDate, endDate, eventTypes, resultingStatuses]);
+
+    const filter = useMemo<InstituteAdjustmentHistoryFilter>(
+        () => ({
+            page,
+            size: PAGE_SIZE,
+            event_types: eventTypes,
+            resulting_statuses: resultingStatuses,
+            adjustment_types:
+                adjustmentTypeFilter === 'ALL' ? undefined : [adjustmentTypeFilter],
+            start_date: startDate || undefined,
+            end_date: endDate || undefined,
+            student_search: studentSearch || undefined,
+        }),
+        [
+            page,
+            eventTypes,
+            resultingStatuses,
+            adjustmentTypeFilter,
+            startDate,
+            endDate,
+            studentSearch,
+        ]
+    );
+
+    const { data, isLoading, isFetching, error } = useQuery({
+        queryKey: getInstituteAdjustmentHistoryQueryKey(filter),
+        queryFn: () => fetchInstituteAdjustmentHistory(filter),
+        placeholderData: keepPreviousData,
+        staleTime: 15000,
+    });
+
+    const totalPages = data?.total_pages ?? data?.totalPages ?? 0;
+    const totalElements = data?.total_elements ?? data?.totalElements ?? 0;
+    const hasActiveFilters =
+        adjustmentTypeFilter !== 'ALL' || startDate || endDate || studentSearch;
+
+    const clearFilters = () => {
+        setAdjustmentTypeFilter('ALL');
+        setStartDate('');
+        setEndDate('');
+        setStudentSearchInput('');
+        setStudentSearch('');
+    };
+
+    return (
+        <div className="space-y-4">
+            {/* Filter bar */}
+            <div className="bg-white rounded-xl border border-gray-100 p-4">
+                <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative min-w-[220px]">
+                        <MagnifyingGlass
+                            size={16}
+                            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                        />
+                        <input
+                            type="text"
+                            placeholder="Search by student name or phone…"
+                            value={studentSearchInput}
+                            onChange={(e) => setStudentSearchInput(e.target.value)}
+                            className="w-full rounded-lg border border-gray-200 pl-9 pr-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                    </div>
+
+                    <div className="flex items-center gap-1">
+                        {(['ALL', 'CONCESSION', 'PENALTY'] as AdjustmentTypeFilter[]).map((t) => (
+                            <button
+                                key={t}
+                                type="button"
+                                onClick={() => setAdjustmentTypeFilter(t)}
+                                className={cn(
+                                    'rounded-full border px-3 py-1 text-xs font-semibold transition-colors',
+                                    adjustmentTypeFilter === t
+                                        ? t === 'CONCESSION'
+                                            ? 'bg-emerald-100 text-emerald-700 border-emerald-300'
+                                            : t === 'PENALTY'
+                                              ? 'bg-red-100 text-red-700 border-red-300'
+                                              : 'bg-blue-100 text-blue-700 border-blue-300'
+                                        : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'
+                                )}
+                            >
+                                {t === 'ALL' ? 'All Types' : t.charAt(0) + t.slice(1).toLowerCase()}
+                            </button>
+                        ))}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <label className="text-xs font-medium text-gray-500">From:</label>
+                        <input
+                            type="date"
+                            value={startDate}
+                            onChange={(e) => setStartDate(e.target.value)}
+                            className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        />
+                        <label className="text-xs font-medium text-gray-500">To:</label>
+                        <input
+                            type="date"
+                            value={endDate}
+                            onChange={(e) => setEndDate(e.target.value)}
+                            className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        />
+                    </div>
+
+                    {hasActiveFilters && (
+                        <button
+                            type="button"
+                            onClick={clearFilters}
+                            className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-red-600 transition-colors"
+                        >
+                            <X size={14} />
+                            Clear
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {/* List */}
+            {isLoading && !data && (
+                <div className="flex h-48 items-center justify-center">
+                    <DashboardLoader />
+                </div>
+            )}
+
+            {error && (
+                <div className="rounded-xl border border-red-200 bg-red-50 p-8 text-center">
+                    <p className="font-semibold text-red-800">Unable to load history</p>
+                    <p className="mt-2 text-sm text-red-600">
+                        {error instanceof Error ? error.message : 'Please try again.'}
+                    </p>
+                </div>
+            )}
+
+            {data && data.content.length === 0 && (
+                <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
+                    <p className="text-lg font-semibold text-gray-600">No activity</p>
+                    <p className="mt-2 text-sm text-gray-400">
+                        {hasActiveFilters
+                            ? 'Try clearing filters.'
+                            : 'No adjustment activity matches this view yet.'}
+                    </p>
+                </div>
+            )}
+
+            {data && data.content.length > 0 && (
+                <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
+                    <div className="overflow-auto">
+                        <table className="w-full text-left border-collapse min-w-[900px]">
+                            <thead>
+                                <tr className="border-b-2 border-gray-200 bg-gray-50/95">
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Date
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Student
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Fee Type
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Type
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Amount
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Event
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        By
+                                    </th>
+                                    <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                        Reason
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-100 text-sm">
+                                {data.content.map((evt: EnrichedAdjustmentHistoryDTO) => {
+                                    const isPenalty = evt.adjustment_type === 'PENALTY';
+                                    const eventStyle =
+                                        EVENT_STYLES[evt.event_type] ?? EVENT_STYLES.SUBMITTED!;
+                                    return (
+                                        <tr
+                                            key={evt.id}
+                                            className="hover:bg-gray-50/40 transition-colors"
+                                        >
+                                            <td className="py-3 px-4 text-gray-700 whitespace-nowrap">
+                                                {dayjs(evt.created_at).format('D MMM YYYY, HH:mm')}
+                                            </td>
+                                            <td className="py-3 px-4 text-gray-800 font-semibold">
+                                                <div>{evt.student_name || evt.student_user_id || '\u2014'}</div>
+                                                {evt.student_phone && (
+                                                    <div className="text-[11px] text-gray-400 font-normal">
+                                                        {evt.student_phone}
+                                                    </div>
+                                                )}
+                                            </td>
+                                            <td className="py-3 px-4 text-gray-600">
+                                                {evt.fee_type_name || '\u2014'}
+                                                {evt.cpo_name && (
+                                                    <div className="text-[11px] text-gray-400">
+                                                        {evt.cpo_name}
+                                                    </div>
+                                                )}
+                                            </td>
+                                            <td className="py-3 px-4">
+                                                <span
+                                                    className={cn(
+                                                        'inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase',
+                                                        isPenalty
+                                                            ? 'bg-red-100 text-red-700'
+                                                            : 'bg-emerald-100 text-emerald-700'
+                                                    )}
+                                                >
+                                                    {isPenalty ? 'Penalty' : 'Concession'}
+                                                </span>
+                                            </td>
+                                            <td
+                                                className={cn(
+                                                    'py-3 px-4 font-semibold',
+                                                    isPenalty ? 'text-red-700' : 'text-emerald-700'
+                                                )}
+                                            >
+                                                {isPenalty ? '+' : '-'}
+                                                {formatCurrency(evt.amount)}
+                                            </td>
+                                            <td className="py-3 px-4">
+                                                <span
+                                                    className={cn(
+                                                        'inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase',
+                                                        eventStyle.bg,
+                                                        eventStyle.text
+                                                    )}
+                                                >
+                                                    {evt.event_type}
+                                                </span>
+                                            </td>
+                                            <td className="py-3 px-4 text-gray-700">
+                                                {evt.actor_name || evt.actor_user_id}
+                                            </td>
+                                            <td
+                                                className="py-3 px-4 text-gray-500 max-w-[260px] truncate"
+                                                title={evt.reason ?? ''}
+                                            >
+                                                {evt.reason || '\u2014'}
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Pagination */}
+                    {totalPages > 1 && (
+                        <div className="flex items-center justify-between border-t border-gray-100 px-4 py-3">
+                            <div className="text-xs text-gray-500">
+                                Page {page + 1} of {totalPages}
+                                {' \u00b7 '}
+                                <span className="font-semibold text-gray-700">
+                                    {totalElements}
+                                </span>{' '}
+                                total{isFetching && data ? ' \u00b7 updating…' : ''}
+                            </div>
+                            <div className="flex items-center gap-1">
+                                <button
+                                    type="button"
+                                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                                    disabled={page === 0}
+                                    className="rounded border border-gray-200 p-1.5 disabled:opacity-40 hover:bg-gray-50"
+                                >
+                                    <CaretLeft size={14} />
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setPage((p) => p + 1)}
+                                    disabled={!!data?.last}
+                                    className="rounded border border-gray-200 p-1.5 disabled:opacity-40 hover:bg-gray-50"
+                                >
+                                    <CaretRight size={14} />
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/PendingApprovalsTable.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/adjustment-approvals/-components/PendingApprovalsTable.tsx
@@ -1,0 +1,207 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import dayjs from 'dayjs';
+import { Check, X } from '@phosphor-icons/react';
+import { DashboardLoader } from '@/components/core/dashboard-loader';
+import {
+    fetchPendingAdjustments,
+    getPendingAdjustmentsQueryKey,
+    reviewAdjustment,
+} from '@/services/manage-finances';
+import { StudentFeeDueDTO } from '@/types/manage-finances';
+import { cn } from '@/lib/utils';
+
+const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' }).format(amount);
+
+export function PendingApprovalsTable() {
+    const queryClient = useQueryClient();
+
+    const { data: pending, isLoading, error } = useQuery({
+        queryKey: getPendingAdjustmentsQueryKey(),
+        queryFn: fetchPendingAdjustments,
+        refetchInterval: 30000,
+    });
+
+    const reviewMutation = useMutation({
+        mutationFn: (params: { id: string; action: 'APPROVED' | 'REJECTED' }) =>
+            reviewAdjustment({
+                student_fee_payment_id: params.id,
+                action: params.action,
+            }),
+        onSuccess: (_data, variables) => {
+            toast.success(
+                variables.action === 'APPROVED' ? 'Adjustment approved' : 'Adjustment rejected'
+            );
+            queryClient.invalidateQueries({ queryKey: getPendingAdjustmentsQueryKey() });
+        },
+        onError: (err: any) => {
+            toast.error(err?.response?.data?.ex || err?.message || 'Failed to review adjustment');
+        },
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex h-48 items-center justify-center">
+                <DashboardLoader />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-8 text-center">
+                <p className="font-semibold text-red-800">Unable to load pending approvals</p>
+                <p className="mt-2 text-sm text-red-600">
+                    {error instanceof Error ? error.message : 'Please try again.'}
+                </p>
+            </div>
+        );
+    }
+
+    if (!pending || pending.length === 0) {
+        return (
+            <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
+                <p className="text-lg font-semibold text-gray-600">No pending approvals</p>
+                <p className="mt-2 text-sm text-gray-400">
+                    All adjustment requests have been reviewed.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div className="overflow-auto">
+                <table className="w-full text-left border-collapse min-w-[800px]">
+                    <thead>
+                        <tr className="border-b-2 border-gray-200 bg-gray-50/95">
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Student
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Fee Type
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                CPO / Plan
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Type
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Expected
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Amount
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Reason
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Due Date
+                            </th>
+                            <th className="py-3 px-4 text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                                Actions
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 text-sm font-medium">
+                        {pending.map((item: StudentFeeDueDTO) => {
+                            const isPenalty = item.adjustment_type === 'PENALTY';
+                            return (
+                                <tr
+                                    key={item.id}
+                                    className={cn(
+                                        'transition-colors border-l-4',
+                                        isPenalty
+                                            ? 'border-l-red-400 hover:bg-red-50/40'
+                                            : 'border-l-emerald-400 hover:bg-emerald-50/40'
+                                    )}
+                                >
+                                    <td className="py-3 px-4 text-gray-800 font-semibold">
+                                        {item.student_name || item.user_id}
+                                    </td>
+                                    <td className="py-3 px-4 text-gray-800 font-semibold">
+                                        {item.fee_type_name}
+                                    </td>
+                                    <td className="py-3 px-4 text-gray-600">
+                                        {item.cpo_name || '\u2014'}
+                                    </td>
+                                    <td className="py-3 px-4">
+                                        <span
+                                            className={cn(
+                                                'inline-flex rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
+                                                isPenalty
+                                                    ? 'bg-red-100 text-red-800'
+                                                    : 'bg-emerald-100 text-emerald-800'
+                                            )}
+                                        >
+                                            {isPenalty ? 'Penalty' : 'Concession'}
+                                        </span>
+                                    </td>
+                                    <td className="py-3 px-4 text-gray-700">
+                                        {formatCurrency(item.amount_expected)}
+                                    </td>
+                                    <td
+                                        className={cn(
+                                            'py-3 px-4 font-semibold',
+                                            isPenalty ? 'text-red-700' : 'text-emerald-700'
+                                        )}
+                                    >
+                                        {isPenalty ? '+' : '-'}
+                                        {formatCurrency(item.adjustment_amount)}
+                                    </td>
+                                    <td
+                                        className="py-3 px-4 text-gray-500 max-w-[200px] truncate"
+                                        title={item.adjustment_reason ?? ''}
+                                    >
+                                        {item.adjustment_reason || '\u2014'}
+                                    </td>
+                                    <td className="py-3 px-4 text-gray-600">
+                                        {item.due_date
+                                            ? dayjs(item.due_date).format('D MMM YYYY')
+                                            : '\u2014'}
+                                    </td>
+                                    <td className="py-3 px-4">
+                                        <div className="flex items-center gap-2">
+                                            <button
+                                                type="button"
+                                                title="Approve"
+                                                onClick={() =>
+                                                    reviewMutation.mutate({
+                                                        id: item.id,
+                                                        action: 'APPROVED',
+                                                    })
+                                                }
+                                                disabled={reviewMutation.isPending}
+                                                className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-lg bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 disabled:opacity-50 transition-colors"
+                                            >
+                                                <Check size={13} weight="bold" />
+                                                Approve
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="Reject"
+                                                onClick={() =>
+                                                    reviewMutation.mutate({
+                                                        id: item.id,
+                                                        action: 'REJECTED',
+                                                    })
+                                                }
+                                                disabled={reviewMutation.isPending}
+                                                className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-lg bg-red-50 text-red-700 border border-red-200 hover:bg-red-100 disabled:opacity-50 transition-colors"
+                                            >
+                                                <X size={13} weight="bold" />
+                                                Reject
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/AdjustmentDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/financial-management/pay-installments/-components/AdjustmentDialog.tsx
@@ -1,17 +1,21 @@
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import dayjs from 'dayjs';
+import { CaretDown, CaretLeft, CaretRight } from '@phosphor-icons/react';
 import {
     Dialog,
     DialogContent,
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { StudentFeeDueDTO } from '@/types/manage-finances';
+import { StudentFeeDueDTO, AdjustmentHistoryDTO } from '@/types/manage-finances';
 import {
     submitAdjustment,
     retractAdjustment,
     getStudentDuesQueryKey,
+    fetchAdjustmentHistory,
+    getAdjustmentHistoryQueryKey,
 } from '@/services/manage-finances';
 import { cn } from '@/lib/utils';
 
@@ -44,6 +48,19 @@ export function AdjustmentDialog({
 
     const hasExistingAdjustment =
         installment.adjustment_status !== null && installment.adjustment_status !== undefined;
+
+    // ── Adjustment history (paginated, 20 per page) ─────────────────────────
+    const [historyOpen, setHistoryOpen] = useState(false);
+    const [historyPage, setHistoryPage] = useState(0);
+    const HISTORY_SIZE = 20;
+
+    const { data: historyData, isLoading: isHistoryLoading } = useQuery({
+        queryKey: getAdjustmentHistoryQueryKey(installment.id, historyPage, HISTORY_SIZE),
+        queryFn: () => fetchAdjustmentHistory(installment.id, historyPage, HISTORY_SIZE),
+        enabled: open && historyOpen,
+        staleTime: 10000,
+        placeholderData: keepPreviousData,
+    });
 
     const submitMutation = useMutation({
         mutationFn: () =>
@@ -291,6 +308,114 @@ export function AdjustmentDialog({
                         )}
                     </div>
                 )}
+
+                {/* Adjustment history — collapsible, paginated 20/page */}
+                <div className="rounded-lg border border-gray-200 bg-white">
+                    <button
+                        type="button"
+                        onClick={() => setHistoryOpen((v) => !v)}
+                        className="flex w-full items-center justify-between px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                    >
+                        <span>History</span>
+                        <CaretDown
+                            size={14}
+                            className={cn('transition-transform', historyOpen && 'rotate-180')}
+                        />
+                    </button>
+                    {historyOpen && (
+                        <div className="border-t border-gray-100 px-3 py-2 space-y-2">
+                            {isHistoryLoading && !historyData && (
+                                <p className="text-xs text-gray-400 text-center py-4">
+                                    Loading history…
+                                </p>
+                            )}
+                            {historyData && historyData.content.length === 0 && (
+                                <p className="text-xs text-gray-400 text-center py-4">
+                                    No adjustment activity yet.
+                                </p>
+                            )}
+                            {historyData && historyData.content.length > 0 && (
+                                <>
+                                    <ul className="space-y-2 max-h-64 overflow-y-auto">
+                                        {historyData.content.map((evt: AdjustmentHistoryDTO) => (
+                                            <li
+                                                key={evt.id}
+                                                className="rounded border border-gray-100 bg-gray-50 p-2 text-xs"
+                                            >
+                                                <div className="flex items-center justify-between">
+                                                    <span
+                                                        className={cn(
+                                                            'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase',
+                                                            evt.event_type === 'SUBMITTED' &&
+                                                                'bg-blue-100 text-blue-700',
+                                                            evt.event_type === 'APPROVED' &&
+                                                                'bg-emerald-100 text-emerald-700',
+                                                            evt.event_type === 'REJECTED' &&
+                                                                'bg-red-100 text-red-700',
+                                                            evt.event_type === 'RETRACTED' &&
+                                                                'bg-gray-200 text-gray-700'
+                                                        )}
+                                                    >
+                                                        {evt.event_type}
+                                                    </span>
+                                                    <span className="text-gray-500">
+                                                        {dayjs(evt.created_at).format(
+                                                            'DD MMM YYYY, HH:mm'
+                                                        )}
+                                                    </span>
+                                                </div>
+                                                <div className="mt-1 flex items-center justify-between text-gray-700">
+                                                    <span>
+                                                        {evt.adjustment_type === 'PENALTY'
+                                                            ? 'Penalty'
+                                                            : 'Concession'}{' '}
+                                                        · {formatCurrency(evt.amount)}
+                                                    </span>
+                                                    <span className="text-gray-500">
+                                                        by {evt.actor_name || evt.actor_user_id}
+                                                    </span>
+                                                </div>
+                                                {evt.reason && (
+                                                    <div className="mt-1 text-gray-500">
+                                                        Reason: {evt.reason}
+                                                    </div>
+                                                )}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                    {(historyData.total_pages ?? historyData.totalPages ?? 1) > 1 && (
+                                        <div className="flex items-center justify-between pt-1 text-[11px] text-gray-500">
+                                            <span>
+                                                Page {historyPage + 1} of{' '}
+                                                {historyData.total_pages ?? historyData.totalPages}
+                                            </span>
+                                            <div className="flex items-center gap-1">
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        setHistoryPage((p) => Math.max(0, p - 1))
+                                                    }
+                                                    disabled={historyPage === 0}
+                                                    className="rounded border border-gray-200 p-1 disabled:opacity-40"
+                                                >
+                                                    <CaretLeft size={12} />
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setHistoryPage((p) => p + 1)}
+                                                    disabled={historyData.last}
+                                                    className="rounded border border-gray-200 p-1 disabled:opacity-40"
+                                                >
+                                                    <CaretRight size={12} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
             </DialogContent>
         </Dialog>
     );

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -6,6 +6,7 @@ import {
     InstallmentDetailDTO,
     StudentFeeDueDTO,
     AllocateSelectedRequest,
+    AdjustmentHistoryPageResponse,
 } from '@/types/manage-finances';
 import { BASE_URL, NOTIFICATION_SERVICE_BASE } from '@/constants/urls';
 
@@ -288,6 +289,23 @@ export const getReceiptUrlForInstallment = async (
 ): Promise<InstallmentReceiptResponse> => {
     const response = await authenticatedAxiosInstance.get<InstallmentReceiptResponse>(
         `${BASE_URL}/admin-core-service/v1/admin/student-fee/installment/${installmentId}/receipt-url`
+    );
+    return response.data;
+};
+
+// ─── Adjustment History (Pay Installments dialog) ──────────────────────────
+
+export const getAdjustmentHistoryQueryKey = (installmentId: string, page: number, size: number) =>
+    ['ADJUSTMENT_HISTORY', installmentId, page, size];
+
+export const fetchAdjustmentHistory = async (
+    installmentId: string,
+    page: number = 0,
+    size: number = 20
+): Promise<AdjustmentHistoryPageResponse> => {
+    const response = await authenticatedAxiosInstance.get<AdjustmentHistoryPageResponse>(
+        `${BASE_URL}/admin-core-service/v1/admin/student-fee/installment/${installmentId}/adjustment-history`,
+        { params: { page, size } }
     );
     return response.data;
 };

--- a/frontend-admin-dashboard/src/services/manage-finances.ts
+++ b/frontend-admin-dashboard/src/services/manage-finances.ts
@@ -7,6 +7,8 @@ import {
     StudentFeeDueDTO,
     AllocateSelectedRequest,
     AdjustmentHistoryPageResponse,
+    InstituteAdjustmentHistoryFilter,
+    EnrichedAdjustmentHistoryPageResponse,
 } from '@/types/manage-finances';
 import { BASE_URL, NOTIFICATION_SERVICE_BASE } from '@/constants/urls';
 
@@ -306,6 +308,26 @@ export const fetchAdjustmentHistory = async (
     const response = await authenticatedAxiosInstance.get<AdjustmentHistoryPageResponse>(
         `${BASE_URL}/admin-core-service/v1/admin/student-fee/installment/${installmentId}/adjustment-history`,
         { params: { page, size } }
+    );
+    return response.data;
+};
+
+// ─── Institute-wide Adjustment History (Adjustment Approvals page) ─────────
+
+export const getInstituteAdjustmentHistoryQueryKey = (
+    filter: InstituteAdjustmentHistoryFilter
+) => ['INSTITUTE_ADJUSTMENT_HISTORY', JSON.stringify(filter)];
+
+export const fetchInstituteAdjustmentHistory = async (
+    filter: InstituteAdjustmentHistoryFilter
+): Promise<EnrichedAdjustmentHistoryPageResponse> => {
+    const instituteId = getInstituteId();
+    if (!instituteId) throw new Error('Institute ID not found');
+
+    const response = await authenticatedAxiosInstance.post<EnrichedAdjustmentHistoryPageResponse>(
+        `${BASE_URL}/admin-core-service/v1/admin/student-fee/adjustment/history`,
+        filter ?? {},
+        { params: { instituteId } }
     );
     return response.data;
 };

--- a/frontend-admin-dashboard/src/types/manage-finances.ts
+++ b/frontend-admin-dashboard/src/types/manage-finances.ts
@@ -118,3 +118,36 @@ export interface AdjustmentHistoryPageResponse {
     totalPages?: number;
     last: boolean;
 }
+
+// ─── Institute-wide Adjustment History (Adjustment Approvals page) ─────────
+export interface InstituteAdjustmentHistoryFilter {
+    page?: number;
+    size?: number;
+    event_types?: ('SUBMITTED' | 'APPROVED' | 'REJECTED' | 'RETRACTED')[];
+    adjustment_types?: ('CONCESSION' | 'PENALTY')[];
+    resulting_statuses?: ('PENDING_FOR_APPROVAL' | 'APPROVED' | 'REJECTED' | 'RETRACTED')[];
+    actor_user_id?: string;
+    start_date?: string; // yyyy-MM-dd
+    end_date?: string;   // yyyy-MM-dd
+    student_search?: string;
+}
+
+export interface EnrichedAdjustmentHistoryDTO extends AdjustmentHistoryDTO {
+    student_user_id?: string | null;
+    student_name?: string | null;
+    student_phone?: string | null;
+    fee_type_name?: string | null;
+    cpo_name?: string | null;
+    installment_due_date?: string | null;
+}
+
+export interface EnrichedAdjustmentHistoryPageResponse {
+    content: EnrichedAdjustmentHistoryDTO[];
+    number: number;
+    size: number;
+    total_elements: number;
+    totalElements?: number;
+    total_pages: number;
+    totalPages?: number;
+    last: boolean;
+}

--- a/frontend-admin-dashboard/src/types/manage-finances.ts
+++ b/frontend-admin-dashboard/src/types/manage-finances.ts
@@ -90,3 +90,31 @@ export interface AllocateSelectedRequest {
     amount: number;
     remarks?: string;
 }
+
+// ─── Adjustment History (Pay Installments dialog) ──────────────────────────
+export interface AdjustmentHistoryDTO {
+    id: string;
+    student_fee_payment_id: string;
+    event_type: 'SUBMITTED' | 'APPROVED' | 'REJECTED' | 'RETRACTED';
+    adjustment_type: string;
+    amount: number;
+    reason: string | null;
+    resulting_status: string;
+    actor_user_id: string;
+    actor_name: string | null;
+    actor_role: string | null;
+    previous_event_id: string | null;
+    metadata: string | null;
+    created_at: string;
+}
+
+export interface AdjustmentHistoryPageResponse {
+    content: AdjustmentHistoryDTO[];
+    number: number;
+    size: number;
+    total_elements: number;
+    totalElements?: number;
+    total_pages: number;
+    totalPages?: number;
+    last: boolean;
+}


### PR DESCRIPTION
## Summary of Changes

Introduces an append-only adjustment history for every installment. Replaces the single-slot adjustment columns on `student_fee_payment` with a FK into a new `student_fee_adjustment_history` table that records every event (submit / approve / reject / retract) with actor, timestamp, and reason — giving us a full audit trail and unblocking history views on both the pay-installments dialog and the Adjustment Approvals page.

**Backend:**
- New migration `V212` — creates `student_fee_adjustment_history` (event log with actor, resulting_status, previous_event_id, JSONB metadata), adds `current_adjustment_history_id` FK to `student_fee_payment`, backfills existing adjustments into history rows, then drops the 4 legacy columns (`adjustment_amount/type/status/reason`).
- `AdjustmentResolver` central helper loads the current effective event per bill (batch or single); a RETRACTED event counts as "no active adjustment" so downstream compute logic stays the same.
- Refactored all read paths (`FeeTrackingService`, `FeeAllocationEngine`, `FeeLedgerAllocationService`, `SchoolFeeReceiptService`, `CollectionDashboardRepositoryImpl`) to fetch adjustment info via the FK instead of the dropped columns. `searchFeePayments`, `getStudentDues`, `buildReceiptDetails`, `getPendingAdjustments` now batch-load history rows to avoid N+1.
- `StudentFeeAdjustmentService.submit/review/retract` now append history events in the same transaction as the FK update. Submit tightened to block when an active adjustment exists (PENDING/APPROVED/REJECTED) — matches existing UX which already hides the form.
- New endpoint `GET /admin-core-service/v1/admin/student-fee/installment/{id}/adjustment-history` — per-installment timeline, DB-paginated (default 20/page).
- New endpoint `POST /admin-core-service/v1/admin/student-fee/adjustment/history?instituteId=X` — institute-wide history with a body filter (event types, adjustment types, actor, date range, student search). DB-level pagination, newest first. Response is enriched with student name/phone, fee type, cpo name.
- `StudentFeeAdjustmentHistorySpecification` builds dynamic WHERE from the filter body; studentSearch resolves user IDs via auth_service and maps to bill IDs for filtering.
- `auth_service` — added `GET /auth-service/internal/user/autosuggest-users` (HMAC-authenticated, reuses existing `userService.autoSuggestUsers`). Needed because the autosuggest endpoint on the `/v1/user/*` public path rejects HMAC with 403. `admin_core_service.AuthService.autosuggestUsers` now calls this for cross-service user search.

**Frontend:**
- `AdjustmentDialog` — collapsible **History** section below the current-adjustment card. Shows chronological event timeline (badge, timestamp, actor, amount, reason) with paginated lazy-load (20/page). Fetches only when the section is expanded.
- Adjustment Approvals page rewritten as a tabbed view: **Pending** (existing concession review flow, unchanged) | **Approved** | **Rejected** | **All History**. History tabs render a new `AdjustmentHistoryList` component with filter bar (student search, adjustment type chips, date range) and cross-page DB-backed pagination.
- `manage-finances` types/services extended with `AdjustmentHistoryDTO`, `EnrichedAdjustmentHistoryDTO`, `InstituteAdjustmentHistoryFilter`, and the two new fetch helpers.

## Related Issue

<link or leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran migration V212 against a dev DB with existing approved concessions and pending adjustments — verified backfill created one seed history row per non-null adjustment and the FK link held after the 4 legacy columns were dropped.
- On Pay Installments: submitted a concession → event recorded with status `PENDING_FOR_APPROVAL`; approver approved → second event linked via `previous_event_id`; retracted → third event with `RETRACTED`; submitted a new penalty → auto-approved with `metadata.auto_approved: true`. Dialog's History section showed the full timeline with correct actor names.
- On Adjustment Approvals page: Pending tab unchanged (approve/reject still works). Approved / Rejected / All History tabs load filtered events. Student-search resolves names via auth_service autosuggest (verified "vik" finds Vikraal Singh after local auth_service was running and connected). Date range and adjustment-type filters work alongside pagination.
- Verified that retract (which now produces a RETRACTED event rather than nulling fields) still presents as "no active adjustment" to the rest of the read paths — due summaries, receipts, and the search page are unaffected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

