### PR TITLE
Feat/bulk enroll dynamic identifier and edit

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -156,9 +156,13 @@ public class BulkAssignmentService {
                 }
             }
         } else if (!CollectionUtils.isEmpty(request.getNewUsers()) && dryRun) {
-            // In dry-run, report new users as "would be created"
-            for (NewUserDTO newUser : request.getNewUsers()) {
-                allUserIds.add("dry-run-new-" + newUser.getEmail());
+            // In dry-run, report new users as "would be created". Use the list
+            // index for placeholder uniqueness — for phone-identifier institutes
+            // email may be blank, and several rows could otherwise collide on
+            // the same "dry-run-new-null" key.
+            List<NewUserDTO> newUsers = request.getNewUsers();
+            for (int i = 0; i < newUsers.size(); i++) {
+                allUserIds.add(dryRunPlaceholderId(i, newUsers.get(i)));
             }
         }
 
@@ -168,14 +172,18 @@ public class BulkAssignmentService {
 
         // 2. Fetch user details for email reporting
         Map<String, UserDTO> userMap = fetchUserDetails(allUserIds);
-        // Add dry-run new user placeholders to userMap
+        // Add dry-run new user placeholders to userMap (keyed by the same id
+        // built above in the dry-run branch — see dryRunPlaceholderId).
         if (dryRun && !CollectionUtils.isEmpty(request.getNewUsers())) {
-            for (NewUserDTO newUser : request.getNewUsers()) {
-                String placeholderId = "dry-run-new-" + newUser.getEmail();
+            List<NewUserDTO> newUsers = request.getNewUsers();
+            for (int i = 0; i < newUsers.size(); i++) {
+                NewUserDTO newUser = newUsers.get(i);
+                String placeholderId = dryRunPlaceholderId(i, newUser);
                 userMap.put(placeholderId, UserDTO.builder()
                         .id(placeholderId)
                         .email(newUser.getEmail())
                         .fullName(newUser.getFullName())
+                        .mobileNumber(newUser.getMobileNumber())
                         .build());
             }
         }
@@ -374,13 +382,24 @@ public class BulkAssignmentService {
      * read-back from auth-service.
      */
     private String createNewUser(NewUserDTO newUser, String instituteId, boolean sendCredentials, String learndashBaseUrl) {
+        // Resolve the username explicitly: caller-supplied → email → null.
+        // Sending null lets auth-service generate a username from full_name
+        // (UsernameGenerator). Passing an empty/whitespace string would slip
+        // past the auth-service's StringUtils.hasText check; passing the email
+        // verbatim (which may be blank for phone-identifier institutes) is
+        // confusing — be explicit instead.
+        String resolvedUsername = null;
+        if (StringUtils.hasText(newUser.getUsername())) {
+            resolvedUsername = newUser.getUsername();
+        } else if (StringUtils.hasText(newUser.getEmail())) {
+            resolvedUsername = newUser.getEmail();
+        }
+
         UserDTO.UserDTOBuilder builder = UserDTO.builder()
-                .email(newUser.getEmail())
+                .email(StringUtils.hasText(newUser.getEmail()) ? newUser.getEmail() : null)
                 .fullName(newUser.getFullName())
                 .mobileNumber(newUser.getMobileNumber())
-                .username(StringUtils.hasText(newUser.getUsername())
-                        ? newUser.getUsername()
-                        : newUser.getEmail())
+                .username(resolvedUsername)
                 .password(newUser.getPassword())
                 .gender(newUser.getGender())
                 .roles(CollectionUtils.isEmpty(newUser.getRoles())
@@ -416,9 +435,35 @@ public class BulkAssignmentService {
                 userDTO, instituteId, sendCredentials, learndashBaseUrl);
 
         if (created == null || !StringUtils.hasText(created.getId())) {
-            throw new VacademyException("User creation returned empty result for " + newUser.getEmail());
+            throw new VacademyException("User creation returned empty result for " + describeNewUser(newUser));
         }
         return created.getId();
+    }
+
+    /**
+     * Identifier-agnostic short label used in error/log messages so phone-only
+     * users do not show up as "null" or empty strings.
+     */
+    private static String describeNewUser(NewUserDTO newUser) {
+        if (newUser == null) return "<null>";
+        if (StringUtils.hasText(newUser.getEmail())) return newUser.getEmail();
+        if (StringUtils.hasText(newUser.getMobileNumber())) return "mobile:" + newUser.getMobileNumber();
+        if (StringUtils.hasText(newUser.getFullName())) return "name:" + newUser.getFullName();
+        return "<no identifier>";
+    }
+
+    /**
+     * Stable, unique placeholder id for a not-yet-created new user during dry
+     * run. Uses the row index so phone-only rows (which may share an empty
+     * email) do not collide on the same key.
+     */
+    private static String dryRunPlaceholderId(int index, NewUserDTO newUser) {
+        String suffix = newUser != null && StringUtils.hasText(newUser.getEmail())
+                ? newUser.getEmail()
+                : newUser != null && StringUtils.hasText(newUser.getMobileNumber())
+                        ? newUser.getMobileNumber()
+                        : "row";
+        return "dry-run-new-" + index + "-" + suffix;
     }
 
     private Map<String, UserDTO> fetchUserDetails(Set<String> userIds) {

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/service/AuthService.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package vacademy.io.auth_service.feature.auth.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Service
+@Slf4j
 public class AuthService {
     @Autowired
     UserRepository userRepository;
@@ -490,10 +492,20 @@ public class AuthService {
             user = userRepository.save(user);
         }
         if (sendWelcomeMail) {
-            if (isAlreadyPresent) {
-                sendLearnerEnrollmentExistingUserEmail(user, instituteId, userRoleSet, overrideLoginUrl);
-            } else {
-                sendLearnerEnrollmentNewUserEmail(user, instituteId, userRoleSet, overrideLoginUrl);
+            // Welcome email is a side-effect: its failure must NEVER roll back the
+            // user creation. The enclosing @Transactional would otherwise mark the
+            // transaction rollback-only on any thrown exception, deleting the new
+            // user (and on the existing-user branch, undoing any patched fields /
+            // newly assigned roles). Catch everything here and log instead.
+            try {
+                if (isAlreadyPresent) {
+                    sendLearnerEnrollmentExistingUserEmail(user, instituteId, userRoleSet, overrideLoginUrl);
+                } else {
+                    sendLearnerEnrollmentNewUserEmail(user, instituteId, userRoleSet, overrideLoginUrl);
+                }
+            } catch (Exception e) {
+                log.error("Welcome email failed for userId={}, instituteId={}: {}",
+                        user.getId(), instituteId, e.getMessage(), e);
             }
         }
         return user;
@@ -507,6 +519,19 @@ public class AuthService {
     }
 
     public void sendLearnerEnrollmentNewUserEmail(User user, String instituteId, Set<UserRole> roles, String overrideLoginUrl) {
+        if (user == null) {
+            log.warn("sendLearnerEnrollmentNewUserEmail called with null user; skipping send.");
+            return;
+        }
+        // For phone-only institutes (USER_IDENTIFIER=PHONE) the learner may have
+        // no email on record. Don't attempt the email send; the unified pipeline
+        // would receive recipient.email=null and either fail or silently drop it.
+        // TODO: add SMS/WhatsApp credential delivery for phone-only learners.
+        if (!StringUtils.hasText(user.getEmail())) {
+            log.warn("Skipping new-learner welcome email for userId={} (no email on file).",
+                    user.getId());
+            return;
+        }
         InstituteInfoDTO instituteInfoDTO = null;
         boolean isLearner = false;
         if (roles != null) {
@@ -554,8 +579,18 @@ public class AuthService {
     }
 
     public void sendLearnerEnrollmentExistingUserEmail(User user, String instituteId, Set<UserRole> roles, String overrideLoginUrl) {
-        if (user == null || user.getEmail() == null) {
-            throw new IllegalArgumentException("User or user email must not be null");
+        if (user == null) {
+            log.warn("sendLearnerEnrollmentExistingUserEmail called with null user; skipping send.");
+            return;
+        }
+        // Same rationale as the new-user path: phone-identifier institutes may
+        // have learners with no email — skip instead of throwing so the caller's
+        // transaction is not marked rollback-only.
+        // TODO: add SMS/WhatsApp credential delivery for phone-only learners.
+        if (!StringUtils.hasText(user.getEmail())) {
+            log.warn("Skipping existing-learner welcome email for userId={} (no email on file).",
+                    user.getId());
+            return;
         }
         InstituteInfoDTO instituteInfoDTO = null;
         boolean isLearner = false;

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step1LearnerSelector.tsx
@@ -2,8 +2,7 @@ import { useState, useRef } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { MyButton } from '@/components/design-system/button';
-import { X, MagnifyingGlass, Upload, UserPlus } from '@phosphor-icons/react';
+import { X, MagnifyingGlass, Upload, UserPlus, PencilSimple } from '@phosphor-icons/react';
 import { useAutosuggestUsers } from '../../../../-hooks/useAutosuggestUsers';
 import {
     AutosuggestUser,
@@ -32,7 +31,28 @@ export const Step1LearnerSelector = ({
 }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
     const [mode, setMode] = useState<LearnerSourceMode>('manual');
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const searchRef = useRef<HTMLInputElement>(null);
+
+    const editingRow =
+        editingIndex !== null && selectedLearners[editingIndex]?.type === 'new'
+            ? (selectedLearners[editingIndex] as { type: 'new'; newUser: NewUserRow }).newUser
+            : undefined;
+
+    const startEditing = (idx: number) => {
+        setEditingIndex(idx);
+        setMode('manual');
+    };
+
+    const handleEditSave = (updated: NewUserRow) => {
+        if (editingIndex === null) return;
+        const next = [...selectedLearners];
+        next[editingIndex] = { type: 'new', newUser: updated };
+        onSelectedLearnersChange(next);
+        setEditingIndex(null);
+    };
+
+    const handleEditCancel = () => setEditingIndex(null);
 
     const { data: suggestedUsers, isFetching } = useAutosuggestUsers({
         instituteId,
@@ -81,29 +101,64 @@ export const Step1LearnerSelector = ({
                         {selectedLearners.length} learner{selectedLearners.length !== 1 ? 's' : ''} selected
                     </p>
                     <div className="flex flex-wrap gap-2">
-                        {selectedLearners.map((l, idx) => (
-                            <div
-                                key={idx}
-                                className="flex items-center gap-1.5 rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs text-primary-700"
-                            >
-                                <div>
-                                    <span className="font-medium">{getLearnerLabel(l)}</span>
-                                    <span className="ml-1 text-primary-400">{getLearnerSub(l)}</span>
-                                </div>
-                                <button
-                                    onClick={() => removeLearner(idx)}
-                                    className="ml-1 rounded-full text-primary-400 hover:text-primary-700"
+                        {selectedLearners.map((l, idx) => {
+                            const isBeingEdited = editingIndex === idx;
+                            return (
+                                <div
+                                    key={idx}
+                                    className={`flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs ${
+                                        isBeingEdited
+                                            ? 'border-warning-400 bg-warning-50 text-warning-700'
+                                            : 'border-primary-200 bg-primary-50 text-primary-700'
+                                    }`}
                                 >
-                                    <X size={12} weight="bold" />
-                                </button>
-                            </div>
-                        ))}
+                                    <div>
+                                        <span className="font-medium">{getLearnerLabel(l)}</span>
+                                        <span className={`ml-1 ${isBeingEdited ? 'text-warning-500' : 'text-primary-400'}`}>
+                                            {isBeingEdited ? '(editing…)' : getLearnerSub(l)}
+                                        </span>
+                                    </div>
+                                    {l.type === 'new' && !isBeingEdited && (
+                                        <button
+                                            onClick={() => startEditing(idx)}
+                                            className="ml-1 rounded-full text-primary-400 hover:text-primary-700"
+                                            title="Edit"
+                                        >
+                                            <PencilSimple size={12} weight="bold" />
+                                        </button>
+                                    )}
+                                    <button
+                                        onClick={() => {
+                                            if (isBeingEdited) setEditingIndex(null);
+                                            removeLearner(idx);
+                                        }}
+                                        className={`ml-1 rounded-full ${
+                                            isBeingEdited
+                                                ? 'text-warning-500 hover:text-warning-700'
+                                                : 'text-primary-400 hover:text-primary-700'
+                                        }`}
+                                        title="Remove"
+                                    >
+                                        <X size={12} weight="bold" />
+                                    </button>
+                                </div>
+                            );
+                        })}
                     </div>
                 </div>
             )}
 
             {/* Source mode tabs — 2x2 grid on mobile, single row on sm+ */}
-            <Tabs value={mode} onValueChange={(v) => setMode(v as LearnerSourceMode)}>
+            <Tabs
+                value={mode}
+                onValueChange={(v) => {
+                    const next = v as LearnerSourceMode;
+                    if (editingIndex !== null && next !== 'manual') {
+                        setEditingIndex(null);
+                    }
+                    setMode(next);
+                }}
+            >
                 <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:flex sm:h-9 sm:gap-0">
                     <TabsTrigger value="search" className="min-w-0 justify-center text-xs sm:flex-1 sm:text-sm">
                         <MagnifyingGlass size={14} className="mr-1.5 shrink-0" />
@@ -204,7 +259,12 @@ export const Step1LearnerSelector = ({
 
                 {/* TAB: Manual entry */}
                 <TabsContent value="manual" className="mt-4">
-                    <ManualUserEntry onAdd={addNewUsers} />
+                    <ManualUserEntry
+                        onAdd={addNewUsers}
+                        editingRow={editingRow}
+                        onEditSave={handleEditSave}
+                        onEditCancel={handleEditCancel}
+                    />
                 </TabsContent>
             </Tabs>
         </div>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/CsvUserImporter.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/CsvUserImporter.tsx
@@ -9,6 +9,7 @@ import {
     CustomField,
     CustomFieldSettingsData,
 } from '@/services/custom-field-settings';
+import { useUserIdentifierSetting } from '@/services/user-identifier-setting';
 import { parse, isValid } from 'date-fns';
 
 // ─── System field definitions ───────────────────────────────────
@@ -32,10 +33,10 @@ interface CsvColumnDef {
 // address_line and pin_code are included here (not in OPTIONAL) because
 // ADDRESS_LINE and PIN_CODE don't exist in DEFAULT_SYSTEM_FIELDS, so
 // the visibility gate would permanently hide them from the CSV template.
-const CORE_COLUMNS: CsvColumnDef[] = [
-    { csvKey: 'email', label: 'Email', required: true, sample: 'student@example.com' },
+const buildCoreColumns = (phoneRequired: boolean): CsvColumnDef[] => [
+    { csvKey: 'email', label: 'Email', required: !phoneRequired, sample: 'student@example.com' },
     { csvKey: 'full_name', label: 'Full Name', required: true, sample: 'John Doe' },
-    { csvKey: 'mobile_number', label: 'Mobile Number', required: false, sample: '+91 9876543210', systemKey: 'MOBILE_NUMBER' },
+    { csvKey: 'mobile_number', label: 'Mobile Number', required: phoneRequired, sample: '+91 9876543210', systemKey: 'MOBILE_NUMBER' },
     { csvKey: 'username', label: 'Username', required: false, sample: '' },
     { csvKey: 'password', label: 'Password', required: false, sample: '' },
     { csvKey: 'address_line', label: 'Address', required: false, sample: '' },
@@ -77,6 +78,8 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
     const [settings, setSettings] = useState<CustomFieldSettingsData | null>(
         () => getCustomFieldSettingsFromCache()
     );
+    const { data: userIdentifier } = useUserIdentifierSetting();
+    const phoneRequired = userIdentifier === 'PHONE';
 
     // If cache is empty (e.g. after settings save invalidates it), fetch
     // from API so the template still includes custom fields.
@@ -100,7 +103,7 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
         }
 
         // Core columns are always included
-        const cols: CsvColumnDef[] = [...CORE_COLUMNS];
+        const cols: CsvColumnDef[] = [...buildCoreColumns(phoneRequired)];
 
         // Add optional system columns if they're visible (or if no settings exist, include all)
         for (const col of OPTIONAL_SYSTEM_COLUMNS) {
@@ -133,7 +136,7 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
         }
 
         return { allColumns: cols, customFieldColumns: cfCols };
-    }, [settings]);
+    }, [settings, phoneRequired]);
 
     const REQUIRED_HEADERS = allColumns.filter((c) => c.required).map((c) => c.csvKey);
 
@@ -177,9 +180,16 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
 
                 result.data.forEach((row, i) => {
                     const rowNum = i + 2;
-                    if (!row.email?.trim()) {
-                        errs.push(`Row ${rowNum}: email is required`);
-                        return;
+                    if (phoneRequired) {
+                        if (!row.mobile_number?.trim()) {
+                            errs.push(`Row ${rowNum}: mobile_number is required`);
+                            return;
+                        }
+                    } else {
+                        if (!row.email?.trim()) {
+                            errs.push(`Row ${rowNum}: email is required`);
+                            return;
+                        }
                     }
                     if (!row.full_name?.trim()) {
                         errs.push(`Row ${rowNum}: full_name is required`);
@@ -213,7 +223,7 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
                     }
 
                     rows.push({
-                        email: row.email.trim(),
+                        email: row.email?.trim() || '',
                         full_name: row.full_name.trim(),
                         mobile_number: row.mobile_number?.trim() || undefined,
                         username: row.username?.trim() || undefined,
@@ -302,7 +312,9 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
                     <p className="text-sm font-medium text-neutral-700">Download Template</p>
                     <p className="text-xs text-neutral-400">
                         Fill in the template and re-upload. Required columns:{' '}
-                        <code className="text-primary-600">email, full_name</code>
+                        <code className="text-primary-600">
+                            {phoneRequired ? 'mobile_number, full_name' : 'email, full_name'}
+                        </code>
                         {extraColCount > 0 && (
                             <span>
                                 {' '}
@@ -384,7 +396,7 @@ export const CsvUserImporter = ({ onImport, onPaymentInfoDetected }: Props) => {
                     <div className="max-h-36 overflow-y-auto">
                         {preview.slice(0, 5).map((r, i) => (
                             <p key={i} className="text-xs text-success-600">
-                                {r.full_name} — {r.email}
+                                {r.full_name} — {r.email || r.mobile_number}
                                 {r.custom_field_values && r.custom_field_values.length > 0 && (
                                     <span className="text-success-400">
                                         {' '}

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import PhoneInput from 'react-phone-input-2';
@@ -9,13 +9,17 @@ import { NewUserRow, CustomFieldValue } from '../../../-types/bulk-assign-types'
 import {
     getCustomFieldSettingsFromCache,
     CustomField,
-    SystemField,
 } from '@/services/custom-field-settings';
+import { useUserIdentifierSetting } from '@/services/user-identifier-setting';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
 interface Props {
     onAdd: (rows: NewUserRow[]) => void;
+    /** When provided, renders a single pre-filled row in edit mode. */
+    editingRow?: NewUserRow;
+    onEditSave?: (row: NewUserRow) => void;
+    onEditCancel?: () => void;
 }
 
 // Internal row state (extends NewUserRow with a custom_fields Record for easy editing)
@@ -66,6 +70,63 @@ const emptyRow = (): EditableRow => ({
     custom_fields: {},
     expanded: false,
 });
+
+const rowFromNewUser = (u: NewUserRow): EditableRow => {
+    const cf: Record<string, string> = {};
+    for (const v of u.custom_field_values || []) cf[v.custom_field_id] = v.value;
+    return {
+        email: u.email || '',
+        full_name: u.full_name || '',
+        mobile_number: u.mobile_number || '',
+        username: u.username || '',
+        password: u.password || '',
+        gender: u.gender || '',
+        date_of_birth: u.date_of_birth || '',
+        address_line: u.address_line || '',
+        city: u.city || '',
+        region: u.region || '',
+        pin_code: u.pin_code || '',
+        fathers_name: u.fathers_name || '',
+        mothers_name: u.mothers_name || '',
+        parents_mobile_number: u.parents_mobile_number || '',
+        parents_email: u.parents_email || '',
+        parents_to_mother_mobile_number: u.parents_to_mother_mobile_number || '',
+        parents_to_mother_email: u.parents_to_mother_email || '',
+        linked_institute_name: u.linked_institute_name || '',
+        custom_fields: cf,
+        expanded: true,
+    };
+};
+
+const editableRowToNewUser = (r: EditableRow): NewUserRow => {
+    const cfValues: CustomFieldValue[] = [];
+    for (const [cfId, val] of Object.entries(r.custom_fields)) {
+        if (val?.trim()) {
+            cfValues.push({ custom_field_id: cfId, value: val.trim() });
+        }
+    }
+    return {
+        email: r.email.trim(),
+        full_name: r.full_name.trim(),
+        mobile_number: r.mobile_number?.trim() || undefined,
+        username: r.username?.trim() || undefined,
+        password: r.password?.trim() || undefined,
+        gender: r.gender?.trim() || undefined,
+        date_of_birth: r.date_of_birth?.trim() || undefined,
+        address_line: r.address_line?.trim() || undefined,
+        city: r.city?.trim() || undefined,
+        region: r.region?.trim() || undefined,
+        pin_code: r.pin_code?.trim() || undefined,
+        fathers_name: r.fathers_name?.trim() || undefined,
+        mothers_name: r.mothers_name?.trim() || undefined,
+        parents_mobile_number: r.parents_mobile_number?.trim() || undefined,
+        parents_email: r.parents_email?.trim() || undefined,
+        parents_to_mother_mobile_number: r.parents_to_mother_mobile_number?.trim() || undefined,
+        parents_to_mother_email: r.parents_to_mother_email?.trim() || undefined,
+        linked_institute_name: r.linked_institute_name?.trim() || undefined,
+        custom_field_values: cfValues.length > 0 ? cfValues : undefined,
+    };
+};
 
 // Map system field key → EditableRow field key + input type
 const SYSTEM_FIELD_MAP: Record<
@@ -132,10 +193,23 @@ interface VisibleSystemField {
     placeholder: string;
 }
 
-export const ManualUserEntry = ({ onAdd }: Props) => {
+export const ManualUserEntry = ({ onAdd, editingRow, onEditSave, onEditCancel }: Props) => {
     const learnerTerm = getTerminology(RoleTerms.Learner, SystemTerms.Learner);
-    const [rows, setRows] = useState<EditableRow[]>([emptyRow()]);
+    const isEditMode = !!editingRow;
+    const { data: userIdentifier } = useUserIdentifierSetting();
+    const phoneRequired = userIdentifier === 'PHONE';
+
+    const [rows, setRows] = useState<EditableRow[]>(() =>
+        editingRow ? [rowFromNewUser(editingRow)] : [emptyRow()],
+    );
     const [submitted, setSubmitted] = useState(false);
+
+    // Reset form whenever edit target changes — entering edit (load row),
+    // switching edit target (reload row), or exiting edit (back to empty add).
+    useEffect(() => {
+        setRows(editingRow ? [rowFromNewUser(editingRow)] : [emptyRow()]);
+        setSubmitted(false);
+    }, [editingRow]);
 
     // ─── Compute dynamic fields from institute settings ────
     const { visibleSystemFields, enrollmentCustomFields } = useMemo(() => {
@@ -201,50 +275,33 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
     const removeRow = (idx: number) =>
         setRows((prev) => (prev.length === 1 ? prev : prev.filter((_, i) => i !== idx)));
 
-    const validate = (row: EditableRow) => row.email.trim() && row.full_name.trim();
+    const validate = (row: EditableRow) => {
+        if (!row.full_name.trim()) return false;
+        if (phoneRequired) {
+            return !!row.mobile_number?.trim();
+        }
+        return !!row.email.trim();
+    };
 
     const handleAdd = () => {
         setSubmitted(true);
         const valid = rows.filter(validate);
         if (valid.length === 0) return;
 
-        onAdd(
-            valid.map((r): NewUserRow => {
-                // Build custom field values
-                const cfValues: CustomFieldValue[] = [];
-                for (const [cfId, val] of Object.entries(r.custom_fields)) {
-                    if (val?.trim()) {
-                        cfValues.push({ custom_field_id: cfId, value: val.trim() });
-                    }
-                }
-
-                return {
-                    email: r.email.trim(),
-                    full_name: r.full_name.trim(),
-                    mobile_number: r.mobile_number?.trim() || undefined,
-                    username: r.username?.trim() || undefined,
-                    password: r.password?.trim() || undefined,
-                    gender: r.gender?.trim() || undefined,
-                    date_of_birth: r.date_of_birth?.trim() || undefined,
-                    address_line: r.address_line?.trim() || undefined,
-                    city: r.city?.trim() || undefined,
-                    region: r.region?.trim() || undefined,
-                    pin_code: r.pin_code?.trim() || undefined,
-                    fathers_name: r.fathers_name?.trim() || undefined,
-                    mothers_name: r.mothers_name?.trim() || undefined,
-                    parents_mobile_number: r.parents_mobile_number?.trim() || undefined,
-                    parents_email: r.parents_email?.trim() || undefined,
-                    parents_to_mother_mobile_number:
-                        r.parents_to_mother_mobile_number?.trim() || undefined,
-                    parents_to_mother_email: r.parents_to_mother_email?.trim() || undefined,
-                    linked_institute_name: r.linked_institute_name?.trim() || undefined,
-                    custom_field_values: cfValues.length > 0 ? cfValues : undefined,
-                };
-            })
-        );
+        onAdd(valid.map(editableRowToNewUser));
         setRows([emptyRow()]);
         setSubmitted(false);
     };
+
+    const handleEditSave = () => {
+        setSubmitted(true);
+        const row = rows[0];
+        if (!row || !validate(row)) return;
+        onEditSave?.(editableRowToNewUser(row));
+    };
+
+    const emailLabel = phoneRequired ? 'Email (optional)' : 'Email';
+    const mobileLabel = phoneRequired ? 'Mobile' : 'Mobile (optional)';
 
     return (
         <div className="flex flex-col gap-4">
@@ -256,7 +313,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                     >
                         <div className="mb-2 flex items-center justify-between">
                             <span className="text-xs font-semibold text-neutral-500">
-                                {learnerTerm} #{idx + 1}
+                                {isEditMode ? `Edit ${learnerTerm}` : `${learnerTerm} #${idx + 1}`}
                             </span>
                             <div className="flex items-center gap-2">
                                 {hasExtraFields && (
@@ -275,7 +332,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                                         )}
                                     </button>
                                 )}
-                                {rows.length > 1 && (
+                                {!isEditMode && rows.length > 1 && (
                                     <button
                                         onClick={() => removeRow(idx)}
                                         className="text-neutral-400 hover:text-danger-500 transition-colors"
@@ -290,7 +347,8 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                             <div>
                                 <Label className="mb-1 text-xs text-neutral-500">
-                                    Email <span className="text-danger-500">*</span>
+                                    {emailLabel}
+                                    {!phoneRequired && <span className="text-danger-500"> *</span>}
                                 </Label>
                                 <Input
                                     type="email"
@@ -298,7 +356,7 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                                     value={row.email}
                                     onChange={(e) => update(idx, 'email', e.target.value)}
                                     className={
-                                        submitted && !row.email.trim()
+                                        submitted && !phoneRequired && !row.email.trim()
                                             ? 'border-danger-400'
                                             : ''
                                     }
@@ -321,7 +379,8 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                             </div>
                             <div>
                                 <Label className="mb-1 text-xs text-neutral-500">
-                                    Mobile (optional)
+                                    {mobileLabel}
+                                    {phoneRequired && <span className="text-danger-500"> *</span>}
                                 </Label>
                                 <PhoneInput
                                     country="in"
@@ -331,7 +390,11 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                                     onChange={(value) =>
                                         update(idx, 'mobile_number', value)
                                     }
-                                    inputClass="!w-full h-7"
+                                    inputClass={`!w-full h-7 ${
+                                        submitted && phoneRequired && !row.mobile_number?.trim()
+                                            ? '!border-danger-400'
+                                            : ''
+                                    }`}
                                     inputProps={{ name: `mobile_number_${idx}` }}
                                 />
                             </div>
@@ -441,25 +504,46 @@ export const ManualUserEntry = ({ onAdd }: Props) => {
                 ))}
             </div>
 
-            <div className="flex items-center gap-3">
-                <button
-                    onClick={addRow}
-                    className="flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 transition-colors"
-                >
-                    <Plus size={14} />
-                    Add another learner
-                </button>
-                <div className="flex-1" />
-                <MyButton
-                    buttonType="primary"
-                    scale="medium"
-                    layoutVariant="default"
-                    onClick={handleAdd}
-                >
-                    Add {rows.filter(validate).length} learner
-                    {rows.filter(validate).length !== 1 ? 's' : ''}
-                </MyButton>
-            </div>
+            {isEditMode ? (
+                <div className="flex items-center justify-end gap-2">
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        layoutVariant="default"
+                        onClick={onEditCancel}
+                    >
+                        Cancel
+                    </MyButton>
+                    <MyButton
+                        buttonType="primary"
+                        scale="medium"
+                        layoutVariant="default"
+                        onClick={handleEditSave}
+                    >
+                        Save changes
+                    </MyButton>
+                </div>
+            ) : (
+                <div className="flex items-center gap-3">
+                    <button
+                        onClick={addRow}
+                        className="flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 transition-colors"
+                    >
+                        <Plus size={14} />
+                        Add another learner
+                    </button>
+                    <div className="flex-1" />
+                    <MyButton
+                        buttonType="primary"
+                        scale="medium"
+                        layoutVariant="default"
+                        onClick={handleAdd}
+                    >
+                        Add {rows.filter(validate).length} learner
+                        {rows.filter(validate).length !== 1 ? 's' : ''}
+                    </MyButton>
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend-admin-dashboard/src/routes/settings/-components/UserIdentifierSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/UserIdentifierSettings.tsx
@@ -2,47 +2,20 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { MyButton } from '@/components/design-system/button';
-import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
-import { GET_INSITITUTE_SETTINGS } from '@/constants/urls';
-import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
-
-const SAVE_SETTING_URL = GET_INSITITUTE_SETTINGS.replace('/get', '/save-setting');
-const SETTING_KEY = 'USER_IDENTIFIER';
-
-type UserIdentifier = 'EMAIL' | 'PHONE';
-
-const fetchUserIdentifierSetting = async (): Promise<UserIdentifier> => {
-    const instituteId = getCurrentInstituteId();
-    const response = await authenticatedAxiosInstance({
-        method: 'GET',
-        url: GET_INSITITUTE_SETTINGS,
-        params: { instituteId, settingKey: SETTING_KEY },
-    });
-    // response.data is SettingDto; .data is the stored value string
-    const val = response.data?.data;
-    return val === 'PHONE' ? 'PHONE' : 'EMAIL';
-};
-
-const saveUserIdentifierSetting = async (identifier: UserIdentifier): Promise<void> => {
-    const instituteId = getCurrentInstituteId();
-    await authenticatedAxiosInstance.post(
-        SAVE_SETTING_URL,
-        { setting_name: 'User Identifier Setting', setting_data: identifier },
-        { params: { instituteId, settingKey: SETTING_KEY } },
-    );
-};
+import {
+    UserIdentifier,
+    saveUserIdentifierSetting,
+    useUserIdentifierSetting,
+    userIdentifierQueryKey,
+} from '@/services/user-identifier-setting';
 
 export default function UserIdentifierSettings() {
     const queryClient = useQueryClient();
 
-    const { data: savedIdentifier, isLoading } = useQuery({
-        queryKey: ['user-identifier-setting'],
-        queryFn: fetchUserIdentifierSetting,
-        staleTime: 5 * 60 * 1000,
-    });
+    const { data: savedIdentifier, isLoading } = useUserIdentifierSetting();
 
     const [selected, setSelected] = useState<UserIdentifier>('EMAIL');
 
@@ -54,7 +27,7 @@ export default function UserIdentifierSettings() {
         mutationFn: saveUserIdentifierSetting,
         onSuccess: () => {
             toast.success('User identifier setting saved successfully');
-            queryClient.invalidateQueries({ queryKey: ['user-identifier-setting'] });
+            queryClient.invalidateQueries({ queryKey: userIdentifierQueryKey() });
         },
         onError: (error: any) => {
             toast.error(error?.response?.data?.message || 'Failed to save setting');

--- a/frontend-admin-dashboard/src/services/user-identifier-setting.ts
+++ b/frontend-admin-dashboard/src/services/user-identifier-setting.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { GET_INSITITUTE_SETTINGS, SAVE_INSTITUTE_SETTING } from '@/constants/urls';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+
+export type UserIdentifier = 'EMAIL' | 'PHONE';
+
+const SETTING_KEY = 'USER_IDENTIFIER';
+
+export const fetchUserIdentifierSetting = async (
+    instituteId?: string,
+): Promise<UserIdentifier> => {
+    const resolvedInstituteId = instituteId || getCurrentInstituteId();
+    const response = await authenticatedAxiosInstance({
+        method: 'GET',
+        url: GET_INSITITUTE_SETTINGS,
+        params: { instituteId: resolvedInstituteId, settingKey: SETTING_KEY },
+    });
+    const val = response.data?.data;
+    return val === 'PHONE' ? 'PHONE' : 'EMAIL';
+};
+
+export const saveUserIdentifierSetting = async (identifier: UserIdentifier): Promise<void> => {
+    const instituteId = getCurrentInstituteId();
+    await authenticatedAxiosInstance.post(
+        SAVE_INSTITUTE_SETTING,
+        { setting_name: 'User Identifier Setting', setting_data: identifier },
+        { params: { instituteId, settingKey: SETTING_KEY } },
+    );
+};
+
+export const userIdentifierQueryKey = (instituteId?: string | null) => [
+    'user-identifier-setting',
+    instituteId || getCurrentInstituteId(),
+];
+
+export const useUserIdentifierSetting = (instituteId?: string) => {
+    return useQuery({
+        queryKey: userIdentifierQueryKey(instituteId),
+        queryFn: () => fetchUserIdentifierSetting(instituteId),
+        staleTime: 5 * 60 * 1000,
+    });
+};


### PR DESCRIPTION
## Summary of Changes

Two related changes to the bulk-enroll "Enroll Customer" wizard's Step 1 (Select Customers), plus the backend hardening required to make phone-identifier institutes actually work end-to-end.

Previously: Email was hardcoded as required and Mobile as optional in the manual entry form and CSV importer — regardless of the institute's `USER_IDENTIFIER` setting. Added new-user chips had no way to be edited; only removed. And on the backend, the welcome-email path for new learners had no null guard on `setTo(user.getEmail())`, so a phone-only learner (no email) would fail the email send inside a `@Transactional` block — silently rolling back the user creation.

Now: Step 1 honors the institute's `USER_IDENTIFIER` setting for the required-field marker, added new-user chips have a pencil icon that loads the row back into the same Manual entry form for editing, and the backend `createUserForLearnerEnrollment` flow correctly handles learners without an email on file.

**Backend:**
- `auth_service/AuthService.createUserForLearnerEnrollment` — welcome-email send now wrapped in try/catch with error log. Email is a side effect; failures must never roll back the user creation or undo newly assigned roles. `@Slf4j` added to the class.
- `auth_service/AuthService.sendLearnerEnrollmentNewUserEmail` — early return + warn log when `user.getEmail()` is blank (was previously `setTo(null)` → notification pipeline would fail or silently drop, with the failure rolling back the surrounding transaction).
- `auth_service/AuthService.sendLearnerEnrollmentExistingUserEmail` — replaced the `throw new IllegalArgumentException("User or user email must not be null")` with the same skip-with-warn pattern, so the existing-user path can't poison the caller's transaction either.
- `admin_core_service/BulkAssignmentService.createNewUser` — username fallback rewritten as an explicit `caller-supplied → email → null` cascade so phone-only rows pass `null` and let auth-service generate a username from `full_name` (was previously passing email verbatim, which is empty for phone-only institutes).
- `admin_core_service/BulkAssignmentService` — new `describeNewUser()` and `dryRunPlaceholderId()` helpers. The dry-run placeholder id is now `dry-run-new-{index}-{email|mobile|"row"}` so several phone-only rows in one batch don't collide on the same `"dry-run-new-null"` key. Log/error messages use the new identifier helper instead of `newUser.getEmail()` directly.

**Frontend:**
- Extracted `useUserIdentifierSetting()` hook + shared service in `src/services/user-identifier-setting.ts`. Refactored the existing `UserIdentifierSettings` settings card to use it (no behavior change). Cached for 5 min via TanStack Query.
- `ManualUserEntry`: both Email and Mobile fields remain visible regardless of identifier; only the `*` required marker, `(optional)` suffix, and `validate()` flip between `email` and `mobile_number`.
- `CsvUserImporter`: when `USER_IDENTIFIER=PHONE`, the template marks `mobile_number` as required instead of `email`, row-level validation message swaps accordingly, and the help text + preview line adapt.
- `Step1LearnerSelector`: pencil icon on `type:'new'` chips opens the row in the Manual entry form (force-switches to that tab). Chip turns warning-colored with `(editing…)` label while being edited. Save updates the chip in place; Cancel discards. Existing-user chips (from Search Existing / From Book) stay remove-only since their data lives in the backend. Switching to a non-Manual tab cancels the edit. `ManualUserEntry` gains optional `editingRow` / `onEditSave` / `onEditCancel` props; backward-compatible.

## Related Issue

_None_

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

Frontend:
- Set `USER_IDENTIFIER=EMAIL` in Course Settings → "Enroll Customer" wizard → Email shows `*`, Mobile shows `(optional)` in both Manual and CSV tabs.
- Set `USER_IDENTIFIER=PHONE` → Email shows `(optional)`, Mobile shows `*`; submitting without a mobile shows red border / row-level error.
- Added a learner via Manual → chip → pencil → form loads with pre-filled values → modified Full Name → Save changes → chip updates in place (no duplicate).
- Edit + Cancel → chip restored to original; form returns to empty add mode.
- Started edit, then switched to Search Existing tab → edit auto-cancelled cleanly.
- Existing-user chips show no pencil — only X.
- Settings page save/load still works after the hook refactor.
- `npx tsc --noEmit` passes.

Backend:
- `mvn compiler:compile` on `auth_service` and `admin_core_service` — both BUILD SUCCESS (after a fresh `common_service` install for transitive deps).
- Reviewed the v3/assign flow end-to-end: `BulkLearnerManagementController` → `BulkAssignmentService.bulkAssign` → `BulkAssignmentService.createNewUser` → `AuthService.createUserFromAuthServiceForLearnerEnrollment` → `auth_service` `UserController.createOrGetExistingLearner` → `AuthService.createUserForLearnerEnrollment`. Confirmed that with `USER_IDENTIFIER=PHONE` the lookup uses `findLatestUserByMobileNumber` first (no email fallback), username auto-generates from `full_name` when blank, and the email column stays nullable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
