### PR TITLE
fix: add a resovle function for invite code from settings_json of ins…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.configuration.updateBuildConfiguration": "automatic",
     "java.debug.settings.onBuildFailureProceed": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.configuration.updateBuildConfiguration": "interactive",
     "java.debug.settings.onBuildFailureProceed": true
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
@@ -57,7 +57,7 @@ public class DynamicNotificationService {
 
     /**
      * If the institute's setting JSON contains
-     *   referral_email_settings.invite_code = "xxxxxx"
+     *   EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code = "xxxxxx"
      * resolve and return that EnrollInvite for use in referral / invitation
      * link generation. Otherwise return the supplied fallback unchanged.
      */
@@ -68,7 +68,7 @@ public class DynamicNotificationService {
             String settingJson = institute.getSetting();
             if (settingJson == null || settingJson.isBlank()) return fallback;
             JsonNode codeNode = objectMapper.readTree(settingJson)
-                    .path("referral_email_settings").path("invite_code");
+                    .path("EMAIL_SETTING").path("data").path("REFERRAL_EMAIL").path("invite_code");
             if (codeNode.isMissingNode() || codeNode.isNull()) return fallback;
             String code = codeNode.asText();
             if (code == null || code.isBlank()) return fallback;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
@@ -3,7 +3,10 @@ package vacademy.io.admin_core_service.features.notification.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
+import vacademy.io.admin_core_service.features.enroll_invite.repository.EnrollInviteRepository;
 import vacademy.io.admin_core_service.features.notification.dto.NotificationTemplateVariables;
 import vacademy.io.admin_core_service.features.notification.dto.WatiConfig;
 import vacademy.io.admin_core_service.features.notification.entity.NotificationEventConfig;
@@ -49,6 +52,33 @@ public class DynamicNotificationService {
     private final WatiContactAttributeService watiContactAttributeService;
     private final CouponCodeService couponCodeService;
     private final vacademy.io.admin_core_service.features.shortlink.service.ShortUrlManagementService shortUrlManagementService;
+    private final EnrollInviteRepository enrollInviteRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * If the institute's setting JSON contains
+     *   referral_email_settings.invite_code = "xxxxxx"
+     * resolve and return that EnrollInvite for use in referral / invitation
+     * link generation. Otherwise return the supplied fallback unchanged.
+     */
+    private EnrollInvite resolveReferralInviteOverride(String instituteId, EnrollInvite fallback) {
+        try {
+            Institute institute = getInstituteFromId(instituteId);
+            if (institute == null) return fallback;
+            String settingJson = institute.getSetting();
+            if (settingJson == null || settingJson.isBlank()) return fallback;
+            JsonNode codeNode = objectMapper.readTree(settingJson)
+                    .path("referral_email_settings").path("invite_code");
+            if (codeNode.isMissingNode() || codeNode.isNull()) return fallback;
+            String code = codeNode.asText();
+            if (code == null || code.isBlank()) return fallback;
+            return enrollInviteRepository.findByInviteCode(code).orElse(fallback);
+        } catch (Exception e) {
+            log.warn("Failed to resolve referral invite override for institute {}: {}",
+                    instituteId, e.getMessage());
+            return fallback;
+        }
+    }
 
     /**
      * Send dynamic notifications based on event and package session
@@ -108,17 +138,18 @@ public class DynamicNotificationService {
 
             // Populate referral and invitation templates for dynamic notifications
             try {
+                EnrollInvite linkInvite = resolveReferralInviteOverride(instituteId, enrollInvite);
                 String invitationLink = learnerInvitationLinkService
-                        .generateLearnerInvitationResponseLink(instituteId, enrollInvite, user.getId());
+                        .generateLearnerInvitationResponseLink(instituteId, linkInvite, user.getId());
                 String shortRefLink = learnerInvitationLinkService
-                        .generateShortLearnerInvitationResponseLink(instituteId, enrollInvite, user.getId());
+                        .generateShortLearnerInvitationResponseLink(instituteId, linkInvite, user.getId());
                 String refCode = learnerInvitationLinkService.getRefFromUserCoupon(user.getId());
 
                 templateVars.setReferralLink(invitationLink);
                 templateVars.setLearnerInvitationResponseLink(invitationLink);
                 templateVars.setShortReferralLink(shortRefLink);
                 templateVars.setRefCode(refCode);
-                templateVars.setInviteCode(enrollInvite != null ? enrollInvite.getInviteCode() : "");
+                templateVars.setInviteCode(linkInvite != null ? linkInvite.getInviteCode() : "");
                 // Only set theme color from parent institute if not already set by sub-org
                 if (templateVars.getThemeColor() == null || templateVars.getThemeColor().isEmpty()) {
                     templateVars.setThemeColor(getThemeColorFromInstitute(getInstituteFromId(instituteId)));
@@ -377,13 +408,15 @@ public class DynamicNotificationService {
             // Get institute details
             Institute institute = getInstituteFromId(instituteId);
 
+            EnrollInvite linkInvite = resolveReferralInviteOverride(instituteId, enrollInvite);
+
             // Generate learner invitation response links (long link)
             String invitationLink = learnerInvitationLinkService
-                    .generateLearnerInvitationResponseLink(instituteId, enrollInvite, user.getId());
+                    .generateLearnerInvitationResponseLink(instituteId, linkInvite, user.getId());
 
             // Generate short invitation link
             String shortRefLink = learnerInvitationLinkService
-                    .generateShortLearnerInvitationResponseLink(instituteId, enrollInvite, user.getId());
+                    .generateShortLearnerInvitationResponseLink(instituteId, linkInvite, user.getId());
 
             // Get the coupon code's short_url to use as referral link if available
             String couponShortUrl = shortRefLink;
@@ -417,9 +450,9 @@ public class DynamicNotificationService {
                     .instituteId(institute.getId())
 
                     // Enroll invite details
-                    .enrollInviteCode(enrollInvite != null ? enrollInvite.getInviteCode() : "")
-                    .enrollInviteExpiryDate(enrollInvite != null && enrollInvite.getEndDate() != null
-                            ? enrollInvite.getEndDate().toString()
+                    .enrollInviteCode(linkInvite != null ? linkInvite.getInviteCode() : "")
+                    .enrollInviteExpiryDate(linkInvite != null && linkInvite.getEndDate() != null
+                            ? linkInvite.getEndDate().toString()
                             : "")
 
                     // Learner invitation response link
@@ -429,7 +462,7 @@ public class DynamicNotificationService {
                     .name(user.getFullName() != null ? user.getFullName() : user.getUsername())
                     .referralLink(invitationLink)
                     .shortReferralLink(couponShortUrl) // Use the coupon short URL
-                    .inviteCode(enrollInvite != null ? enrollInvite.getInviteCode() : "")
+                    .inviteCode(linkInvite != null ? linkInvite.getInviteCode() : "")
                     .themeColor(themeColor)
                     .build();
 


### PR DESCRIPTION
## Summary of Changes

Adds an institute-level override for the enroll invite used in referral / invitation emails. The override lives inside the institute's existing `setting_json` under `EMAIL_SETTING.data.REFERRAL_EMAIL`:

{
  "EMAIL_SETTING": {
    "key": "EMAIL_SETTING",
    "name": "Email Setting",
    "data": {
      "MARKETING_EMAIL": { ... },
      "UTILITY_EMAIL": { ... },
      "REFERRAL_EMAIL": {
        "invite_code": "xxxxxx"
      }
    }
  }
}

When that path is set, `DynamicNotificationService` resolves the matching `EnrollInvite` and uses it for `referralLink`, `shortReferralLink`, `learnerInvitationResponseLink`, `inviteCode` (and `enrollInviteCode` / `enrollInviteExpiryDate` in the referral-invitation flow). When the setting is missing, blank, or doesn't resolve to an existing invite, behavior is unchanged — the link continues to use the invite the user enrolled in.

Implementation:
- Added `resolveReferralInviteOverride(instituteId, fallback)` helper in `DynamicNotificationService` — parses `institute.setting`, reads `EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code`, and looks up the `EnrollInvite` via `EnrollInviteRepository.findByInviteCode`.
- Applied the override in `sendDynamicNotification` and `sendReferralInvitationNotification`.
- No schema change. No API change. No data migration required.

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Triggered the bulk-assign flow (`POST /admin-core-service/v3/learner-management/assign`) on stage with `notify_learners=true` against an institute whose `setting_json` has `EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code` set; verified the short URL and inline `inviteCode` in the email resolve to the configured invite, not the package_session's DEFAULT.
- Repeated for an institute with no `REFERRAL_EMAIL` block configured; verified email continues to use the enrolled package_session's invite (existing behavior preserved).
- Verified malformed / missing JSON falls back gracefully (no exception bubbles up, original invite used, `WARN` logged).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
