### PR TITLE
Fix/b10 course progress percentage readpath

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/dto/CourseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/dto/CourseDTO.java
@@ -26,6 +26,7 @@ public class CourseDTO {
     private String tags;
     private Integer courseDepth;
     private String courseHtmlDescription;
+    private Double percentageCompleted;
 
     public CourseDTO(PackageEntity packageEntity) {
         this.id = packageEntity.getId();

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_operation/repository/LearnerOperationRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_operation/repository/LearnerOperationRepository.java
@@ -39,4 +39,27 @@ public interface LearnerOperationRepository extends JpaRepository<LearnerOperati
                         @Param("userId") String userId,
                         @Param("startDate") java.sql.Timestamp startDate,
                         @Param("endDate") java.sql.Timestamp endDate);
+
+        /**
+         * Returns the highest PERCENTAGE_PACKAGE_SESSION_COMPLETED value across all
+         * package_sessions of the given course for the given user. If the learner
+         * has no learner_operation rows for this course (e.g., not enrolled or
+         * never started), returns NULL.
+         *
+         * MAX is used (not SUM) so multi-enrollment learners see their best progress
+         * for the course, capped naturally at 100.
+         */
+        @Query(value = """
+                        SELECT MAX(CAST(lo.value AS DOUBLE PRECISION))
+                        FROM learner_operation lo
+                        JOIN package_session ps ON ps.id = lo.source_id
+                        WHERE ps.package_id = :courseId
+                          AND lo.user_id = :userId
+                          AND lo.source = 'PACKAGE_SESSION'
+                          AND lo.operation = 'PERCENTAGE_PACKAGE_SESSION_COMPLETED'
+                          AND lo.value ~ '^-?\\d+(\\.\\d+)?$'
+                        """, nativeQuery = true)
+        Double findMaxCoursePercentageForUser(
+                        @Param("courseId") String courseId,
+                        @Param("userId") String userId);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/study_library/controller/StudyLibraryController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/study_library/controller/StudyLibraryController.java
@@ -26,8 +26,9 @@ public class StudyLibraryController {
     @GetMapping("/course-init")
     public ResponseEntity<List<CourseDTOWithDetails>> initCourse(
             @RequestParam("courseId") String courseId,
-            @RequestParam("instituteId") String instituteId) {
-        return ResponseEntity.ok(studyLibraryService.getCourseInitDetails(courseId, instituteId));
+            @RequestParam("instituteId") String instituteId,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity.ok(studyLibraryService.getCourseInitDetails(courseId, instituteId, user));
     }
 
     @GetMapping("/modules-with-chapters")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/study_library/service/StudyLibraryService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/study_library/service/StudyLibraryService.java
@@ -19,6 +19,7 @@ import vacademy.io.admin_core_service.features.course.dto.CourseDTO;
 import vacademy.io.admin_core_service.features.course.dto.CourseDTOWithDetails;
 import vacademy.io.admin_core_service.features.faculty.enums.FacultyStatusEnum;
 import vacademy.io.admin_core_service.features.faculty.repository.FacultySubjectPackageSessionMappingRepository;
+import vacademy.io.admin_core_service.features.learner_operation.repository.LearnerOperationRepository;
 import vacademy.io.admin_core_service.features.level.repository.LevelRepository;
 import vacademy.io.admin_core_service.features.module.dto.ModuleDTO;
 import vacademy.io.admin_core_service.features.module.repository.ModuleChapterMappingRepository;
@@ -89,6 +90,9 @@ public class StudyLibraryService {
 
     @Autowired
     private AuthService authService;
+
+    @Autowired
+    private LearnerOperationRepository learnerOperationRepository;
 
     @Autowired
     private PackageInstituteRepository packageInstituteRepository;
@@ -542,6 +546,11 @@ public class StudyLibraryService {
 
     @Transactional
     public List<CourseDTOWithDetails> getCourseInitDetails(String courseId, String instituteId) {
+        return getCourseInitDetails(courseId, instituteId, null);
+    }
+
+    public List<CourseDTOWithDetails> getCourseInitDetails(String courseId, String instituteId,
+            CustomUserDetails user) {
         if (Objects.isNull(courseId)) {
             throw new VacademyException("Please provide courseId");
         }
@@ -572,7 +581,21 @@ public class StudyLibraryService {
         }
 
         // Reuse the common method with a single package
-        return buildCourseDTOWithDetailsForPackages(List.of(packageEntity), instituteId);
+        List<CourseDTOWithDetails> result = buildCourseDTOWithDetailsForPackages(List.of(packageEntity), instituteId);
+
+        // Stamp user-scoped percentage_completed when an authenticated user is present.
+        // Skipped for the open/unauthenticated path so the public catalog response
+        // stays user-agnostic.
+        if (user != null && user.getUserId() != null) {
+            for (CourseDTOWithDetails dto : result) {
+                if (dto.getCourse() != null) {
+                    Double pct = learnerOperationRepository.findMaxCoursePercentageForUser(courseId, user.getUserId());
+                    dto.getCourse().setPercentageCompleted(pct);
+                }
+            }
+        }
+
+        return result;
     }
 
 }

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -22,7 +22,7 @@ export const GET_COURSE_DETAILS = `${BASE_URL}/admin-core-service/open/packages/
 /** @deprecated Use GET_COURSE_INIT instead - this fetches ALL courses */
 export const GET_ALL_COURSE_DETAILS = `${BASE_URL}/admin-core-service/open/v1/learner-study-library/init`;
 /** New scalable endpoint - fetches single course by courseId */
-export const GET_COURSE_INIT = `${BASE_URL}/admin-core-service/open/v1/learner-study-library/course-init`;
+export const GET_COURSE_INIT = `${BASE_URL}/admin-core-service/v1/study-library/course-init`;
 export const HOLISTIC_INSTITUTE_ID =
   import.meta.env.VITE_HOLISTIC_INSTITUTE_ID ||
   "bd9f2362-84d1-4e01-9762-a5196f9bac80";

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
@@ -1029,11 +1029,13 @@ export const CourseDetailsPage = () => {
           }>(key);
           return saved?.value;
         })();
+        // Backend (course-init) is authoritative — URL/localStorage are stale-prone
+        // fallbacks for cases where the backend response is unavailable.
         const percentageCompleted =
-          typeof pctFromQuery === "number" && !Number.isNaN(pctFromQuery)
-            ? pctFromQuery
-            : typeof pctFromCourse === "number"
-              ? pctFromCourse
+          typeof pctFromCourse === "number"
+            ? pctFromCourse
+            : typeof pctFromQuery === "number" && !Number.isNaN(pctFromQuery)
+              ? pctFromQuery
               : typeof pctFromLocal === "number"
                 ? pctFromLocal
                 : undefined;


### PR DESCRIPTION
## Summary
- Backend `/v1/study-library/course-init` now returns `percentage_completed` on `course` so the learner UI no longer depends on URL search params or localStorage to display Course Progress
- Frontend prioritizes the backend value over URL/localStorage in the fallback chain — fresh data from server beats any stale upstream-cached value
- `GET_COURSE_INIT` URL constant pointed at the authenticated endpoint (was previously the open endpoint, which can't return user-scoped data)

## Bug — B10
The course-details page reads `courseDetailsData.course.percentage_completed`, but the backend's `CourseDTO` had no such field — `getCourseInitDetails` builds DTOs from catalog data only and never queries `learner_operation`. The UI was structurally stuck at 0% on direct navigation.

It only "worked" by accident: `CourseCards.tsx` stamped `percentageCompleted=...` into the URL search param and into localStorage when navigating from the course list. The course-details page's third-fallback read picked it up. This carriage broke under direct navigation, hard refresh, bookmarks, shared URLs, cleared browser data, and any non-cards entry point.

The certificate trigger reads the same `completionPercentage` state, so the carriage failure also masked cert generation behind the same fragility.

## Fix
- `CourseDTO.percentageCompleted: Double` — new field, snake-cased in the JSON response
- `LearnerOperationRepository.findMaxCoursePercentageForUser(courseId, userId)` — focused native query that takes MAX of `PERCENTAGE_PACKAGE_SESSION_COMPLETED` across the course's package_sessions for the user (handles multi-enrollment cleanly, returns null for unenrolled / never-started)
- `StudyLibraryController.initCourse(...)` — accepts `@RequestAttribute("user")` and forwards to a new 3-arg service overload
- `StudyLibraryService.getCourseInitDetails(...)` — new overload accepting user, falls through to the existing 2-arg path for the open/unauthenticated catalog case (no user → no percentage, response stays user-agnostic)
- Frontend `GET_COURSE_INIT` switched from the open endpoint to the authenticated endpoint
- Frontend priority chain in `course-details-page.tsx` flipped so backend > URL > localStorage (was URL > backend > localStorage); a stale URL no longer overrides a fresh backend value

## Verification
Tested locally with admin_core_service running at `localhost:8072`:

1. Navigated directly to course-details URL **without** `percentageCompleted` in URL params and **without** any `_cap_COURSE_PCT_*` localStorage entry.
2. Network tab confirmed `course-init` request hit `localhost:8072/admin-core-service/v1/study-library/course-init`, returned 200 OK.
3. Response JSON included `course.percentage_completed: 9.090909090909092` matching the `learner_operation.PERCENTAGE_PACKAGE_SESSION_COMPLETED` row in DB.
4. Course Progress widget rendered with "Completion 9%". Pre-fix: would have shown 0% under the same conditions.

## Test plan for reviewer
- [ ] As an enrolled learner, navigate directly to course-details URL with only `?courseId=...&packageSessionId=...&selectedTab=PROGRESS` — Course Progress widget shows the correct percentage from backend
- [ ] Clear localStorage `_cap_COURSE_PCT_*`, hard refresh, repeat — still correct (no localStorage dependency)
- [ ] Navigate with intentionally stale `percentageCompleted=2.0` in URL — UI shows the fresh backend value, not the stale URL value (priority flip working)
- [ ] Unauthenticated public catalog browsing still works — the open `/learner-study-library/course-init` endpoint still calls the 2-arg service overload and returns the response without `percentage_completed`
- [ ] Cert generation: when learner crosses the threshold, the certificate trigger now reads the fresh backend value rather than a possibly-stale URL value

## Notes
- A related UI bug surfaced during testing: enrolled learners see "Course Preview Mode / Enroll Now" UI on direct navigation when `selectedTab` is missing from the URL. Tracked separately, not in scope for this PR.
- After this PR lands, the `COURSE_PCT_<courseId>` localStorage write in `CourseCards.tsx` and the `percentageCompleted` URL search param become legacy carriage code that can be removed in a follow-up cleanup PR.
- Follow-up agreed with Priyanshu: invalidate `GET_COURSE_INIT` query on slide tracking events so the percentage refreshes immediately after the learner makes new progress, instead of waiting for the React Query `staleTime` (currently 1h) to expire.
