### PR TITLE
fix: correct referral invite override path and generate coupon in bulk assign

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -63,6 +63,7 @@ public class BulkAssignmentService {
     private final CustomFieldValueService customFieldValueService;
     private final StudentRegistrationManager studentRegistrationManager;
     private final SubOrgAutoLinkService subOrgAutoLinkService;
+    private final vacademy.io.admin_core_service.features.learner.service.LearnerCouponService learnerCouponService;
     private final vacademy.io.admin_core_service.features.user_subscription.service.PaymentLogService paymentLogService;
     private final PaymentLogRepository paymentLogRepository;
     private final InvoiceService invoiceService;
@@ -449,6 +450,15 @@ public class BulkAssignmentService {
                     .build();
 
             mappingId = studentRegistrationManager.linkStudentToInstitute(student, details);
+
+            // Generate USER-source coupon code so referral links carry the user's
+            // own ref instead of the hardcoded "xyz" fallback (same as manual flow).
+            try {
+                learnerCouponService.generateCouponCodeForLearner(userId, instituteId,
+                        config.getEnrollInvite() != null ? config.getEnrollInvite().getInviteCode() : null);
+            } catch (Exception e) {
+                log.warn("Failed to generate coupon code for userId={}: {}", userId, e.getMessage());
+            }
 
             // Trigger enrollment workflow (same as manual flow)
             try {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/notification/service/DynamicNotificationService.java
@@ -57,7 +57,7 @@ public class DynamicNotificationService {
 
     /**
      * If the institute's setting JSON contains
-     *   EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code = "xxxxxx"
+     *   setting.EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code = "xxxxxx"
      * resolve and return that EnrollInvite for use in referral / invitation
      * link generation. Otherwise return the supplied fallback unchanged.
      */
@@ -68,7 +68,11 @@ public class DynamicNotificationService {
             String settingJson = institute.getSetting();
             if (settingJson == null || settingJson.isBlank()) return fallback;
             JsonNode codeNode = objectMapper.readTree(settingJson)
-                    .path("EMAIL_SETTING").path("data").path("REFERRAL_EMAIL").path("invite_code");
+                    .path("setting")
+                    .path("EMAIL_SETTING")
+                    .path("data")
+                    .path("REFERRAL_EMAIL")
+                    .path("invite_code");
             if (codeNode.isMissingNode() || codeNode.isNull()) return fallback;
             String code = codeNode.asText();
             if (code == null || code.isBlank()) return fallback;


### PR DESCRIPTION
## Summary of Changes

Fixes two bugs in the referral / invitation email generated by the bulk-assign flow (`POST /admin-core-service/v3/learner-management/assign`):

1. **Referral invite override JSON path was wrong.** `DynamicNotificationService.resolveReferralInviteOverride` was reading the institute's invite override at `EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code` (top level), but the actual JSON in `institutes.setting_json` wraps everything under a `setting` root. Path corrected to `setting.EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code`. The override is now picked up and the email's URL carries the configured invite code instead of falling back to the package_session's DEFAULT.

2. **`ref` query param was always the literal `"xyz"` for bulk-assigned users.** `LearnerInvitationLinkService.getRefFromUserCoupon` looks up a `coupon_code` row with `(source_id=<userId>, source="USER")` and returns the hardcoded `"xyz"` as a fallback. The bulk-assign path was bypassing the wrapper `StudentRegistrationManager.addStudentToInstitute` (where the manual flow generates this coupon), so the row never existed for bulk-assigned learners. Added a call to `learnerCouponService.generateCouponCodeForLearner(userId, instituteId, inviteCode)` in `BulkAssignmentService.handleNewEnrollment` right after `linkStudentToInstitute`. The method is idempotent — it short-circuits if the user already has a USER-source coupon — so re-runs are safe.

Verified locally: emails generated by the bulk-assign curl now contain `inviteCode=<configured override>` and `ref=<user's coupon code>` instead of `inviteCode=<wrong default>` and `ref=xyz`.

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran admin_core_service locally, set `MEDIA_SERVER_BASE_URL=https://backend-stage.vacademy.io` to exercise the real shortener, and fired `POST /admin-core-service/v3/learner-management/assign` with `notify_learners=true` against an institute whose `setting_json` has `setting.EMAIL_SETTING.data.REFERRAL_EMAIL.invite_code` configured. The emailed referral URL contains the configured `inviteCode` and a real `ref` from the user's freshly-created coupon row.
- Ran the same curl against an institute with no `REFERRAL_EMAIL` block; verified the URL falls back to the package_session's DEFAULT invite (existing behavior preserved).
- Verified `generateCouponCodeForLearner` is idempotent — re-running bulk-assign for a user who already has a coupon does not insert a duplicate row.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly