### PR TITLE
fix: phantom 365-day expiry on one-time purchases + multi-card sessio…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/dto/bulk/BulkCoursePaymentConfigDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/dto/bulk/BulkCoursePaymentConfigDTO.java
@@ -56,7 +56,7 @@ public class BulkCoursePaymentConfigDTO {
 
     /**
      * Validity in days for ONE_TIME payments.
-     * Defaults to 365 (1 year) if not provided.
+     * Null means no expiry (one-time purchase, lifetime access).
      */
     private Integer validityInDays;
 
@@ -86,10 +86,12 @@ public class BulkCoursePaymentConfigDTO {
     }
 
     /**
-     * Returns effective validity in days, defaulting to 365.
+     * Returns validity in days as-is. Null = no expiry (lifetime access);
+     * propagates through to payment_plan.validity_in_days and ultimately to
+     * SSIGM.expiry_date so one-time purchases don't accrue phantom expiries.
      */
-    public int getEffectiveValidityInDays() {
-        return validityInDays != null ? validityInDays : 365;
+    public Integer getEffectiveValidityInDays() {
+        return validityInDays;
     }
 
     /**

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/course/service/BulkCourseServiceTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/course/service/BulkCourseServiceTest.java
@@ -828,7 +828,7 @@ class BulkCourseServiceTest {
                     .build();
 
             assertEquals("INR", config.getEffectiveCurrency()); // Default
-            assertEquals(365, config.getEffectiveValidityInDays()); // Default
+            assertNull(config.getEffectiveValidityInDays()); // Null = no expiry (lifetime)
             assertEquals(100.0, config.getEffectiveElevatedPrice()); // Falls back to price
             assertFalse(config.isEffectiveRequireApproval()); // Default false
         }

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/batch-selector-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/batch-selector-dialog.tsx
@@ -18,6 +18,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Switch } from '@/components/ui/switch';
 import { Plus } from '@phosphor-icons/react';
 import { BatchConfig, LevelOption, SessionOption, PaymentType } from '../-types/bulk-create-types';
 import { toast } from 'sonner';
@@ -68,6 +69,7 @@ export function BatchSelectorDialog({
     const [paymentType, setPaymentType] = useState<PaymentType>('FREE');
     const [price, setPrice] = useState<string>('');
     const [validityDays, setValidityDays] = useState<string>('');
+    const [isValidityApplicable, setIsValidityApplicable] = useState<boolean>(true);
     const [currency, setCurrency] = useState<string>('INR');
 
     const handleCreateLevel = async () => {
@@ -132,7 +134,13 @@ export function BatchSelectorDialog({
             payment_config: {
                 payment_type: paymentType,
                 price: price ? Number(price) : undefined,
-                validity_in_days: validityDays ? Number(validityDays) : undefined,
+                is_validity_applicable: isValidityApplicable,
+                validity_in_days:
+                    paymentType === 'ONE_TIME' && !isValidityApplicable
+                        ? null
+                        : validityDays
+                          ? Number(validityDays)
+                          : undefined,
                 currency: currency,
             },
         };
@@ -159,6 +167,7 @@ export function BatchSelectorDialog({
         setPaymentType('FREE');
         setPrice('');
         setValidityDays('');
+        setIsValidityApplicable(true);
         setCurrency('INR');
     };
 
@@ -326,17 +335,38 @@ export function BatchSelectorDialog({
                                         className="h-9 text-sm"
                                     />
                                 </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm">Validity (Days)</Label>
-                                    <Input
-                                        type="number"
-                                        placeholder="e.g., 365"
-                                        value={validityDays}
-                                        onChange={(e) => setValidityDays(e.target.value)}
-                                        className="h-9 text-sm"
+                                {(paymentType === 'SUBSCRIPTION' || isValidityApplicable) && (
+                                    <div className="space-y-2">
+                                        <Label className="text-sm">Validity (Days)</Label>
+                                        <Input
+                                            type="number"
+                                            placeholder="e.g., 365"
+                                            value={validityDays}
+                                            onChange={(e) => setValidityDays(e.target.value)}
+                                            className="h-9 text-sm"
+                                        />
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* Set Validity toggle (one-time only) */}
+                            {paymentType === 'ONE_TIME' && (
+                                <div className="flex items-center justify-between rounded-lg border p-3">
+                                    <div>
+                                        <Label className="text-sm font-medium">Set validity</Label>
+                                        <p className="text-xs text-neutral-500">
+                                            Turn off for one-time purchases that don&apos;t expire
+                                        </p>
+                                    </div>
+                                    <Switch
+                                        checked={isValidityApplicable}
+                                        onCheckedChange={(checked) => {
+                                            setIsValidityApplicable(checked);
+                                            if (!checked) setValidityDays('');
+                                        }}
                                     />
                                 </div>
-                            </div>
+                            )}
                         </>
                     )}
 

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/global-defaults-section.tsx
@@ -178,6 +178,61 @@ export function GlobalDefaultsSection({
                         </div>
                     )}
 
+                    {/* Default Validity (Days) — hidden when ONE_TIME with toggle off */}
+                    {(globalDefaults.payment_config.payment_type === 'SUBSCRIPTION' ||
+                        (globalDefaults.payment_config.payment_type === 'ONE_TIME' &&
+                            globalDefaults.payment_config.is_validity_applicable !== false)) && (
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-neutral-600">
+                                Default Validity (Days)
+                            </Label>
+                            <Input
+                                type="number"
+                                className="h-8 text-xs"
+                                placeholder="e.g., 365"
+                                value={globalDefaults.payment_config.validity_in_days ?? ''}
+                                onChange={(e) =>
+                                    onUpdate({
+                                        payment_config: {
+                                            ...globalDefaults.payment_config,
+                                            validity_in_days: e.target.value
+                                                ? Number(e.target.value)
+                                                : undefined,
+                                        },
+                                    })
+                                }
+                            />
+                        </div>
+                    )}
+
+                    {/* Set Validity toggle (ONE_TIME only) */}
+                    {globalDefaults.payment_config.payment_type === 'ONE_TIME' && (
+                        <div className="flex items-center gap-2 pt-5">
+                            <Switch
+                                id="global-set-validity"
+                                checked={globalDefaults.payment_config.is_validity_applicable !== false}
+                                onCheckedChange={(checked) =>
+                                    onUpdate({
+                                        payment_config: {
+                                            ...globalDefaults.payment_config,
+                                            is_validity_applicable: checked,
+                                            validity_in_days: checked
+                                                ? globalDefaults.payment_config.validity_in_days
+                                                : null,
+                                        },
+                                    })
+                                }
+                            />
+                            <Label
+                                htmlFor="global-set-validity"
+                                className="text-xs text-neutral-600"
+                                title="Turn off for one-time purchases that don't expire"
+                            >
+                                Set validity
+                            </Label>
+                        </div>
+                    )}
+
                     {/* Max Slots */}
                     <div className="space-y-1.5">
                         <Label className="text-xs text-neutral-600">

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-types/bulk-create-types.ts
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-types/bulk-create-types.ts
@@ -23,7 +23,8 @@ export interface PaymentConfig {
     price?: number;
     elevated_price?: number;
     currency?: string;
-    validity_in_days?: number;
+    validity_in_days?: number | null;
+    is_validity_applicable?: boolean;
     payment_option_name?: string;
     plan_name?: string;
     require_approval?: boolean;

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
@@ -15,12 +15,15 @@ import {
 } from '@phosphor-icons/react';
 import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { OverViewData, OverviewDetailsType } from './overview';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import { EditStudentDetails } from './EditStudentDetails';
 import { useStudentCredentialsStore } from '@/stores/students/students-list/useStudentCredentialsStore';
 import { useGetStudentDetails } from '@/services/get-student-details';
+import { getUserPlans, type UserPlan } from '@/services/user-plan';
+import { getInstituteId } from '@/constants/helper';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
 import { StudentTable } from '@/types/student-table-types';
 import { getFieldsForLocation, type FieldForLocation } from '@/lib/custom-fields/utils';
@@ -34,13 +37,25 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
     const { selectedStudent } = useStudentSidebar();
 
     const [overviewData, setOverviewData] = useState<OverviewDetailsType[] | null>(null);
-    const [daysUntilExpiry, setDaysUntilExpiry] = useState<number>(0);
     const [copiedField, setCopiedField] = useState<string>('');
     const [customFields, setCustomFields] = useState<FieldForLocation[]>([]);
     const [fieldGroups, setFieldGroups] = useState<FieldGroup[]>([]);
     const [tncFileUrl, setTncFileUrl] = useState<string | null>(null);
     const userId = isSubmissionTab ? selectedStudent?.id : selectedStudent?.user_id;
     const { data: studentDetails, isLoading, isError, error } = useGetStudentDetails(userId || '');
+
+    // Fetch all ACTIVE plans for this user; render one Session Expiry card per plan
+    // that has a real expiry date set. Empty array → no cards (e.g., buy-only books).
+    const instituteIdForPlans = getInstituteId();
+    const { data: userPlansResponse } = useQuery({
+        queryKey: ['STUDENT_OVERVIEW_USER_PLANS', userId, instituteIdForPlans],
+        queryFn: () => getUserPlans(1, 50, ['ACTIVE'], userId || '', instituteIdForPlans || ''),
+        enabled: !!userId && !!instituteIdForPlans,
+        staleTime: 60_000,
+    });
+    const expiringPlans: UserPlan[] = (userPlansResponse?.content || []).filter(
+        (plan) => plan.end_date != null
+    );
 
     const { getDetailsFromPackageSessionId, instituteDetails } = useInstituteDetailsStore();
     const { getCredentials } = useStudentCredentialsStore();
@@ -181,22 +196,6 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
             })
         );
 
-        // Calculate days until expiry
-        if (selectedStudent?.expiry_date) {
-            const expiryDate = new Date(selectedStudent.expiry_date);
-            const currentDate = new Date();
-
-            // Calculate the difference in milliseconds
-            const diffTime = expiryDate.getTime() - currentDate.getTime();
-
-            // Convert to days and round down
-            const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-
-            // Set the days until expiry (0 if negative)
-            setDaysUntilExpiry(diffDays > 0 ? diffDays : 0);
-        } else {
-            setDaysUntilExpiry(0);
-        }
     }, [selectedStudent, instituteDetails, password, studentDetails]);
 
     if (isLoading) {
@@ -215,52 +214,72 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
                 <EditStudentDetails />
             </div>
 
-            {/* Compact Session Expiry Card */}
-            <div className="rounded-lg border border-neutral-200/50 bg-gradient-to-br from-white to-neutral-50/30 p-3 transition-all duration-200 hover:border-primary-200/50 hover:shadow-md">
-                <div className="mb-2 flex items-center gap-2.5">
-                    <div className="rounded-md bg-gradient-to-br from-primary-50 to-primary-100 p-1.5">
-                        <Clock className="size-4 text-primary-600" />
-                    </div>
-                    <div className="flex-1">
-                        <h4 className="mb-0.5 text-xs font-medium text-neutral-700">
-                            Session Expiry
-                        </h4>
-                        <div className="flex items-center gap-1.5">
-                            <span
-                                className={`text-base font-bold ${
-                                    daysUntilExpiry >= 180
-                                    ? 'text-success-600'
-                                    : daysUntilExpiry >= 30
-                                        ? 'text-warning-600'
-                                        : 'text-danger-600'
-                                    }`}
-                            >
-                                {daysUntilExpiry}
-                            </span>
-                            <span className="text-xs text-neutral-500">days</span>
-                        </div>
-                    </div>
-                    <TrendUp
-                        className={`size-3.5 ${
-                            daysUntilExpiry >= 180
+            {/* Session Expiry cards — one per active plan with a non-null end_date.
+                Empty list (e.g., user only owns one-time-purchase books) → nothing renders. */}
+            {expiringPlans
+                .slice()
+                .sort((a, b) => {
+                    const ad = a.end_date ? new Date(a.end_date).getTime() : Infinity;
+                    const bd = b.end_date ? new Date(b.end_date).getTime() : Infinity;
+                    return ad - bd;
+                })
+                .map((plan) => {
+                    const expiryMs = plan.end_date ? new Date(plan.end_date).getTime() : null;
+                    const diffMs = expiryMs != null ? expiryMs - Date.now() : 0;
+                    const daysLeft = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+                    const label = plan.enroll_invite?.name?.trim() || 'Session';
+                    const colorClass =
+                        daysLeft >= 180
+                            ? 'text-success-600'
+                            : daysLeft >= 30
+                              ? 'text-warning-600'
+                              : 'text-danger-600';
+                    const trendColor =
+                        daysLeft >= 180
                             ? 'text-success-500'
-                            : daysUntilExpiry >= 30
-                                ? 'text-warning-500'
-                                : 'text-danger-500'
-                            }`}
-                    />
-                </div>
-                <div className="relative">
-                    <ProgressBar progress={daysUntilExpiry} />
-                    <div className="mt-1 text-center text-[10px] leading-tight text-neutral-500">
-                        {daysUntilExpiry >= 180
+                            : daysLeft >= 30
+                              ? 'text-warning-500'
+                              : 'text-danger-500';
+                    const status =
+                        daysLeft >= 180
                             ? 'Active session'
-                            : daysUntilExpiry >= 30
-                                ? 'Renewal due soon'
-                                : 'Urgent renewal required'}
-                    </div>
-                </div>
-            </div>
+                            : daysLeft >= 30
+                              ? 'Renewal due soon'
+                              : 'Urgent renewal required';
+                    return (
+                        <div
+                            key={plan.id}
+                            className="rounded-lg border border-neutral-200/50 bg-gradient-to-br from-white to-neutral-50/30 p-3 transition-all duration-200 hover:border-primary-200/50 hover:shadow-md"
+                        >
+                            <div className="mb-2 flex items-center gap-2.5">
+                                <div className="rounded-md bg-gradient-to-br from-primary-50 to-primary-100 p-1.5">
+                                    <Clock className="size-4 text-primary-600" />
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                    <h4
+                                        className="mb-0.5 text-xs font-medium text-neutral-700 truncate"
+                                        title={label}
+                                    >
+                                        {label}
+                                    </h4>
+                                    <div className="flex items-center gap-1.5">
+                                        <span className={`text-base font-bold ${colorClass}`}>
+                                            {daysLeft}
+                                        </span>
+                                        <span className="text-xs text-neutral-500">days</span>
+                                    </div>
+                                </div>
+                                <TrendUp className={`size-3.5 ${trendColor}`} />
+                            </div>
+                            <div className="relative">
+                                <ProgressBar progress={daysLeft} />
+                                <div className="mt-1 text-center text-[10px] leading-tight text-neutral-500">
+                                    {status}
+                                </div>
+                            </div>
+                        </div>
+                    );
+                })}
 
             {/* Compact overview sections */}
             <div className="space-y-2.5">


### PR DESCRIPTION
## Summary of Changes

ReadOnRent customers (and any tenant using one-time book/product purchases) were getting a phantom 364-day Session Expiry on the Customer Profile sidebar — even for buy-only items that should never expire. Root cause was a `?? 365` default hiding in two layers: the admin frontend's payment config UI and the bulk-create backend DTO's `getEffectiveValidityInDays()`. So even when no validity was specified, `payment_plan.validity_in_days` was being persisted as `365`, propagating through to `user_plan.end_date` and `SSIGM.expiry_date` on every enrollment.

Fix introduces an explicit "Set validity" toggle (default ON, multi-tenant friendly), removes the silent 365 fallbacks, and relaxes the type chain to let `null` flow through cleanly to the DB. Verified end-to-end: frontend `null` → `payment_plan.validity_in_days = NULL` → `SSIGM.expiry_date = NULL` → sidebar widget hidden.

Also redesigns the sidebar's Session Expiry section: previously a single card showing one arbitrary SSIGM's expiry (because the student-list backend silently dedupes multiple SSIGMs per user to one row, keeping whichever comes first). Now renders one card per active plan with a non-null `end_date`, sorted soonest-expiring first, labeled with the plan/package name.

**Backend:**
- `BulkCoursePaymentConfigDTO.getEffectiveValidityInDays()` now returns `Integer` (nullable) instead of primitive `int` with a `?? 365` fallback. `null` passes through to `payment_plan.validity_in_days = NULL`.
- Test assertion updated from `assertEquals(365, ...)` to `assertNull(...)` to reflect the new contract.

**Frontend:**
- New "Set validity" toggle (default ON) in three bulk-create surfaces: Global Defaults inline section, per-book Add Book dialog, and CSV import template (`is_validity_applicable` column).
- Removed silent `|| 365` fallback in `transformLocalPlanToApiFormat` and hardcoded `validity_in_days: 365` in the UPFRONT branch of `transformLocalPlanToApiFormatArray`.
- Relaxed types: `PaymentPlanApi.validity_in_days`, `PaymentPlan.validityDays`, `PaymentConfig.validity_in_days`, and `StudentTable.expiry_date` now allow `null`.
- Sidebar Overview: replaced single hardcoded Session Expiry card with multi-card render. Fetches via `getUserPlans(userId, instituteId, ['ACTIVE'])` (React Query, 60s staleTime), filters `end_date != null`, sorts soonest-first, one card per surviving plan.

## Related Issue

<!-- link if applicable -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

End-to-end against a local admin_core_service on `localhost:8072` with the bulk-create + bulk-assign curl flows verified in both DB and UI:

- **S2 (toggle OFF, the bug fix):** Created a book "the one to live" with One-Time Payment, toggle Set validity = OFF. Request body confirmed `validity_in_days: null` in Network tab. DB: `payment_plan.validity_in_days = NULL`. Enrolled a learner via `/v3/learner-management/assign` → `SSIGM.expiry_date = NULL`, `user_plan.end_date = NULL`. Sidebar Overview for that learner renders no Session Expiry card.
- **S5 (toggle ON regression):** Created "membership of 60 days" with validity = 60. DB: `payment_plan.validity_in_days = 60`. Enrolled learner → `SSIGM.expiry_date` set to ~now + 60 days. Sidebar shows "59 days, Renewal due soon" (correct — slightly after creation time).
- **Multi-card sidebar:** Enrolled the same learner (devdutt paddikal) in both a buy-book + 60-day membership + 180-day membership. Sidebar now renders two cards (60d orange "Renewal due soon", 180d green "Active session"), sorted soonest-first. Buy-book correctly hidden (no expiry).
- TypeScript `tsc --noEmit` clean across the frontend changes.
- Java `mvn compile` clean for the touched files (`BulkCoursePaymentConfigDTO`, `BulkCourseService`, `BulkCourseServiceTest`). Pre-existing unrelated compile errors in `PlatformInvoiceService` and `CourseContentCopyService` were not introduced by this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

## Notes / Out of scope

- Existing rows in production with `payment_plan.validity_in_days = 365` from before this fix will continue to surface as 365-day cards in the sidebar (cards source from `UserPlan.end_date`, which inherited the bad value at enrollment time). A one-time cleanup SQL scoped to one-time-purchase enrollments (`UPDATE student_session_institute_group_mapping SET expiry_date = NULL WHERE ...` plus the corresponding `user_plan.end_date = NULL`) is the path forward but is intentionally not part of this PR — needs a separate decision on which payment_options to scope it to.
- `StudentListManager.getLinkedStudentsV2` dedupes multiple SSIGMs per user to one row via `Collectors.toMap(userId, p -> p, (a, b) -> a)`. This pre-existed and means the table row's `expiry_date` column reflects one arbitrary SSIGM. The sidebar's new multi-card view sidesteps this by fetching all UserPlans independently. The dedupe itself is a separate latent issue worth its own follow-up.
- Dead component `frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/payment-config-dialog.tsx` is exported from the barrel but never imported anywhere. Left in place per scope discipline.
