### PR TITLE
Fix/readonrent price on catalogue page

### DIFF
--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/batch-selector-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/batch-selector-dialog.tsx
@@ -109,11 +109,8 @@ export function BatchSelectorDialog({
     };
 
     const handleConfirm = () => {
-        const effectiveLevelId = selectedLevel === 'DEFAULT_VALUE' ? '' : selectedLevel;
-        const effectiveSessionId = selectedSession === 'DEFAULT_VALUE' ? '' : selectedSession;
-
-        const levelOption = levels.find((l) => l.id === effectiveLevelId);
-        const sessionOption = sessions.find((s) => s.id === effectiveSessionId);
+        const levelOption = levels.find((l) => l.id === selectedLevel);
+        const sessionOption = sessions.find((s) => s.id === selectedSession);
 
         // Validate price for paid types
         if ((paymentType === 'ONE_TIME' || paymentType === 'SUBSCRIPTION') && !price) {
@@ -122,8 +119,8 @@ export function BatchSelectorDialog({
         }
 
         const batch: BatchConfig = {
-            level_id: effectiveLevelId || null,
-            session_id: effectiveSessionId || null,
+            level_id: selectedLevel || null,
+            session_id: selectedSession || null,
             level_name: levelOption?.name || 'DEFAULT',
             session_name: sessionOption?.name || 'DEFAULT',
             inventory_config: maxSlots
@@ -193,10 +190,9 @@ export function BatchSelectorDialog({
                             <TabsContent value="existing" className="mt-2">
                                 <Select value={selectedLevel} onValueChange={setSelectedLevel}>
                                     <SelectTrigger className="h-9 text-sm">
-                                        <SelectValue placeholder={`Select ${getTerminology(ContentTerms.Level, SystemTerms.Level).toLowerCase()} (or leave for DEFAULT)`} />
+                                        <SelectValue placeholder={`Select ${getTerminology(ContentTerms.Level, SystemTerms.Level).toLowerCase()}`} />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="DEFAULT_VALUE">DEFAULT</SelectItem>
                                         {levels.map((level) => (
                                             <SelectItem key={level.id} value={level.id}>
                                                 {level.name}
@@ -240,10 +236,9 @@ export function BatchSelectorDialog({
                             <TabsContent value="existing" className="mt-2">
                                 <Select value={selectedSession} onValueChange={setSelectedSession}>
                                     <SelectTrigger className="h-9 text-sm">
-                                        <SelectValue placeholder={`Select ${getTerminology(ContentTerms.Session, SystemTerms.Session).toLowerCase()} (or leave for DEFAULT)`} />
+                                        <SelectValue placeholder={`Select ${getTerminology(ContentTerms.Session, SystemTerms.Session).toLowerCase()}`} />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="DEFAULT_VALUE">DEFAULT</SelectItem>
                                         {sessions.map((session) => (
                                             <SelectItem key={session.id} value={session.id}>
                                                 {session.name}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
@@ -717,6 +717,11 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                       <h3 className="text-base font-bold text-gray-800 line-clamp-2 leading-tight group-hover:text-primary-500 transition-colors duration-300">
                         {book.title}
                       </h3>
+                      {render.cardFields.includes("price") && cartMode === 'buy' && (
+                        <div className="text-lg font-extrabold text-gray-900 tracking-tight">
+                          {book.price === 0 ? <span className="text-green-600">Free</span> : `₹${book.price}`}
+                        </div>
+                      )}
                       <div className="flex items-center justify-between">
                         <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 line-clamp-1">
                           {(() => {
@@ -746,9 +751,6 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                                 ))}
                               </div>
                             )}
-                            {/* <div className="text-lg font-extrabold text-gray-900 tracking-tight">
-                              {book.price === 0 ? <span className="text-green-600">Free</span> : `₹${book.price}`}
-                            </div> */}
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Summary of Changes

Two small UI fixes across the learner and admin apps.

**Frontend (learner — ReadOnRent catalogue):**
- Show the book price on the catalogue cards when the cart is in **buy** mode. Previously the price was only visible on the book details page. Format matches the details page (`₹{price}` or `Free` in green for `price === 0`). Hidden in rent mode and still gated by the existing `cardFields.includes("price")` config.
- Removed the dead commented-out price block that previously sat on the right column of the card.

**Frontend (admin — bulk-create batch selector):**
- Removed the `DEFAULT` `<SelectItem>` from both the level and session dropdowns in the "Add Batch" dialog (it was creating an unnecessary item users didn't need to pick — empty selection still produces the same `level_id: null` / `session_id: null` with `level_name: 'DEFAULT'` fallback).
- Cleaned up the now-dead `selectedLevel === 'DEFAULT_VALUE' ? '' : selectedLevel` ternaries in `handleConfirm` and inlined `selectedLevel` / `selectedSession` directly.
- Updated both placeholders from `Select <level> (or leave for DEFAULT)` to `Select <level>` since the DEFAULT affordance no longer exists in the UI.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Loaded the ReadOnRent catalogue page and toggled cart mode between Buy and Rent — price appears under each book title in Buy, disappears in Rent.
- Verified `price === 0` renders as green "Free" on the cards, matching the book details page.
- Opened the admin "Add Batch" dialog in bulk-create — neither the level nor the session dropdown shows the `DEFAULT` item anymore.
- Confirmed an empty level/session selection still produces a default batch (`level_id: null`, `level_name: 'DEFAULT'`) when added.
- Verified TypeScript shows no errors after removing the `effectiveLevelId` / `effectiveSessionId` references.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
