### PR TITLE
fix: generate invoice on manual admin enrollment for non-FREE payments

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -20,9 +20,13 @@ import vacademy.io.admin_core_service.features.institute_learner.notification.Le
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionRepository;
 import vacademy.io.admin_core_service.features.learner.service.LearnerService;
 import vacademy.io.admin_core_service.features.learner_management.dto.*;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentLog;
 import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan;
+import vacademy.io.admin_core_service.features.user_subscription.enums.PaymentOptionType;
 import vacademy.io.admin_core_service.features.user_subscription.enums.UserPlanStatusEnum;
+import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentLogRepository;
 import vacademy.io.admin_core_service.features.user_subscription.service.UserPlanService;
+import vacademy.io.admin_core_service.features.invoice.service.InvoiceService;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.auth.dto.learner.LearnerExtraDetails;
 import vacademy.io.common.common.dto.CustomFieldValueDTO;
@@ -60,6 +64,8 @@ public class BulkAssignmentService {
     private final StudentRegistrationManager studentRegistrationManager;
     private final SubOrgAutoLinkService subOrgAutoLinkService;
     private final vacademy.io.admin_core_service.features.user_subscription.service.PaymentLogService paymentLogService;
+    private final PaymentLogRepository paymentLogRepository;
+    private final InvoiceService invoiceService;
 
     @org.springframework.beans.factory.annotation.Autowired
     @org.springframework.context.annotation.Lazy
@@ -504,12 +510,30 @@ public class BulkAssignmentService {
                 }
                 paymentSpecificData.put("source", "BULK_ASSIGN");
 
-                // Use updatePaymentLogOnly to avoid triggering invoice generation and email notifications
+                // Use updatePaymentLogOnly to avoid triggering the sync payment-gateway post-payment
+                // logic (abandoned-cart cleanup). Invoice generation is handled explicitly below.
                 paymentLogService.updatePaymentLogOnly(
                         paymentLogId,
                         vacademy.io.admin_core_service.features.user_subscription.enums.PaymentLogStatusEnum.SUCCESS.name(),
                         vacademy.io.common.payment.enums.PaymentStatusEnum.PAID.name(),
                         vacademy.io.admin_core_service.features.common.util.JsonUtil.toJson(paymentSpecificData));
+
+                // Generate invoice for non-FREE payments (e.g. ReadOnRent buy). FREE paths
+                // (e.g. rent/membership, school enrollment) skip invoice generation entirely.
+                // INVOICE_SETTING.sendInvoiceEmail is honored inside generateInvoice for the email step.
+                String paymentType = config.getPaymentOption() != null ? config.getPaymentOption().getType() : null;
+                if (StringUtils.hasText(paymentType)
+                        && !PaymentOptionType.FREE.name().equalsIgnoreCase(paymentType)) {
+                    try {
+                        PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
+                                .orElseThrow(() -> new RuntimeException(
+                                        "Payment log not found: " + paymentLogId));
+                        invoiceService.generateInvoice(userPlan, persistedLog, instituteId);
+                    } catch (Exception e) {
+                        log.warn("Failed to generate invoice for userId={}, paymentLogId={}: {}",
+                                userId, paymentLogId, e.getMessage());
+                    }
+                }
             } catch (Exception e) {
                 log.warn("Failed to create payment log for userId={}: {}", userId, e.getMessage());
             }


### PR DESCRIPTION
## Summary of Changes

Fixes missing invoice generation when an admin manually enrolls a learner via the bulk assign endpoint (`POST /v3/learner-management/assign`). Previously this path created a `payment_log` with status `PAID` but deliberately called `updatePaymentLogOnly` to bypass all post-payment logic, so no `Invoice` / `InvoiceLineItems` / S3 PDF was ever generated and no email was sent — customers enrolled in "buy" mode never received a receipt. Rental (FREE) and school-style FREE enrollments remain unchanged.

**Backend:**
- `BulkAssignmentService.handleNewEnrollment`: after `updatePaymentLogOnly`, re-fetch the persisted `PaymentLog` and call `invoiceService.generateInvoice(userPlan, paymentLog, instituteId)` when `paymentOption.type` is non-FREE (null type is also treated as "skip" for safety).
- `INVOICE_SETTING.sendInvoiceEmail` continues to gate the actual email step inside `generateInvoice`, matching the existing online-checkout behavior — no semantic change there.
- Invoice generation is wrapped in try/catch so a template/S3/email failure never fails the enrollment. `generateInvoice` already dedupes by `paymentLogId`, so retries are safe.
- Added `PaymentLogRepository` and `InvoiceService` to the constructor-injected dependencies; added imports for `PaymentLog` and `PaymentOptionType`.

**Frontend:**
- No frontend changes.

## Related Issue



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Manually enrolled a customer into a ReadOnRent "buy" `PackageSession` via `Manage Contacts → Enroll Customer → Enroll in Bulk` with `payment_date` set; verified a new `invoice` row, `invoice_line_items` row, and `invoice_payment_log_mapping` row were created and the PDF was uploaded to S3.
- Verified the invoice email was sent when `INVOICE_SETTING.sendInvoiceEmail=true` and was skipped (invoice record still generated) when the flag was absent/false.
- Manually enrolled into a "rent"/membership `PackageSession` (FREE payment option) and confirmed no invoice was generated.
- Re-ran the same assign call to confirm `existsByPaymentLogId` dedupe prevents duplicate invoices.
- Confirmed invoice generation failure does not break enrollment — temporarily broke the template path locally; SSIGM + UserPlan still created, only a warn log emitted.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly