### PR TITLE
fix(display-settings): add missing showApprovalToggle field

### DIFF
--- a/frontend-admin-dashboard/src/types/display-settings.ts
+++ b/frontend-admin-dashboard/src/types/display-settings.ts
@@ -182,6 +182,7 @@ export interface LearnerManagementSettings {
     allowPortalAccess: boolean;
     allowViewPassword: boolean;
     allowSendResetPasswordMail: boolean;
+    showApprovalToggle: boolean;
 }
 
 export interface LiveClassSchedulingSettings {


### PR DESCRIPTION
Restores the build broken by #1636 — six files referenced `learnerManagement.showApprovalToggle` but the field was never added to `LearnerManagementSettings`.