### PR TITLE
fix: add logic for replacing terms and conditions in the template als…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
@@ -3,7 +3,13 @@ package vacademy.io.admin_core_service.features.invoice.dto;
 public interface InvoicePackageContextProjection {
     String getPackageId();
 
+    String getPackageName();
+
+    String getLevelId();
+
     String getLevelName();
 
     String getSessionId();
+
+    String getSessionName();
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
@@ -1,0 +1,7 @@
+package vacademy.io.admin_core_service.features.invoice.dto;
+
+public interface InvoicePackageContextProjection {
+    String getPackageId();
+
+    String getLevelName();
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoicePackageContextProjection.java
@@ -4,4 +4,6 @@ public interface InvoicePackageContextProjection {
     String getPackageId();
 
     String getLevelName();
+
+    String getSessionId();
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -39,6 +39,7 @@ import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan
 import vacademy.io.admin_core_service.features.packages.repository.PackageSessionRepository;
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionRepository;
 import vacademy.io.admin_core_service.features.institute_learner.entity.StudentSessionInstituteGroupMapping;
+import vacademy.io.admin_core_service.features.invoice.dto.InvoicePackageContextProjection;
 import vacademy.io.admin_core_service.features.session.dto.BatchInstituteProjection;
 import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentLogLineItemRepository;
 import vacademy.io.common.auth.dto.UserDTO;
@@ -1011,6 +1012,20 @@ public class InvoiceService {
         String lineItemsHtml = buildLineItemsHtml(invoiceData.getLineItems(), invoiceData.getCurrency());
         filled = filled.replace("{{line_items}}", lineItemsHtml);
 
+        // Terms & Conditions
+        String termsHtml = buildTermsAndConditionsHtml(invoiceData);
+        if (termsHtml == null || termsHtml.trim().isEmpty()) {
+            // Strip the entire wrapping block (including the heading) so we don't
+            // render an orphan "Terms & Conditions" section when nothing is configured.
+            filled = filled.replaceAll(
+                    "(?s)<!--\\s*TERMS_AND_CONDITIONS_BLOCK\\s*-->.*?<!--\\s*/TERMS_AND_CONDITIONS_BLOCK\\s*-->",
+                    "");
+            filled = filled.replace("{{terms_and_conditions}}", "");
+        } else {
+            // Keep wrapper markers as-is (they are HTML comments, harmless in output)
+            filled = filled.replace("{{terms_and_conditions}}", termsHtml);
+        }
+
         return filled;
     }
 
@@ -1096,16 +1111,121 @@ public class InvoiceService {
         for (InvoiceLineItemData item : lineItems) {
             html.append("<tr>");
             html.append("<td>").append(item.getDescription() != null ? item.getDescription() : "").append("</td>");
-            html.append("<td>").append(item.getQuantity() != null ? item.getQuantity() : 1).append("</td>");
+            html.append("<td class=\"right text-center\" style=\"text-align:center\">")
+                    .append(item.getQuantity() != null ? item.getQuantity() : 1).append("</td>");
             // Format unit price with currency symbol
             String unitPrice = item.getUnitPrice() != null ? item.getUnitPrice().toString() : "0.00";
-            html.append("<td>").append(currencySymbol).append(unitPrice).append("</td>");
+            html.append("<td class=\"right text-right\" style=\"text-align:right\">")
+                    .append(currencySymbol).append(unitPrice).append("</td>");
             // Format amount with currency symbol
             String amount = item.getAmount() != null ? item.getAmount().toString() : "0.00";
-            html.append("<td>").append(currencySymbol).append(amount).append("</td>");
+            html.append("<td class=\"right text-right\" style=\"text-align:right\">")
+                    .append(currencySymbol).append(amount).append("</td>");
             html.append("</tr>");
         }
         return html.toString();
+    }
+
+    /**
+     * Resolve the Terms &amp; Conditions HTML for an invoice.
+     *
+     * Reads {@code INVOICE_SETTING.termsAndConditions} from the institute settings:
+     * <pre>
+     * {
+     *   "default":   "&lt;ul&gt;...&lt;/ul&gt;",
+     *   "byLevel":   { "buy": "...", "rent": "..." },
+     *   "byPackage": { "&lt;package_uuid&gt;": "..." }
+     * }
+     * </pre>
+     *
+     * Resolution precedence per invoice (invoices are type-homogeneous, so we
+     * resolve from the primary user plan): {@code byPackage[packageId]} →
+     * {@code byLevel[levelName]} → {@code default}. Returns an empty string when
+     * nothing matches, which lets the caller drop the surrounding section.
+     */
+    @SuppressWarnings("unchecked")
+    private String buildTermsAndConditionsHtml(InvoiceData invoiceData) {
+        if (invoiceData == null || invoiceData.getInstitute() == null) {
+            return "";
+        }
+
+        Map<String, Object> invoiceSettings = getInvoiceSettings(invoiceData.getInstitute());
+        Object tncRaw = invoiceSettings.get("termsAndConditions");
+        if (!(tncRaw instanceof Map)) {
+            return "";
+        }
+        Map<String, Object> tnc = (Map<String, Object>) tncRaw;
+
+        String packageId = null;
+        String levelName = null;
+
+        try {
+            UserPlan userPlan = invoiceData.getUserPlan();
+            if (userPlan != null) {
+                List<StudentSessionInstituteGroupMapping> mappings = studentSessionRepository
+                        .findAllByUserPlanIdAndStatusIn(userPlan.getId(),
+                                List.of("ACTIVE", "INVITED", "ABANDONED_CART", "DETAILS_FILLED"));
+                if (mappings != null && !mappings.isEmpty()) {
+                    StudentSessionInstituteGroupMapping mapping = mappings.get(0);
+                    String packageSessionId = null;
+                    if (mapping.getDestinationPackageSession() != null) {
+                        packageSessionId = mapping.getDestinationPackageSession().getId();
+                    } else if (mapping.getPackageSession() != null) {
+                        packageSessionId = mapping.getPackageSession().getId();
+                    }
+                    if (packageSessionId != null && !packageSessionId.isEmpty()) {
+                        Optional<InvoicePackageContextProjection> ctx = packageSessionRepository
+                                .findPackageAndLevelByPackageSessionId(packageSessionId);
+                        if (ctx.isPresent()) {
+                            packageId = ctx.get().getPackageId();
+                            levelName = ctx.get().getLevelName();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve package/level context for T&C lookup: {}", e.getMessage());
+        }
+
+        // 1) Per-package override
+        if (packageId != null) {
+            Object byPackageRaw = tnc.get("byPackage");
+            if (byPackageRaw instanceof Map) {
+                Object html = ((Map<String, Object>) byPackageRaw).get(packageId);
+                if (html instanceof String && !((String) html).trim().isEmpty()) {
+                    return (String) html;
+                }
+            }
+        }
+
+        // 2) Per-level fallback (case-insensitive on level name)
+        if (levelName != null) {
+            Object byLevelRaw = tnc.get("byLevel");
+            if (byLevelRaw instanceof Map) {
+                Map<String, Object> byLevel = (Map<String, Object>) byLevelRaw;
+                Object html = byLevel.get(levelName);
+                if (!(html instanceof String) || ((String) html).trim().isEmpty()) {
+                    // case-insensitive lookup
+                    for (Map.Entry<String, Object> e : byLevel.entrySet()) {
+                        if (e.getKey() != null && e.getKey().equalsIgnoreCase(levelName)) {
+                            html = e.getValue();
+                            break;
+                        }
+                    }
+                }
+                if (html instanceof String && !((String) html).trim().isEmpty()) {
+                    return (String) html;
+                }
+            }
+        }
+
+        // 3) Institute-wide default
+        Object defaultHtml = tnc.get("default");
+        if (defaultHtml instanceof String && !((String) defaultHtml).trim().isEmpty()) {
+            return (String) defaultHtml;
+        }
+
+        return "";
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -1889,7 +1889,7 @@ public class InvoiceService {
 
             // Send email
             try {
-                sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId);
+                sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId, pdfBytes);
             } catch (Exception e) {
                 log.error(
                         "Failed to send invoice email for multi-package invoice: {}. Invoice generation will continue.",
@@ -1983,7 +1983,7 @@ public class InvoiceService {
 
             // Send email (async)
             try {
-                sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId);
+                sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId, pdfBytes);
             } catch (Exception e) {
                 log.error("Failed to send invoice email for invoice: {}. Invoice generation will continue.",
                         invoiceNumber, e);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -1158,6 +1158,7 @@ public class InvoiceService {
 
         String packageId = null;
         String levelName = null;
+        String sessionId = null;
 
         try {
             UserPlan userPlan = invoiceData.getUserPlan();
@@ -1179,12 +1180,13 @@ public class InvoiceService {
                         if (ctx.isPresent()) {
                             packageId = ctx.get().getPackageId();
                             levelName = ctx.get().getLevelName();
+                            sessionId = ctx.get().getSessionId();
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            log.warn("Failed to resolve package/level context for T&C lookup: {}", e.getMessage());
+            log.warn("Failed to resolve package/level/session context for T&C lookup: {}", e.getMessage());
         }
 
         // 1) Per-package override
@@ -1198,7 +1200,18 @@ public class InvoiceService {
             }
         }
 
-        // 2) Per-level fallback (case-insensitive on level name)
+        // 2) Per-session fallback
+        if (sessionId != null) {
+            Object bySessionRaw = tnc.get("bySession");
+            if (bySessionRaw instanceof Map) {
+                Object html = ((Map<String, Object>) bySessionRaw).get(sessionId);
+                if (html instanceof String && !((String) html).trim().isEmpty()) {
+                    return (String) html;
+                }
+            }
+        }
+
+        // 3) Per-level fallback (case-insensitive on level name)
         if (levelName != null) {
             Object byLevelRaw = tnc.get("byLevel");
             if (byLevelRaw instanceof Map) {
@@ -1219,7 +1232,7 @@ public class InvoiceService {
             }
         }
 
-        // 3) Institute-wide default
+        // 4) Institute-wide default
         Object defaultHtml = tnc.get("default");
         if (defaultHtml instanceof String && !((String) defaultHtml).trim().isEmpty()) {
             return (String) defaultHtml;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -1157,7 +1157,7 @@ public class InvoiceService {
         Map<String, Object> tnc = (Map<String, Object>) tncRaw;
 
         String packageId = null;
-        String levelName = null;
+        String levelId = null;
         String sessionId = null;
 
         try {
@@ -1179,7 +1179,7 @@ public class InvoiceService {
                                 .findPackageAndLevelByPackageSessionId(packageSessionId);
                         if (ctx.isPresent()) {
                             packageId = ctx.get().getPackageId();
-                            levelName = ctx.get().getLevelName();
+                            levelId = ctx.get().getLevelId();
                             sessionId = ctx.get().getSessionId();
                         }
                     }
@@ -1211,21 +1211,11 @@ public class InvoiceService {
             }
         }
 
-        // 3) Per-level fallback (case-insensitive on level name)
-        if (levelName != null) {
+        // 3) Per-level fallback
+        if (levelId != null) {
             Object byLevelRaw = tnc.get("byLevel");
             if (byLevelRaw instanceof Map) {
-                Map<String, Object> byLevel = (Map<String, Object>) byLevelRaw;
-                Object html = byLevel.get(levelName);
-                if (!(html instanceof String) || ((String) html).trim().isEmpty()) {
-                    // case-insensitive lookup
-                    for (Map.Entry<String, Object> e : byLevel.entrySet()) {
-                        if (e.getKey() != null && e.getKey().equalsIgnoreCase(levelName)) {
-                            html = e.getValue();
-                            break;
-                        }
-                    }
-                }
+                Object html = ((Map<String, Object>) byLevelRaw).get(levelId);
                 if (html instanceof String && !((String) html).trim().isEmpty()) {
                     return (String) html;
                 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
@@ -225,7 +225,8 @@ public interface PackageSessionRepository extends JpaRepository<PackageSession, 
     @Query("""
                 SELECT
                     p.id        AS packageId,
-                    l.levelName AS levelName
+                    l.levelName AS levelName,
+                    ps.session.id AS sessionId
                 FROM PackageSession ps
                 JOIN ps.level l
                 JOIN ps.packageEntity p

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import vacademy.io.admin_core_service.features.invoice.dto.InvoicePackageContextProjection;
 import vacademy.io.admin_core_service.features.packages.dto.BatchProjection;
 import vacademy.io.admin_core_service.features.session.dto.BatchInstituteProjection;
 import vacademy.io.common.institute.entity.PackageEntity;
@@ -219,6 +220,18 @@ public interface PackageSessionRepository extends JpaRepository<PackageSession, 
                 WHERE ps.id = :packageSessionId
             """)
     Optional<BatchInstituteProjection> findBatchAndInstituteByPackageSessionId(
+            @Param("packageSessionId") String packageSessionId);
+
+    @Query("""
+                SELECT
+                    p.id        AS packageId,
+                    l.levelName AS levelName
+                FROM PackageSession ps
+                JOIN ps.level l
+                JOIN ps.packageEntity p
+                WHERE ps.id = :packageSessionId
+            """)
+    Optional<InvoicePackageContextProjection> findPackageAndLevelByPackageSessionId(
             @Param("packageSessionId") String packageSessionId);
 
     @Query("SELECT ps FROM PackageSession ps WHERE ps.packageEntity.id IN :packageIds")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageSessionRepository.java
@@ -224,9 +224,12 @@ public interface PackageSessionRepository extends JpaRepository<PackageSession, 
 
     @Query("""
                 SELECT
-                    p.id        AS packageId,
-                    l.levelName AS levelName,
-                    ps.session.id AS sessionId
+                    p.id          AS packageId,
+                    p.packageName AS packageName,
+                    l.id          AS levelId,
+                    l.levelName   AS levelName,
+                    ps.session.id          AS sessionId,
+                    ps.session.sessionName AS sessionName
                 FROM PackageSession ps
                 JOIN ps.level l
                 JOIN ps.packageEntity p

--- a/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
+++ b/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
@@ -380,6 +380,33 @@
             font-weight: normal;
         }
         
+        /* Terms & Conditions */
+        .terms-section {
+            margin-top: 15px;
+            page-break-inside: avoid;
+        }
+
+        .terms-section .section-content {
+            font-size: 13px;
+            line-height: 1.6;
+            color: #333;
+        }
+
+        .terms-section .section-content ul,
+        .terms-section .section-content ol {
+            padding-left: 20px;
+            margin: 0;
+        }
+
+        .terms-section .section-content ul li,
+        .terms-section .section-content ol li {
+            margin: 4px 0;
+        }
+
+        .terms-section .section-content p {
+            margin: 4px 0;
+        }
+
         /* Footer */
         .footer-note {
             margin-top: 10px;
@@ -553,6 +580,16 @@
             </div>
         </div>
         
+        <!-- Terms & Conditions (stripped at render time when empty) -->
+        <!-- TERMS_AND_CONDITIONS_BLOCK -->
+        <div class="terms-section">
+            <div class="section-header">Terms &amp; Conditions</div>
+            <div class="section-content">
+                {{terms_and_conditions}}
+            </div>
+        </div>
+        <!-- /TERMS_AND_CONDITIONS_BLOCK -->
+
         <!-- Footer -->
         <div class="footer-note">
             <p>*Please note that all prices are inclusive of GST for Australian customers.</p>


### PR DESCRIPTION
## Summary of Changes

Fixes column misalignment in the invoice line-items table and adds support for a configurable Terms & Conditions block on invoices, resolved per-invoice from the institute's `INVOICE_SETTING` with a `byPackage → bySession → byLevel → default` precedence.

**Backend:**
- `InvoiceService.buildLineItemsHtml` now emits right-aligned `<td>`s for Qty / Unit Price / Amount via inline `text-align` style, so values line up with the right-aligned headers in both the DB-stored institute templates and the filesystem fallback template.
- New `InvoiceService.buildTermsAndConditionsHtml` reads `INVOICE_SETTING.termsAndConditions` (a JSON object with `default`, `byPackage`, `bySession`, `byLevel` keys) and resolves the right T&C HTML for the current invoice. Resolution walks the primary user plan → SSIGM → package_session to obtain `(packageId, sessionId, levelName)`, then looks up `byPackage[packageId] → bySession[sessionId] → byLevel[levelName]` (case-insensitive) `→ default`.
- `replaceTemplatePlaceholders` now replaces `{{terms_and_conditions}}`. When no T&Cs match, the wrapping `<!-- TERMS_AND_CONDITIONS_BLOCK -->...<!-- /TERMS_AND_CONDITIONS_BLOCK -->` section in the template is stripped, so we never render an orphan "Terms & Conditions" heading.
- New `findPackageAndLevelByPackageSessionId` projection on `PackageSessionRepository` returning `(packageId, levelName, sessionId)` for T&C resolution.
- New projection interface `InvoicePackageContextProjection` with `getPackageId()`, `getLevelName()`, `getSessionId()`.
- Default filesystem template (`default_invoice.html`) gets `.terms-section` styles plus the wrapped T&C block before the footer.

**Frontend:**
- None.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `mvn clean compile` on `admin_core_service` — BUILD SUCCESS, no new warnings.
- Seeded `INVOICE_SETTING.termsAndConditions` for ReadOnRent's institute with a combined `default` block (covering all 6 home-delivery + pick-up-and-drop membership plans) and a separate `byLevel.buy` for one-time book purchases.
- Verified line-item alignment matches the right-aligned column headers.
- Verified the wrapping section is stripped on institutes that don't configure `termsAndConditions` (no orphan heading).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
