### PR TITLE
Force-refresh role display settings on course pages so admin toggles …

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/-components/authored-courses-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/-components/authored-courses-tab.tsx
@@ -200,14 +200,15 @@ export const AuthoredCoursesTab: React.FC<AuthoredCoursesTabProps> = ({
     const [roleDisplay, setRoleDisplay] = useState<DisplaySettingsData | null>(null);
     useEffect(() => {
         const roleKey = getActiveRoleDisplaySettingsKey();
-        const cached = getDisplaySettingsFromCache(roleKey);
-        if (cached) {
-            setRoleDisplay(cached);
-            return;
-        }
-        getDisplaySettings(roleKey)
+        // Force-refresh on mount so admin policy changes (Course Permission
+        // toggles) take effect on the next page load without waiting for
+        // the 24h localStorage TTL.
+        getDisplaySettings(roleKey, true)
             .then(setRoleDisplay)
-            .catch(() => setRoleDisplay(null));
+            .catch(() => {
+                const cached = getDisplaySettingsFromCache(roleKey);
+                setRoleDisplay(cached ?? null);
+            });
     }, []);
     const cardSettings = roleDisplay?.authoredCoursesCard;
     const allowDirectEditPublished =

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
@@ -1138,14 +1138,17 @@ export const CourseDetailsPage = () => {
     );
     useEffect(() => {
         const roleKeyInner = getActiveRoleDisplaySettingsKey();
-        const cached = getDisplaySettingsFromCache(roleKeyInner);
-        if (cached) {
-            setRoleDisplay(cached);
-            return;
-        }
-        getDisplaySettings(roleKeyInner)
+        // Always force-refresh on mount so admin policy changes
+        // (e.g. directEditPublishedCourse) take effect on the next page load
+        // without waiting for the 24h localStorage TTL to expire.
+        getDisplaySettings(roleKeyInner, true)
             .then(setRoleDisplay)
-            .catch(() => setRoleDisplay(null));
+            .catch(() => {
+                // On failure, fall back to whatever is cached so the page
+                // still renders something sensible.
+                const cached = getDisplaySettingsFromCache(roleKeyInner);
+                if (cached) setRoleDisplay(cached);
+            });
     }, []);
     const coursePage = roleDisplay?.coursePage;
     const allowDirectEditPublished = coursePage?.directEditPublishedCourse === true;

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
@@ -326,14 +326,15 @@ export const CourseStructureDetails = ({
         try {
             // Use getActiveRoleDisplaySettingsKey which handles ADMIN, TEACHER, and custom roles (faculty)
             const roleKeyInner = getActiveRoleDisplaySettingsKey();
-            const cached = getDisplaySettingsFromCache(roleKeyInner);
-            if (cached) {
-                setRoleDisplay(cached);
-            } else {
-                getDisplaySettings(roleKeyInner)
-                    .then(setRoleDisplay)
-                    .catch(() => setRoleDisplay(null));
-            }
+            // Force-refresh on mount so admin policy changes (Course Permission
+            // toggles) take effect on the next page load without waiting for
+            // the 24h localStorage TTL.
+            getDisplaySettings(roleKeyInner, true)
+                .then(setRoleDisplay)
+                .catch(() => {
+                    const cached = getDisplaySettingsFromCache(roleKeyInner);
+                    setRoleDisplay(cached ?? null);
+                });
         } catch {
             setRoleDisplay(null);
         }


### PR DESCRIPTION
## Summary of Changes

- Force-refresh role display settings on course pages so admin toggles take effect immediately


## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
