### PR TITLE
Fix/genre filter learner side

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/controller/OpenPackageController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/controller/OpenPackageController.java
@@ -48,5 +48,13 @@ public class OpenPackageController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/v1/tags")
+    @ClientCacheable(maxAgeSeconds = 300, scope = CacheScope.PUBLIC)
+    public ResponseEntity<java.util.List<String>> getInstituteDistinctTags(
+            @RequestParam("instituteId") String instituteId
+    ) {
+        return ResponseEntity.ok(openPackageService.getDistinctCatalogTags(instituteId));
+    }
+
 
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/service/OpenPackageService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/service/OpenPackageService.java
@@ -34,6 +34,13 @@ public class OpenPackageService {
         @Autowired
         private AuthService authService;
 
+        public List<String> getDistinctCatalogTags(String instituteId) {
+                if (!StringUtils.hasText(instituteId)) {
+                        return List.of();
+                }
+                return packageRepository.findAllDistinctTagsByInstituteId(instituteId);
+        }
+
         @Transactional
         public Page<PackageDetailDTO> getLearnerPackageDetail(
                         LearnerPackageFilterDTO learnerPackageFilterDTO,

--- a/frontend-admin-dashboard/src/lib/utils.ts
+++ b/frontend-admin-dashboard/src/lib/utils.ts
@@ -20,6 +20,28 @@ export function parseHtmlToString(html: string) {
     return doc.body.textContent || doc.body.innerText || '';
 }
 
+/**
+ * Title-cases a package/genre tag while preserving separators.
+ * Bulk-create stores tags as trim().toLowerCase(), keeping spaces and
+ * hyphens intact. This helper capitalizes each word without flattening
+ * hyphens into spaces.
+ *
+ * Examples:
+ *   "sci-fi"           -> "Sci-Fi"
+ *   "science fiction"  -> "Science Fiction"
+ *   "rom-com thriller" -> "Rom-Com Thriller"
+ */
+export function formatTagForDisplay(tag: string): string {
+    if (!tag) return '';
+    const cap = (s: string) =>
+        s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+    return tag
+        .trim()
+        .split(/\s+/)
+        .map((word) => word.split('-').map(cap).join('-'))
+        .join(' ');
+}
+
 export const goToWhatsappSupport = () => {
     const phoneNumber = '+919201534254'; // Your WhatsApp number (with country code)
     const message = encodeURIComponent('Hello, I have a question.');

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
@@ -31,7 +31,7 @@ import {
 import { BatchSelectorDialog } from './batch-selector-dialog';
 import { CourseContentDialog } from './course-content-dialog';
 import { TagSelectorDialog } from './tag-selector-dialog';
-import { cn } from '@/lib/utils';
+import { cn, formatTagForDisplay } from '@/lib/utils';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
@@ -334,7 +334,7 @@ export function BulkCreateTable({
                                                     variant="outline"
                                                     className="rounded-full text-[10px]"
                                                 >
-                                                    {tag}
+                                                    {formatTagForDisplay(tag)}
                                                     <button
                                                         onClick={() =>
                                                             handleRemoveTag(course.id, tag)

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/tooltip';
 import { BatchSelectorDialog } from './batch-selector-dialog';
 import { TagSelectorDialog } from './tag-selector-dialog';
+import { formatTagForDisplay } from '@/lib/utils';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
@@ -263,12 +264,12 @@ export function GlobalDefaultsSection({
                                     variant="outline"
                                     className="flex items-center gap-1 rounded-full text-xs"
                                 >
-                                    {tag}
+                                    {formatTagForDisplay(tag)}
                                     <button
                                         type="button"
                                         onClick={() => handleRemoveTag(tag)}
                                         className="hover:text-red-500"
-                                        aria-label={`Remove ${tag}`}
+                                        aria-label={`Remove ${formatTagForDisplay(tag)}`}
                                     >
                                         <X className="size-3" />
                                     </button>

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/tag-selector-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/tag-selector-dialog.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { X, Plus } from '@phosphor-icons/react';
 import { useInstituteTags } from '../-hooks/useInstituteTags';
+import { formatTagForDisplay } from '@/lib/utils';
 
 interface TagSelectorDialogProps {
     open: boolean;
@@ -93,12 +94,12 @@ export function TagSelectorDialog({
                                         variant="outline"
                                         className="flex items-center gap-1 rounded-full border-primary-300 bg-primary-50 text-xs text-primary-700"
                                     >
-                                        {tag}
+                                        {formatTagForDisplay(tag)}
                                         <button
                                             type="button"
                                             onClick={() => handleRemove(tag)}
                                             className="hover:text-red-500"
-                                            aria-label={`Remove ${tag}`}
+                                            aria-label={`Remove ${formatTagForDisplay(tag)}`}
                                         >
                                             <X className="size-3" />
                                         </button>
@@ -164,7 +165,7 @@ export function TagSelectorDialog({
                                             onClick={() => handleSelect(tag)}
                                             className="rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-xs text-neutral-700 transition-colors hover:border-primary-400 hover:bg-primary-50 hover:text-primary-700"
                                         >
-                                            {tag}
+                                            {formatTagForDisplay(tag)}
                                         </button>
                                     ))}
                                 </div>

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -157,6 +157,7 @@ export const PUBLIC_INSTITUTE_BRANDING_URL = `${BASE_URL}/admin-core-service/pub
 export const DOMAIN_ROUTING_RESOLVE_URL = `${BASE_URL}/admin-core-service/public/domain-routing/v1/resolve`;
 export const urlCourseDetails = `${BASE_URL}/admin-core-service/open/packages/v2/search`;
 export const urlOpenLevels = `${BASE_URL}/admin-core-service/open/level/v1/get-levels`;
+export const urlOpenInstituteTags = `${BASE_URL}/admin-core-service/open/packages/v1/tags`;
 export const urlPublicCourseDetails = `${BASE_URL}/admin-core-service/learner-packages/v1/search`;
 // export const urlInstructor = `${BASE_URL}/auth-service/public/v1/users-of-status`;
 export const urlInstructor = `${BASE_URL}/admin-core-service/open/institute/v1/faculty/by-institute/only-creator`;

--- a/frontend-learner-dashboard-app/src/lib/utils.ts
+++ b/frontend-learner-dashboard-app/src/lib/utils.ts
@@ -371,3 +371,25 @@ export function toTitleCase(text: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
 }
+
+/**
+ * Title-cases a package/genre tag while preserving separators.
+ * Bulk-create stores tags as trim().toLowerCase(), keeping spaces and
+ * hyphens intact. This helper capitalizes each word without flattening
+ * hyphens into spaces (which toTitleCase does).
+ *
+ * Examples:
+ *   "sci-fi"           -> "Sci-Fi"
+ *   "science fiction"  -> "Science Fiction"
+ *   "rom-com thriller" -> "Rom-Com Thriller"
+ */
+export function formatTagForDisplay(tag: string): string {
+  if (!tag) return "";
+  const cap = (s: string) =>
+    s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+  return tag
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.split("-").map(cap).join("-"))
+    .join(" ");
+}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
@@ -11,6 +11,7 @@ import {
   buildLevelNameToIdMap,
   LevelNameToIdMap,
 } from "../../-services/level-service";
+import { fetchInstituteCatalogueTags } from "../../-services/institute-tags-service";
 import { Button } from "@/components/ui/button";
 import {
   Search,
@@ -24,7 +25,7 @@ import {
   ShoppingBag,
   Trash2,
 } from "lucide-react";
-import { toTitleCase } from "@/lib/utils";
+import { toTitleCase, formatTagForDisplay } from "@/lib/utils";
 import { useCartStore, CartItem } from "../../-stores/cart-store";
 import { toast } from "sonner";
 import { ShareButton } from "./ShareButton";
@@ -257,9 +258,19 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]); // re-run when route changes so new searchTerms on route apply
 
-  // Extract Genre (Tag) config for the top UI
+  // Genre filter is enabled whenever catalogue_json has a "tag" filter entry.
+  // The actual genre list is fetched live from the institute's distinct catalogue
+  // tags, so admin-created tags show up automatically without editing catalogue_json.
   const genreConfig = useMemo(() => filtersConfig?.find((f) => f.id === "tag"), [filtersConfig]);
-  const genres = genreConfig?.options || [];
+  const showGenreFilter = Boolean(genreConfig);
+
+  const { data: genres = [] } = useQuery<string[]>({
+    queryKey: ["institute-catalogue-tags", instituteId],
+    queryFn: () => fetchInstituteCatalogueTags(instituteId),
+    enabled: !!instituteId && showGenreFilter,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+  });
 
   // Resolve level_name ("buy" / "rent") -> level_id via the open levels endpoint.
   // Cached long-term; levels rarely change and this is shared across mode toggles.
@@ -457,7 +468,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-0">
 
           {/* 2. Enhanced Genres UI - Horizontal Scrollable Chips */}
-          {genres.length > 0 && (
+          {showGenreFilter && genres.length > 0 && (
             <div className="mt-0">
               <div className="flex font-bold flex-col gap-1">
                 <div className="flex items-center justify-between ">
@@ -495,7 +506,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                           }
                         `}
                       >
-                        <span>{genre}</span>
+                        <span>{formatTagForDisplay(genre)}</span>
                         {isSelected && (
                           <span className="bg-white/20 rounded-full p-0.5 ml-1 hover:bg-white/30 active:bg-white/40 text-black transition-colors">
                             <X className="h-3 w-3" />

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-services/institute-tags-service.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-services/institute-tags-service.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { urlOpenInstituteTags } from "@/constants/urls";
+
+export const fetchInstituteCatalogueTags = async (
+    instituteId: string
+): Promise<string[]> => {
+    if (!instituteId) return [];
+    const response = await axios.get<string[]>(urlOpenInstituteTags, {
+        params: { instituteId },
+    });
+    return Array.isArray(response.data) ? response.data : [];
+};


### PR DESCRIPTION
## Summary of Changes

Makes the learner-side genre filter on the public book-catalogue page pull its chip list live from the admin's actual saved tags instead of a hardcoded array in `catalogue_json`, and renders every tag chip in title case on both admin and learner sides so stored lowercase/hyphenated values display cleanly. No changes to how tags are stored — all existing write paths are untouched.

**Backend:**
- New public endpoint `GET /admin-core-service/open/packages/v1/tags?instituteId=…` returning distinct tags from `package.comma_separated_tags` for the institute. Wraps the existing `findAllDistinctTagsByInstituteId` query, no transformation applied. Cached 5 min (`ClientCacheable`, PUBLIC scope).
- `OpenPackageService.getDistinctCatalogTags(instituteId)` added as a thin service method.

**Frontend:**
- New shared display helper `formatTagForDisplay(tag)` in both `frontend-admin-dashboard/src/lib/utils.ts` and `frontend-learner-dashboard-app/src/lib/utils.ts`. Preserves separators the admin typed (`"sci-fi"` → `"Sci-Fi"`, `"science fiction"` → `"Science Fiction"`).
- Learner `BookCatalogueComponent` now fetches genres via React Query from the new endpoint (10-min stale). The `catalogue_json.filtersConfig[id="tag"]` entry is now an on/off gate only; its `options` array is ignored. Genre chips rendered via `formatTagForDisplay`. Click sends the raw stored value as the filter, unchanged.
- New learner service `institute-tags-service.ts` + `urlOpenInstituteTags` in `urls.ts`.
- Admin bulk-create page chip displays updated to use `formatTagForDisplay`: `tag-selector-dialog` (selected + available chips), `bulk-create-table` (per-course Tags column), `global-defaults-section` (Default Tags).

## Related Issue

_N/A_

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Hit the new endpoint directly with a valid `instituteId` and verified it returns the distinct tag list from the DB.
- Bulk-created a course with tags and confirmed the chips render in title case in the bulk-create table and global defaults.
- Opened the tag-selector dialog and verified existing institute tags render in title case while the raw stored value is used for selection state / remove.
- Loaded the learner catalogue page and confirmed genre chips now come from the endpoint (not the hardcoded `catalogue_json` options), render in title case, and clicking a chip filters packages correctly via the existing V2 `&&` query.
- Verified round-trip: admin types `"Sci-Fi"` in bulk-create → stored as `"sci-fi"` → learner sees chip `"Sci-Fi"` → click sends `"sci-fi"` → matching package returns.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
