### PR TITLE
fix: add missing open-in-browser util to unblock build

### DIFF
--- a/frontend-learner-dashboard-app/src/lib/open-in-browser.ts
+++ b/frontend-learner-dashboard-app/src/lib/open-in-browser.ts
@@ -1,0 +1,17 @@
+import { Browser } from "@capacitor/browser";
+import { Capacitor } from "@capacitor/core";
+
+// Opens a URL in the system browser across all platforms:
+//   Electron  → shell.openExternal via IPC (opens system browser, not a new Electron window)
+//   iOS/Android → Capacitor Browser plugin
+//   Web       → window.open
+export async function openInBrowser(url: string): Promise<void> {
+    const electronAPI = (window as any).electronAPI;
+    if (electronAPI?.openExternal) {
+        await electronAPI.openExternal(url);
+    } else if (Capacitor.isNativePlatform()) {
+        await Browser.open({ url, presentationStyle: "fullscreen" });
+    } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+    }
+}


### PR DESCRIPTION
## Summary of Changes

- fix: add missing open-in-browser util to unblock build


## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
