### PR TITLE
Feat/enroll bulk filter level session step2 v2

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/BulkAssignDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/BulkAssignDialog.tsx
@@ -18,10 +18,15 @@ import { Step3EnrollConfig } from './steps/Step3EnrollConfig';
 import { Step4Preview } from './steps/Step4Preview';
 import { cn } from '@/lib/utils';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
-import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
-import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
-
-const STEPS = ['Select Learners', 'Select Courses', 'Enrollment Config', 'Preview & Confirm'];
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import {
+    ContentTerms,
+    RoleTerms,
+    SystemTerms,
+} from '@/routes/settings/-components/NamingSettings';
 
 interface BulkAssignDialogProps {
     open: boolean;
@@ -54,6 +59,13 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
         }
         return [];
     };
+
+    const STEPS = [
+        `Select ${getTerminologyPlural(RoleTerms.Learner, SystemTerms.Learner)}`,
+        `Select ${getTerminologyPlural(ContentTerms.Course, SystemTerms.Course)}`,
+        'Enrollment Config',
+        'Preview & Confirm',
+    ];
 
     const [step, setStep] = useState(0);
     const [selectedLearners, setSelectedLearners] = useState<SelectedLearner[]>([]);

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
@@ -14,6 +14,8 @@ import {
 import { CsvUserImporter, CsvPaymentInfo } from '../../components/CsvUserImporter';
 import { ManualUserEntry } from '../../components/ManualUserEntry';
 import { FromCourseSelector } from '../../components/FromCourseSelector';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     instituteId: string;
@@ -109,7 +111,7 @@ export const Step1LearnerSelector = ({
                     </TabsTrigger>
                     <TabsTrigger value="from_course" className="flex-1">
                         <UserPlus size={14} className="mr-1.5" />
-                        From Course
+                        From {getTerminology(ContentTerms.Course, SystemTerms.Course)}
                     </TabsTrigger>
                     <TabsTrigger value="csv" className="flex-1">
                         <Upload size={14} className="mr-1.5" />

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
@@ -1,10 +1,44 @@
-import { useState } from 'react';
-import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
-import { MagnifyingGlass, BookOpen } from '@phosphor-icons/react';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import {
+    MagnifyingGlass,
+    BookOpen,
+    FunnelSimple,
+    X,
+    CaretDown,
+    CaretLeft,
+    CaretRight,
+    Warning,
+} from '@phosphor-icons/react';
 import { SelectedPackageSession } from '../../../../-types/bulk-assign-types';
 import { cn } from '@/lib/utils';
+import { getAllCoursesWithFilters } from '@/routes/study-library/courses/-services/courses-services';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+import { GET_LEVELS_BY_INSTITUTE, GET_SESSION_DETAILS } from '@/constants/urls';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import type { CourseItem } from '@/routes/study-library/courses/-components/course-material';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import {
+    ContentTerms,
+    RoleTerms,
+    SystemTerms,
+} from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     selectedPackageSessions: SelectedPackageSession[];
@@ -12,155 +46,519 @@ interface Props {
     initialPackageSessionId?: string;
 }
 
+function useDebounce<T>(value: T, delay: number): T {
+    const [debounced, setDebounced] = useState(value);
+    useEffect(() => {
+        const t = setTimeout(() => setDebounced(value), delay);
+        return () => clearTimeout(t);
+    }, [value, delay]);
+    return debounced;
+}
+
+const PAGE_SIZE = 20;
+
 export const Step2CourseSelector = ({
     selectedPackageSessions,
     onSelectedPackageSessionsChange,
     initialPackageSessionId,
 }: Props) => {
+    const instituteId = getCurrentInstituteId();
+
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+    const coursesTerm = getTerminologyPlural(ContentTerms.Course, SystemTerms.Course);
+    const levelTerm = getTerminology(ContentTerms.Level, SystemTerms.Level);
+    const levelsTerm = getTerminologyPlural(ContentTerms.Level, SystemTerms.Level);
+    const sessionTerm = getTerminology(ContentTerms.Session, SystemTerms.Session);
+    const sessionsTerm = getTerminologyPlural(ContentTerms.Session, SystemTerms.Session);
+    const batchTerm = getTerminology(ContentTerms.Batch, SystemTerms.Batch);
+    const batchesTerm = getTerminologyPlural(ContentTerms.Batch, SystemTerms.Batch);
+    const learnersTerm = getTerminologyPlural(RoleTerms.Learner, SystemTerms.Learner);
+
     const [searchQuery, setSearchQuery] = useState('');
-    const { getPackageWiseLevels } = useInstituteDetailsStore();
+    const [selectedLevelIds, setSelectedLevelIds] = useState<string[]>([]);
+    const [selectedSessionIds, setSelectedSessionIds] = useState<string[]>([]);
+    const [page, setPage] = useState(0);
+    const debouncedSearch = useDebounce(searchQuery, 400);
 
-    const packageGroups = getPackageWiseLevels();
+    useEffect(() => {
+        setPage(0);
+    }, [debouncedSearch, selectedLevelIds, selectedSessionIds]);
 
-    const filtered = packageGroups
-        .map((group) => ({
-            ...group,
-            level: group.level.filter((l) =>
-                searchQuery
-                    ? group.package_dto.package_name
-                          .toLowerCase()
-                          .includes(searchQuery.toLowerCase()) ||
-                      l.level_dto.level_name
-                          .toLowerCase()
-                          .includes(searchQuery.toLowerCase())
-                    : true
-            ),
-        }))
-        .filter((g) => g.level.length > 0)
-        .sort((a, b) => {
-            if (!initialPackageSessionId) return 0;
-            const aHas = a.level.some((l) => l.package_session_id === initialPackageSessionId);
-            const bHas = b.level.some((l) => l.package_session_id === initialPackageSessionId);
-            if (aHas && !bHas) return -1;
-            if (!aHas && bHas) return 1;
-            return 0;
-        });
+    const { data: levelOptions = [], isLoading: isLevelsLoading } = useQuery<
+        { id: string; level_name: string }[]
+    >({
+        queryKey: ['STEP2_LEVELS', instituteId],
+        queryFn: async () => {
+            const response = await authenticatedAxiosInstance.get(GET_LEVELS_BY_INSTITUTE, {
+                params: { instituteId },
+            });
+            return response.data;
+        },
+        staleTime: 300000,
+        enabled: !!instituteId,
+    });
 
-    const isSelected = (packageSessionId: string) =>
-        selectedPackageSessions.some((s) => s.packageSessionId === packageSessionId);
-
-    const toggle = (
-        group: ReturnType<typeof getPackageWiseLevels>[number],
-        levelEntry: ReturnType<typeof getPackageWiseLevels>[number]['level'][number]
-    ) => {
-        const psId = levelEntry.package_session_id;
-        if (isSelected(psId)) {
-            onSelectedPackageSessionsChange(
-                selectedPackageSessions.filter((s) => s.packageSessionId !== psId)
+    // GET_SESSION_DETAILS returns [{ session: { id, session_name, ... }, packages: [...] }]
+    // must map to flatten
+    const { data: sessionOptions = [], isLoading: isSessionsLoading } = useQuery<
+        { id: string; session_name: string }[]
+    >({
+        queryKey: ['STEP2_SESSIONS', instituteId],
+        queryFn: async () => {
+            const response = await authenticatedAxiosInstance.get(GET_SESSION_DETAILS, {
+                params: { instituteId },
+            });
+            return (response.data ?? []).map(
+                (item: { session: { id: string; session_name: string } }) => ({
+                    id: item.session.id,
+                    session_name: item.session.session_name,
+                })
             );
-        } else {
-            const newSession: SelectedPackageSession = {
-                packageSessionId: psId,
-                courseName: group.package_dto.package_name,
-                sessionName: '', // resolved via store if needed
-                levelName: levelEntry.level_dto.level_name,
-                enrollInviteId: null,
-                accessDays: null,
-            };
-            onSelectedPackageSessionsChange([...selectedPackageSessions, newSession]);
+        },
+        staleTime: 300000,
+        enabled: !!instituteId,
+    });
+
+    const {
+        data: courseData,
+        isLoading: isCoursesLoading,
+        isError,
+        error,
+    } = useQuery({
+        queryKey: [
+            'STEP2_COURSES',
+            instituteId,
+            debouncedSearch,
+            selectedLevelIds,
+            selectedSessionIds,
+            page,
+        ],
+        queryFn: () =>
+            getAllCoursesWithFilters(page, PAGE_SIZE, instituteId, {
+                status: ['ACTIVE'],
+                level_ids: selectedLevelIds,
+                session_ids: selectedSessionIds,
+                tag: [],
+                faculty_ids: [],
+                search_by_name: debouncedSearch || '',
+                min_percentage_completed: 0,
+                max_percentage_completed: 0,
+                sort_columns: { created_at: 'DESC' },
+                package_ids: [],
+                package_session_ids: [],
+                package_view: false,
+            }),
+        enabled: !!instituteId,
+        staleTime: 1000 * 30,
+    });
+
+    const items: CourseItem[] = courseData?.content ?? [];
+    const totalPages: number = courseData?.totalPages ?? 0;
+    const totalElements: number = courseData?.totalElements ?? 0;
+
+    const groups = useMemo(() => {
+        const map: Record<string, { packageName: string; items: CourseItem[] }> = {};
+        items.forEach((item) => {
+            if (!map[item.id]) {
+                map[item.id] = { packageName: item.package_name, items: [] };
+            }
+            map[item.id]!.items.push(item);
+        });
+        const arr = Object.entries(map).map(([pkgId, group]) => ({
+            id: pkgId,
+            packageName: group.packageName,
+            batches: group.items,
+        }));
+        if (initialPackageSessionId) {
+            arr.sort((a, b) => {
+                const aHas = a.batches.some(
+                    (x) => x.package_session_id === initialPackageSessionId
+                );
+                const bHas = b.batches.some(
+                    (x) => x.package_session_id === initialPackageSessionId
+                );
+                if (aHas && !bHas) return -1;
+                if (!aHas && bHas) return 1;
+                return 0;
+            });
         }
+        return arr;
+    }, [items, initialPackageSessionId]);
+
+    const isSelected = useCallback(
+        (packageSessionId: string) =>
+            selectedPackageSessions.some((s) => s.packageSessionId === packageSessionId),
+        [selectedPackageSessions]
+    );
+
+    const toggle = useCallback(
+        (item: CourseItem) => {
+            const psId = item.package_session_id;
+            if (isSelected(psId)) {
+                onSelectedPackageSessionsChange(
+                    selectedPackageSessions.filter((s) => s.packageSessionId !== psId)
+                );
+            } else {
+                onSelectedPackageSessionsChange([
+                    ...selectedPackageSessions,
+                    {
+                        packageSessionId: psId,
+                        courseName: item.package_name,
+                        sessionName: item.session_name ?? '',
+                        levelName: item.level_name,
+                        enrollInviteId: null,
+                        accessDays: null,
+                    },
+                ]);
+            }
+        },
+        [isSelected, selectedPackageSessions, onSelectedPackageSessionsChange]
+    );
+
+    const activeFilterCount = selectedLevelIds.length + selectedSessionIds.length;
+
+    const clearFilters = () => {
+        setSelectedLevelIds([]);
+        setSelectedSessionIds([]);
     };
+
+    const isDropdownLoading = isLevelsLoading || isSessionsLoading;
 
     return (
         <div className="flex flex-col gap-4 px-6 py-5">
-            {/* Selection summary */}
             {selectedPackageSessions.length > 0 && (
-                <div className="rounded-lg border border-primary-200 bg-primary-50 px-4 py-2 text-sm text-primary-700">
+                <div className="flex items-center gap-2 rounded-lg border border-primary-200 bg-primary-50 px-4 py-2 text-sm text-primary-700">
                     <span className="font-semibold">{selectedPackageSessions.length}</span>{' '}
-                    course{selectedPackageSessions.length !== 1 ? 's' : ''} selected — students
-                    will be enrolled in all selected courses.
+                    {(selectedPackageSessions.length !== 1
+                        ? batchesTerm
+                        : batchTerm
+                    ).toLowerCase()}{' '}
+                    selected — {learnersTerm.toLowerCase()} will be enrolled in all selected.
                 </div>
             )}
 
-            {/* Search */}
-            <div className="relative">
-                <MagnifyingGlass
-                    size={16}
-                    className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
-                />
-                <Input
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    placeholder="Search courses or levels…"
-                    className="pl-9"
-                />
+            <div className="flex items-center gap-2">
+                <div className="relative flex-1">
+                    <MagnifyingGlass
+                        size={15}
+                        className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
+                    />
+                    <Input
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder={`Search ${coursesTerm.toLowerCase()}, ${levelsTerm.toLowerCase()}...`}
+                        className="h-9 pl-9 text-sm"
+                    />
+                </div>
+
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className={cn(
+                                'h-9 gap-1.5 text-xs font-medium',
+                                selectedLevelIds.length > 0 &&
+                                    'border-primary-300 bg-primary-50 text-primary-700'
+                            )}
+                        >
+                            <FunnelSimple size={13} />
+                            {levelTerm}
+                            {selectedLevelIds.length > 0 && (
+                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-[10px] leading-none">
+                                    {selectedLevelIds.length}
+                                </Badge>
+                            )}
+                            <CaretDown size={11} className="text-neutral-400" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="max-h-60 w-48 overflow-y-auto">
+                        <DropdownMenuLabel className="text-xs text-neutral-500">
+                            Filter by {levelTerm}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        {isDropdownLoading ? (
+                            <div className="space-y-1 p-2">
+                                <Skeleton className="h-5 w-full" />
+                                <Skeleton className="h-5 w-3/4" />
+                            </div>
+                        ) : levelOptions.length === 0 ? (
+                            <p className="px-2 py-1 text-xs text-neutral-400">
+                                No {levelsTerm.toLowerCase()} found
+                            </p>
+                        ) : (
+                            levelOptions.map((lvl) => (
+                                <DropdownMenuCheckboxItem
+                                    key={lvl.id}
+                                    checked={selectedLevelIds.includes(lvl.id)}
+                                    onCheckedChange={(checked) =>
+                                        setSelectedLevelIds((prev) =>
+                                            checked
+                                                ? [...prev, lvl.id]
+                                                : prev.filter((id) => id !== lvl.id)
+                                        )
+                                    }
+                                    className="text-xs"
+                                >
+                                    {lvl.level_name}
+                                </DropdownMenuCheckboxItem>
+                            ))
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className={cn(
+                                'h-9 gap-1.5 text-xs font-medium',
+                                selectedSessionIds.length > 0 &&
+                                    'border-primary-300 bg-primary-50 text-primary-700'
+                            )}
+                        >
+                            <FunnelSimple size={13} />
+                            {sessionTerm}
+                            {selectedSessionIds.length > 0 && (
+                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-[10px] leading-none">
+                                    {selectedSessionIds.length}
+                                </Badge>
+                            )}
+                            <CaretDown size={11} className="text-neutral-400" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="max-h-60 w-48 overflow-y-auto">
+                        <DropdownMenuLabel className="text-xs text-neutral-500">
+                            Filter by {sessionTerm}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        {isDropdownLoading ? (
+                            <div className="space-y-1 p-2">
+                                <Skeleton className="h-5 w-full" />
+                                <Skeleton className="h-5 w-3/4" />
+                            </div>
+                        ) : sessionOptions.length === 0 ? (
+                            <p className="px-2 py-1 text-xs text-neutral-400">
+                                No {sessionsTerm.toLowerCase()} found
+                            </p>
+                        ) : (
+                            sessionOptions.map((ses) => (
+                                <DropdownMenuCheckboxItem
+                                    key={ses.id}
+                                    checked={selectedSessionIds.includes(ses.id)}
+                                    onCheckedChange={(checked) =>
+                                        setSelectedSessionIds((prev) =>
+                                            checked
+                                                ? [...prev, ses.id]
+                                                : prev.filter((id) => id !== ses.id)
+                                        )
+                                    }
+                                    className="text-xs"
+                                >
+                                    {ses.session_name}
+                                </DropdownMenuCheckboxItem>
+                            ))
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
             </div>
 
-            {/* Course groups */}
-            <div className="flex flex-col gap-3">
-                {filtered.length === 0 && (
-                    <p className="text-center text-sm text-neutral-400 py-8">
-                        No courses found. Please add courses first.
-                    </p>
-                )}
-                {filtered.map((group) => (
-                    <div
-                        key={group.package_dto.id}
-                        className="rounded-lg border border-neutral-200 bg-white"
-                    >
-                        {/* Course header */}
-                        <div className="flex items-center gap-3 border-b border-neutral-100 px-4 py-3">
-                            <BookOpen size={18} className="text-primary-500" weight="duotone" />
-                            <span className="font-semibold text-neutral-800">
-                                {group.package_dto.package_name}
+            {activeFilterCount > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                    {selectedLevelIds.map((id) => {
+                        const lvl = levelOptions.find((l) => l.id === id);
+                        return (
+                            <span
+                                key={id}
+                                className="inline-flex items-center gap-1 rounded-full border border-primary-200 bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700"
+                            >
+                                {levelTerm}: {lvl?.level_name ?? id}
+                                <button
+                                    onClick={() =>
+                                        setSelectedLevelIds((prev) =>
+                                            prev.filter((x) => x !== id)
+                                        )
+                                    }
+                                    className="ml-0.5 rounded-full hover:text-primary-900"
+                                >
+                                    <X size={11} />
+                                </button>
                             </span>
+                        );
+                    })}
+                    {selectedSessionIds.map((id) => {
+                        const ses = sessionOptions.find((s) => s.id === id);
+                        return (
+                            <span
+                                key={id}
+                                className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700"
+                            >
+                                {sessionTerm}: {ses?.session_name ?? id}
+                                <button
+                                    onClick={() =>
+                                        setSelectedSessionIds((prev) =>
+                                            prev.filter((x) => x !== id)
+                                        )
+                                    }
+                                    className="ml-0.5 rounded-full hover:text-violet-900"
+                                >
+                                    <X size={11} />
+                                </button>
+                            </span>
+                        );
+                    })}
+                    <button
+                        onClick={clearFilters}
+                        className="text-xs text-neutral-400 underline-offset-2 hover:text-neutral-600 hover:underline"
+                    >
+                        Clear all
+                    </button>
+                </div>
+            )}
+
+            {isError && (
+                <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    <Warning size={16} weight="fill" className="shrink-0" />
+                    <span>
+                        Failed to load {coursesTerm.toLowerCase()}.{' '}
+                        {error instanceof Error ? error.message : 'Please try again.'}
+                    </span>
+                </div>
+            )}
+
+            <div className="flex flex-col gap-3">
+                {isCoursesLoading ? (
+                    Array.from({ length: 3 }).map((_, i) => (
+                        <div key={i} className="rounded-lg border border-neutral-200 bg-white">
+                            <div className="flex items-center gap-3 border-b border-neutral-100 px-4 py-3">
+                                <Skeleton className="size-4 rounded" />
+                                <Skeleton className="h-4 w-40" />
+                            </div>
+                            <div className="space-y-2 px-4 py-3">
+                                <Skeleton className="h-9 w-full" />
+                                <Skeleton className="h-9 w-full" />
+                            </div>
                         </div>
-                        {/* Level rows */}
-                        <div className="flex flex-col divide-y divide-neutral-50">
-                            {group.level.map((levelEntry) => {
-                                const psId = levelEntry.package_session_id;
-                                const selected = isSelected(psId);
-                                return (
-                                    <button
-                                        key={psId}
-                                        onClick={() => toggle(group, levelEntry)}
-                                        className={cn(
-                                            'flex w-full items-center gap-3 px-4 py-3 text-left text-sm transition-colors hover:bg-primary-50',
-                                            selected && 'bg-primary-50'
-                                        )}
-                                    >
-                                        <Checkbox
-                                            checked={selected}
-                                            onCheckedChange={() => toggle(group, levelEntry)}
-                                            className="pointer-events-none"
-                                        />
-                                        <div className="flex-1">
-                                            <span className="font-medium text-neutral-700">
-                                                {levelEntry.level_dto.level_name}
-                                            </span>
-                                            {(levelEntry.level_dto.duration_in_days ?? 0) > 0 && (
-                                                <span className="ml-2 text-xs text-neutral-400">
-                                                    • {levelEntry.level_dto.duration_in_days} days
-                                                </span>
-                                            )}
-                                        </div>
-                                        <span
+                    ))
+                ) : groups.length === 0 && !isError ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <BookOpen
+                            size={36}
+                            className="mb-3 text-neutral-300"
+                            weight="duotone"
+                        />
+                        <p className="text-sm font-medium text-neutral-500">
+                            No {coursesTerm.toLowerCase()} found
+                        </p>
+                        <p className="mt-1 text-xs text-neutral-400">
+                            Try adjusting your search or filters.
+                        </p>
+                    </div>
+                ) : (
+                    groups.map((group) => (
+                        <div
+                            key={group.id}
+                            className="overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm"
+                        >
+                            <div className="flex items-center gap-2.5 border-b border-neutral-100 bg-neutral-50 px-4 py-2.5">
+                                <BookOpen
+                                    size={15}
+                                    className="shrink-0 text-primary-500"
+                                    weight="duotone"
+                                />
+                                <span className="text-sm font-semibold leading-tight text-neutral-800">
+                                    {group.packageName}
+                                </span>
+                                <span className="ml-auto text-xs text-neutral-400">
+                                    {group.batches.length}{' '}
+                                    {(group.batches.length !== 1
+                                        ? batchesTerm
+                                        : batchTerm
+                                    ).toLowerCase()}
+                                </span>
+                            </div>
+
+                            <div className="divide-y divide-neutral-50">
+                                {group.batches.map((batch) => {
+                                    const selected = isSelected(batch.package_session_id);
+                                    return (
+                                        <button
+                                            key={batch.package_session_id}
+                                            onClick={() => toggle(batch)}
                                             className={cn(
-                                                'text-xs font-medium',
-                                                selected
-                                                    ? 'text-primary-600'
-                                                    : 'text-neutral-400'
+                                                'flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors hover:bg-primary-50/60',
+                                                selected && 'bg-primary-50'
                                             )}
                                         >
-                                            {selected ? '✓ Selected' : 'Select'}
-                                        </span>
-                                    </button>
-                                );
-                            })}
+                                            <Checkbox
+                                                checked={selected}
+                                                onCheckedChange={() => toggle(batch)}
+                                                className="pointer-events-none shrink-0"
+                                            />
+                                            <div className="flex min-w-0 flex-1 items-center gap-2">
+                                                <span className="truncate text-xs font-medium text-neutral-700">
+                                                    {batch.level_name}
+                                                </span>
+                                                {batch.session_name && (
+                                                    <>
+                                                        <span className="text-neutral-300">·</span>
+                                                        <span className="truncate text-xs text-neutral-500">
+                                                            {batch.session_name}
+                                                        </span>
+                                                    </>
+                                                )}
+                                            </div>
+                                            <span
+                                                className={cn(
+                                                    'shrink-0 text-xs font-medium',
+                                                    selected
+                                                        ? 'text-primary-600'
+                                                        : 'text-neutral-300'
+                                                )}
+                                            >
+                                                {selected ? '✓' : '+'}
+                                            </span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
                         </div>
-                    </div>
-                ))}
+                    ))
+                )}
             </div>
+
+            {totalPages > 1 && (
+                <div className="flex items-center justify-between border-t border-neutral-100 pt-3">
+                    <span className="text-xs text-neutral-400">
+                        Showing {page * PAGE_SIZE + 1}–
+                        {Math.min((page + 1) * PAGE_SIZE, totalElements)} of {totalElements}
+                    </span>
+                    <div className="flex items-center gap-1">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            disabled={page === 0}
+                            onClick={() => setPage((p) => p - 1)}
+                        >
+                            <CaretLeft size={13} />
+                        </Button>
+                        <span className="px-2 text-xs text-neutral-600">
+                            {page + 1} / {totalPages}
+                        </span>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            disabled={page >= totalPages - 1}
+                            onClick={() => setPage((p) => p + 1)}
+                        >
+                            <CaretRight size={13} />
+                        </Button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step3EnrollConfig.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step3EnrollConfig.tsx
@@ -17,6 +17,15 @@ import { Button } from '@/components/ui/button';
 import { CalendarIcon } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import {
+    ContentTerms,
+    RoleTerms,
+    SystemTerms,
+} from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     instituteId: string;
@@ -33,6 +42,10 @@ export const Step3EnrollConfig = ({
     options,
     onOptionsChange,
 }: Props) => {
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+    const learnerTerm = getTerminology(RoleTerms.Learner, SystemTerms.Learner);
+    const learnersTerm = getTerminologyPlural(RoleTerms.Learner, SystemTerms.Learner);
+
     const updateSession = (packageSessionId: string, patch: Partial<SelectedPackageSession>) => {
         onSelectedPackageSessionsChange(
             selectedPackageSessions.map((ps) =>
@@ -46,10 +59,11 @@ export const Step3EnrollConfig = ({
             {/* Per-course invite configuration */}
             <div>
                 <h3 className="mb-1 text-sm font-semibold text-neutral-700">
-                    Enrollment Invite per Course
+                    Enrollment Invite per {courseTerm}
                 </h3>
                 <p className="mb-3 text-xs text-neutral-400">
-                    Choose an invite link for each course. Leave blank to auto-use the default invite.
+                    Choose an invite link for each {courseTerm.toLowerCase()}. Leave blank to
+                    auto-use the default invite.
                 </p>
                 <div className="flex flex-col gap-3">
                     {selectedPackageSessions.map((ps) => (
@@ -119,10 +133,11 @@ export const Step3EnrollConfig = ({
                     <div className="flex items-center justify-between">
                         <div>
                             <Label className="text-sm font-medium text-neutral-700">
-                                Notify Learners
+                                Notify {learnersTerm}
                             </Label>
                             <p className="text-xs text-neutral-400">
-                                Send enrollment confirmation emails to newly enrolled students
+                                Send enrollment confirmation emails to newly enrolled{' '}
+                                {learnersTerm.toLowerCase()}
                             </p>
                         </div>
                         <Switch
@@ -140,7 +155,8 @@ export const Step3EnrollConfig = ({
                                 Send Credentials
                             </Label>
                             <p className="text-xs text-neutral-400">
-                                Send registration email with login credentials to new students
+                                Send registration email with login credentials to new{' '}
+                                {learnersTerm.toLowerCase()}
                             </p>
                         </div>
                         <Switch
@@ -154,7 +170,7 @@ export const Step3EnrollConfig = ({
                     {/* Duplicate handling */}
                     <div>
                         <Label className="mb-1 text-sm font-medium text-neutral-700">
-                            If Student is Already Enrolled
+                            If {learnerTerm} is Already Enrolled
                         </Label>
                         <Select
                             value={options.duplicateHandling}
@@ -178,11 +194,11 @@ export const Step3EnrollConfig = ({
                         </Select>
                         <p className="mt-1 text-xs text-neutral-400">
                             {options.duplicateHandling === 'SKIP' &&
-                                'Already enrolled students will be silently skipped.'}
+                                `Already enrolled ${learnersTerm.toLowerCase()} will be silently skipped.`}
                             {options.duplicateHandling === 'RE_ENROLL' &&
-                                'Students with expired or terminated access will be re-activated.'}
+                                `${learnersTerm} with expired or terminated access will be re-activated.`}
                             {options.duplicateHandling === 'ERROR' &&
-                                'Already enrolled students will appear as failures in the results.'}
+                                `Already enrolled ${learnersTerm.toLowerCase()} will appear as failures in the results.`}
                         </p>
                     </div>
 

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4Preview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4Preview.tsx
@@ -1,6 +1,15 @@
 import { BulkAssignResponse, SelectedPackageSession } from '../../../../-types/bulk-assign-types';
 import { cn } from '@/lib/utils';
 import { CheckCircle, XCircle, SkipForward } from '@phosphor-icons/react';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import {
+    ContentTerms,
+    RoleTerms,
+    SystemTerms,
+} from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     previewResponse: BulkAssignResponse;
@@ -34,6 +43,11 @@ export const Step4Preview = ({ previewResponse, selectedPackageSessions }: Props
         selectedPackageSessions.map((ps) => [ps.packageSessionId, ps])
     );
 
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+    const levelTerm = getTerminology(ContentTerms.Level, SystemTerms.Level);
+    const learnerTerm = getTerminology(RoleTerms.Learner, SystemTerms.Learner);
+    const learnersTerm = getTerminologyPlural(RoleTerms.Learner, SystemTerms.Learner);
+
     return (
         <div className="flex flex-col gap-5 px-6 py-5">
             {/* Summary banner */}
@@ -62,16 +76,16 @@ export const Step4Preview = ({ previewResponse, selectedPackageSessions }: Props
 
             {summary.re_enrolled > 0 && (
                 <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-700">
-                    🔄 <strong>{summary.re_enrolled}</strong> student
-                    {summary.re_enrolled !== 1 ? 's' : ''} will be re-enrolled (previously
-                    expired/terminated access).
+                    🔄 <strong>{summary.re_enrolled}</strong>{' '}
+                    {(summary.re_enrolled !== 1 ? learnersTerm : learnerTerm).toLowerCase()} will
+                    be re-enrolled (previously expired/terminated access).
                 </div>
             )}
 
             {summary.successful === 0 && summary.re_enrolled === 0 && (
                 <div className="rounded-md border border-warning-200 bg-warning-50 px-4 py-2 text-sm text-warning-700">
-                    ⚠️ No students will be newly enrolled. Review your selections or change the
-                    duplicate handling option.
+                    ⚠️ No {learnersTerm.toLowerCase()} will be newly enrolled. Review your
+                    selections or change the duplicate handling option.
                 </div>
             )}
 
@@ -81,10 +95,10 @@ export const Step4Preview = ({ previewResponse, selectedPackageSessions }: Props
                     <thead className="bg-neutral-50">
                         <tr>
                             <th className="px-4 py-2 text-left text-xs font-semibold text-neutral-500">
-                                Learner
+                                {learnerTerm}
                             </th>
                             <th className="px-4 py-2 text-left text-xs font-semibold text-neutral-500">
-                                Course / Level
+                                {courseTerm} / {levelTerm}
                             </th>
                             <th className="px-4 py-2 text-left text-xs font-semibold text-neutral-500">
                                 Action

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/FromCourseSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/FromCourseSelector.tsx
@@ -14,6 +14,15 @@ import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { GET_STUDENTS } from '@/constants/urls';
 import { SelectedLearner } from '../../../-types/bulk-assign-types';
 import { toast } from 'sonner';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import {
+    ContentTerms,
+    RoleTerms,
+    SystemTerms,
+} from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     instituteId: string;
@@ -31,6 +40,11 @@ interface StudentRow {
 export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Props) => {
     const { getPackageWiseLevels } = useInstituteDetailsStore();
     const packageGroups = getPackageWiseLevels();
+
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+    const levelTerm = getTerminology(ContentTerms.Level, SystemTerms.Level);
+    const learnerTerm = getTerminology(RoleTerms.Learner, SystemTerms.Learner);
+    const learnersTerm = getTerminologyPlural(RoleTerms.Learner, SystemTerms.Learner);
 
     const [selectedCourseId, setSelectedCourseId] = useState('');
     const [selectedPackageSessionId, setSelectedPackageSessionId] = useState('');
@@ -119,7 +133,7 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
             {/* Source course picker */}
             <div className="grid grid-cols-2 gap-3">
                 <div>
-                    <Label className="mb-1 text-xs text-neutral-500">Source Course</Label>
+                    <Label className="mb-1 text-xs text-neutral-500">Source {courseTerm}</Label>
                     <Select
                         value={selectedCourseId}
                         onValueChange={(v) => {
@@ -129,7 +143,7 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
                         }}
                     >
                         <SelectTrigger>
-                            <SelectValue placeholder="Select course" />
+                            <SelectValue placeholder={`Select ${courseTerm.toLowerCase()}`} />
                         </SelectTrigger>
                         <SelectContent>
                             {packageGroups.map((g) => (
@@ -141,7 +155,7 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
                     </Select>
                 </div>
                 <div>
-                    <Label className="mb-1 text-xs text-neutral-500">Level</Label>
+                    <Label className="mb-1 text-xs text-neutral-500">{levelTerm}</Label>
                     <Select
                         value={selectedPackageSessionId}
                         onValueChange={(v) => {
@@ -151,7 +165,7 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
                         disabled={!selectedCourseId}
                     >
                         <SelectTrigger>
-                            <SelectValue placeholder="Select level" />
+                            <SelectValue placeholder={`Select ${levelTerm.toLowerCase()}`} />
                         </SelectTrigger>
                         <SelectContent>
                             {levels.map((l) => (
@@ -186,7 +200,7 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
                         onClick={handleSearch}
                         disable={!selectedPackageSessionId || loading}
                     >
-                        {loading ? 'Loading…' : 'Load Students'}
+                        {loading ? 'Loading…' : `Load ${learnersTerm}`}
                     </MyButton>
                 </div>
             </div>
@@ -209,7 +223,11 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
                                 layoutVariant="default"
                                 onClick={handleAdd}
                             >
-                                Add {checkedIds.size} student{checkedIds.size !== 1 ? 's' : ''}
+                                Add {checkedIds.size}{' '}
+                                {(checkedIds.size !== 1
+                                    ? learnersTerm
+                                    : learnerTerm
+                                ).toLowerCase()}
                             </MyButton>
                         )}
                     </div>
@@ -238,7 +256,8 @@ export const FromCourseSelector = ({ instituteId, selectedLearners, onAdd }: Pro
             )}
             {students.length === 0 && !loading && selectedPackageSessionId && (
                 <p className="text-center text-sm text-neutral-400 py-6">
-                    No students found. Click "Load Students" to search.
+                    No {learnersTerm.toLowerCase()} found. Click &quot;Load {learnersTerm}&quot; to
+                    search.
                 </p>
             )}
         </div>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
@@ -11,6 +11,8 @@ import {
     CustomField,
     SystemField,
 } from '@/services/custom-field-settings';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     onAdd: (rows: NewUserRow[]) => void;
@@ -131,6 +133,7 @@ interface VisibleSystemField {
 }
 
 export const ManualUserEntry = ({ onAdd }: Props) => {
+    const learnerTerm = getTerminology(RoleTerms.Learner, SystemTerms.Learner);
     const [rows, setRows] = useState<EditableRow[]>([emptyRow()]);
     const [submitted, setSubmitted] = useState(false);
 
@@ -253,7 +256,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                     >
                         <div className="mb-2 flex items-center justify-between">
                             <span className="text-xs font-semibold text-neutral-500">
-                                Learner #{idx + 1}
+                                {learnerTerm} #{idx + 1}
                             </span>
                             <div className="flex items-center gap-2">
                                 {hasExtraFields && (


### PR DESCRIPTION
## Summary of Changes

Re-implements server-side level/session filtering and pagination for the bulk enrollment flow's Step 2 (course selector). Previously Step2 loaded the full institute course list from a client-side store and did all filtering client-side — unreliable at scale and incompatible with pagination.

This is a re-implementation of the closed PR #1277 on a fresh branch (that branch had ~9k commits of merged main and severe conflicts). The backend changes from #1277 have since been merged to main separately, so only frontend changes remain.

Also sweeps the whole bulk-enroll dialog for hardcoded terms (Course, Learner, Level, Session, Batch, Student) and wraps them with `getTerminology` / `getTerminologyPlural`, so institute naming overrides (e.g. ReadOnRent: Learner → Customer, Course → Book) render correctly across all four steps.

**Backend:**
- No changes — equivalent backend work (sessionIds filter on LearnerPackageFilterDTO + PackageRepository overloads + PackageDetailDTO session fields) already landed on main independently.

**Frontend:**
- `Step2CourseSelector.tsx` — full rewrite:
  - Levels fetched from dedicated `GET_LEVELS_BY_INSTITUTE` API (flat response)
  - Sessions fetched from `GET_SESSION_DETAILS` API (nested response — mapped to flat)
  - Level and session filters sent server-side via `level_ids` / `session_ids`
  - Debounced search (400ms), 20 items/page with prev/next pagination
  - Loading skeletons, error state, active filter chips with clear-all
  - Groups results by package for display; preserves `initialPackageSessionId` behavior (pre-selects + sorts matching group to top)
- Terminology fixes across the bulk enroll flow:
  - `BulkAssignDialog.tsx` — STEPS array now uses `getTerminologyPlural` for "Select Learners" / "Select Courses"
  - `Step1LearnerSelector.tsx` — "From Course" tab
  - `Step3EnrollConfig.tsx` — "Enrollment Invite per Course", "Notify Learners", "If Student is Already Enrolled", duplicate-handling descriptions
  - `Step4Preview.tsx` — "Learner" / "Course / Level" table headers, re-enrolled banner, no-enrollment banner
  - `FromCourseSelector.tsx` — "Source Course", "Select course", "Level", "Select level", "Load Students", "Add N student(s)", empty state
  - `ManualUserEntry.tsx` — "Learner #N" row header

## Related Issue

Re-implementation of closed PR #1277

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Opened the Enroll Customer → Enroll in Bulk dialog and verified Step 2 loads paginated courses
- Applied level filter alone — results narrow correctly, pagination resets to page 0
- Applied session filter alone — results narrow correctly
- Applied level + session together with search text — combines filters server-side
- Cleared filters via chip × and "Clear all" — list returns to unfiltered state
- Verified `initialPackageSessionId` still pre-selects and pins the matching group to top
- On a ReadOnRent institute (Learner → Customer, Course → Book), verified step titles render as "Select Customers" / "Select Books", tab as "From Book", labels as "Source Book" / "Load Customers" across all four steps
- `tsc --noEmit` passes clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
