### PR TITLE
fix(admin): mobile responsiveness for package management, bulk create…

### DIFF
--- a/frontend-admin-dashboard/src/components/common/students/enroll-students-button.tsx
+++ b/frontend-admin-dashboard/src/components/common/students/enroll-students-button.tsx
@@ -32,13 +32,15 @@ export const EnrollStudentsButton = ({
                 onClick={() => setOpen(true)}
                 disable={isDisabled}
                 className={cn(
-                    'group flex items-center gap-2 px-8 py-2 text-sm',
+                    'group flex items-center gap-1.5 px-3 py-1.5 text-xs sm:gap-2 sm:px-8 sm:py-2 sm:text-sm',
                     isDisabled && 'pointer-events-none opacity-55',
                     className
                 )}
             >
-                <GraduationCap className="size-4 transition-transform duration-200 group-hover:scale-110" />
-                Enroll {getTerminology(RoleTerms.Learner, SystemTerms.Learner)}
+                <GraduationCap className="size-3.5 shrink-0 transition-transform duration-200 group-hover:scale-110 sm:size-4" />
+                <span className="truncate">
+                    Enroll {getTerminology(RoleTerms.Learner, SystemTerms.Learner)}
+                </span>
             </MyButton>
 
             <BulkAssignDialog open={open} onOpenChange={setOpen} initialPackageSessionId={initialPackageSessionId} />

--- a/frontend-admin-dashboard/src/components/ui/sidebar.tsx
+++ b/frontend-admin-dashboard/src/components/ui/sidebar.tsx
@@ -59,7 +59,7 @@ const SidebarProvider = React.forwardRef<
         ref
     ) => {
         const isMobile = useIsMobile();
-        const [openMobile, setOpenMobile] = React.useState(false);
+        const [_openMobile, _setOpenMobile] = React.useState(false);
 
         // This is the internal state of the sidebar.
         // We use openProp and setOpenProp for control from outside the component.
@@ -78,6 +78,23 @@ const SidebarProvider = React.forwardRef<
                 document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
             },
             [setOpenProp, open]
+        );
+
+        // When the provider is controlled via `open`/`onOpenChange`, the mobile
+        // Sheet should mirror that same state so callers don't need to manage
+        // a separate `openMobile` value. Uncontrolled callers keep the original
+        // internal `openMobile` state.
+        const isControlled = openProp !== undefined;
+        const openMobile = isControlled ? open : _openMobile;
+        const setOpenMobile = React.useCallback(
+            (value: boolean | ((value: boolean) => boolean)) => {
+                if (isControlled) {
+                    setOpen(value);
+                } else {
+                    _setOpenMobile(value);
+                }
+            },
+            [isControlled, setOpen]
         );
 
         // Helper to toggle the sidebar.

--- a/frontend-admin-dashboard/src/routes/admin-package-management/-components/package-management-section.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/-components/package-management-section.tsx
@@ -5,6 +5,7 @@ import { MyPagination } from '@/components/design-system/pagination';
 import { DashboardLoader, ErrorBoundary } from '@/components/core/dashboard-loader';
 import { SmartErrorPage } from '@/components/core/SmartErrorPage';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { Package } from '@phosphor-icons/react';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
@@ -17,6 +18,7 @@ import { PackageSessionDTO } from '../-types/package-types';
 
 export function PackageManagementSection() {
     const { setNavHeading } = useNavHeadingStore();
+    const isMobile = useIsMobile();
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     const [selectedPackage, setSelectedPackage] = useState<{ id: string; name: string } | null>(
         null
@@ -28,6 +30,10 @@ export function PackageManagementSection() {
     }, [setNavHeading]);
 
     useEffect(() => {
+        // On mobile the sidebar renders as a Sheet in a portal — outside `tableRef`.
+        // The Sheet handles its own backdrop dismiss, and running this handler
+        // would close it immediately on any tap inside the sheet.
+        if (isMobile) return;
         const handleClickOutside = (event: MouseEvent) => {
             if (
                 tableRef.current &&
@@ -42,7 +48,7 @@ export function PackageManagementSection() {
         return () => {
             document.removeEventListener('mousedown', handleClickOutside);
         };
-    }, [isSidebarOpen]);
+    }, [isSidebarOpen, isMobile]);
 
     const {
         columnFilters,

--- a/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-page.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-package-management/bulk-create/-components/bulk-create-page.tsx
@@ -113,9 +113,9 @@ export function BulkCreatePage() {
     const courseCount = courses.length;
 
     return (
-        <section className="animate-fadeIn flex max-w-full flex-col gap-4 p-4">
+        <section className="animate-fadeIn flex max-w-full flex-col gap-4 p-3 sm:p-4">
             {/* Header Actions */}
-            <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+            <div className="flex flex-col gap-3 rounded-lg border border-neutral-200 bg-white p-3 shadow-sm sm:p-4 lg:flex-row lg:flex-wrap lg:items-center lg:justify-between lg:gap-4">
                 <div>
                     <h2 className="text-base font-semibold text-neutral-800">
                         Create Multiple {getTerminologyPlural(ContentTerms.Course, SystemTerms.Course)}
@@ -124,38 +124,47 @@ export function BulkCreatePage() {
                         Add {getTerminologyPlural(ContentTerms.Course, SystemTerms.Course).toLowerCase()} quickly with global defaults and individual customization
                     </p>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="grid grid-cols-2 gap-2 lg:flex lg:flex-wrap lg:items-center">
                     <Button
                         variant="outline"
                         size="sm"
                         onClick={() => setShowSimilarPackages(true)}
-                        className="h-9"
+                        className="h-9 min-w-0 justify-center"
                     >
-                        <MagnifyingGlass className="mr-1 size-4" />
-                        Search already added {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package)}
+                        <MagnifyingGlass className="mr-1 size-4 shrink-0" />
+                        <span className="truncate">
+                            Search already added {getTerminologyPlural(ContentTerms.Package, SystemTerms.Package)}
+                        </span>
                     </Button>
                     <Button
                         variant="outline"
                         size="sm"
                         onClick={() => setShowCsvImport(true)}
-                        className="h-9"
+                        className="h-9 min-w-0 justify-center"
                     >
-                        <FileCsv className="mr-1 size-4" />
-                        Import CSV
+                        <FileCsv className="mr-1 size-4 shrink-0" />
+                        <span className="truncate">Import CSV</span>
                     </Button>
-                    <Button variant="outline" size="sm" onClick={handleReset} className="h-9">
-                        <ArrowClockwise className="mr-1 size-4" />
-                        Reset
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleReset}
+                        className="h-9 min-w-0 justify-center"
+                    >
+                        <ArrowClockwise className="mr-1 size-4 shrink-0" />
+                        <span className="truncate">Reset</span>
                     </Button>
                     <Button
                         variant="outline"
                         size="sm"
                         onClick={handleValidate}
                         disabled={isValidating || courseCount === 0}
-                        className="h-9"
+                        className="h-9 min-w-0 justify-center"
                     >
-                        <Eye className="mr-1 size-4" />
-                        {isValidating ? 'Validating...' : 'Validate & Preview'}
+                        <Eye className="mr-1 size-4 shrink-0" />
+                        <span className="truncate">
+                            {isValidating ? 'Validating...' : 'Validate & Preview'}
+                        </span>
                     </Button>
                 </div>
             </div>
@@ -229,14 +238,14 @@ export function BulkCreatePage() {
             </div>
 
             {/* Footer Actions */}
-            <div className="sticky bottom-4 flex justify-end gap-2 rounded-lg border border-neutral-200 bg-white/95 p-4 shadow-lg backdrop-blur">
-                <span className="mr-auto text-sm text-neutral-500">
+            <div className="sticky bottom-4 flex flex-wrap items-center justify-end gap-2 rounded-lg border border-neutral-200 bg-white/95 p-3 shadow-lg backdrop-blur sm:p-4">
+                <span className="mr-auto text-xs text-neutral-500 sm:text-sm">
                     {courseCount} {courseCount !== 1 ? getTerminologyPlural(ContentTerms.Course, SystemTerms.Course).toLowerCase() : getTerminology(ContentTerms.Course, SystemTerms.Course).toLowerCase()} to create
                 </span>
-                <Button variant="outline" asChild>
+                <Button variant="outline" size="sm" asChild>
                     <Link to="/admin-package-management">Cancel</Link>
                 </Button>
-                <Button onClick={handleValidate} disabled={isValidating || courseCount === 0}>
+                <Button size="sm" onClick={handleValidate} disabled={isValidating || courseCount === 0}>
                     <Eye className="mr-1 size-4" />
                     {isValidating ? 'Validating...' : 'Preview & Create'}
                 </Button>

--- a/frontend-admin-dashboard/src/routes/manage-inventory/-components/inventory-filters.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-inventory/-components/inventory-filters.tsx
@@ -82,69 +82,72 @@ export const InventoryFilters = ({
 
     return (
         <Card className="border shadow-sm">
-            <CardContent className="p-4">
-                <div className="flex flex-wrap items-center gap-4">
+            <CardContent className="p-3 sm:p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
                     <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
                         <Filter className="size-4" />
                         Filters
                     </div>
 
                     {/* Search */}
-                    <div className="relative">
+                    <div className="relative w-full sm:w-auto">
                         <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                         <Input
                             placeholder="Search by name..."
                             value={searchInput}
                             onChange={(e) => setSearchInput(e.target.value)}
-                            className="h-9 w-[200px] pl-8"
+                            className="h-9 w-full pl-8 sm:w-[200px]"
                         />
                     </div>
 
-                    {/* Level Filter */}
-                    <Select
-                        value={filters.levelId || '__all__'}
-                        onValueChange={(value) =>
-                            onFiltersChange({
-                                ...filters,
-                                levelId: value === '__all__' ? undefined : value,
-                            })
-                        }
-                    >
-                        <SelectTrigger className="h-9 w-[180px]">
-                            <SelectValue placeholder="{`All ${getTerminologyPlural(ContentTerms.Level, SystemTerms.Level)}`}" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="__all__">{`All ${getTerminologyPlural(ContentTerms.Level, SystemTerms.Level)}`}</SelectItem>
-                            {filterOptions.levels.map((level) => (
-                                <SelectItem key={level.id} value={level.id}>
-                                    {level.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                    {/* Level + Session: two-column grid on mobile, inline on sm+ */}
+                    <div className="grid w-full grid-cols-2 gap-2 sm:contents sm:w-auto">
+                        {/* Level Filter */}
+                        <Select
+                            value={filters.levelId || '__all__'}
+                            onValueChange={(value) =>
+                                onFiltersChange({
+                                    ...filters,
+                                    levelId: value === '__all__' ? undefined : value,
+                                })
+                            }
+                        >
+                            <SelectTrigger className="h-9 w-full sm:w-[180px]">
+                                <SelectValue placeholder={`All ${getTerminologyPlural(ContentTerms.Level, SystemTerms.Level)}`} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="__all__">{`All ${getTerminologyPlural(ContentTerms.Level, SystemTerms.Level)}`}</SelectItem>
+                                {filterOptions.levels.map((level) => (
+                                    <SelectItem key={level.id} value={level.id}>
+                                        {level.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
 
-                    {/* Session Filter */}
-                    <Select
-                        value={filters.sessionId || '__all__'}
-                        onValueChange={(value) =>
-                            onFiltersChange({
-                                ...filters,
-                                sessionId: value === '__all__' ? undefined : value,
-                            })
-                        }
-                    >
-                        <SelectTrigger className="h-9 w-[180px]">
-                            <SelectValue placeholder="{`All ${getTerminologyPlural(ContentTerms.Session, SystemTerms.Session)}`}" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="__all__">{`All ${getTerminologyPlural(ContentTerms.Session, SystemTerms.Session)}`}</SelectItem>
-                            {filterOptions.sessions.map((session) => (
-                                <SelectItem key={session.id} value={session.id}>
-                                    {session.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                        {/* Session Filter */}
+                        <Select
+                            value={filters.sessionId || '__all__'}
+                            onValueChange={(value) =>
+                                onFiltersChange({
+                                    ...filters,
+                                    sessionId: value === '__all__' ? undefined : value,
+                                })
+                            }
+                        >
+                            <SelectTrigger className="h-9 w-full sm:w-[180px]">
+                                <SelectValue placeholder={`All ${getTerminologyPlural(ContentTerms.Session, SystemTerms.Session)}`} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="__all__">{`All ${getTerminologyPlural(ContentTerms.Session, SystemTerms.Session)}`}</SelectItem>
+                                {filterOptions.sessions.map((session) => (
+                                    <SelectItem key={session.id} value={session.id}>
+                                        {session.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
 
                     {/* Clear All Button */}
                     {hasActiveFilters && (

--- a/frontend-admin-dashboard/src/routes/manage-inventory/-components/inventory-stats-cards.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-inventory/-components/inventory-stats-cards.tsx
@@ -62,10 +62,10 @@ export const InventoryStatsCards = () => {
 
     if (isLoading) {
         return (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-5">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 lg:grid-cols-5 lg:gap-4">
                 {[1, 2, 3, 4, 5].map((i) => (
                     <Card key={i} className="overflow-hidden">
-                        <CardContent className="p-6">
+                        <CardContent className="p-3 sm:p-4 lg:p-6">
                             <Skeleton className="mb-2 h-4 w-24" />
                             <Skeleton className="mb-1 h-8 w-16" />
                             <Skeleton className="h-3 w-20" />
@@ -77,7 +77,7 @@ export const InventoryStatsCards = () => {
     }
 
     return (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-5">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 lg:grid-cols-5 lg:gap-4">
             {statCards.map((stat, index) => {
                 const isCritical = 'critical' in stat && stat.critical;
                 const isWarning = 'warning' in stat && stat.warning;
@@ -87,19 +87,19 @@ export const InventoryStatsCards = () => {
                         key={index}
                         className={`overflow-hidden border-0 bg-gradient-to-br shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl ${stat.bgGradient} ${isCritical ? 'animate-pulse ring-2 ring-red-500/50' : ''}`}
                     >
-                        <CardContent className="p-6">
-                            <div className="mb-3 flex items-center justify-between">
-                                <span className="text-sm font-medium text-muted-foreground">
+                        <CardContent className="p-3 sm:p-4 lg:p-6">
+                            <div className="mb-2 flex items-center justify-between gap-2 lg:mb-3">
+                                <span className="truncate text-xs font-medium text-muted-foreground sm:text-sm">
                                     {stat.title}
                                 </span>
                                 <div
-                                    className={`rounded-lg bg-gradient-to-br p-2 shadow-md ${stat.gradient}`}
+                                    className={`shrink-0 rounded-lg bg-gradient-to-br p-1.5 shadow-md sm:p-2 ${stat.gradient}`}
                                 >
-                                    <stat.icon className="size-4 text-white" />
+                                    <stat.icon className="size-3.5 text-white sm:size-4" />
                                 </div>
                             </div>
                             <div
-                                className={`mb-1 text-3xl font-bold ${
+                                className={`mb-1 text-xl font-bold sm:text-2xl lg:text-3xl ${
                                     isCritical
                                         ? 'text-red-600 dark:text-red-400'
                                         : isWarning
@@ -109,7 +109,7 @@ export const InventoryStatsCards = () => {
                             >
                                 {stat.value}
                             </div>
-                            <div className="text-xs text-muted-foreground">{stat.subtitle}</div>
+                            <div className="truncate text-[10px] text-muted-foreground sm:text-xs">{stat.subtitle}</div>
                         </CardContent>
                     </Card>
                 );

--- a/frontend-admin-dashboard/src/routes/manage-inventory/-components/manage-inventory-page.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-inventory/-components/manage-inventory-page.tsx
@@ -83,24 +83,24 @@ const ManageInventoryPage = () => {
     };
 
     return (
-        <div className="container mx-auto space-y-6 py-6">
+        <div className="container mx-auto space-y-4 px-3 py-4 sm:px-4 sm:py-6 lg:space-y-6 lg:px-8">
             {/* Header */}
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex items-center gap-3">
-                    <div className="rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 p-2 shadow-lg">
-                        <Package className="size-6 text-white" />
+                    <div className="shrink-0 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 p-2 shadow-lg">
+                        <Package className="size-5 text-white sm:size-6" />
                     </div>
-                    <div>
-                        <h1 className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-3xl font-bold text-transparent dark:from-white dark:to-gray-400">
+                    <div className="min-w-0">
+                        <h1 className="truncate bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-xl font-bold text-transparent dark:from-white dark:to-gray-400 sm:text-2xl lg:text-3xl">
                             {`Manage ${getTerminology(OtherTerms.Inventory, SystemTerms.Inventory)}`}
                         </h1>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-xs text-muted-foreground sm:text-sm">
                             {`Manage seats and capacity for your ${getTerminologyPlural(ContentTerms.Package, SystemTerms.Package).toLowerCase()} ${getTerminologyPlural(ContentTerms.Batch, SystemTerms.Batch).toLowerCase()}`}
                         </p>
                     </div>
                 </div>
 
-                <div className="flex items-center gap-3">
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
                     <Button
                         variant="outline"
                         size="sm"

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/BulkAssignDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/BulkAssignDialog.tsx
@@ -184,19 +184,19 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
 
     return (
         <Dialog open={open} onOpenChange={handleClose}>
-            <DialogContent className="flex h-[85vh] max-h-[85vh] w-[820px] max-w-[820px] flex-col gap-0 overflow-hidden p-0 font-normal">
+            <DialogContent className="z-[1100] flex h-[90vh] max-h-[90vh] w-[95vw] max-w-[820px] flex-col gap-0 overflow-hidden p-0 font-normal sm:h-[85vh] sm:max-h-[85vh]">
                 {/* Header */}
                 <DialogHeader>
-                    <div className="bg-primary-50 px-6 py-4">
+                    <div className="bg-primary-50 px-4 py-3 sm:px-6 sm:py-4">
                         <h2 className="text-h3 font-semibold text-primary-500">Enroll {getTerminology(RoleTerms.Learner, SystemTerms.Learner)}</h2>
                         {/* Step progress bar */}
                         <div className="mt-3 flex items-center gap-0">
                             {STEPS.map((label, idx) => (
                                 <div key={idx} className="flex flex-1 items-center">
-                                    <div className="flex flex-col items-center">
+                                    <div className="flex min-w-0 flex-col items-center">
                                         <div
                                             className={cn(
-                                                'flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold transition-all',
+                                                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold transition-all sm:h-7 sm:w-7 sm:text-xs',
                                                 idx < step
                                                     ? 'bg-primary-500 text-white'
                                                     : idx === step
@@ -208,7 +208,7 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
                                         </div>
                                         <span
                                             className={cn(
-                                                'mt-1 whitespace-nowrap text-[10px]',
+                                                'mt-1 max-w-full truncate text-center text-[9px] sm:whitespace-nowrap sm:text-[10px]',
                                                 idx === step
                                                     ? 'font-semibold text-primary-500'
                                                     : 'text-neutral-400'
@@ -272,12 +272,12 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
                 </div>
 
                 {/* Footer */}
-                <div className="flex items-center justify-between border-t border-neutral-100 px-6 py-4">
+                <div className="flex items-center justify-between gap-2 border-t border-neutral-100 px-4 py-3 sm:px-6 sm:py-4">
                     <div>
                         {step > 0 && (
                             <MyButton
                                 buttonType="secondary"
-                                scale="large"
+                                scale="small"
                                 layoutVariant="default"
                                 onClick={() => setStep((s) => s - 1)}
                                 disabled={isSubmitting}
@@ -286,10 +286,10 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
                             </MyButton>
                         )}
                     </div>
-                    <div className="flex gap-3">
+                    <div className="flex gap-2 sm:gap-3">
                         <MyButton
                             buttonType="secondary"
-                            scale="large"
+                            scale="small"
                             layoutVariant="default"
                             onClick={handleClose}
                             disabled={isSubmitting}
@@ -299,7 +299,7 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
                         {step < 3 ? (
                             <MyButton
                                 buttonType="primary"
-                                scale="large"
+                                scale="small"
                                 layoutVariant="default"
                                 onClick={handleNext}
                                 disable={!canGoNext() || isSubmitting}
@@ -313,7 +313,7 @@ export const BulkAssignDialog = ({ open, onOpenChange, onSuccess, initialPackage
                         ) : (
                             <MyButton
                                 buttonType="primary"
-                                scale="large"
+                                scale="small"
                                 layoutVariant="default"
                                 onClick={handleConfirm}
                                 disable={

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
@@ -73,7 +73,7 @@ export const Step1LearnerSelector = ({
         l.type === 'existing' ? l.email : '(new user)';
 
     return (
-        <div className="flex h-full flex-col gap-4 px-6 py-5">
+        <div className="flex h-full flex-col gap-4 px-4 py-4 sm:px-6 sm:py-5">
             {/* Selected learners chip list */}
             {selectedLearners.length > 0 && (
                 <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3">
@@ -102,24 +102,26 @@ export const Step1LearnerSelector = ({
                 </div>
             )}
 
-            {/* Source mode tabs */}
+            {/* Source mode tabs — 2x2 grid on mobile, single row on sm+ */}
             <Tabs value={mode} onValueChange={(v) => setMode(v as LearnerSourceMode)}>
-                <TabsList className="w-full">
-                    <TabsTrigger value="search" className="flex-1">
-                        <MagnifyingGlass size={14} className="mr-1.5" />
-                        Search Existing
+                <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:flex sm:h-9 sm:gap-0">
+                    <TabsTrigger value="search" className="min-w-0 justify-center text-xs sm:flex-1 sm:text-sm">
+                        <MagnifyingGlass size={14} className="mr-1.5 shrink-0" />
+                        <span className="truncate">Search Existing</span>
                     </TabsTrigger>
-                    <TabsTrigger value="from_course" className="flex-1">
-                        <UserPlus size={14} className="mr-1.5" />
-                        From {getTerminology(ContentTerms.Course, SystemTerms.Course)}
+                    <TabsTrigger value="from_course" className="min-w-0 justify-center text-xs sm:flex-1 sm:text-sm">
+                        <UserPlus size={14} className="mr-1.5 shrink-0" />
+                        <span className="truncate">
+                            From {getTerminology(ContentTerms.Course, SystemTerms.Course)}
+                        </span>
                     </TabsTrigger>
-                    <TabsTrigger value="csv" className="flex-1">
-                        <Upload size={14} className="mr-1.5" />
-                        Import CSV
+                    <TabsTrigger value="csv" className="min-w-0 justify-center text-xs sm:flex-1 sm:text-sm">
+                        <Upload size={14} className="mr-1.5 shrink-0" />
+                        <span className="truncate">Import CSV</span>
                     </TabsTrigger>
-                    <TabsTrigger value="manual" className="flex-1">
-                        <UserPlus size={14} className="mr-1.5" />
-                        Add Manually
+                    <TabsTrigger value="manual" className="min-w-0 justify-center text-xs sm:flex-1 sm:text-sm">
+                        <UserPlus size={14} className="mr-1.5 shrink-0" />
+                        <span className="truncate">Add Manually</span>
                     </TabsTrigger>
                 </TabsList>
 

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
@@ -225,7 +225,7 @@ export const Step2CourseSelector = ({
     const isDropdownLoading = isLevelsLoading || isSessionsLoading;
 
     return (
-        <div className="flex flex-col gap-4 px-6 py-5">
+        <div className="flex flex-col gap-4 px-4 py-4 sm:px-6 sm:py-5">
             {selectedPackageSessions.length > 0 && (
                 <div className="flex items-center gap-2 rounded-lg border border-primary-200 bg-primary-50 px-4 py-2 text-sm text-primary-700">
                     <span className="font-semibold">{selectedPackageSessions.length}</span>{' '}
@@ -237,8 +237,9 @@ export const Step2CourseSelector = ({
                 </div>
             )}
 
-            <div className="flex items-center gap-2">
-                <div className="relative flex-1">
+            {/* Search on its own row on mobile, inline on sm+ */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="relative w-full sm:flex-1">
                     <MagnifyingGlass
                         size={15}
                         className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
@@ -247,17 +248,19 @@ export const Step2CourseSelector = ({
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
                         placeholder={`Search ${coursesTerm.toLowerCase()}, ${levelsTerm.toLowerCase()}...`}
-                        className="h-9 pl-9 text-sm"
+                        className="h-9 w-full pl-9 text-sm"
                     />
                 </div>
 
+                {/* Filter dropdowns — 2-col grid below search on mobile, inline on sm+ */}
+                <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:items-center">
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                         <Button
                             variant="outline"
                             size="sm"
                             className={cn(
-                                'h-9 gap-1.5 text-xs font-medium',
+                                'h-9 w-full justify-center gap-1.5 text-xs font-medium sm:w-auto',
                                 selectedLevelIds.length > 0 &&
                                     'border-primary-300 bg-primary-50 text-primary-700'
                             )}
@@ -313,7 +316,7 @@ export const Step2CourseSelector = ({
                             variant="outline"
                             size="sm"
                             className={cn(
-                                'h-9 gap-1.5 text-xs font-medium',
+                                'h-9 w-full justify-center gap-1.5 text-xs font-medium sm:w-auto',
                                 selectedSessionIds.length > 0 &&
                                     'border-primary-300 bg-primary-50 text-primary-700'
                             )}
@@ -362,6 +365,7 @@ export const Step2CourseSelector = ({
                         )}
                     </DropdownMenuContent>
                 </DropdownMenu>
+                </div>
             </div>
 
             {activeFilterCount > 0 && (
@@ -529,12 +533,12 @@ export const Step2CourseSelector = ({
             </div>
 
             {totalPages > 1 && (
-                <div className="flex items-center justify-between border-t border-neutral-100 pt-3">
+                <div className="flex flex-wrap items-center justify-between gap-2 border-t border-neutral-100 pt-3">
                     <span className="text-xs text-neutral-400">
                         Showing {page * PAGE_SIZE + 1}–
                         {Math.min((page + 1) * PAGE_SIZE, totalElements)} of {totalElements}
                     </span>
-                    <div className="flex items-center gap-1">
+                    <div className="flex shrink-0 items-center gap-1">
                         <Button
                             variant="outline"
                             size="sm"

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
@@ -287,7 +287,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                         </div>
 
                         {/* Core fields — always visible */}
-                        <div className="grid grid-cols-2 gap-3">
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                             <div>
                                 <Label className="mb-1 text-xs text-neutral-500">
                                     Email <span className="text-danger-500">*</span>
@@ -364,7 +364,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                                 <p className="mb-2 text-xs font-semibold text-neutral-400 uppercase tracking-wide">
                                     Additional Details
                                 </p>
-                                <div className="grid grid-cols-2 gap-3">
+                                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                     {/* Dynamic system fields */}
                                     {visibleSystemFields.map((sf) => (
                                         <div key={sf.key}>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-list-section/student-filters.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-list-section/student-filters.tsx
@@ -124,10 +124,12 @@ export const StudentFilters = ({
 
     return (
         <div className="animate-fadeIn space-y-4">
-            {/* Top section with session selector and export buttons */}
-            <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+            {/* Top section with session selector and export buttons.
+                Mobile: Session row + 2-col Export grid row.
+                lg+: All side-by-side in a single row. */}
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between lg:gap-4">
                 {/* Session selector */}
-                <div className="max-w-xs flex-1">
+                <div className="min-w-0 w-full max-w-xs lg:flex-1">
                     {sessionList.length == 0 ? (
                         <AddSessionDialog
                             isAddSessionDiaogOpen={isAddSessionDiaogOpen}
@@ -170,21 +172,22 @@ export const StudentFilters = ({
                     )}
                 </div>
 
-                {/* Export buttons */}
-                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+                {/* Export buttons — 2-col grid on mobile with full labels, inline row on sm+ */}
+                <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0 sm:items-center">
                     <MyButton
                         scale="medium"
                         buttonType="secondary"
                         layoutVariant="default"
                         onClick={handleExportAccountDetails}
                         className={cn(
-                            "hover:scale-102 group flex items-center gap-2 bg-gradient-to-r from-neutral-50 to-neutral-100 transition-all duration-200 hover:from-neutral-100 hover:to-neutral-200",
-                            isCompact ? "px-2 py-1 text-xs" : "px-4 py-2 text-sm"
+                            "hover:scale-102 group flex items-center justify-center gap-1.5 bg-gradient-to-r from-neutral-50 to-neutral-100 transition-all duration-200 hover:from-neutral-100 hover:to-neutral-200",
+                            isCompact ? "px-2 py-1 text-xs" : "px-2.5 py-1.5 text-xs sm:gap-2 sm:px-4 sm:py-2 sm:text-sm"
                         )}
                     >
-                        <Export className={cn("transition-transform duration-200 group-hover:scale-110", isCompact ? "size-3" : "size-4")} />
-                        <span className="hidden md:inline">Export account details</span>
-                        <span className="md:hidden">Account Details</span>
+                        <Export className={cn("shrink-0 transition-transform duration-200 group-hover:scale-110", isCompact ? "size-3" : "size-3.5 sm:size-4")} />
+                        <span className="truncate sm:hidden">Account Details</span>
+                        <span className="hidden truncate sm:inline md:hidden">Account</span>
+                        <span className="hidden truncate md:inline">Export account details</span>
                     </MyButton>
                     <MyButton
                         scale="medium"
@@ -193,13 +196,14 @@ export const StudentFilters = ({
                         id="export-data"
                         onClick={handleExportClick}
                         className={cn(
-                            "hover:scale-102 group flex items-center gap-2 border-emerald-200 bg-gradient-to-r from-emerald-50 to-emerald-100 text-emerald-700 transition-all duration-200 hover:from-emerald-100 hover:to-emerald-200",
-                            isCompact ? "px-2 py-1 text-xs" : "px-4 py-2 text-sm"
+                            "hover:scale-102 group flex items-center justify-center gap-1.5 border-emerald-200 bg-gradient-to-r from-emerald-50 to-emerald-100 text-emerald-700 transition-all duration-200 hover:from-emerald-100 hover:to-emerald-200",
+                            isCompact ? "px-2 py-1 text-xs" : "px-2.5 py-1.5 text-xs sm:gap-2 sm:px-4 sm:py-2 sm:text-sm"
                         )}
                     >
-                        <Export className={cn("transition-transform duration-200 group-hover:scale-110", isCompact ? "size-3" : "size-4")} />
-                        <span className="hidden md:inline">Export Data</span>
-                        <span className="md:hidden">Export</span>
+                        <Export className={cn("shrink-0 transition-transform duration-200 group-hover:scale-110", isCompact ? "size-3" : "size-3.5 sm:size-4")} />
+                        <span className="truncate sm:hidden">Export</span>
+                        <span className="hidden truncate sm:inline md:hidden">Export</span>
+                        <span className="hidden truncate md:inline">Export Data</span>
                     </MyButton>
                 </div>
             </div>


### PR DESCRIPTION
## Summary of Changes

Mobile (≤768px) responsiveness pass across the admin dashboard. Desktop layouts are preserved at `lg+` everywhere — every change is gated behind a mobile-only class with explicit `sm:`/`lg:` overrides to restore original styling on larger screens.

**Frontend:**
- **Shared `SidebarProvider`** (`components/ui/sidebar.tsx`): when used in controlled mode (`open` / `onOpenChange`), the mobile `Sheet` now mirrors the controlled state. Previously the parent could set `isSidebarOpen=true` but the mobile sheet — backed by an internal `openMobile` state — would never open. Fixes the bug for ~12 controlled callers (Package Management, Recent Leads, Enquiries, Campaign Users, Registrations, Manage Contacts, Students List, Assessment Submissions, Subjects Student List, Certificate Generation Student Data, Attendance Tracker, Enroll Requests). Uncontrolled callers (main app sidebar, AdminSlidesView) get the original internal-state behavior.
- **Package Management** (`/admin-package-management`): book detail panel now opens correctly on mobile (via the sidebar fix above) and the document click-outside handler is skipped on mobile so the portal-rendered Sheet doesn't auto-close on backdrop tap.
- **Bulk Create** (`/admin-package-management/bulk-create`): 4 action buttons (Search added books / Import CSV / Reset / Validate & Preview) become a 2-col grid on mobile so all are visible; sticky footer wraps cleanly on narrow widths.
- **Inventory Management** (`/manage-inventory`):
  - Stat cards go from `grid-cols-1` to `grid-cols-2` on mobile with smaller padding + text (5 cards now fit in ~3 rows instead of 5).
  - Filter row collapses to a stack: Search full-width on its own row, Level + Session as a 2-col sub-grid.
  - Header stacks below `lg`; container padding reduced on mobile, restored to Tailwind container default on `lg+`.
  - Fixed a pre-existing bug where filter Select placeholders rendered the literal template-string text (`"{\`All ${...}\`}"` was inside a JSX string literal instead of a JSX expression).
- **Learners** (`/manage-students/students-list`):
  - `EnrollStudentsButton` compact on mobile (`px-3 py-1.5 text-xs` → `sm:px-8 sm:py-2 sm:text-sm`).
  - Session dropdown + Account Details + Export buttons restructured: Session row 1, Account + Export as 2-col grid with visible labels + small icons + real gap (no more icon-only confusion). Single inline row on `lg+`.
- **Enroll Learner dialog** (`BulkAssignDialog`):
  - `w-[820px]` → `w-[95vw] max-w-[820px]` so it stops overflowing on mobile; height `h-[90vh] sm:h-[85vh]`.
  - Step indicator (4 circles + labels) shrinks on mobile (`h-6 w-6 text-[10px]` → `sm:h-7 sm:w-7 sm:text-xs`).
  - Footer buttons all `scale="small"` so Back / Cancel / Next fit on ~390px viewports without clipping.
  - Bumped `DialogContent` to `z-[1100]` so floating widgets (FABs at `z-[1003]`) don't sit on top of the dialog.
  - **Step 1 — Source mode tabs**: become a 2×2 grid on mobile (was single row, overflowed).
  - **Step 1 — Manual entry form**: input grids go `grid-cols-1` on mobile so each field stacks on its own line.
  - **Step 2 — Course selector**: Search input on its own row on mobile, Level + Session filter dropdowns as a 2-col grid below; pagination row uses `flex-wrap` so count + prev/next can stack if needed.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Manually tested in Chrome DevTools responsive mode at ~390px (iPhone) and at desktop widths for each affected page.
- Manage Books: clicked book row on mobile — detail Sheet now slides in correctly; tapping inside the sheet no longer auto-dismisses it. Verified the right-side sidebar still opens normally on desktop.
- Bulk Create: confirmed all 4 action buttons are visible on mobile in a 2-col grid; desktop row layout unchanged.
- Inventory: stat cards fit in 2 columns on mobile with readable text; filter row collapses cleanly; placeholder bug fix verified by opening the filter dropdowns.
- Learners page: Session/Account/Export controls have clear labels with proper spacing on mobile.
- Enroll Learner dialog: all 4 steps render within the viewport on mobile; Back/Cancel/Next footer buttons all visible and tappable; tab strip in Step 1 fits in 2×2 grid; Step 2 search and filters stack properly.
- TypeScript: `tsc --noEmit` passes on the whole frontend project.
- No backend changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
