### PR TITLE
fix(learner-cart): sort membership plans by name and duration

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CartComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CartComponent.tsx
@@ -598,6 +598,18 @@ export const CartComponent: React.FC<CartComponentProps> = ({
 
   // RENT MODE LAYOUT (Horizontal Scroll)
   if (isRentMode) {
+    const sortedMembershipPlans = [...membershipPlans].sort((a, b) => {
+      const extractDuration = (name: string) => {
+        const match = (name || "").match(/(\d+)\s*months?/i);
+        return match ? parseInt(match[1], 10) : 0;
+      };
+      const stripDuration = (name: string) =>
+        (name || "").replace(/\d+\s*months?/i, "").trim().toLowerCase();
+      const prefixCmp = stripDuration(a.package_name).localeCompare(stripDuration(b.package_name));
+      if (prefixCmp !== 0) return prefixCmp;
+      return extractDuration(a.package_name) - extractDuration(b.package_name);
+    });
+
     return (
       <>
         <div
@@ -659,9 +671,9 @@ export const CartComponent: React.FC<CartComponentProps> = ({
                   <div key={i} className="h-32 bg-gray-200 rounded-lg animate-pulse" />
                 ))}
               </div>
-            ) : membershipPlans.length > 0 ? (
+            ) : sortedMembershipPlans.length > 0 ? (
               <div className="grid grid-cols-3 gap-2 sm:gap-3">
-                {membershipPlans.map((plan) => (
+                {sortedMembershipPlans.map((plan) => (
                   <MembershipPlanCard key={plan.id} plan={plan} />
                 ))}
               </div>


### PR DESCRIPTION
## Summary of Changes

Sort membership subscription plans in the ReadOnRent cart so each plan family lines up in its own row of the 3-column grid (Home Delivery Service together, Store Pick Up and Drop together) instead of the current interleaved order.

**Backend:**
- No backend changes.

**Frontend:**
- `CartComponent` (rent mode) sorts membership plans before rendering.
- Primary sort key: the plan name with the duration stripped → groups all "Home Delivery Service …" before all "Store Pick Up and Drop …".
- Secondary sort key: the numeric month count → orders 2 → 6 → 12 within each group.
- Plans whose names don't match the `N Months` pattern fall back to duration `0` and sort first within their group.

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Verified on the readonrent.in cart: Home Delivery rows render first (2 → 6 → 12 months) followed by Store Pick Up rows (2 → 6 → 12 months) in the 3-column grid.
- Confirmed plans without a `N Months` suffix don't break the layout.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
