### PR TITLE
fix(offer-pricing): admin-configurable whole-unit rounding + isolate …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/utils/InstituteSettingUtils.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/utils/InstituteSettingUtils.java
@@ -41,4 +41,36 @@ public class InstituteSettingUtils {
 
         return false;
     }
+
+    /**
+     * Returns the admin-configured rounding mode for offer pricing.
+     * Reads COURSE_SETTING.data.offerPricing.rounding from institute setting_json.
+     * Falls back to "NONE" (keep computed decimals) when absent or unparseable.
+     *
+     * Recognized values: "NONE", "CEIL", "FLOOR". Unknown values fall back to "NONE".
+     */
+    public static String getOfferPricingRounding(String json) {
+        if (!StringUtils.hasText(json)) {
+            return "NONE";
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            InstituteSettingDto instituteSettingDto = mapper.readValue(json, InstituteSettingDto.class);
+            if (instituteSettingDto.getSetting() == null) return "NONE";
+
+            SettingDto courseSetting = instituteSettingDto.getSetting().get("COURSE_SETTING");
+            if (courseSetting == null || courseSetting.getData() == null) return "NONE";
+
+            JsonNode dataNode = mapper.convertValue(courseSetting.getData(), JsonNode.class);
+            JsonNode offerPricing = dataNode.get("offerPricing");
+            if (offerPricing == null || !offerPricing.has("rounding")) return "NONE";
+
+            String value = offerPricing.get("rounding").asText("NONE");
+            if ("CEIL".equalsIgnoreCase(value)) return "CEIL";
+            if ("FLOOR".equalsIgnoreCase(value)) return "FLOOR";
+            return "NONE";
+        } catch (Exception e) {
+            return "NONE";
+        }
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanMarkdownService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanMarkdownService.java
@@ -8,6 +8,8 @@ import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.enroll_invite.entity.PackageSessionLearnerInvitationToPaymentOption;
 import vacademy.io.admin_core_service.features.enroll_invite.repository.PackageSessionLearnerInvitationToPaymentOptionRepository;
+import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
+import vacademy.io.admin_core_service.features.institute.utils.InstituteSettingUtils;
 import vacademy.io.admin_core_service.features.user_subscription.dto.markdown.ApplyMarkdownRequestDTO;
 import vacademy.io.admin_core_service.features.user_subscription.dto.markdown.MarkdownErrorCode;
 import vacademy.io.admin_core_service.features.user_subscription.dto.markdown.MarkdownLookupItemDTO;
@@ -23,6 +25,7 @@ import vacademy.io.admin_core_service.features.user_subscription.enums.PaymentOp
 import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentPlanRepository;
 import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.common.institute.entity.Institute;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,16 +60,18 @@ public class PaymentPlanMarkdownService {
 
     private final PackageSessionLearnerInvitationToPaymentOptionRepository psLinkRepository;
     private final PaymentPlanRepository paymentPlanRepository;
+    private final InstituteRepository instituteRepository;
 
     @Transactional
     public MarkdownResponseDTO applyMarkdown(ApplyMarkdownRequestDTO request, CustomUserDetails user) {
         validateApplyRequest(request);
         MarkdownMode mode = MarkdownMode.fromString(request.getMode());
         double value = request.getValue();
+        String roundingMode = resolveRoundingMode(request.getInstituteId());
         return process(
                 request.getInstituteId(),
                 request.getPackageSessionIds(),
-                plan -> computeMarkdownPrice(plan, mode, value));
+                plan -> computeMarkdownPrice(plan, mode, value, roundingMode));
     }
 
     @Transactional
@@ -311,29 +316,51 @@ public class PaymentPlanMarkdownService {
         return map;
     }
 
-    private double computeMarkdownPrice(PaymentPlan plan, MarkdownMode mode, double value) {
+    private double computeMarkdownPrice(PaymentPlan plan, MarkdownMode mode, double value, String roundingMode) {
         if (Double.isNaN(value) || Double.isInfinite(value)) {
             throw new IllegalArgumentException("Value must be a finite number.");
         }
         double elevated = plan.getElevatedPrice();
+        double raw;
         if (mode == MarkdownMode.PERCENT) {
             if (value < 0 || value > 100) {
                 throw new IllegalArgumentException("Percent must be between 0 and 100 (got " + value + ").");
             }
-            return roundTo2(elevated * (1.0 - value / 100.0));
+            raw = elevated * (1.0 - value / 100.0);
+        } else {
+            if (value < 0) {
+                throw new IllegalArgumentException("Absolute price must be >= 0 (got " + value + ").");
+            }
+            if (value > elevated) {
+                throw new IllegalArgumentException(
+                        "New price (" + value + ") must not exceed elevated price (" + elevated + ").");
+            }
+            raw = value;
         }
-        if (value < 0) {
-            throw new IllegalArgumentException("Absolute price must be >= 0 (got " + value + ").");
-        }
-        if (value > elevated) {
-            throw new IllegalArgumentException(
-                    "New price (" + value + ") must not exceed elevated price (" + elevated + ").");
-        }
-        return roundTo2(value);
+        return applyRounding(roundTo2(raw), roundingMode);
     }
 
     private static double roundTo2(double v) {
         return Math.round(v * 100.0) / 100.0;
+    }
+
+    /**
+     * Apply the institute's configured whole-unit rounding on top of the 2dp baseline.
+     * CEIL/FLOOR round to the nearest whole currency unit (₹1, $1, etc.);
+     * NONE keeps the 2dp value as-is.
+     */
+    private static double applyRounding(double v, String roundingMode) {
+        if ("CEIL".equals(roundingMode)) return Math.ceil(v);
+        if ("FLOOR".equals(roundingMode)) return Math.floor(v);
+        return v;
+    }
+
+    private String resolveRoundingMode(String instituteId) {
+        if (!StringUtils.hasText(instituteId)) return "NONE";
+        return instituteRepository.findById(instituteId)
+                .map(Institute::getSetting)
+                .map(InstituteSettingUtils::getOfferPricingRounding)
+                .orElse("NONE");
     }
 
     private static void fail(MarkdownResultDTO r, MarkdownErrorCode code, String message) {

--- a/frontend-admin-dashboard/src/routes/settings/-components/Course/OfferPricingCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Course/OfferPricingCard.tsx
@@ -1,7 +1,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { OfferPricingSettings } from '@/types/course-settings';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { OfferPricingSettings, OfferPriceRoundingMode } from '@/types/course-settings';
 import { Tag, Info } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
@@ -23,8 +24,13 @@ export const OfferPricingCard: React.FC<OfferPricingCardProps> = ({ settings, on
         onUpdate({ ...settings, enabled });
     };
 
+    const handleRoundingChange = (value: string) => {
+        onUpdate({ ...settings, rounding: value as OfferPriceRoundingMode });
+    };
+
     const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
     const coursesTerm = getTerminologyPlural(ContentTerms.Course, SystemTerms.Course).toLowerCase();
+    const rounding: OfferPriceRoundingMode = settings.rounding ?? 'NONE';
 
     return (
         <Card>
@@ -46,7 +52,7 @@ export const OfferPricingCard: React.FC<OfferPricingCardProps> = ({ settings, on
                     </div>
                 </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-4">
                 <Alert>
                     <Info className="size-4" />
                     <AlertDescription>
@@ -55,6 +61,49 @@ export const OfferPricingCard: React.FC<OfferPricingCardProps> = ({ settings, on
                         management page.
                     </AlertDescription>
                 </Alert>
+
+                {settings.enabled && (
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium">Offer price rounding</Label>
+                        <p className="text-xs text-neutral-500">
+                            Round the discounted price to a whole unit (₹1, $1, etc.). Applies to
+                            the price saved when an offer is applied — regardless of currency.
+                        </p>
+                        <RadioGroup
+                            value={rounding}
+                            onValueChange={handleRoundingChange}
+                            className="flex flex-col gap-2 pt-1"
+                        >
+                            <div className="flex items-center gap-2">
+                                <RadioGroupItem value="NONE" id="offer-rounding-none" />
+                                <Label
+                                    htmlFor="offer-rounding-none"
+                                    className="cursor-pointer font-normal"
+                                >
+                                    Off (keep decimals as computed)
+                                </Label>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <RadioGroupItem value="CEIL" id="offer-rounding-ceil" />
+                                <Label
+                                    htmlFor="offer-rounding-ceil"
+                                    className="cursor-pointer font-normal"
+                                >
+                                    Round up (e.g. 479.20 → 480)
+                                </Label>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <RadioGroupItem value="FLOOR" id="offer-rounding-floor" />
+                                <Label
+                                    htmlFor="offer-rounding-floor"
+                                    className="cursor-pointer font-normal"
+                                >
+                                    Round down (e.g. 479.80 → 479)
+                                </Label>
+                            </div>
+                        </RadioGroup>
+                    </div>
+                )}
             </CardContent>
         </Card>
     );

--- a/frontend-admin-dashboard/src/services/course-settings.ts
+++ b/frontend-admin-dashboard/src/services/course-settings.ts
@@ -303,6 +303,7 @@ export const mergeWithDefaults = (settings: Partial<CourseSettingsData>): Course
         },
         offerPricing: {
             enabled: settings.offerPricing?.enabled ?? false,
+            rounding: settings.offerPricing?.rounding ?? 'NONE',
         },
     };
 };

--- a/frontend-admin-dashboard/src/types/course-settings.ts
+++ b/frontend-admin-dashboard/src/types/course-settings.ts
@@ -111,8 +111,11 @@ export interface DripConditionsSettings {
     conditions: DripCondition[];
 }
 
+export type OfferPriceRoundingMode = 'NONE' | 'CEIL' | 'FLOOR';
+
 export interface OfferPricingSettings {
     enabled: boolean; // Opt-in toggle for the per-course offer-price tool
+    rounding?: OfferPriceRoundingMode; // Whole-unit rounding applied to discounted price; default 'NONE'
 }
 
 export interface CourseSettingsData {
@@ -186,5 +189,6 @@ export const DEFAULT_COURSE_SETTINGS: CourseSettingsData = {
     },
     offerPricing: {
         enabled: false,
+        rounding: 'NONE',
     },
 };

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
@@ -726,7 +726,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                 return (
                   <div
                     key={book.id}
-                    className="group relative flex flex-col cursor-pointer perspective-1000   rounded-xl"
+                    className="group relative isolate flex flex-col cursor-pointer perspective-1000   rounded-xl"
 
                     onClick={() => handleBookClick(book)}
                   >


### PR DESCRIPTION
## Summary of Changes

Two unrelated-but-bundled fixes for the offer-pricing feature shipped on `feat/offer-price-implementation`:

1. **Decimal offer prices** — Applying a percentage markdown (e.g. 20% off 599) was producing `actual_price = 479.2` and persisting that to `payment_plan`. Added an admin-configurable rounding mode in Course Settings → Offer Pricing so admins can choose to round the discounted price up (CEIL), down (FLOOR), or keep decimals (NONE, default). The setting lives in `institutes.setting_json → COURSE_SETTING.data.offerPricing.rounding`; backend reads it once per markdown apply and rounds to a whole currency unit. Currency-agnostic — the admin owns the decision (a USD plan rounded with CEIL would also lose its decimals, which is the admin's intent when they flip the toggle).
2. **Store dropdown overlap on learner catalogue** — Book card overlays (offer badge, share button) were poking through the open store-picker dropdown because the card had `position: relative` without a stacking context, so its `z-20` absolute children escaped and out-stacked the store section's `z-10` parent. Added `isolate` to the card so its overlays stay contained.

**Backend:**
- `InstituteSettingUtils.getOfferPricingRounding(json)` — new helper, returns `"NONE" | "CEIL" | "FLOOR"`, defaults to `"NONE"` on missing key / parse failure.
- `PaymentPlanMarkdownService` — injects `InstituteRepository`, resolves the rounding mode once per `applyMarkdown` call, applies `Math.ceil` / `Math.floor` on top of the existing 2dp baseline. Reset path is untouched (it restores the elevated price, which was never massaged by the service).

**Frontend (admin):**
- New `OfferPriceRoundingMode = 'NONE' | 'CEIL' | 'FLOOR'` type; optional `rounding` field on `OfferPricingSettings` defaulting to `'NONE'`.
- `OfferPricingCard.tsx` — radio group shown only when offer pricing is enabled, three options (Off / Round up / Round down).
- `mergeWithDefaults` in `course-settings.ts` service preserves the field across cache hydration.

**Frontend (learner):**
- Added `isolate` to the book card outer div in `BookCatalogueComponent.tsx` so its `z-20` overlays no longer escape the card's stacking context.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Open Course Settings → Offer Pricing on an institute that has offer pricing enabled; confirm the rounding radio appears with three options and persists across save/reload.
- Confirm the rounding radio is hidden when the Offer Pricing toggle is off.
- With rounding = NONE: apply 20% markdown on a ₹599 plan; verify `payment_plan.actual_price = 479.2` (existing behavior).
- With rounding = CEIL: apply 20% markdown on a ₹599 plan; verify `payment_plan.actual_price = 480`.
- With rounding = FLOOR: apply the same; verify `payment_plan.actual_price = 479`.
- With rounding = CEIL: apply an ABSOLUTE markdown of `479.50`; verify it lands at `480` (rounding applies to absolute mode too).
- Reset markdown: confirm the plan returns to its original `elevated_price` regardless of rounding setting.
- On the learner catalogue page (readonrent.in), open the store picker dropdown over a book grid with at least one card showing the offer badge and share button on its row; confirm the dropdown menu is fully visible and no card overlay punches through.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
