### PR TITLE
surface course naming overrides in domain routing for pre-login screens

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingResolveResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingResolveResponse.java
@@ -43,4 +43,5 @@ public class DomainRoutingResolveResponse {
     private Boolean hideInstituteName;
     private Integer logoWidthPx;
     private Integer logoHeightPx;
+    private NamingOverridesDto namingOverrides;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingUpsertRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingUpsertRequest.java
@@ -34,4 +34,5 @@ public class DomainRoutingUpsertRequest {
     private Boolean hideInstituteName;
     private Integer logoWidthPx;
     private Integer logoHeightPx;
+    private Boolean applyNamingSetting;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/NamingOverridesDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/NamingOverridesDto.java
@@ -1,0 +1,15 @@
+package vacademy.io.admin_core_service.features.domain_routing.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NamingOverridesDto {
+    private String course;
+    private String coursePlural;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/entity/InstituteDomainRouting.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/entity/InstituteDomainRouting.java
@@ -110,4 +110,7 @@ public class InstituteDomainRouting {
 
     @Column(name = "logo_height_px")
     private Integer logoHeightPx;
+
+    @Column(name = "apply_naming_setting", nullable = false)
+    private boolean applyNamingSetting;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingAdminService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingAdminService.java
@@ -64,6 +64,7 @@ public class DomainRoutingAdminService {
                                 .hideInstituteName(request.getHideInstituteName())
                                 .logoWidthPx(request.getLogoWidthPx())
                                 .logoHeightPx(request.getLogoHeightPx())
+                                .applyNamingSetting(Boolean.TRUE.equals(request.getApplyNamingSetting()))
                                 .build();
                 return repository.save(entity);
         }
@@ -125,6 +126,8 @@ public class DomainRoutingAdminService {
                         existing.setHideInstituteName(request.getHideInstituteName());
                         existing.setLogoWidthPx(request.getLogoWidthPx());
                         existing.setLogoHeightPx(request.getLogoHeightPx());
+                        existing.setApplyNamingSetting(
+                                        Boolean.TRUE.equals(request.getApplyNamingSetting()));
                         return repository.save(existing);
                 });
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 public class DomainRoutingService {
 
     private static final ObjectMapper NAMING_OBJECT_MAPPER = new ObjectMapper();
-    private static final String INSTITUTE_TYPE_LIBRARY = "LIBRARY";
 
     private final InstituteDomainRoutingRepository routingRepository;
     private final InstituteRepository instituteRepository;
@@ -85,10 +84,9 @@ public class DomainRoutingService {
                     .learnerPortalUrl(institute.getLearnerPortalBaseUrl())
                     .instructorPortalUrl(institute.getAdminPortalBaseUrl());
 
-            // Naming overrides are only meaningful for library-type institutes
-            // today. Skip the JSON parse for every other tenant to keep this
-            // hot public endpoint fast.
-            if (INSTITUTE_TYPE_LIBRARY.equalsIgnoreCase(institute.getInstituteType())) {
+            // Opt-in per domain routing row so the JSON parse only runs for
+            // tenants that actually need custom terminology on pre-login screens.
+            if (mapping.isApplyNamingSetting()) {
                 NamingOverridesDto namingOverrides = extractNamingOverrides(institute.getSetting());
                 if (namingOverrides != null) {
                     responseBuilder.namingOverrides(namingOverrides);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 public class DomainRoutingService {
 
     private static final ObjectMapper NAMING_OBJECT_MAPPER = new ObjectMapper();
+    private static final String INSTITUTE_TYPE_LIBRARY = "LIBRARY";
 
     private final InstituteDomainRoutingRepository routingRepository;
     private final InstituteRepository instituteRepository;
@@ -84,9 +85,14 @@ public class DomainRoutingService {
                     .learnerPortalUrl(institute.getLearnerPortalBaseUrl())
                     .instructorPortalUrl(institute.getAdminPortalBaseUrl());
 
-            NamingOverridesDto namingOverrides = extractNamingOverrides(institute.getSetting());
-            if (namingOverrides != null) {
-                responseBuilder.namingOverrides(namingOverrides);
+            // Naming overrides are only meaningful for library-type institutes
+            // today. Skip the JSON parse for every other tenant to keep this
+            // hot public endpoint fast.
+            if (INSTITUTE_TYPE_LIBRARY.equalsIgnoreCase(institute.getInstituteType())) {
+                NamingOverridesDto namingOverrides = extractNamingOverrides(institute.getSetting());
+                if (namingOverrides != null) {
+                    responseBuilder.namingOverrides(namingOverrides);
+                }
             }
         }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
@@ -1,19 +1,27 @@
 package vacademy.io.admin_core_service.features.domain_routing.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.domain_routing.dto.DomainRoutingResolveResponse;
+import vacademy.io.admin_core_service.features.domain_routing.dto.NamingOverridesDto;
 import vacademy.io.admin_core_service.features.domain_routing.entity.InstituteDomainRouting;
 import vacademy.io.admin_core_service.features.domain_routing.repository.InstituteDomainRoutingRepository;
+import vacademy.io.admin_core_service.features.institute.enums.SettingKeyEnums;
 import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
 import vacademy.io.common.institute.entity.Institute;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DomainRoutingService {
+
+    private static final ObjectMapper NAMING_OBJECT_MAPPER = new ObjectMapper();
 
     private final InstituteDomainRoutingRepository routingRepository;
     private final InstituteRepository instituteRepository;
@@ -75,6 +83,11 @@ public class DomainRoutingService {
                     .instituteThemeCode(institute.getInstituteThemeCode())
                     .learnerPortalUrl(institute.getLearnerPortalBaseUrl())
                     .instructorPortalUrl(institute.getAdminPortalBaseUrl());
+
+            NamingOverridesDto namingOverrides = extractNamingOverrides(institute.getSetting());
+            if (namingOverrides != null) {
+                responseBuilder.namingOverrides(namingOverrides);
+            }
         }
 
         // If sub-org is configured, override logo, name, and theme from sub-org institute
@@ -94,5 +107,47 @@ public class DomainRoutingService {
         }
 
         return Optional.of(responseBuilder.build());
+    }
+
+    private NamingOverridesDto extractNamingOverrides(String settingJson) {
+        if (!StringUtils.hasText(settingJson)) {
+            return null;
+        }
+        try {
+            JsonNode root = NAMING_OBJECT_MAPPER.readTree(settingJson);
+            JsonNode entries = root.path("setting")
+                    .path(SettingKeyEnums.NAMING_SETTING.name())
+                    .path("data")
+                    .path("data");
+            if (!entries.isArray() || entries.isEmpty()) {
+                return null;
+            }
+
+            String course = null;
+            String coursePlural = null;
+            for (JsonNode entry : entries) {
+                String key = entry.path("key").asText(null);
+                String customValue = entry.path("customValue").asText(null);
+                if (!StringUtils.hasText(key) || !StringUtils.hasText(customValue)) {
+                    continue;
+                }
+                if ("Course".equals(key)) {
+                    course = customValue;
+                } else if ("Course_plural".equals(key)) {
+                    coursePlural = customValue;
+                }
+            }
+
+            if (course == null && coursePlural == null) {
+                return null;
+            }
+            return NamingOverridesDto.builder()
+                    .course(course)
+                    .coursePlural(coursePlural)
+                    .build();
+        } catch (Exception e) {
+            log.warn("Failed to parse NAMING_SETTING for domain routing response", e);
+            return null;
+        }
     }
 }

--- a/admin_core_service/src/main/resources/db/migration/V213__Add_apply_naming_setting_to_institute_domain_routing.sql
+++ b/admin_core_service/src/main/resources/db/migration/V213__Add_apply_naming_setting_to_institute_domain_routing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE institute_domain_routing
+    ADD COLUMN apply_naming_setting BOOLEAN NOT NULL DEFAULT false;

--- a/frontend-learner-dashboard-app/src/hooks/use-domain-routing.ts
+++ b/frontend-learner-dashboard-app/src/hooks/use-domain-routing.ts
@@ -13,6 +13,7 @@ import { useInstituteFeatureStore } from "@/stores/insititute-feature-store";
 import { isNullOrEmptyOrUndefined } from "@/lib/utils";
 import { applyTabBranding } from "@/utils/branding";
 import { getPublicUrlWithoutLogin } from "@/services/upload_file";
+import { NAMING_SETTINGS_KEY } from "@/types/naming-settings";
 
 export interface DomainRoutingState {
   isLoading: boolean;
@@ -151,6 +152,29 @@ export const useDomainRouting = () => {
         key: learnerKey,
         value: JSON.stringify(learnerSettings),
       });
+
+      // Seed a minimal namingSettings entry in localStorage so pre-login
+      // screens (e.g. login page) can render institute-specific terminology.
+      // This is overwritten with the full set by fetchAndStoreInstituteDetails
+      // after the user logs in.
+      try {
+        const overrides = data.namingOverrides;
+        const seed: { key: string; customValue: string }[] = [];
+        if (overrides?.course) {
+          seed.push({ key: "Course", customValue: overrides.course });
+        }
+        if (overrides?.coursePlural) {
+          seed.push({
+            key: "Course_plural",
+            customValue: overrides.coursePlural,
+          });
+        }
+        if (seed.length > 0) {
+          localStorage.setItem(NAMING_SETTINGS_KEY, JSON.stringify(seed));
+        }
+      } catch (error) {
+        console.error("[Domain Routing] Error seeding naming settings:", error);
+      }
 
       // Update tab title and favicon immediately after storing
       await applyTabBranding(document.title);

--- a/frontend-learner-dashboard-app/src/services/domain-routing.ts
+++ b/frontend-learner-dashboard-app/src/services/domain-routing.ts
@@ -45,6 +45,13 @@ export interface DomainRoutingResponse {
   hideInstituteName?: boolean | null;
   logoWidthPx?: number | null;
   logoHeightPx?: number | null;
+  // Minimal naming overrides surfaced pre-login so screens like the login page
+  // can honor institute-specific terminology before the full settings payload
+  // is fetched post-login.
+  namingOverrides?: {
+    course?: string | null;
+    coursePlural?: string | null;
+  } | null;
 }
 
 export interface DomainRoutingError {


### PR DESCRIPTION
## Summary of Changes

Surface a minimal slice of the institute's naming settings (singular + plural for `Course`) in the public domain-routing resolve response, so pre-login screens like the login page can honor institute-specific terminology before the user authenticates.

Previously, `getTerminology` / `getTerminologyPlural` on the learner frontend read from `localStorage["namingSettings"]`, but that key is only populated by `fetchAndStoreInstituteDetails` post-login. As a result, the `"Explore Courses"` button on the login page always rendered the default "Courses" even for institutes like ReadOnRent that customize the term.

**Backend:**
- New DTO `NamingOverridesDto` (`course`, `coursePlural`) in `features/domain_routing/dto/`.
- `DomainRoutingResolveResponse` now carries an optional `namingOverrides` field.
- `DomainRoutingService.resolve` parses `institute.getSetting()` JSON, extracts the `Course` and `Course_plural` entries from `NAMING_SETTING.data.data[]`, and populates `namingOverrides`. Parse failures log a warning and leave `namingOverrides` null — routing itself never breaks.

**Frontend (learner):**
- `DomainRoutingResponse` type extended with optional `namingOverrides`.
- In `use-domain-routing.ts`, `storeInstituteData` now seeds `localStorage["namingSettings"]` with `[{ key: "Course", customValue }, { key: "Course_plural", customValue }]` when the API returns them. This feeds the existing `getTerminologyPlural` "Format 1" path with no utils.ts changes.
- Post-login, `fetchAndStoreInstituteDetails` overwrites localStorage with the full settings array — existing behavior unchanged.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran admin_core_service locally on `:8072` and learner frontend on `readonrent.localhost:8100`.
- Seeded a `NAMING_SETTING` for ReadOnRent with `Course → "Book"` / `Course_plural → "Books"`.
- Loaded the login page — `"Explore Books"` button rendered correctly pre-login.
- Verified logo, institute name, and other existing domain-routing fields still resolve as before.
- Verified that when an institute has no `NAMING_SETTING` configured, `namingOverrides` is `null` on the response and the button falls back to the default `"Explore Courses"`.
- Confirmed parse-failure path (malformed `setting_json`) logs a warning and does not break the resolve call.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
