### PR TITLE
fix(progress-tracking): video and audio tracking accuracy and durabil…

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-video-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-video-dialog.tsx
@@ -124,14 +124,24 @@ export const AddVideoDialog = ({ openState }: { openState?: (open: boolean) => v
                 playerVars: { autoplay: 0, controls: 0 },
                 events: {
                     onReady: (event) => {
-                        const duration = event.target.getDuration();
-                        submitFormWithDuration(data, duration * 1000);
+                        const durationSeconds = event.target.getDuration();
+                        if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+                            toast.error(
+                                'Could not read video duration from YouTube. Please try again.'
+                            );
+                            event.target.destroy();
+                            return;
+                        }
+                        submitFormWithDuration(data, Math.round(durationSeconds * 1000));
                         event.target.destroy();
                     },
                 },
             });
         } else {
-            submitFormWithDuration(data, 0);
+            // YouTube IFrame API hasn't finished loading yet. Don't submit with
+            // length=0 — that would break learner-side progress tracking on
+            // this slide forever. Ask the user to retry.
+            toast.error('YouTube is still loading. Please wait a moment and try again.');
         }
     };
 

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-video-file-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-video-file-dialog.tsx
@@ -29,6 +29,34 @@ type FormValues = z.infer<typeof formSchema>;
 
 const INSTITUTE_ID = 'your-institute-id'; // Replace this in real usage
 
+// Read the video file's intrinsic duration in milliseconds. Without this,
+// the slide is created with length=0 and the learner-side cascade can never
+// compute PERCENTAGE_VIDEO_WATCHED (the `length > 0` guard in
+// LearnerTrackingAsyncService skips the write), so the slide stays at 0%
+// forever for every learner.
+const readVideoDurationMillis = (file: File): Promise<number> => {
+    return new Promise((resolve, reject) => {
+        const video = document.createElement('video');
+        video.preload = 'metadata';
+        const objectUrl = URL.createObjectURL(file);
+        const cleanup = () => URL.revokeObjectURL(objectUrl);
+        video.onloadedmetadata = () => {
+            cleanup();
+            const seconds = video.duration;
+            if (!Number.isFinite(seconds) || seconds <= 0) {
+                reject(new Error('Could not determine video duration'));
+                return;
+            }
+            resolve(Math.round(seconds * 1000));
+        };
+        video.onerror = () => {
+            cleanup();
+            reject(new Error('Failed to read video metadata'));
+        };
+        video.src = objectUrl;
+    });
+};
+
 export const AddVideoFileDialog = ({ openState }: { openState?: (open: boolean) => void }) => {
     const { getPackageSessionId } = useInstituteDetailsStore();
     const { courseId, levelId, chapterId, moduleId, subjectId, sessionId } = Route.useSearch();
@@ -102,6 +130,19 @@ export const AddVideoFileDialog = ({ openState }: { openState?: (open: boolean) 
         try {
             setIsUploading(true);
 
+            // Read duration from the file before upload. If we can't read it,
+            // refuse to create the slide rather than silently storing length=0,
+            // which would break learner progress tracking on this slide.
+            let durationMillis: number;
+            try {
+                durationMillis = await readVideoDurationMillis(data.videoFile);
+            } catch {
+                toast.error(
+                    'Could not read video duration. Please try a different file or re-encode it.'
+                );
+                return;
+            }
+
             const fileId = await UploadFileInS3(
                 data.videoFile,
                 (progress) => {
@@ -126,9 +167,10 @@ export const AddVideoFileDialog = ({ openState }: { openState?: (open: boolean) 
                     description: '',
                     url: fileId ?? null,
                     title: data.videoName,
-                    video_length_in_millis: 0,
+                    video_length_in_millis: durationMillis,
                     published_url: slideStatus === 'PUBLISHED' ? (fileId ?? null) : null,
-                    published_video_length_in_millis: slideStatus === 'PUBLISHED' ? 0 : 0,
+                    published_video_length_in_millis:
+                        slideStatus === 'PUBLISHED' ? durationMillis : 0,
                     source_type: 'FILE_ID',
                 },
                 status: slideStatus,

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-vimeo-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-vimeo-dialog.tsx
@@ -104,6 +104,15 @@ export const AddVimeoDialog = ({ openState }: { openState?: (open: boolean) => v
             return;
         }
 
+        // Don't submit with length=0 (oEmbed failed or hasn't returned yet) —
+        // that would break learner-side progress tracking on this slide forever.
+        if (!videoDuration || videoDuration <= 0) {
+            toast.error(
+                'Could not read video duration from Vimeo. The video may be private or oEmbed failed. Please retry.'
+            );
+            return;
+        }
+
         setIsVideoUploading(true);
         try {
             const slideId = crypto.randomUUID();

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/audio-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/audio-player.tsx
@@ -127,18 +127,29 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ audioSlide }) => {
         }
     }, [syncAudioTrackingData]);
 
-    // Initialize Interval Sync
+    // Initialize Interval Sync — cadence = min(audio duration, 60s) so short
+    // audios sync at their own length and the worst-case unsynced window is
+    // bounded by audio length, not by a fixed 15s.
     useEffect(() => {
+        const periodMs = Math.max(
+            1000,
+            Math.min(
+                Number.isFinite(duration) && duration > 0
+                    ? Math.round(duration * 1000)
+                    : 60000,
+                60000
+            )
+        );
         syncIntervalRef.current = setInterval(() => {
             if (isPlaying) {
                 debouncedSync();
             }
-        }, 15000);
-        
+        }, periodMs);
+
         return () => {
             if (syncIntervalRef.current) clearInterval(syncIntervalRef.current);
         };
-    }, [debouncedSync, isPlaying]);
+    }, [debouncedSync, isPlaying, duration]);
 
     // Sync on unmount
     useEffect(() => {
@@ -260,7 +271,10 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ audioSlide }) => {
             saveCurrentSegment(audioRef.current.currentTime);
         }
         setIsPlaying(false);
-        debouncedSync();
+        // Bypass the 10s debounce on natural end so the learner sees 100%
+        // immediately — debouncedSync() can drop this call if a periodic
+        // sync just fired moments before, leaving the final segment unsynced.
+        syncAudioTrackingData().catch(console.error);
     };
 
     const formatTime = (time: number) => {

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/custom-video-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/custom-video-player.tsx
@@ -1105,12 +1105,23 @@ const CustomVideoPlayer = forwardRef<any, CustomVideoPlayerProps>(
                         setIsFirstPlay(false);
 
                         if (!updateIntervalRef.current) {
+                            // Periodic sync cadence = min(video duration, 60s).
+                            // Short videos sync at their own length, so a 6s
+                            // clip never has more than ~6s of unsynced data
+                            // sitting in storage if the user closes the tab.
+                            const durSec = videoRef.current?.duration;
+                            const periodMs = Math.max(
+                                1000,
+                                Math.min(
+                                    Number.isFinite(durSec) && (durSec as number) > 0
+                                        ? Math.round((durSec as number) * 1000)
+                                        : 60000,
+                                    60000
+                                )
+                            );
                             updateIntervalRef.current = setInterval(() => {
-                                console.log(
-                                    "integrate update video activity api now"
-                                );
                                 syncVideoTrackingData();
-                            }, 60 * 1000);
+                            }, periodMs);
                         }
                     }
 
@@ -1260,23 +1271,38 @@ const CustomVideoPlayer = forwardRef<any, CustomVideoPlayerProps>(
             const now = getEpochTimeInMillis();
             videoEndTime.current = now;
 
-            const currentStartTimeInSeconds = convertTimeToSeconds(
-                currentStartTimeRef.current
-            );
-            const endTimeInSeconds =
-                currentStartTimeInSeconds + timestampDurationRef.current;
-            const endTimeStamp = formatVideoTime(endTimeInSeconds);
+            // On natural end, snap the interval end to the player's actual
+            // duration rather than a wall-clock-tick estimate. The 1-Hz timer
+            // can lag the onEnded event by up to ~1 s, undercounting the watch.
+            const startTimeInMillis =
+                convertTimeToSeconds(currentStartTimeRef.current) * 1000;
+            const playerDuration = videoRef.current?.duration;
+            const endTimeInMillis =
+                Number.isFinite(playerDuration) && (playerDuration as number) > 0
+                    ? Math.round((playerDuration as number) * 1000)
+                    : startTimeInMillis;
 
-            currentTimestamps.current.push({
-                id: uuidv4(),
-                start_time: currentStartTimeRef.current,
-                end_time: endTimeStamp,
-                start: convertTimeToSeconds(currentStartTimeRef.current) * 1000,
-                end: convertTimeToSeconds(endTimeStamp) * 1000,
-            });
+            if (endTimeInMillis > startTimeInMillis) {
+                const endTimeStamp = formatVideoTime(endTimeInMillis / 1000);
+                currentTimestamps.current.push({
+                    id: uuidv4(),
+                    start_time: currentStartTimeRef.current,
+                    end_time: endTimeStamp,
+                    start: startTimeInMillis,
+                    end: endTimeInMillis,
+                });
+            }
 
             currentStartTimeRef.current = formatVideoTime(currentTime);
             timestampDurationRef.current = 0;
+
+            // Sync immediately on natural end so the learner sees 100%
+            // without waiting for the periodic timer (or for tab close).
+            // syncVideoTrackingData reads from Capacitor Preferences which
+            // is populated by the activity-tracking useEffect on every tick;
+            // by the time onEnded fires, the latest interval push has
+            // already been written.
+            syncVideoTrackingData();
         };
 
         const handleVideoPlay = () => {
@@ -1296,10 +1322,20 @@ const CustomVideoPlayer = forwardRef<any, CustomVideoPlayerProps>(
                 setIsFirstPlay(false);
 
                 if (!updateIntervalRef.current) {
+                    // Periodic sync cadence = min(video duration, 60s).
+                    const durSec = videoRef.current?.duration;
+                    const periodMs = Math.max(
+                        1000,
+                        Math.min(
+                            Number.isFinite(durSec) && (durSec as number) > 0
+                                ? Math.round((durSec as number) * 1000)
+                                : 60000,
+                            60000
+                        )
+                    );
                     updateIntervalRef.current = setInterval(() => {
-                        console.log("integrate update video activity api now");
                         syncVideoTrackingData();
-                    }, 60 * 1000);
+                    }, periodMs);
                 }
             }
 
@@ -1317,20 +1353,27 @@ const CustomVideoPlayer = forwardRef<any, CustomVideoPlayerProps>(
             const now = getEpochTimeInMillis();
             videoEndTime.current = now;
 
-            const currentStartTimeInSeconds = convertTimeToSeconds(
-                currentStartTimeRef.current
-            );
-            const endTimeInSeconds =
-                currentStartTimeInSeconds + timestampDurationRef.current;
-            const endTimeStamp = formatVideoTime(endTimeInSeconds);
+            // Use the player's actual playback position rather than a
+            // wall-clock-tick estimate. The 1-Hz timer rounds down to the
+            // last whole second, undercounting partial seconds.
+            const startTimeInMillis =
+                convertTimeToSeconds(currentStartTimeRef.current) * 1000;
+            const playerCurrent = videoRef.current?.currentTime;
+            const endTimeInMillis =
+                Number.isFinite(playerCurrent) && (playerCurrent as number) >= 0
+                    ? Math.round((playerCurrent as number) * 1000)
+                    : startTimeInMillis;
 
-            currentTimestamps.current.push({
-                id: uuidv4(),
-                start_time: currentStartTimeRef.current,
-                end_time: endTimeStamp,
-                start: convertTimeToSeconds(currentStartTimeRef.current) * 1000,
-                end: convertTimeToSeconds(endTimeStamp) * 1000,
-            });
+            if (endTimeInMillis > startTimeInMillis) {
+                const endTimeStamp = formatVideoTime(endTimeInMillis / 1000);
+                currentTimestamps.current.push({
+                    id: uuidv4(),
+                    start_time: currentStartTimeRef.current,
+                    end_time: endTimeStamp,
+                    start: startTimeInMillis,
+                    end: endTimeInMillis,
+                });
+            }
 
             currentStartTimeRef.current = formatVideoTime(currentTime);
             timestampDurationRef.current = 0;

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/vimeo-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/vimeo-player.tsx
@@ -709,14 +709,25 @@ export const VimeoPlayerComp: React.FC<VimeoPlayerProps> = ({
     }
   }, [isPlayed]);
 
-  // Periodic sync
+  // Periodic sync — cadence = min(video duration, 60s). Short videos sync at
+  // their own length so the worst-case unsynced window is bounded by the
+  // video length, not by a fixed 60s.
   useEffect(() => {
     if (!isPlayed) return;
+    const periodMs = Math.max(
+      1000,
+      Math.min(
+        Number.isFinite(duration) && duration > 0
+          ? Math.round(duration * 1000)
+          : 60000,
+        60000
+      )
+    );
     const interval = setInterval(() => {
       syncTrackingData();
-    }, 60000);
+    }, periodMs);
     return () => clearInterval(interval);
-  }, [isPlayed, syncTrackingData]);
+  }, [isPlayed, syncTrackingData, duration]);
 
   // Activity tracking effect
   useEffect(() => {

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
@@ -1345,9 +1345,22 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
         setIsFirstPlay(false);
 
         if (!updateIntervalRef.current) {
+          // Periodic sync cadence = min(video duration, 60s). For short
+          // videos the cadence shrinks so the worst-case unsynced window
+          // is bounded by the video length.
+          const durSec = await safeGetNumber(player.getDuration());
+          const periodMs = Math.max(
+            1000,
+            Math.min(
+              Number.isFinite(durSec) && durSec > 0
+                ? Math.round(durSec * 1000)
+                : 60000,
+              60000
+            )
+          );
           updateIntervalRef.current = setInterval(() => {
             syncVideoTrackingData();
-          }, 60 * 1000);
+          }, periodMs);
         }
       }
 
@@ -1360,24 +1373,29 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
       stopProgressTracking();
       videoEndTime.current = now;
 
-      const currentStartTimeInSeconds = convertTimeToSeconds(
-        currentStartTimeRef.current
-      );
-      const endTimeInSeconds =
-        currentStartTimeInSeconds + timestampDurationRef.current;
-      const endTimeStamp = formatVideoTime(endTimeInSeconds);
+      // Use the player's actual playback position rather than a wall-clock
+      // tick estimate. The 1-Hz timer rounds down to the last whole second,
+      // and the natural-end event fires before the next tick lands —
+      // together they undercount each watch by up to ~1 s. On natural ENDED,
+      // snap to getDuration() because YouTube's getCurrentTime() at end
+      // can also be slightly short.
+      const startTimeInMillis =
+        convertTimeToSeconds(currentStartTimeRef.current) * 1000;
+      let endTimeInMillis: number;
+      if (event.data === ENDED_STATE) {
+        const dur = await safeGetNumber(player.getDuration());
+        endTimeInMillis = Math.round(dur * 1000);
+      } else {
+        const cur = await safeGetNumber(player.getCurrentTime());
+        endTimeInMillis = Math.round(cur * 1000);
+      }
+      const endTimeStamp = formatVideoTime(endTimeInMillis / 1000);
 
-      // Only create timestamp if we have a valid start time (not empty or zero when it shouldn't be)
-      // This prevents creating timestamps when pause/end event fires before any play event
-      const startTimeInMillis = convertTimeToSeconds(currentStartTimeRef.current) * 1000;
-      const endTimeInMillis = convertTimeToSeconds(endTimeStamp) * 1000;
-      
       if (
         currentStartTimeRef.current !== "" &&
         !isNaN(startTimeInMillis) &&
         !isNaN(endTimeInMillis) &&
-        endTimeInMillis >= startTimeInMillis &&
-        timestampDurationRef.current > 0 // Only add if there was actual playback duration
+        endTimeInMillis > startTimeInMillis
       ) {
         currentTimestamps.current.push({
           id: uuidv4(),
@@ -1392,13 +1410,20 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
           endTime: endTimeStamp,
           startTimeInMillis,
           endTimeInMillis,
-          timestampDuration: timestampDurationRef.current,
         });
       }
 
       currentStartTimeRef.current = formatVideoTime(currentTime);
       timestampDurationRef.current = 0;
       setIsPlayed(false);
+
+      // Sync immediately on natural end so the learner sees 100% within the
+      // cascade-refresh window (~700 ms) instead of waiting for the periodic
+      // tick or for tab close. PAUSED still relies on the periodic tick to
+      // avoid a per-pause POST storm during scrubbing.
+      if (event.data === ENDED_STATE) {
+        syncVideoTrackingData();
+      }
     }
   };
 

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useAudioSync.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useAudioSync.ts
@@ -5,6 +5,8 @@ import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
 import { Preferences } from "@capacitor/preferences";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
+import { useSlidesRefresh } from "./useSlidesRefresh";
+import { ADD_UPDATE_AUDIO_ACTIVITY } from "@/constants/urls";
 
 const STORAGE_KEY = "audio_tracking_data";
 const USER_ID_KEY = "StudentDetails";
@@ -13,6 +15,7 @@ export const useAudioSync = () => {
     const addUpdateAudioActivity = useAddAudioActivity();
     const { activeItem } = useContentStore();
     const [userId, setUserId] = useState<string | null>(null);
+    const { refreshSlides } = useSlidesRefresh();
     
     // Use refs for values that shouldn't trigger re-renders
     const activeItemIdRef = useRef<string | null>(null);
@@ -33,6 +36,102 @@ export const useAudioSync = () => {
             setUserId(userDetails?.user_id || null);
         };
         loadUserId();
+    }, []);
+
+    // Tab-close safety net (web only). Mirror of the video flow's pagehide
+    // handler: read pending tracking data synchronously from localStorage
+    // (Capacitor Preferences is async, can't be used in pagehide), then
+    // fire fetch with keepalive:true so the browser flushes the request
+    // even after the page unloads.
+    useEffect(() => {
+        const handlePageHide = () => {
+            try {
+                const raw = localStorage.getItem("CapacitorStorage." + STORAGE_KEY);
+                if (!raw) return;
+                const parsed = JSON.parse(raw);
+                const activities = (parsed?.data ?? []) as Array<
+                    z.infer<typeof AudioActivitySchema>
+                >;
+                const pending = activities.filter(
+                    (a) =>
+                        a.sync_status !== "SYNCED" &&
+                        Array.isArray(a.timestamps) &&
+                        a.timestamps.length > 0
+                );
+                if (pending.length === 0) return;
+
+                const accessToken = localStorage.getItem(
+                    "CapacitorStorage.accessToken"
+                );
+                if (!accessToken) return;
+
+                const studentRaw = localStorage.getItem(
+                    "CapacitorStorage.StudentDetails"
+                );
+                const student = studentRaw ? JSON.parse(studentRaw) : null;
+                const userIdSync: string | undefined =
+                    student?.user_id || student?.userId;
+                if (!userIdSync) return;
+
+                const instituteId =
+                    localStorage.getItem("CapacitorStorage.InstituteId") ||
+                    localStorage.getItem("CapacitorStorage.instituteId") ||
+                    "";
+                const headers: Record<string, string> = {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${accessToken}`,
+                    "X-User-Id": String(userIdSync),
+                };
+                if (instituteId) {
+                    headers["clientId"] = instituteId;
+                    headers["X-Institute-Id"] = instituteId;
+                }
+
+                for (const activity of pending) {
+                    const validTimestamps = activity.timestamps.filter(
+                        (t) =>
+                            t.start != null &&
+                            t.end != null &&
+                            typeof t.start === "number" &&
+                            typeof t.end === "number" &&
+                            !isNaN(t.start) &&
+                            !isNaN(t.end) &&
+                            t.end > t.start
+                    );
+                    if (validTimestamps.length === 0) continue;
+
+                    const payload: AudioActivityPayload = {
+                        slide_id: activity.id,
+                        user_id: userIdSync,
+                        is_new_activity: activity.new_activity,
+                        learner_operation: "AUDIO_LAST_TIMESTAMP",
+                        audios: validTimestamps.map((t) => ({
+                            start_time_in_millis: t.start,
+                            end_time_in_millis: t.end,
+                            playback_speed: t.speed,
+                        })),
+                    };
+
+                    try {
+                        fetch(ADD_UPDATE_AUDIO_ACTIVITY, {
+                            method: "POST",
+                            keepalive: true,
+                            headers,
+                            body: JSON.stringify(payload),
+                        }).catch(() => {
+                            /* swallow — pagehide must not throw */
+                        });
+                    } catch {
+                        /* swallow */
+                    }
+                }
+            } catch {
+                /* swallow — pagehide must never block tab close */
+            }
+        };
+
+        window.addEventListener("pagehide", handlePageHide);
+        return () => window.removeEventListener("pagehide", handlePageHide);
     }, []);
 
     const syncAudioTrackingData = useCallback(async () => {
@@ -110,15 +209,13 @@ export const useAudioSync = () => {
                     console.log(`📡 [useAudioSync] Syncing audio activity: ${activity.activity_id}`);
                     await addUpdateAudioActivity.mutateAsync(apiPayload);
                     console.log(`✅ [useAudioSync] Audio activity synced successfully`);
-                    
+
                     // Mark as synced
                     updatedActivities.push({
                         ...activity,
                         sync_status: "SYNCED",
                         new_activity: false,
                     });
-
-                    // NOTE: Do NOT call refreshSlides() here as it causes re-renders and potential loops
                 } catch (error) {
                     console.error("[useAudioSync] API call failed:", error);
                     // Keep as STALE for retry
@@ -131,14 +228,22 @@ export const useAudioSync = () => {
                 key: STORAGE_KEY,
                 value: JSON.stringify({ data: updatedActivities }),
             });
-            
+
             console.log("[useAudioSync] Sync completed, storage updated");
+
+            // Refresh every progress-bearing cache so the sidebar / chapter /
+            // course % update live. Safe to call here despite the prior
+            // "loop" concern because the new useSlidesRefresh adds a 600 ms
+            // delay and invalidates without an explicit refetch — combined
+            // with isSyncingRef guarding concurrent syncs above, no loop is
+            // reachable.
+            void refreshSlides();
         } catch (error) {
             console.error("[useAudioSync] Failed to sync audio tracking data:", error);
         } finally {
             isSyncingRef.current = false;
         }
-    }, [userId, addUpdateAudioActivity]);
+    }, [userId, addUpdateAudioActivity, refreshSlides]);
 
     return { syncAudioTrackingData };
 };

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useSlidesRefresh.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useSlidesRefresh.ts
@@ -6,32 +6,34 @@ export const useSlidesRefresh = () => {
   const router = useRouter();
   const { chapterId } = router.state.location.search;
 
+  // Refresh every progress-bearing cache after a slide-tracking POST. The
+  // backend cascade (slide → chapter → module → subject → package_session)
+  // runs @Async, so we wait briefly before invalidating; otherwise the
+  // refetch races the cascade and reads stale data. Same pattern is used in
+  // QuizViewer's refreshProgressAfterSubmit.
   const refreshSlides = async () => {
-    console.log("🔄 [useSlidesRefresh] Starting slides refresh process");
-    console.log("📋 [useSlidesRefresh] Chapter ID:", chapterId);
-    
-    if (chapterId) {
-      try {
-        console.log("🗂️ [useSlidesRefresh] Invalidating query with key:", ["slides", chapterId]);
-        
-        // Invalidate and refetch the slides query
-        await queryClient.invalidateQueries({
-          queryKey: ["slides", chapterId],
-        });
-        
-        console.log("✅ [useSlidesRefresh] Query invalidation completed");
-        
-        // Force refetch to ensure data is updated immediately
-        await queryClient.refetchQueries({
-          queryKey: ["slides", chapterId],
-        });
-        
-        console.log("✅ [useSlidesRefresh] Query refetch completed - slides data should be updated");
-      } catch (error) {
-        console.error("❌ [useSlidesRefresh] Failed to refresh slides data:", error);
-      }
-    } else {
+    if (!chapterId) {
       console.warn("⚠️ [useSlidesRefresh] No chapter ID available, skipping refresh");
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    try {
+      await queryClient.invalidateQueries({
+        predicate: (q) => {
+          const k = q.queryKey;
+          if (!Array.isArray(k)) return false;
+          return (
+            k[0] === "MODULES_WITH_CHAPTERS" ||
+            k[0] === "GET_MODULES_WITH_CHAPTERS" ||
+            k[0] === "GET_COURSE_INIT" ||
+            (k[0] === "slides" && k[1] === chapterId)
+          );
+        },
+      });
+    } catch (error) {
+      console.error("❌ [useSlidesRefresh] Failed to refresh progress caches:", error);
     }
   };
 
@@ -39,4 +41,4 @@ export const useSlidesRefresh = () => {
     refreshSlides,
     chapterId,
   };
-}; 
+};

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useVideoSync.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useVideoSync.ts
@@ -10,6 +10,7 @@ import { useRouter } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { useSlidesRefresh } from "./useSlidesRefresh";
+import { ADD_UPDATE_VIDEO_ACTIVITY } from "@/constants/urls";
 
 const STORAGE_KEY = "video_tracking_data";
 const USER_ID_KEY = "StudentDetails";
@@ -35,6 +36,155 @@ export const useVideoSync = () => {
       setPackageSessionId(id);
     };
     fetchPackageSessionId();
+  }, []);
+
+  // Tab-close safety net. The periodic 60s sync covers the "user keeps the
+  // tab open" case; this covers "user pauses then closes the tab". We use
+  // fetch with keepalive:true (not sendBeacon, which can't set Authorization)
+  // so the browser is guaranteed to flush the request even after the page
+  // unloads. Web only — Capacitor native has its own background lifecycle.
+  useEffect(() => {
+    const handlePageHide = () => {
+      try {
+        const raw = localStorage.getItem("CapacitorStorage." + STORAGE_KEY);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        const activities = (parsed?.data ?? []) as Array<
+          z.infer<typeof ActivitySchema>
+        >;
+        const pending = activities.filter(
+          (a) =>
+            a.sync_status !== "SYNCED" &&
+            Array.isArray(a.timestamps) &&
+            a.timestamps.length > 0
+        );
+        if (pending.length === 0) return;
+
+        const accessToken = localStorage.getItem(
+          "CapacitorStorage.accessToken"
+        );
+        if (!accessToken) return;
+
+        const studentRaw = localStorage.getItem(
+          "CapacitorStorage.StudentDetails"
+        );
+        const student = studentRaw ? JSON.parse(studentRaw) : null;
+        const userId: string | undefined = student?.user_id || student?.userId;
+        if (!userId) return;
+
+        // Snapshot route context from current URL — synchronous and reliable
+        // during pagehide. We only flush activities for the slide that's
+        // currently in the URL, since older slides' route context isn't
+        // available here.
+        const params = new URLSearchParams(window.location.search);
+        const slideIdInUrl = params.get("slideId") || "";
+        const chapterIdInUrl = params.get("chapterId") || "";
+        const moduleIdInUrl = params.get("moduleId") || "";
+        const subjectIdInUrl = params.get("subjectId") || "";
+        const packageSessionIdInUrl = (
+          params.get("sessionId") ||
+          params.get("courseId") ||
+          ""
+        ).trim();
+        if (
+          !slideIdInUrl ||
+          !chapterIdInUrl ||
+          !moduleIdInUrl ||
+          !subjectIdInUrl ||
+          !packageSessionIdInUrl
+        ) {
+          return;
+        }
+
+        const url =
+          ADD_UPDATE_VIDEO_ACTIVITY +
+          `?slideId=${slideIdInUrl}` +
+          `&chapterId=${chapterIdInUrl}` +
+          `&packageSessionId=${packageSessionIdInUrl}` +
+          `&moduleId=${moduleIdInUrl}` +
+          `&subjectId=${subjectIdInUrl}`;
+
+        const instituteId =
+          localStorage.getItem("CapacitorStorage.InstituteId") ||
+          localStorage.getItem("CapacitorStorage.instituteId") ||
+          "";
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+          "X-User-Id": String(userId),
+          "X-Package-Session-Id": packageSessionIdInUrl,
+        };
+        if (instituteId) {
+          headers["clientId"] = instituteId;
+          headers["X-Institute-Id"] = instituteId;
+        }
+
+        for (const activity of pending) {
+          // Only flush activities that match the current slide — we don't
+          // have route context for other slides during pagehide.
+          if (activity.id !== slideIdInUrl) continue;
+
+          const validTimestamps = activity.timestamps.filter(
+            (t) =>
+              t.start != null &&
+              t.end != null &&
+              typeof t.start === "number" &&
+              typeof t.end === "number" &&
+              !isNaN(t.start) &&
+              !isNaN(t.end) &&
+              t.end > t.start
+          );
+          if (validTimestamps.length === 0) continue;
+
+          const payload: TrackingDataType = {
+            id: activity.activity_id,
+            source_id: "",
+            source_type: activity.source,
+            user_id: userId,
+            slide_id: slideIdInUrl,
+            start_time_in_millis: activity.start_time,
+            end_time_in_millis: activity.end_time,
+            percentage_watched: parseFloat(activity.percentage_watched),
+            videos: validTimestamps.map((t) => ({
+              id: t.id,
+              start_time_in_millis: t.start,
+              end_time_in_millis: t.end,
+            })),
+            documents: null,
+            new_activity: activity.new_activity,
+            concentration_score: {
+              id:
+                crypto.randomUUID?.() ??
+                Math.random().toString(36).substring(2, 15),
+              concentration_score: 0,
+              tab_switch_count: 0,
+              pause_count: 0,
+              answer_times_in_seconds: [],
+            },
+          };
+
+          // Fire-and-forget. keepalive:true lets the browser complete the
+          // request after the page unloads. We don't await the response.
+          try {
+            fetch(url, {
+              method: "POST",
+              keepalive: true,
+              headers,
+              body: JSON.stringify(payload),
+            }).catch(() => {
+              /* swallow — pagehide must not throw */
+            });
+          } catch {
+            /* swallow */
+          }
+        }
+      } catch {
+        /* swallow — pagehide must never block tab close */
+      }
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
   }, []);
 
   const syncVideoTrackingData = async () => {


### PR DESCRIPTION
## Summary of Changes

The video/audio progress tracking pipeline had four independent issues causing learner progress to be inaccurate, lost, or invisible. This PR fixes all four end-to-end.

1. **Admin file-upload dialog hardcoded `length = 0`**, so every new file-upload video shipped with no duration. The learner-side cascade silently skips the % write when length is 0 (`if (length > 0)` guard), so the slide stayed at 0% forever for every learner. Same silent-zero fallback existed in the YouTube and Vimeo dialogs when their oEmbed/IFrame-API duration lookup failed.
2. **B12 — wall-clock-tick interval undercount.** Both YouTube and the file-upload (HTML5) players computed interval end-time from a 1-Hz `setInterval` tick counter. Watching to natural end consistently undercounted by ~1–2 s (an 18 s YouTube video reported 16 s = 88.89 %). Vimeo was already correct (used `currentTime` from `onTimeUpdate`).
3. **Sidebar / chapter / course bars stayed stale after submit.** `useSlidesRefresh` only invalidated `["slides", chapterId]` and refetched immediately — racing the @Async cascade and reading old data. `MODULES_WITH_CHAPTERS` and `GET_COURSE_INIT` never refetched at all.
4. **Tab-close lost progress.** Pause data sat in Capacitor Preferences; if the user closed the tab before the next periodic 60 s sync, the data never reached the backend. No `pagehide`/`sendBeacon` handler existed.

**Backend:**
- _no changes in this PR_ — all backend cascade math was already correct after the earlier B9/staleness work. Cascade is `@Async` and idempotent; firing more often is safe.

**Frontend (admin):**
- `add-video-file-dialog.tsx` — new helper `readVideoDurationMillis(file)` reads duration via a hidden `<video>` + `loadedmetadata` event before submit. Refuses with toast if duration can't be read; never silently submits with `length = 0`.
- `add-video-dialog.tsx` (YouTube) — silent-0 fallback when IFrame API isn't ready replaced with a "YouTube is still loading" toast. Duration validated before submit.
- `add-vimeo-dialog.tsx` — refuses to submit if oEmbed didn't return a valid duration (private video / CORS / not yet loaded).

**Frontend (learner playback):**
- `custom-video-player.tsx` and `youtube-player.tsx` — B12 fix: replace the wall-clock-tick estimate with `videoRef.current.currentTime` (pause) / `videoRef.current.duration` (natural end) for HTML5, and `player.getCurrentTime()` / `player.getDuration()` for YouTube. Vimeo unchanged (already correct).
- All three video players + audio player — sync immediately on natural end so the learner sees 100 % within the cascade-refresh window (~700 ms) instead of waiting up to 60 s. Audio's end-handler now bypasses the 10 s debounce so the final segment doesn't get dropped.
- All three video players + audio player — periodic sync cadence is now `min(media duration, 60 s)` instead of a fixed `60 s`. Short content syncs at its own length; long content stays at 60 s to bound DB load (per senior review). Worst-case unsynced window for a 6 s clip drops from 60 s to 6 s.

**Frontend (hooks):**
- `useSlidesRefresh.ts` — 600 ms cascade-window delay before invalidating, single `predicate` invalidate covering `["slides", chapterId]` + `MODULES_WITH_CHAPTERS` + `GET_MODULES_WITH_CHAPTERS` (both naming variants live in the codebase) + `GET_COURSE_INIT`. Used by video, presentation, and PDF flows in one pass.
- `useAudioSync.ts` — wired up `refreshSlides()` after sync. The earlier "loop concern" comment is moot under the new hook shape (single invalidate, 600 ms delay) combined with audio's existing `isSyncingRef` guard.
- `useVideoSync.ts` and `useAudioSync.ts` — `pagehide` listener using `fetch` with `keepalive: true`. `sendBeacon` can't set `Authorization`; `fetch keepalive` can, gives the same browser-guaranteed-flush behavior. Reads pending data + auth context synchronously from `localStorage` (where Capacitor Preferences is backed on web). Fires fire-and-forget POSTs that complete after the page unloads. Web-only — Capacitor native has its own background lifecycle.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- **Reproduced the original bugs end-to-end on staging** before fixing: file-upload slide created with `published_video_length = 0`, cascade skipped the % write (only `VIDEO_LAST_TIMESTAMP` row landed), sidebar stuck on "Not Started" even after backend backfill due to `["slides", chapterId]` only invalidating against a still-pending cascade, and B12 reproducing on YouTube (interval `[0, 16000]` for an 18 s video) and on file-upload (interval `[3000, 5000]` for a 3 s natural-end watch).
- **Backfilled the broken Test Video 1 slide** (`UPDATE video SET video_length = 6000, published_video_length = 6000 WHERE id = '...'`) and confirmed the cascade then writes `PERCENTAGE_VIDEO_WATCHED = 100`, with chapter / module / subject / package_session rollups all updating accordingly.
- **Pending hands-on verification on the new commit** (deferred to Monday): upload a fresh file-upload video → confirm `video.video_length > 0` in DB; play any video to natural end → confirm immediate POST visible in DevTools network tab and slide flips to "Done" within ~1 s; pause then close tab → use "Preserve log" to confirm the `keepalive` POST fires before page unload; short video (<60 s) syncs at its own length cadence.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
