### PR TITLE
fix bulk create content dialog showing previous course content

### DIFF
--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-table.tsx
@@ -483,6 +483,7 @@ export function BulkCreateTable({
             {/* Course Content Dialog */}
             {activeCourse && (
                 <CourseContentDialog
+                    key={activeCourse.id}
                     open={contentDialogOpen}
                     onOpenChange={setContentDialogOpen}
                     courseName={activeCourse.course_name || `Untitled ${getTerminology(ContentTerms.Course, SystemTerms.Course)}`}


### PR DESCRIPTION
## Summary of Changes

Fix stale content in the Bulk Create Books "Book Content & Media" dialog. When a user opened the content dialog for one book, saved it, then opened the dialog for a different book, the editor visually showed the previously-edited book's content. Submitted payload was correct (parent state was untouched until Save), but if the user clicked Save Book Content on the stale view, the previous book's content would silently overwrite the current book's row.

**Backend:**
- No changes

**Frontend:**
- Add `key={activeCourse.id}` to `CourseContentDialog` mount in `bulk-create-table.tsx` so the dialog (and the TipTap editor inside) fully unmounts and remounts when the active book changes, instead of relying on a `useEffect`-based reset that races with TipTap's internal editor state

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Open Bulk Create Books with two rows; add content + media for row 1, save. Open the content dialog for row 2 — verified all editor fields and media uploads are empty, not stale from row 1
- Repeat in the reverse order (configure row 2 first, then open row 1) — row 1 opens empty, not stale
- Reopen the same row's dialog after saving — content reloads correctly
- Submit the bulk create after only configuring row 1 — payload still contains content only for row 1, none leaks to row 2

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
