### PR TITLE
fix(admin-dashboard): stop doubts sidebar from refetching on every ad…

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/doubt-resolution/doubtResolutionSidebar.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/doubt-resolution/doubtResolutionSidebar.tsx
@@ -62,8 +62,14 @@ const DoubtResolutionSidebar = () => {
         batch_ids: packageSessionId ? [packageSessionId] : [],
     });
 
+    // Gate the doubts query on sidebar visibility. The sidebar component stays
+    // mounted with w-0 when closed, so without this gate the hook would fire
+    // on every parent re-render — including the per-keystroke re-renders
+    // driven by the chapter-sidebar store's autosave-on-edit pattern. With
+    // `enabled: open`, the query simply doesn't run when the panel isn't
+    // visible. Opening the sidebar triggers a fresh fetch the first time.
     const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
-        useGetDoubts(filter);
+        useGetDoubts(filter, open);
 
     const [allDoubts, setAllDoubts] = useState<DoubtType[]>(
         (data as any)?.pages?.flatMap((page: { content: DoubtType[] }) => page.content) || []
@@ -75,6 +81,12 @@ const DoubtResolutionSidebar = () => {
         );
     }, [data]);
 
+    // Narrow the deps to the primitive fields we actually read inside.
+    // Previously this was `[activeItem, packageSessionId]`, but `activeItem`
+    // is a reference from the chapter-sidebar store that mutates on every
+    // admin-side autosave (per-keystroke), causing the effect to fire on
+    // every keystroke and produce a fresh filter object. Now we only re-run
+    // when the slide id, slide type, or doc-slide subtype actually change.
     useEffect(() => {
         setFilter((prev) => ({
             ...prev,
@@ -86,11 +98,19 @@ const DoubtResolutionSidebar = () => {
             ],
             batch_ids: packageSessionId ? [packageSessionId] : [],
         }));
-    }, [activeItem, packageSessionId]);
+    }, [
+        activeItem?.id,
+        activeItem?.source_type,
+        activeItem?.document_slide?.type,
+        packageSessionId,
+    ]);
 
-    useEffect(() => {
-        refetch();
-    }, [filter]);
+    // Note: the previous `useEffect(() => refetch(), [filter])` block was
+    // removed. The stable primitive-fielded queryKey on useGetDoubts already
+    // makes React Query auto-refetch when any meaningful filter field
+    // changes. The manual refetch was firing alongside it (double-fire) AND
+    // bypassed the `enabled` gate above, so it would have undone the
+    // sidebar-open guard.
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-services/GetDoubts.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-services/GetDoubts.tsx
@@ -3,10 +3,34 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { DoubtFilter, PaginatedDoubtResponse } from '../-types/get-doubts-type';
 import { GET_DOUBTS } from '@/constants/urls';
 
-export const useGetDoubts = (filter: Omit<DoubtFilter, 'page_no' | 'page_size'>) => {
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+// Stable, primitive queryKey. The previous form was `['GET_DOUBTS', filter]`,
+// where `filter` is whatever object the caller passes in. React Query
+// reference-compares array entries, so any time the caller produced a fresh
+// object literal — typical in a parent component that does `setFilter({...})`
+// inside a useEffect keyed on a churning value — the queryKey looked "new"
+// and the hook auto-refetched. Live in DoubtResolutionSidebar that meant one
+// refetch per admin keystroke (the chapter-sidebar store mutates `activeItem`
+// on every autosave, which fires a useEffect that produces a new filter).
+//
+// Picking only the fields that actually distinguish a query keeps the key
+// stable across the parent's irrelevant re-renders. The payload still POSTs
+// the whole filter so the backend keeps full filter semantics.
+export const useGetDoubts = (
+    filter: Omit<DoubtFilter, 'page_no' | 'page_size'>,
+    enabled: boolean = true,
+) => {
     return useInfiniteQuery({
-        queryKey: ['GET_DOUBTS', filter],
+        queryKey: [
+            'GET_DOUBTS',
+            filter.source_ids?.[0] ?? '',
+            filter.content_types?.[0] ?? '',
+            filter.batch_ids?.[0] ?? '',
+            filter.status?.join(',') ?? '',
+            filter.start_date,
+            filter.end_date,
+            filter.name ?? '',
+        ],
+        enabled,
         queryFn: async ({ pageParam = 0 }) => {
             const response = await authenticatedAxiosInstance.post<PaginatedDoubtResponse>(
                 `${GET_DOUBTS}?pageNo=${pageParam}&pageSize=10`,


### PR DESCRIPTION
## Summary of Changes

The doubt-resolution sidebar in the slide editor was firing a `POST /admin-core-service/institute/v1/doubts/get-all` request on **every admin keystroke** while editing any slide (MCQ options, question text, etc.). Three compounding problems in the same component caused this. Even worse, the sidebar component stays mounted with `w-0` when closed, so the per-keystroke refetch was happening regardless of whether the doubts panel was visible to the admin.

Root causes, in order:

1. **Unstable queryKey.** `useGetDoubts` passed the whole `filter` object as the second entry of its React Query `queryKey`. React Query reference-compares array entries, so any time the parent produced a fresh `filter` object literal, the queryKey looked "new" and the hook auto-refetched. A telltale `// eslint-disable-next-line react-hooks/exhaustive-deps` comment in the hook confirmed the original author had been warned about the unstable deps and silenced the lint instead of fixing the structure.
2. **Activity-store churn.** `DoubtResolutionSidebar` had a `useEffect` keyed on `[activeItem, packageSessionId]`. `activeItem` comes from the chapter-sidebar Zustand store and mutates on every admin-side autosave (the slide editor autosaves draft content on each keystroke). Every store update → fresh `activeItem` reference → effect fires → `setFilter({...})` produces a new object literal → unstable queryKey from (1) trips → refetch.
3. **Redundant manual `refetch()`.** A separate `useEffect(() => refetch(), [filter])` double-fired alongside the queryKey-triggered auto-refetch. It also bypassed React Query's `enabled` gate, so it would have undone any fix that tried to disable the query while the sidebar is closed.

**Frontend:**
- `useGetDoubts(filter)` → `useGetDoubts(filter, enabled = true)`. The queryKey is now a stable array of primitive fields (`source_ids[0]`, `content_types[0]`, `batch_ids[0]`, joined `status`, dates, `name`) rather than the whole filter object reference. The POST payload still sends the full filter so backend semantics are unchanged. Removed the `eslint-disable-next-line` bandaid.
- `DoubtResolutionSidebar` now calls `useGetDoubts(filter, open)`, gating the query on the sidebar's open state from `useSidebar()`. When the sidebar is closed (the common case during MCQ editing), zero requests fire. Opening the sidebar triggers a fresh fetch the first time.
- Narrowed the `activeItem`-effect deps from `[activeItem, packageSessionId]` to `[activeItem?.id, activeItem?.source_type, activeItem?.document_slide?.type, packageSessionId]` so it only re-runs when fields that actually matter to the doubts filter change — not on every reference-mutation of `activeItem`.
- Removed the redundant `useEffect(() => refetch(), [filter])`. The stable primitive-fielded queryKey already drives auto-refetch when a meaningful filter field changes, and the manual `refetch` was bypassing the new `enabled: open` gate.

## Related Issue

_None_

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Opened the slide editor with an MCQ slide and the doubts sidebar **closed**. Typed several characters into the question text and an option. Confirmed zero `POST /admin-core-service/institute/v1/doubts/get-all` requests in the Network tab — previously ~1-2 per keystroke.
- Opened the sidebar afterward. Confirmed a single fresh fetch lands.
- Switched between All / Resolved / Unresolved tabs while the sidebar was open. Confirmed exactly one fetch per tab change (no double-fire).
- Navigated to a different slide while the sidebar was open. Confirmed exactly one fetch (the query refetched because `source_ids[0]` actually changed).
- Closed the sidebar mid-edit, kept typing in the MCQ option, re-opened the sidebar. Confirmed one fetch on re-open with the current slide's doubts.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
