### PR TITLE
fix(progress-tracking): wire code editor question + practice mode int…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/coding_submission/dto/SubmitCodingRequestDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/coding_submission/dto/SubmitCodingRequestDto.java
@@ -19,6 +19,13 @@ import java.util.Date;
 public class SubmitCodingRequestDto {
     private String slideId;
     private String packageSessionId;
+    // Cascade-context IDs. Needed so a successful submission can fire the
+    // learner_operation cascade (slide → chapter → module → subject →
+    // package_session). The frontend reads these from the router search
+    // params alongside slideId.
+    private String chapterId;
+    private String moduleId;
+    private String subjectId;
     private String language;
     private String sourceCode;
     private String verdict;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/coding_submission/service/CodingSubmissionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/coding_submission/service/CodingSubmissionService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,16 +16,21 @@ import vacademy.io.admin_core_service.features.coding_submission.dto.CodingSubmi
 import vacademy.io.admin_core_service.features.coding_submission.dto.SubmitCodingRequestDto;
 import vacademy.io.admin_core_service.features.coding_submission.entity.CodingSubmission;
 import vacademy.io.admin_core_service.features.coding_submission.repository.CodingSubmissionRepository;
+import vacademy.io.admin_core_service.features.learner_tracking.service.LearnerTrackingAsyncService;
 import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.Date;
 
+@Slf4j
 @Service
 public class CodingSubmissionService {
 
     @Autowired
     private CodingSubmissionRepository repository;
+
+    @Autowired
+    private LearnerTrackingAsyncService learnerTrackingAsyncService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -66,7 +72,48 @@ public class CodingSubmissionService {
                 .sessionStartedAt(req.getSessionStartedAt())
                 .build();
 
-        return CodingSubmissionDto.from(repository.save(entity));
+        CodingSubmission saved = repository.save(entity);
+
+        // Fire the learner_operation cascade so this slide counts as completed
+        // in chapter / module / subject / package_session rollups. Code Editor
+        // is stored under source_type = DOCUMENT so the cascade writes
+        // PERCENTAGE_DOCUMENT_COMPLETED = 100. Any submission counts —
+        // verdict / score / passing tests don't gate this (intentional product
+        // call: completion bar is "the learner submitted," and grade quality
+        // lives separately on coding_submission for admin review). The
+        // cascade runs @Async, so this call returns immediately.
+        if (hasFullCascadeContext(req)) {
+            learnerTrackingAsyncService.updateLearnerOperationsForCodingSubmission(
+                    user.getUserId(),
+                    req.getSlideId(),
+                    req.getChapterId(),
+                    req.getModuleId(),
+                    req.getSubjectId(),
+                    req.getPackageSessionId());
+        } else {
+            // Submission persisted, but cascade can't fire without all four
+            // parent IDs. Log so this is visible if any caller forgets to
+            // ship the context. Not throwing — the submission itself is
+            // saved and recoverable; only the rollup is missed.
+            log.warn("Coding submission {} saved without full cascade context "
+                    + "(chapterId={}, moduleId={}, subjectId={}, packageSessionId={}). "
+                    + "Slide-level progress not updated.",
+                    saved.getId(), req.getChapterId(), req.getModuleId(),
+                    req.getSubjectId(), req.getPackageSessionId());
+        }
+
+        return CodingSubmissionDto.from(saved);
+    }
+
+    private static boolean hasFullCascadeContext(SubmitCodingRequestDto req) {
+        return notBlank(req.getChapterId())
+                && notBlank(req.getModuleId())
+                && notBlank(req.getSubjectId())
+                && notBlank(req.getPackageSessionId());
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
@@ -205,6 +205,31 @@ public class LearnerTrackingAsyncService {
                 updateLearnerOperationsForChapter(userId, chapterId, moduleId, subjectId, packageSessionId);
         }
 
+        // ==== Coding Submission Tracking ====
+        //
+        // Code Editor slides are stored as source_type = DOCUMENT, so they live in
+        // the cascade under PERCENTAGE_DOCUMENT_COMPLETED (no new enum / no change
+        // to the cascade source-type list). Question Mode submissions don't go
+        // through the normal /add-or-update-document-activity path — they POST to
+        // /coding/submissions which has its own table (coding_submission). This
+        // method is the bridge: after CodingSubmissionService saves the row, it
+        // calls this so the slide gets a learner_operation entry and the cascade
+        // updates the chapter / module / subject / package_session rollups.
+        //
+        // Completion bar: any submission = 100%. The verdict / score / passed
+        // count still live on coding_submission for admin review and learner
+        // history; here we only signal "the slide has been completed." Slide-level
+        // monotonic guard (B9) makes re-submits a no-op at this layer.
+        @Async
+        @Transactional
+        public void updateLearnerOperationsForCodingSubmission(String userId, String slideId, String chapterId,
+                        String moduleId, String subjectId, String packageSessionId) {
+                addOrUpdatePercentageOperation(userId, LearnerOperationSourceEnum.SLIDE.name(), slideId,
+                                LearnerOperationEnum.PERCENTAGE_DOCUMENT_COMPLETED.name(), 100.0);
+
+                updateLearnerOperationsForChapter(userId, chapterId, moduleId, subjectId, packageSessionId);
+        }
+
         // ==== Video Slide Tracking ====
 
         @Async

--- a/docs/CERTIFICATE_SYSTEM_AUDIT.md
+++ b/docs/CERTIFICATE_SYSTEM_AUDIT.md
@@ -4,8 +4,25 @@
 > Out of scope: the bulk admin CSV-issuance tool at `/certificate-generation/student-data` (separate page, separate use case).
 >
 > **Audit date:** 2026-05-08
-> **Last updated:** 2026-05-09 — see "Update note" below.
+> **Last updated:** 2026-05-12 — Code Editor (Question Mode and Practice Mode) is now wired into the completion cascade. See "Update note (2026-05-12)" below.
 > **Audience:** engineers planning the next iteration of the certificate feature.
+
+## Update note (2026-05-12) — Code Editor cascade integration shipped
+
+Branch `fix/code-editor-progress-tracking`, commit `3a8537126`. Two changes worth noting for anyone planning the next iteration of the cert flow:
+
+1. **Code Editor in Question Mode** now writes a `learner_operation` row on every submission. The new `LearnerTrackingAsyncService.updateLearnerOperationsForCodingSubmission(...)` is called from `CodingSubmissionService.submit(...)` after the submission persists. It writes `PERCENTAGE_DOCUMENT_COMPLETED = 100` (Code Editor is `source_type = DOCUMENT`, so no new operation enum / no change to the cascade source-type list at `LearnerTrackingAsyncService.java:430-433`) and cascades up through chapter → module → subject → package_session in the usual pass. Completion bar is "any submission" — verdict / score / passing tests don't gate this.
+
+2. **Code Editor in Practice Mode** now also marks the slide 100% on the learner's first edit, rather than waiting for the ~60-second dwell sync. Implementation is a one-shot synthetic page_view force-flushed via `addActivity` + `syncPDFTrackingData` on the first user-initiated Monaco `onChange` event. The 60s-dwell fallback via `calculateAndUpdatePageViews` is intentionally left in place as a secondary path.
+
+**Implications for §5 "Slide types — the ground truth" and §13 "Hidden bugs":**
+
+- The "Code Editor" rows in the §5 table no longer have the "tracked but never aggregated" caveat for Question Mode. Both modes now contribute to chapter completion via the standard cascade.
+- The bullet in §11 about "what's implemented today" should be read alongside this: chapter completion math now reaches 100% for Code Editor-containing chapters without requiring administrator workarounds.
+- The §13 bullet about "VIDEO_QUESTION is tracked but never aggregated" is unchanged. SCORM and ASSESSMENT exclusions from §13 are also unchanged.
+- For the auto-trigger work (§15, Phase 2 / Bucket B): courses containing Code Editor slides as their final gate will now legitimately cross the threshold, which previously required mixed content to compensate. No new code needed on the cert side — the threshold gate continues to read from the existing `learner_operation` rollup.
+
+
 
 ## Update note (2026-05-09) — rollup percentages can now legitimately drop
 
@@ -175,7 +192,8 @@ The **cascade list** is hardcoded at [LearnerTrackingAsyncService.java:430-433](
 | Audio | `AUDIO` | — | AudioTracked | `/learner-tracking/v1/add-or-update-audio-activity` | ✅ | ✅ |
 | Jupyter Notebook | `DOCUMENT` | `JUPYTER` | DocumentTracked (re-used) | document endpoint | ✅ | ✅ — interactions tracked as page views via `pdf-tracking-store` |
 | Scratch Project | `DOCUMENT` | `SCRATCH` | DocumentTracked (re-used) | document endpoint | ✅ | ✅ — same pattern |
-| Code Editor | `DOCUMENT` | `CODE` | DocumentTracked (re-used) | document endpoint | ✅ | ✅ — same pattern |
+| Code Editor — Practice Mode | `DOCUMENT` | `CODE` | DocumentTracked (re-used) | document endpoint | ✅ | ✅ — first user edit force-flushes immediately (2026-05-12); 60s dwell fallback still applies |
+| Code Editor — Question Mode | `DOCUMENT` | `CODE` (with `mode: "question"` in `published_data`) | `coding_submission` + DocumentTracked via cascade hook | `/admin-core-service/coding/submissions` triggers cascade (2026-05-12) | ✅ | ✅ — any submission writes `PERCENTAGE_DOCUMENT_COMPLETED = 100` |
 | **Presentation (Excalidraw)** | `DOCUMENT` | (Excalidraw JSON) | — | none | ✅ (in denominator) | ❌ **`presentation-tracking-store.syncActivities` is local-only — never POSTs.** |
 | SCORM Package | `SCORM` | — | `ScormLearnerProgress` (lives in `slide/entity/`, not `learner_tracking/`) | `/admin-core-service/slide/scorm-tracking/v1/...` | ❌ **excluded from cascade** | n/a — orphan |
 | Assessment | `ASSESSMENT` | — | none locally — delegated to `assessment_service` | `assessment_service` endpoints | ❌ **excluded from cascade** | n/a — orphan |

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/code-editor-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/code-editor-slide.tsx
@@ -117,6 +117,12 @@ const PracticeModeView: React.FC<CodeEditorSlideProps> = ({
   const startTimeInMillis = useRef(getEpochTimeInMillis());
   const [isFirstView, setIsFirstView] = useState(true);
   const updateIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  // One-shot guard: fire the completion POST on the FIRST user-initiated
+  // edit of this slide visit, then never again until the component unmounts.
+  // Without this guard every keystroke would re-fire the sync — B9's
+  // slide-level monotonic guard makes the extra writes no-ops at the DB
+  // level, but the network traffic would be wasteful and noisy.
+  const hasFiredCompletionRef = useRef(false);
 
   // Activity tracking for code editor (treating each action as a "page view")
   const [currentAction, setCurrentAction] = useState(1); // 1 for editing, 2 for running code, etc.
@@ -675,8 +681,80 @@ const PracticeModeView: React.FC<CodeEditorSlideProps> = ({
     handleUserActivity(); // Track theme change activity
   };
 
-  const handleCodeChange = (value: string | undefined) => {
+  // Practice-Mode completion bar (per product decision 2026-05-12): the slide
+  // counts as 100% complete as soon as the learner makes their first real
+  // edit to the code. The existing 60s-interval sync would eventually fire
+  // anyway via calculateAndUpdatePageViews synthesizing a page_view from
+  // elapsed time, but that means a learner who opens, types, and leaves
+  // within 60 seconds gets no credit. This path makes completion immediate.
+  //
+  // Implementation: push a synthetic page_view (page=1, since admin-create
+  // hardcodes published_document_total_pages=1) onto actionViews.current,
+  // then directly call addActivity+syncPDFTrackingData rather than waiting
+  // for the next 1s elapsedTime tick to flush the ref into storage. The
+  // hasFiredCompletionRef guard makes this a one-shot per slide visit.
+  const fireCompletionOnFirstEdit = async () => {
+    if (hasFiredCompletionRef.current) return;
+    hasFiredCompletionRef.current = true;
+
+    const now = getEpochTimeInMillis();
+    const nowIso = getISTTime();
+
+    actionViews.current.push({
+      id: uuidv4(),
+      page: 1,
+      duration: Math.max(1, elapsedTime),
+      start_time: startTime.current,
+      end_time: nowIso,
+      start_time_in_millis: startTimeInMillis.current,
+      end_time_in_millis: now,
+    });
+
+    try {
+      await addActivity({
+        slide_id: activeItem?.id || "",
+        activity_id: activityId.current,
+        source: "DOCUMENT" as const,
+        source_id: documentId || "",
+        start_time: startTime.current,
+        end_time: nowIso,
+        start_time_in_millis: startTimeInMillis.current,
+        end_time_in_millis: now,
+        duration: elapsedTime.toString(),
+        page_views: [...actionViews.current],
+        total_pages_read: new Set(actionViews.current.map((v) => v.page)).size,
+        sync_status: "STALE",
+        current_page: currentAction,
+        current_page_start_time_in_millis: actionStartTime.current.getTime(),
+        new_activity: true,
+        concentration_score: {
+          id: activityId.current,
+          concentration_score: 0,
+          tab_switch_count: tabSwitchCount,
+          pause_count: missedAnswerCount,
+          wrong_answer_count: wrongAnswerCount,
+          answer_times_in_seconds: answeredTimeArray,
+        },
+      });
+      await syncPDFTrackingData();
+    } catch (err) {
+      console.error("[PracticeMode] Completion POST failed", err);
+      // Reset so a subsequent edit can retry. Per-keystroke retries are
+      // bounded by the guard flipping back to true on the next attempt.
+      hasFiredCompletionRef.current = false;
+    }
+  };
+
+  const handleCodeChange = (
+    value: string | undefined,
+    event?: { isFlush?: boolean; changes?: unknown[] }
+  ) => {
     if (editorState.readOnly || editorState.viewMode === "view") return;
+
+    // Monaco fires onChange for both user typing AND programmatic setValue
+    // (starter code load on mount, language switch, etc.). isFlush=true
+    // marks the latter; we only want to count user edits.
+    const isUserEdit = event ? event.isFlush === false : true;
 
     const newCode = value || "";
     setEditorState((prev) => ({
@@ -689,6 +767,10 @@ const PracticeModeView: React.FC<CodeEditorSlideProps> = ({
 
     // Track code editing activity
     handleUserActivity();
+
+    if (isUserEdit) {
+      void fireCompletionOnFirstEdit();
+    }
   };
 
   const handleEditorDidMount = (editor: any, monaco: any) => {

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/coding-question/QuestionModeView.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/coding-question/QuestionModeView.tsx
@@ -4,6 +4,9 @@ import { Play, Send, Check, X, Loader2, Clock } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import confetti from "canvas-confetti";
 import { Preferences } from "@capacitor/preferences";
+import { useRouter } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -55,6 +58,13 @@ function classify(passed: number, total: number, hadError: boolean): Verdict {
 }
 
 export function QuestionModeView({ question, slideId }: Props) {
+  // Router search params carry the cascade-context IDs we ship to the backend
+  // alongside each submission so the learner_operation cascade can run. The
+  // slide route URL uses `sessionId` for what the backend calls
+  // `packageSessionId` — see routes/.../slides/index.tsx validateSearch.
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
   const codeStorageKey = `coding_code_${slideId}`;
   // Per-language code, persisted per-slide in Capacitor Preferences so a
   // refresh / app re-open doesn't wipe in-progress work. Hydrated below.
@@ -368,7 +378,31 @@ export function QuestionModeView({ question, slideId }: Props) {
           sessionStartedAt,
         };
 
-        await saveSubmission(submission);
+        // Pull cascade-context IDs from the current route. `sessionId` in the
+        // URL is the packageSessionId on the backend (per the slide route's
+        // validateSearch). Sending all four lets the backend fire the
+        // learner_operation cascade so this slide counts toward chapter /
+        // module / subject / course progress.
+        const search = router.state.location.search as Record<string, unknown>;
+        const chapterIdForCascade = (search.chapterId as string | undefined) ?? "";
+        const moduleIdForCascade = (search.moduleId as string | undefined) ?? "";
+        const subjectIdForCascade = (search.subjectId as string | undefined) ?? "";
+        const packageSessionIdForCascade =
+          (search.sessionId as string | undefined) ?? "";
+
+        await saveSubmission(submission, {
+          chapterId: chapterIdForCascade,
+          moduleId: moduleIdForCascade,
+          subjectId: subjectIdForCascade,
+          packageSessionId: packageSessionIdForCascade,
+        });
+
+        // Invalidate every progress cache so the chapter sidebar, module
+        // rollups, and course % refetch with the new value. Mirror of the
+        // quiz submit path (see quiz-viewer.tsx).
+        if (chapterIdForCascade) {
+          void refreshProgressAfterSubmit(queryClient, chapterIdForCascade);
+        }
         // Redact hidden-test answer keys before they land in React state —
         // otherwise a learner can open DevTools and read `expected`/`stdout`
         // for hidden cases they just failed. The full payload already went

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/coding-question/submission-store.ts
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/coding-question/submission-store.ts
@@ -14,7 +14,7 @@
 // still surfaces the most-recent attempt during a flaky connection.
 
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
-import { BASE_URL } from "@/constants/urls";
+import { CODING_SUBMISSIONS } from "@/constants/urls";
 import type {
   CodingSubmission,
   LangId,
@@ -22,7 +22,7 @@ import type {
   Verdict,
 } from "./types";
 
-const ENDPOINT = `${BASE_URL}/admin-core-service/coding/submissions`;
+const ENDPOINT = CODING_SUBMISSIONS;
 
 // In-flight cache so an offline Submit isn't lost from the UI before the next
 // listSubmissions() call. Keyed by slideId.
@@ -123,8 +123,21 @@ export async function getSubmission(
   }
 }
 
+// Cascade-context IDs that the backend needs in order to fire the
+// learner_operation cascade (slide → chapter → module → subject →
+// package_session). Callers pull these from the router search params so the
+// submission contributes to progress rollups. If any is missing, the backend
+// still saves the submission but skips the cascade (logged on the server).
+export interface CascadeContext {
+  chapterId: string;
+  moduleId: string;
+  subjectId: string;
+  packageSessionId: string;
+}
+
 export async function saveSubmission(
   submission: CodingSubmission,
+  cascade?: CascadeContext,
 ): Promise<void> {
   // learnerId is set server-side from the JWT — we don't send it.
   const payload = {
@@ -142,6 +155,10 @@ export async function saveSubmission(
     sessionStartedAt: submission.sessionStartedAt
       ? new Date(submission.sessionStartedAt).toISOString()
       : null,
+    chapterId: cascade?.chapterId,
+    moduleId: cascade?.moduleId,
+    subjectId: cascade?.subjectId,
+    packageSessionId: cascade?.packageSessionId,
   };
 
   try {

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/quiz-viewer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/quiz-viewer.tsx
@@ -19,6 +19,7 @@ import "katex/dist/katex.css";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Slide } from "@/hooks/study-library/use-slides";
 import { useSelectedSessionStore } from "@/stores/study-library/selected-session-store";
+import { refreshProgressAfterSubmit as invalidateProgressCaches } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 
 interface Option {
   id: string;
@@ -178,26 +179,12 @@ export const QuizViewer: React.FC<QuizViewerProps> = ({
     });
   }, [queryClient]);
 
-  // Refresh every progress-bearing cache after a quiz submit. The backend
-  // cascade (slide → chapter → module → subject → package_session) runs
-  // @Async, so we wait briefly before invalidating, then hit every key
-  // that feeds a progress UI: chapter sidebar (slides), module list
-  // (MODULES_WITH_CHAPTERS — both naming conventions exist in this codebase),
-  // and the course-level overall % (GET_COURSE_INIT).
+  // Cache invalidation moved to @/utils/study-library/tracking/refreshProgressAfterSubmit
+  // so other slide-type submit paths (e.g. coding-question) can reuse it.
+  // Quiz still needs its own wrapper to also run the localStorage-based 100%
+  // restore, which is quiz-specific.
   const refreshProgressAfterSubmit = useCallback(async (chapterIdToRefresh: string) => {
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    await queryClient.invalidateQueries({
-      predicate: (q) => {
-        const k = q.queryKey;
-        if (!Array.isArray(k)) return false;
-        return (
-          k[0] === "MODULES_WITH_CHAPTERS" ||
-          k[0] === "GET_MODULES_WITH_CHAPTERS" ||
-          k[0] === "GET_COURSE_INIT" ||
-          (k[0] === "slides" && k[1] === chapterIdToRefresh)
-        );
-      },
-    });
+    await invalidateProgressCaches(queryClient, chapterIdToRefresh);
     restoreLocalStorageCompletions(chapterIdToRefresh);
   }, [queryClient, restoreLocalStorageCompletions]);
 

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -165,6 +165,7 @@ export const FEEDBACK_URL = `${BASE_URL}/admin-core-service/rating`;
 
 export const SUBMIT_QUIZ_SLIDE_ACTIVITY_LOG = `${BASE_URL}/admin-core-service/learner-tracking/activity-log/quiz-slide/add-or-update-quiz-slide-activity-log`;
 export const GET_QUIZ_SLIDE_ACTIVITY_LOGS = `${BASE_URL}/admin-core-service/learner-tracking/activity-log/quiz-slide/quiz-slide-activity-logs`;
+export const CODING_SUBMISSIONS = `${BASE_URL}/admin-core-service/coding/submissions`;
 export const LIVE_SESSION_ATTENDANCE_REPORT_BY_BATCH = `${BASE_URL}/admin-core-service/live-session-report/by-batch-session`;
 export const LIVE_SESSION_ATTENDANCE_REPORT_BY_STUDENT = `${BASE_URL}/admin-core-service/live-session-report/student-report`;
 export const LEARNER_FULL_ATTENDANCE_REPORT = `${BASE_URL}/admin-core-service/learner/reports/attendance`;

--- a/frontend-learner-dashboard-app/src/utils/study-library/tracking/refreshProgressAfterSubmit.ts
+++ b/frontend-learner-dashboard-app/src/utils/study-library/tracking/refreshProgressAfterSubmit.ts
@@ -1,0 +1,32 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+// Invalidate every React Query cache that feeds a progress UI after a slide
+// submit. The backend cascade (slide → chapter → module → subject →
+// package_session) runs @Async, so we wait briefly before invalidating so the
+// refetch sees the new rows. Keys covered:
+//   - ["slides", chapterId]            — chapter sidebar (per-slide %)
+//   - ["MODULES_WITH_CHAPTERS", ...]   — module list (rollup chapter %)
+//   - ["GET_MODULES_WITH_CHAPTERS",...] — alternate naming used in this codebase
+//   - ["GET_COURSE_INIT", ...]         — course-overall % tile
+//
+// The 600ms delay is the empirical settle window for the @Async cascade
+// (see 2026-05-09 work in .samar/). Shorter risks invalidating before the
+// backend has written; longer makes the UI feel laggy.
+export const refreshProgressAfterSubmit = async (
+  queryClient: QueryClient,
+  chapterId: string
+): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  await queryClient.invalidateQueries({
+    predicate: (q) => {
+      const k = q.queryKey;
+      if (!Array.isArray(k)) return false;
+      return (
+        k[0] === "MODULES_WITH_CHAPTERS" ||
+        k[0] === "GET_MODULES_WITH_CHAPTERS" ||
+        k[0] === "GET_COURSE_INIT" ||
+        (k[0] === "slides" && k[1] === chapterId)
+      );
+    },
+  });
+};


### PR DESCRIPTION
## Summary of Changes

Wire the Code Editor slide (both Question Mode and Practice Mode) into the learner-progress completion cascade so submissions and edits actually update chapter / module / subject / course progress. Previously Question Mode submissions landed in `coding_submission` but never wrote a `learner_operation` row, and Practice Mode required ~60 seconds of dwell before the existing tracking pipeline would synthesize a page_view and flush.

**Backend:**
- `SubmitCodingRequestDto`: added `chapterId`, `moduleId`, `subjectId` (packageSessionId was already present) so the cascade has full context.
- `LearnerTrackingAsyncService`: new `@Async @Transactional updateLearnerOperationsForCodingSubmission(...)` writes `PERCENTAGE_DOCUMENT_COMPLETED = 100` for the slide (Code Editor lives under `source_type = DOCUMENT`, so no new enum / no cascade-list change) and triggers the chapter → module → subject → package_session rollup. Same shape as `updateLearnerOperationsForQuestion`.
- `CodingSubmissionService.submit(...)`: autowires the tracking service and calls the new method after `repository.save(entity)`. If any of the four parent IDs is missing, the submission still persists but the cascade is skipped with a warn log. Completion bar is "the learner submitted" — verdict / score / passing tests don't gate this.

**Frontend:**
- New shared helper `src/utils/study-library/tracking/refreshProgressAfterSubmit.ts` extracted from `quiz-viewer.tsx`. Waits 600 ms for the `@Async` cascade, then invalidates `MODULES_WITH_CHAPTERS`, `GET_MODULES_WITH_CHAPTERS`, `GET_COURSE_INIT`, and `["slides", chapterId]` so the chapter sidebar / module rollups / Course Progress tile refetch immediately.
- `quiz-viewer.tsx`: replaced inline helper with the shared one; kept its local wrapper for the quiz-specific localStorage 100%-restore. No behavior change.
- `submission-store.ts`: `saveSubmission` now accepts an optional `CascadeContext` (chapterId / moduleId / subjectId / packageSessionId) and includes the four IDs in the POST payload. The inline `coding/submissions` URL lifted to a new `CODING_SUBMISSIONS` constant in `src/constants/urls.ts`.
- `QuestionModeView.tsx`: pulls the four IDs from `router.state.location.search` (`sessionId` in the URL is `packageSessionId` on the backend per the slide route's `validateSearch`), passes them to `saveSubmission`, then calls `refreshProgressAfterSubmit(queryClient, chapterId)`.
- `code-editor-slide.tsx` (PracticeModeView): on the first user-initiated Monaco edit (`isFlush === false`), push a synthetic `page=1` page_view onto `actionViews.current` and force-flush via `addActivity` + `syncPDFTrackingData`. Guarded by a `useRef(false)` one-shot so subsequent keystrokes don't re-fire — the slide-level monotonic guard in `addOrUpdatePercentageOperation` would no-op the writes anyway, but this avoids the network noise. Existing 60s-dwell fallback via `calculateAndUpdatePageViews` is left intact.

## Related Issue

_None_

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Question Mode: submitted a passing Two Sum solution against a 5-test problem (2 visible, 3 hidden). DB confirmed `PERCENTAGE_DOCUMENT_COMPLETED = 100` row written for the slide, plus the chapter / module / subject / package_session rollup rows. Course Progress tile refreshed within ~600 ms after submit.
- Question Mode: submitted with empty code / failing tests → slide still completes (intentional per design — quality lives separately in `coding_submission`).
- Practice Mode: opened slide, typed a single character, left within 5 seconds → completion POST fired immediately, `PERCENTAGE_DOCUMENT_COMPLETED = 100` landed in DB.
- Practice Mode: opened slide without editing → Monaco's programmatic starter-code load (`isFlush=true`) did NOT trigger completion.
- Practice Mode: edited multiple times → only the first edit fired the POST (one-shot ref guard verified via Network tab).
- Practice Mode: dwell-without-edit for 60s+ still completes via the pre-existing `calculateAndUpdatePageViews` synthetic page_view path — pre-existing behavior left intact.
- Quiz: existing submit path unchanged behaviorally; cache invalidation still fires (refactor only — local wrapper now delegates to the shared helper).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
