### PR TITLE
fix(progress-tracking): refresh course progress on submit and unfreez…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
@@ -549,11 +549,21 @@ public class LearnerTrackingAsyncService {
         // ==== Private Helper for Percentage Operations ====
 
         /**
-         * Saves percentage operation with specific rules:
+         * Saves a percentage operation with these rules:
          * 1. If value is null, do nothing.
          * 2. If value > 100, save as 100.
-         * 3. If an existing percentage is already >= the new value, do nothing.
-         *    Re-visiting a slide must never decrease previously-recorded progress.
+         * 3. Monotonic guard at SLIDE level only: never lower a previously-recorded
+         *    slide percentage. A learner re-opening a PDF (or scrubbing back in a
+         *    video) must not see their per-slide progress drop because of a stale
+         *    re-computation.
+         *
+         *    The guard is intentionally NOT applied at rollup levels (CHAPTER,
+         *    MODULE, SUBJECT, PACKAGE_SESSION). Rollups are aggregates over
+         *    potentially-changing structure (new slides added to a chapter, new
+         *    chapters added to a module, etc.). If we kept rollups monotonic, any
+         *    content edit that legitimately lowers an aggregate would permanently
+         *    freeze the old higher value, and the displayed course % would diverge
+         *    from the actual chapter/module math forever.
          */
         private void addOrUpdatePercentageOperation(String userId, String source, String sourceId, String operation,
                         Double value) {
@@ -564,11 +574,14 @@ public class LearnerTrackingAsyncService {
                         value = 100.0;
                 }
 
-                Double existing = learnerOperationService
-                                .findDoubleValueByUserIdSourceAndSourceIdAndOperation(userId, source, sourceId, operation)
-                                .orElse(null);
-                if (existing != null && existing >= value) {
-                        return;
+                if (LearnerOperationSourceEnum.SLIDE.name().equals(source)) {
+                        Double existing = learnerOperationService
+                                        .findDoubleValueByUserIdSourceAndSourceIdAndOperation(userId, source, sourceId,
+                                                        operation)
+                                        .orElse(null);
+                        if (existing != null && existing >= value) {
+                                return;
+                        }
                 }
 
                 learnerOperationService.addOrUpdateOperation(userId, source, sourceId, operation,

--- a/docs/CERTIFICATE_SYSTEM_AUDIT.md
+++ b/docs/CERTIFICATE_SYSTEM_AUDIT.md
@@ -4,7 +4,18 @@
 > Out of scope: the bulk admin CSV-issuance tool at `/certificate-generation/student-data` (separate page, separate use case).
 >
 > **Audit date:** 2026-05-08
+> **Last updated:** 2026-05-09 — see "Update note" below.
 > **Audience:** engineers planning the next iteration of the certificate feature.
+
+## Update note (2026-05-09) — rollup percentages can now legitimately drop
+
+The progress-tracking cascade was changed today (branch `fix/progress-tracking-staleness`): the B9 monotonic guard in `LearnerTrackingAsyncService.addOrUpdatePercentageOperation` was scoped to slide-level writes only. Chapter / module / subject / **package_session** percentages now overwrite freely on every cascade run, so they reflect current course structure (slides added/removed, chapters re-published, etc.) instead of being frozen at a previous high-water mark.
+
+**Implication for this doc / for the cert flow:**
+
+- The frontend threshold gate at `course-details-page.tsx:1066-1077` — `if (percentageCompleted >= threshold) generate(...)` — used to be effectively one-way once crossed: the underlying `PERCENTAGE_PACKAGE_SESSION_COMPLETED` row was monotonic, so a learner who crossed the threshold once stayed eligible. After today, the same row can legitimately drop below threshold if course content is edited. With the current idempotency check (`if SSIGM.automatedCompletionCertificateFileId is set, return cached file`), an already-issued cert is preserved — no regression for learners who already received one. **But** if Bucket B (auto-trigger from cascade) is implemented later, the trigger logic needs to be deliberate about "should we issue a cert when crossing threshold for the first time, even though the learner may dip below threshold later?" — otherwise content edits could cause spurious second-issuance attempts or, worse, retract eligibility that was previously granted.
+- §13's "Threshold rounding semantics" subsection grows in importance: the gate is now a fresh comparison every time, not a one-time crossing. Decide explicitly whether the gate is `>=` or `> threshold - epsilon`, and whether crossing-down should ever revoke a cert.
+- §13's "Idempotency under re-enrollment" remains correct as written; the rollup change doesn't affect SSIGM lifecycle, only the % stored in `learner_operation`.
 
 ---
 

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/quiz-viewer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/quiz-viewer.tsx
@@ -162,21 +162,44 @@ export const QuizViewer: React.FC<QuizViewerProps> = ({
   const restoreLocalStorageCompletions = useCallback((chapterId: string) => {
     queryClient.setQueryData<Slide[]>(["slides", chapterId], (oldSlides) => {
       if (!oldSlides) return oldSlides;
-      
+
       return oldSlides.map((slide) => {
         // Check if this slide has completed answers in localStorage
         const storageKey = `quiz_answers_${slide.id}_${chapterId}`;
         const hasStoredAnswers = localStorage.getItem(storageKey);
-        
+
         // If quiz is completed, ensure 100%
         if (hasStoredAnswers && slide.source_type === 'QUIZ') {
           return { ...slide, percentage_completed: 100 };
         }
-        
+
         return slide;
       });
     });
   }, [queryClient]);
+
+  // Refresh every progress-bearing cache after a quiz submit. The backend
+  // cascade (slide → chapter → module → subject → package_session) runs
+  // @Async, so we wait briefly before invalidating, then hit every key
+  // that feeds a progress UI: chapter sidebar (slides), module list
+  // (MODULES_WITH_CHAPTERS — both naming conventions exist in this codebase),
+  // and the course-level overall % (GET_COURSE_INIT).
+  const refreshProgressAfterSubmit = useCallback(async (chapterIdToRefresh: string) => {
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await queryClient.invalidateQueries({
+      predicate: (q) => {
+        const k = q.queryKey;
+        if (!Array.isArray(k)) return false;
+        return (
+          k[0] === "MODULES_WITH_CHAPTERS" ||
+          k[0] === "GET_MODULES_WITH_CHAPTERS" ||
+          k[0] === "GET_COURSE_INIT" ||
+          (k[0] === "slides" && k[1] === chapterIdToRefresh)
+        );
+      },
+    });
+    restoreLocalStorageCompletions(chapterIdToRefresh);
+  }, [queryClient, restoreLocalStorageCompletions]);
 
   // Helpers: decode HTML entities and render KaTeX spans
   const decodeHtml = (input: string): string => {
@@ -570,19 +593,7 @@ export const QuizViewer: React.FC<QuizViewerProps> = ({
         );
       });
 
-      setTimeout(async () => {
-        try {
-          await queryClient.invalidateQueries({ predicate: (q) => Array.isArray(q.queryKey) && q.queryKey[0] === "GET_MODULES_WITH_CHAPTERS" });
-          await queryClient.refetchQueries({ predicate: (q) => Array.isArray(q.queryKey) && q.queryKey[0] === "GET_MODULES_WITH_CHAPTERS" });
-          setTimeout(async () => {
-            try {
-              await queryClient.invalidateQueries({ queryKey: ["slides", chapterId] });
-              await queryClient.refetchQueries({ queryKey: ["slides", chapterId] });
-              restoreLocalStorageCompletions(chapterId);
-            } catch { /* ignore */ }
-          }, 3000);
-        } catch { /* ignore */ }
-      }, 2000);
+      void refreshProgressAfterSubmit(chapterId);
 
       const card = computeScore(finalAnswers);
       setScoreCard(card);
@@ -722,66 +733,15 @@ export const QuizViewer: React.FC<QuizViewerProps> = ({
         // ✅ STEP 2: Optimistic UI update - instantly show 100% in sidebar
         queryClient.setQueryData<Slide[]>(["slides", chapterId], (oldSlides) => {
           if (!oldSlides) return oldSlides;
-          console.log("🎯 [QuizViewer] Setting optimistic 100% for slideId:", slideId);
           return oldSlides.map((slide) =>
             slide.id === slideId
               ? { ...slide, percentage_completed: 100 }
               : slide
           );
         });
-        console.log("✅ [QuizViewer] Optimistic 100% set in React Query cache");
-        
-        // ✅ STEP 3: Background refresh (delayed to avoid overwriting optimistic update)
-        setTimeout(async () => {
-          try {
-            console.log("🔄 [QuizViewer] Background (3s): Updating course structure...");
-            
-            // Invalidate and refetch modules query - this updates course structure
-            await queryClient.invalidateQueries({
-                predicate: (query) => {
-                const queryKey = query.queryKey;
-                return Array.isArray(queryKey) && queryKey[0] === "GET_MODULES_WITH_CHAPTERS";
-                },
-            });
-              
-            await queryClient.refetchQueries({
-                predicate: (query) => {
-                const queryKey = query.queryKey;
-                return Array.isArray(queryKey) && queryKey[0] === "GET_MODULES_WITH_CHAPTERS";
-              },
-            });
-            
-            console.log("✅ [QuizViewer] Course structure updated successfully");
-            
-            // ✅ STEP 4: After another delay, sync slides with server data
-            setTimeout(async () => {
-              try {
-                console.log("🔄 [QuizViewer] Background (8s): Syncing slides with server...");
-                
-                // Now it's safe to refetch slides from server
-                await queryClient.invalidateQueries({
-                  queryKey: ["slides", chapterId],
-                });
-                
-                await queryClient.refetchQueries({
-                  queryKey: ["slides", chapterId],
-                });
-                
-                console.log("✅ [QuizViewer] Slides synced with server data");
-            
-                // ✅ CRITICAL: After refetch, restore localStorage completions again
-                console.log("🔄 [QuizViewer] Re-applying localStorage completions after server sync...");
-            restoreLocalStorageCompletions(chapterId);
-                console.log("✅ [QuizViewer] localStorage completions restored after server sync");
-              } catch (e) {
-                console.error("❌ [QuizViewer] Slides sync error:", e);
-              }
-            }, 3000); // Wait additional 5 seconds for slides sync (total 8s)
-            
-          } catch (e) {
-            console.error("❌ [QuizViewer] Background refresh error:", e);
-          }
-        }, 2000); // Wait 3 seconds before updating course structure
+
+        // ✅ STEP 3: Refresh every progress-bearing cache (slides + module rollup + course %)
+        void refreshProgressAfterSubmit(chapterId);
         if (celebrateOnQuizComplete) {
           try {
             // Confetti: multi-wave, spread across screen with streamers and bursts

--- a/frontend-learner-dashboard-app/src/hooks/study-library/use-slides.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/use-slides.ts
@@ -218,7 +218,7 @@ export const useSlides = (chapterId: string) => {
       
       return response.data;
     },
-    staleTime: 3600000,
+    staleTime: 60_000,
   });
 
   return {

--- a/frontend-learner-dashboard-app/src/routes/courses/-services/getModulesWithChapters.ts
+++ b/frontend-learner-dashboard-app/src/routes/courses/-services/getModulesWithChapters.ts
@@ -18,7 +18,7 @@ export const handleFetchModulesWithChapters = (subjectId: string, packageSession
     return {
         queryKey: ['MODULES_WITH_CHAPTERS', subjectId, packageSessionId],
         queryFn: () => fetchModulesWithChapters(subjectId, packageSessionId),
-        staleTime: 60 * 60 * 1000,
+        staleTime: 60_000,
     };
 };
 
@@ -31,7 +31,7 @@ export const useModulesWithChaptersQuery = (subjectId: string, packageSessionId:
             setModulesData(data);
             return data;
         },
-        staleTime: 3600000,
+        staleTime: 60_000,
         enabled: !!subjectId && !!packageSessionId,
         refetchOnMount: 'always',
     });

--- a/frontend-learner-dashboard-app/src/routes/courses/course-details/-services/get-course-details.ts
+++ b/frontend-learner-dashboard-app/src/routes/courses/course-details/-services/get-course-details.ts
@@ -96,7 +96,7 @@ export const handleGetCourseInit = ({
     return {
         queryKey: ["GET_COURSE_INIT", courseId, instituteId],
         queryFn: () => getCourseInitData({ courseId, instituteId }),
-        staleTime: 60 * 60 * 1000,
+        staleTime: 60_000,
         enabled: Boolean(courseId && instituteId),
     };
 };

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/-services/getModulesWithChapters.ts
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/-services/getModulesWithChapters.ts
@@ -18,7 +18,7 @@ export const handleFetchModulesWithChapters = (subjectId: string, packageSession
     return {
         queryKey: ['MODULES_WITH_CHAPTERS', subjectId, packageSessionId],
         queryFn: () => fetchModulesWithChapters(subjectId, packageSessionId),
-        staleTime: 60 * 60 * 1000,
+        staleTime: 60_000,
     };
 };
 
@@ -31,7 +31,7 @@ export const useModulesWithChaptersQuery = (subjectId: string, packageSessionId:
             setModulesData(data);
             return data;
         },
-        staleTime: 3600000,
+        staleTime: 60_000,
         enabled: !!subjectId && !!packageSessionId,
         refetchOnMount: 'always',
     });

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-services/get-course-details.ts
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-services/get-course-details.ts
@@ -96,7 +96,7 @@ export const handleGetCourseInit = ({
   return {
     queryKey: ["GET_COURSE_INIT", courseId, instituteId],
     queryFn: () => getCourseInitData({ courseId, instituteId }),
-    staleTime: 60 * 60 * 1000,
+    staleTime: 60_000,
     enabled: Boolean(courseId && instituteId),
   };
 };


### PR DESCRIPTION
## Summary of Changes

Course / module / chapter progress was visibly diverging from live slide math: the right-panel "Course Progress" sat at stale values for up to ~60 minutes after a quiz submit, and even after refresh it could remain permanently stuck-too-high once course content was edited. Two unrelated layers were causing this — a frontend cache miss and a backend monotonic guard applied at the wrong scope.

**Backend:**
- Scoped the B9 monotonic guard in `LearnerTrackingAsyncService.addOrUpdatePercentageOperation` to `source == SLIDE` only. Per-slide progress still cannot regress (re-opening a PDF can't lower your reading %), but rollup levels (`CHAPTER`, `MODULE`, `SUBJECT`, `PACKAGE_SESSION`) now overwrite freely so they track current course structure when slides/chapters are added or removed. Without this, any content edit that legitimately lowers an aggregate would freeze the old higher value indefinitely and the displayed course % would diverge from chapter math forever.
- Updated the Javadoc on `addOrUpdatePercentageOperation` to spell out why rollups are intentionally not monotonic, so the broader guard isn't reintroduced by mistake.

**Frontend:**
- `quiz-viewer.tsx`: extracted `refreshProgressAfterSubmit(chapterId)` helper that waits ~600 ms for the backend `@Async` cascade to land, then invalidates every progress-bearing React Query cache in one pass — `MODULES_WITH_CHAPTERS` and `GET_MODULES_WITH_CHAPTERS` (both naming conventions exist in the codebase), `GET_COURSE_INIT`, and `["slides", chapterId]`. Replaced the brittle nested `setTimeout(2s) → setTimeout(8s)` chain in both submit paths (`handleQuizSubmit` for timer expiry, `handleNext` for the Finish button) with a single call to the helper. Optimistic 100% on the slide cache is preserved.
- Lowered `staleTime` from 1 hour → 1 minute on the three progress-bearing query configs so even if some other write path forgets to invalidate, returning to the tab refetches inside 60 seconds instead of 60 minutes:
  - `hooks/study-library/use-slides.ts` — `["slides", chapterId]`
  - `routes/study-library/courses/-services/getModulesWithChapters.ts` and the alternate `routes/courses/-services/getModulesWithChapters.ts`
  - `routes/study-library/courses/course-details/-services/get-course-details.ts` (`handleGetCourseInit` only) and the alternate `routes/courses/course-details/-services/get-course-details.ts`

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Submitted a quiz on the test course (`Testing CourseDepth`, chapter `c9b3cfa2-…`); confirmed sidebar slide jumps to 100% optimistically and chapter / module / course-overall bars all refresh within ~1 second.
- Verified the frozen-rollup case via `learner_operation` SQL: chapter 1 was stuck at 53.535% (from yesterday) while live math said 44%, with module/subject/PSE all rolled up to 76.77%. After the B9 scoping change the cascade overwrites the chapter row on the next slide submit and the rollup chain heals automatically — no DB cleanup script needed.
- Re-submit regression check: re-submitted the same quiz with fewer answers; per-slide stays at 100% (slide-level monotonicity preserved).
- Stale-fallback check: switched away from the course-details tab and back after >60 s; `GET_COURSE_INIT` refetched and bars re-synced (defense-in-depth `staleTime` reduction works).
- Non-quiz regression: opened a PDF slide and flipped pages; existing PDF tracking unaffected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
