### PR TITLE
Feat/buy mode shipping charges

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerDashBoardService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerDashBoardService.java
@@ -139,8 +139,22 @@ public class LearnerDashBoardService {
         List<String> validPackageSessionIds = (packageSessionId == null) ? List.of()
                 : packageSessionId.stream().filter(id -> id != null && !id.isBlank()).collect(java.util.stream.Collectors.toList());
 
+        // Count of user-visible packages — excludes internal types (DELIVERY_CHARGE,
+        // SECURITY_DEPOSIT) so the dashboard "books" count matches what the My Books
+        // widget renders. Filtering here (not in the repo) keeps the underlying query
+        // reusable by other callers that legitimately need internal types.
+        int visiblePackagesCount = packageRepository
+                .findDistinctPackagesByUserIdAndInstituteId(user.getUserId(), instituteId)
+                .stream()
+                .filter(p -> {
+                    String t = p.getPackageType();
+                    return t == null || (!"DELIVERY_CHARGE".equals(t) && !"SECURITY_DEPOSIT".equals(t));
+                })
+                .toList()
+                .size();
+
         return new LeanerDashBoardDetailDTO(
-                packageRepository.countDistinctPackagesByUserIdAndInstituteId(user.getUserId(), instituteId),
+                visiblePackagesCount,
                 0,
                 validPackageSessionIds.isEmpty() ? List.of() : slideRepository.findRecentIncompleteSlides(
                         user.getUserId(),

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/MultiPackageLearnerEnrollService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/MultiPackageLearnerEnrollService.java
@@ -112,6 +112,34 @@ public class MultiPackageLearnerEnrollService {
             paymentInit.setEmail(request.getUser().getEmail());
         }
 
+        // 0.3 Verify the client-supplied amount equals the sum of plan prices for
+        // every enrollment item. Closes the trust gap where any caller could submit
+        // an arbitrary `amount` for the v2 multi-package endpoint. Skipped for
+        // free/manual enrollments — those paths bypass payment entirely.
+        boolean willSkipPaymentVerification =
+                "MANUAL".equalsIgnoreCase(request.getEnrollmentType())
+                        || (paymentInit.getAmount() != null && paymentInit.getAmount() <= 0);
+        if (!willSkipPaymentVerification && paymentInit.getAmount() != null) {
+            double expectedSum = 0.0;
+            for (LearnerPackageSessionEnrollmentItemDTO item : items) {
+                if (!StringUtils.hasText(item.getPlanId())) {
+                    throw new VacademyException(
+                            "Each enrollment item must include a plan_id so the amount can be verified");
+                }
+                vacademy.io.admin_core_service.features.user_subscription.entity.PaymentPlan plan =
+                        paymentPlanService.findById(item.getPlanId()).orElseThrow(
+                                () -> new VacademyException("PaymentPlan not found: " + item.getPlanId()));
+                expectedSum += plan.getActualPrice();
+            }
+            double clientAmount = paymentInit.getAmount();
+            if (Math.abs(clientAmount - expectedSum) > 0.01) {
+                log.warn("Amount mismatch on multi-package enroll: client sent {}, expected {} (from {} plans)",
+                        clientAmount, expectedSum, items.size());
+                throw new VacademyException(String.format(
+                        "Payment amount mismatch: submitted %.2f, expected %.2f", clientAmount, expectedSum));
+            }
+        }
+
         // 1. Ensure a consistent OrderId for the entire multi-package transaction
         if (!StringUtils.hasText(paymentInit.getOrderId())) {
             // Generate Order ID that fits PhonePe's 38-character limit

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
@@ -79,8 +79,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             "AND ssgm.user_id = :userId " +
             "AND p.status != 'DELETED' " +
             "AND ps.status != 'DELETED' " +
-            "AND ssgm.status != 'DELETED' " +
-            "AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))", nativeQuery = true)
+            "AND ssgm.status != 'DELETED'", nativeQuery = true)
     List<PackageEntity> findDistinctPackagesByUserIdAndInstituteId(
             @Param("userId") String userId,
             @Param("instituteId") String instituteId);
@@ -92,8 +91,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             "AND ssgm.user_id = :userId " +
             "AND p.status != 'DELETED' " +
             "AND ps.status != 'DELETED' " +
-            "AND ssgm.status != 'DELETED' " +
-            "AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))", nativeQuery = true)
+            "AND ssgm.status != 'DELETED'", nativeQuery = true)
     Integer countDistinctPackagesByUserIdAndInstituteId(
             @Param("userId") String userId,
             @Param("instituteId") String instituteId);
@@ -122,7 +120,6 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE pi.institute_id = :instituteId
             AND p.status = 'ACTIVE'
             AND p.is_course_published_to_catalaouge = true
-            AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))
             AND p.comma_separated_tags IS NOT NULL
             AND p.comma_separated_tags != ''
             AND TRIM(t.tag) != ''
@@ -293,7 +290,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -352,7 +349,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -514,7 +511,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:userId IS NULL OR lo.user_id = :userId)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :name IS NULL OR
@@ -556,7 +553,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:userId IS NULL OR lo.user_id = :userId)
                                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :name IS NULL OR
@@ -696,7 +693,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -735,7 +732,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -893,7 +890,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE
                 (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                 AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
@@ -950,7 +947,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                         WHERE
                             (:instituteId IS NULL OR pi.institute_id = :instituteId)
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                             AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
@@ -1218,7 +1215,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
                     AND (:#{#packageSessionIds == null || #packageSessionIds.isEmpty()} = true OR ps.id IN (:packageSessionIds))
@@ -1275,7 +1272,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                         AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                         AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                         AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                         AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
                         AND (:#{#packageSessionIds == null || #packageSessionIds.isEmpty()} = true OR ps.id IN (:packageSessionIds))
@@ -1441,7 +1438,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
                     AND (
@@ -1494,7 +1491,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
                     AND (
@@ -1561,7 +1558,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:isPublishedOnly = false OR p.is_course_published_to_catalaouge = true)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
@@ -1649,7 +1646,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:isPublishedOnly = false OR p.is_course_published_to_catalaouge = true)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
@@ -1852,7 +1849,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -1911,7 +1908,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                             AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (
                                 :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2160,7 +2157,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE
               (:instituteId IS NULL OR pi.institute_id = :instituteId)
               AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
               AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
               AND (
                   :name IS NULL OR
@@ -2198,7 +2195,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     WHERE
                       (:instituteId IS NULL OR pi.institute_id = :instituteId)
                       AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                       AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                       AND (
                           :name IS NULL OR
@@ -2339,7 +2336,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2391,7 +2388,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                             AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (
                                 :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2541,7 +2538,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:userId IS NULL OR lo.user_id = :userId)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :name IS NULL OR
@@ -2581,7 +2578,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:userId IS NULL OR lo.user_id = :userId)
                                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :name IS NULL OR
@@ -3074,7 +3071,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
@@ -3123,7 +3120,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
@@ -3328,7 +3325,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#tags == null || #tags.isEmpty()} = true OR string_to_array(p.comma_separated_tags, ',') && CAST(ARRAY[:tags] AS text[]))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -3379,7 +3376,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#tags == null || #tags.isEmpty()} = true OR string_to_array(p.comma_separated_tags, ',') && CAST(ARRAY[:tags] AS text[]))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
@@ -79,7 +79,8 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             "AND ssgm.user_id = :userId " +
             "AND p.status != 'DELETED' " +
             "AND ps.status != 'DELETED' " +
-            "AND ssgm.status != 'DELETED'", nativeQuery = true)
+            "AND ssgm.status != 'DELETED' " +
+            "AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))", nativeQuery = true)
     List<PackageEntity> findDistinctPackagesByUserIdAndInstituteId(
             @Param("userId") String userId,
             @Param("instituteId") String instituteId);
@@ -91,7 +92,8 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             "AND ssgm.user_id = :userId " +
             "AND p.status != 'DELETED' " +
             "AND ps.status != 'DELETED' " +
-            "AND ssgm.status != 'DELETED'", nativeQuery = true)
+            "AND ssgm.status != 'DELETED' " +
+            "AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))", nativeQuery = true)
     Integer countDistinctPackagesByUserIdAndInstituteId(
             @Param("userId") String userId,
             @Param("instituteId") String instituteId);
@@ -120,6 +122,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE pi.institute_id = :instituteId
             AND p.status = 'ACTIVE'
             AND p.is_course_published_to_catalaouge = true
+            AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))
             AND p.comma_separated_tags IS NOT NULL
             AND p.comma_separated_tags != ''
             AND TRIM(t.tag) != ''
@@ -290,7 +293,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -349,7 +352,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -511,7 +514,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:userId IS NULL OR lo.user_id = :userId)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :name IS NULL OR
@@ -553,7 +556,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:userId IS NULL OR lo.user_id = :userId)
                                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :name IS NULL OR
@@ -693,7 +696,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -732,7 +735,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -890,7 +893,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE
                 (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                 AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
@@ -947,7 +950,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                         WHERE
                             (:instituteId IS NULL OR pi.institute_id = :instituteId)
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                             AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
@@ -1215,7 +1218,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
                     AND (:#{#packageSessionIds == null || #packageSessionIds.isEmpty()} = true OR ps.id IN (:packageSessionIds))
@@ -1272,7 +1275,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                         AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                         AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                         AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                         AND (:#{#packageIds == null || #packageIds.isEmpty()} = true OR p.id IN (:packageIds))
                         AND (:#{#packageSessionIds == null || #packageSessionIds.isEmpty()} = true OR ps.id IN (:packageSessionIds))
@@ -1438,7 +1441,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
                     AND (
@@ -1491,7 +1494,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
                     AND (
@@ -1558,7 +1561,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:isPublishedOnly = false OR p.is_course_published_to_catalaouge = true)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
@@ -1646,7 +1649,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:isPublishedOnly = false OR p.is_course_published_to_catalaouge = true)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
@@ -1849,7 +1852,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -1908,7 +1911,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                             AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (
                                 :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2157,7 +2160,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             WHERE
               (:instituteId IS NULL OR pi.institute_id = :instituteId)
               AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
               AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
               AND (
                   :name IS NULL OR
@@ -2195,7 +2198,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     WHERE
                       (:instituteId IS NULL OR pi.institute_id = :instituteId)
                       AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                            AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                       AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                       AND (
                           :name IS NULL OR
@@ -2336,7 +2339,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2388,7 +2391,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                             AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                             AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                             AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                             AND (
                                 :#{#facultyIds == null || #facultyIds.isEmpty()} = true
@@ -2538,7 +2541,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 AND (:userId IS NULL OR lo.user_id = :userId)
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                 AND (
                     :name IS NULL OR
@@ -2578,7 +2581,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                                 AND (:userId IS NULL OR lo.user_id = :userId)
                                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                                 AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                                 AND (
                                     :name IS NULL OR
@@ -3071,7 +3074,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
@@ -3120,7 +3123,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.is_course_published_to_catalaouge = true
                     AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                    AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                 AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR l.id IN (:levelIds))
@@ -3325,7 +3328,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#tags == null || #tags.isEmpty()} = true OR string_to_array(p.comma_separated_tags, ',') && CAST(ARRAY[:tags] AS text[]))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)
@@ -3376,7 +3379,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     AND (:#{#sessionIds == null || #sessionIds.isEmpty()} = true OR ps.session_id IN (:sessionIds))
                     AND (:#{#levelStatus == null || #levelStatus.isEmpty()} = true OR l.status IN (:levelStatus))
                     AND (:#{#packageStatus == null || #packageStatus.isEmpty()} = true OR p.status IN (:packageStatus))
-                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true OR p.package_type IN (:packageTypes))
+                        AND (:#{#packageTypes == null || #packageTypes.isEmpty()} = true AND (p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')) OR p.package_type IN (:packageTypes))
                     AND (:#{#packageSessionStatus == null || #packageSessionStatus.isEmpty()} = true OR ps.status IN (:packageSessionStatus))
                     AND (:#{#tags == null || #tags.isEmpty()} = true OR string_to_array(p.comma_separated_tags, ',') && CAST(ARRAY[:tags] AS text[]))
                     AND (:#{#createdByUserId == null || #createdByUserId.isEmpty()} = true OR p.created_by_user_id = :createdByUserId)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/PaymentLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/PaymentLogRepository.java
@@ -174,6 +174,14 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                 AND psli.status = 'ACTIVE'
                 AND psli.package_session_id IN (:packageSessionIds)
             ))
+        AND NOT EXISTS (
+              SELECT 1
+              FROM package_session_learner_invitation_to_payment_option psli_int
+              JOIN package_session ps_int ON psli_int.package_session_id = ps_int.id
+              JOIN package p_int ON ps_int.package_id = p_int.id
+              WHERE psli_int.enroll_invite_id = ei.id
+                AND p_int.package_type IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
+            )
       """, countQuery = """
       SELECT COUNT(DISTINCT pl.id)
       FROM payment_log pl
@@ -193,6 +201,14 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                 AND psli.status = 'ACTIVE'
                 AND psli.package_session_id IN (:packageSessionIds)
             ))
+        AND NOT EXISTS (
+              SELECT 1
+              FROM package_session_learner_invitation_to_payment_option psli_int
+              JOIN package_session ps_int ON psli_int.package_session_id = ps_int.id
+              JOIN package p_int ON ps_int.package_id = p_int.id
+              WHERE psli_int.enroll_invite_id = ei.id
+                AND p_int.package_type IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
+            )
       """, nativeQuery = true)
   Page<PaymentLogWithUserPlanProjection> findPaymentLogsByFiltersNative(
       @Param("instituteId") String instituteId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/PaymentLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/PaymentLogRepository.java
@@ -56,6 +56,12 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                       AND psli.packageSession.id IN (:packageSessionIds)
                   ))
               AND (:#{#userId == null ? 1 : 0} = 1 OR up.userId = :userId)
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM PackageSessionLearnerInvitationToPaymentOption psli_int
+                    WHERE psli_int.enrollInvite.id = ei.id
+                      AND psli_int.packageSession.packageEntity.packageType IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
+                  )
             ORDER BY pl.createdAt DESC
       """, countQuery = """
       SELECT COUNT(pl) FROM PaymentLog pl
@@ -76,6 +82,12 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                 AND psli.packageSession.id IN (:packageSessionIds)
             ))
         AND (:#{#userId == null ? 1 : 0} = 1 OR up.userId = :userId)
+        AND NOT EXISTS (
+              SELECT 1
+              FROM PackageSessionLearnerInvitationToPaymentOption psli_int
+              WHERE psli_int.enrollInvite.id = ei.id
+                AND psli_int.packageSession.packageEntity.packageType IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
+            )
       """)
   Page<PaymentLog> findPaymentLogIdsWithFilters(
       @Param("instituteId") String instituteId,
@@ -174,14 +186,6 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                 AND psli.status = 'ACTIVE'
                 AND psli.package_session_id IN (:packageSessionIds)
             ))
-        AND NOT EXISTS (
-              SELECT 1
-              FROM package_session_learner_invitation_to_payment_option psli_int
-              JOIN package_session ps_int ON psli_int.package_session_id = ps_int.id
-              JOIN package p_int ON ps_int.package_id = p_int.id
-              WHERE psli_int.enroll_invite_id = ei.id
-                AND p_int.package_type IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
-            )
       """, countQuery = """
       SELECT COUNT(DISTINCT pl.id)
       FROM payment_log pl
@@ -201,14 +205,6 @@ public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> 
                 AND psli.status = 'ACTIVE'
                 AND psli.package_session_id IN (:packageSessionIds)
             ))
-        AND NOT EXISTS (
-              SELECT 1
-              FROM package_session_learner_invitation_to_payment_option psli_int
-              JOIN package_session ps_int ON psli_int.package_session_id = ps_int.id
-              JOIN package p_int ON ps_int.package_id = p_int.id
-              WHERE psli_int.enroll_invite_id = ei.id
-                AND p_int.package_type IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT')
-            )
       """, nativeQuery = true)
   Page<PaymentLogWithUserPlanProjection> findPaymentLogsByFiltersNative(
       @Param("instituteId") String instituteId,

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -183,6 +183,7 @@ export const ENROLLMENT_PAYMENT_GATEWAY_DETAILS = `${BASE_URL}/admin-core-servic
 export const ENROLLMENT_INVITE_DETAILS = `${BASE_URL}/admin-core-service/v1/enroll-invite`;
 export const ENROLLMENT_PAYMENT_INITIATION = `${BASE_URL}/admin-core-service/v1/learner/enroll`;
 export const ENROLLMENT_PAYMENT_INITIATION_V2 = `${BASE_URL}/admin-core-service/v2/learner/enroll`;
+export const PAYMENT_LOGS_URL = `${BASE_URL}/admin-core-service/v1/user-plan/payment-logs`;
 export const COLLECT_PUBLIC_USER_DATA = `${BASE_URL}/admin-core-service/v1/learner/enroll/detail`;
 
 export const GENERATE_CERTIFICATE = `${BASE_URL}/admin-core-service/institute/v1/certificate/learner/get`;

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
@@ -156,7 +156,7 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
       case "testimonialSection":
         return <TestimonialSectionComponent key={id} {...props} />;
       case "cartComponent":
-        return <CartComponent key={id} {...props} instituteId={instituteId} />;
+        return <CartComponent key={id} {...props} instituteId={instituteId} globalSettings={globalSettings} />;
       case "buyRentSection":
         return <BuyRentSectionComponent key={id} {...props} tagName={tagName} />;
       case "policyRenderer":

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CartComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CartComponent.tsx
@@ -14,6 +14,11 @@ import { getTokenFromStorage } from "@/lib/auth/sessionUtility";
 import { TokenKey } from "@/constants/auth/tokens";
 import { Preferences } from "@capacitor/preferences";
 import { PriceWithMrp } from "@/components/common/price-with-mrp";
+import {
+  resolveAdditionalCharges,
+  sumChargeAmounts,
+  ResolvedCharge,
+} from "../../-utils/additional-charges-util";
 
 
 // Helper for simple image loading in Rent loop
@@ -353,6 +358,7 @@ export const CartComponent: React.FC<CartComponentProps> = ({
   emptyStateMessage = "Your cart is empty. Add some books!",
   styles = {},
   instituteId, // Accept instituteId prop
+  globalSettings,
   onlyLogic = false,
 }) => {
 
@@ -623,6 +629,17 @@ export const CartComponent: React.FC<CartComponentProps> = ({
   const roundedEdges = styles.roundedEdges ? "rounded-lg" : "";
   const backgroundColor = styles.backgroundColor || "#ffffff";
 
+  // Buy-mode additional charges (shipping). Rent mode is intentionally excluded —
+  // security deposit / rent-mode shipping is a separate piece of work.
+  const buyModeItemQty = items.reduce((sum, item) => sum + (item.quantity || 0), 0);
+  const resolvedAdditionalCharges = useMemo<ResolvedCharge[]>(() => {
+    if (isRentMode) return [];
+    return resolveAdditionalCharges(globalSettings, "buy", buyModeItemQty);
+  }, [globalSettings, isRentMode, buyModeItemQty]);
+  const additionalChargesTotal = sumChargeAmounts(resolvedAdditionalCharges);
+  const buyModeSubtotal = getTotal();
+  const buyModeGrandTotal = buyModeSubtotal + additionalChargesTotal;
+
   const paymentBanner = paymentMessage ? (
     <div className={`w-full p-4 mb-4 rounded-lg flex items-start sm:items-center justify-between gap-4 animate-in fade-in slide-in-from-top-2 duration-300 ${paymentMessage.type === 'error' ? 'bg-red-50 text-red-700 border border-red-200' :
       paymentMessage.type === 'success' ? 'bg-green-50 text-green-700 border border-green-200' :
@@ -840,14 +857,26 @@ export const CartComponent: React.FC<CartComponentProps> = ({
       {/* Checkout Button for Buy mode */}
       {items.length > 0 && !isRentMode && (
         <div className="mt-5 bg-gray-50 rounded-lg p-3 sm:p-4 border border-gray-200">
-          <div className="flex justify-between items-center pt-3 border-t border-gray-200 mb-3">
-            <span className="text-base sm:text-lg font-semibold text-gray-900">Total</span>
-            <span className="text-base sm:text-lg font-bold text-gray-900">₹{getTotal().toFixed(2)}</span>
+          <div className="space-y-1.5 pt-2 mb-3">
+            <div className="flex justify-between items-center text-sm text-gray-700">
+              <span>Subtotal ({buyModeItemQty} {buyModeItemQty === 1 ? "book" : "books"})</span>
+              <span className="font-medium">₹{buyModeSubtotal.toFixed(2)}</span>
+            </div>
+            {resolvedAdditionalCharges.map((charge) => (
+              <div key={charge.key} className="flex justify-between items-center text-sm text-gray-700">
+                <span>{charge.label}</span>
+                <span className="font-medium">₹{charge.amount.toFixed(2)}</span>
+              </div>
+            ))}
+            <div className="flex justify-between items-center pt-2 border-t border-gray-200">
+              <span className="text-base sm:text-lg font-semibold text-gray-900">Total</span>
+              <span className="text-base sm:text-lg font-bold text-gray-900">₹{buyModeGrandTotal.toFixed(2)}</span>
+            </div>
           </div>
 
           <Button
             onClick={() => {
-              console.log("[CartComponent] Proceeding to checkout (Buy) with items:", items);
+              console.log("[CartComponent] Proceeding to checkout (Buy) with items:", items, "charges:", resolvedAdditionalCharges);
               setIsCheckoutFormOpen(true);
             }}
             className="w-full bg-primary-400 hover:bg-primary-500 active:bg-primary-500 text-white font-semibold text-sm sm:text-base py-2.5 sm:py-3 rounded-lg shadow-md transition-all duration-200 active:scale-[0.98]"
@@ -862,10 +891,11 @@ export const CartComponent: React.FC<CartComponentProps> = ({
         open={isCheckoutFormOpen}
         onOpenChange={setIsCheckoutFormOpen}
         instituteId={instituteId || INSTITUTE_ID}
-        totalAmount={getTotal()}
+        totalAmount={buyModeGrandTotal}
         items={items}
         membershipPlan={membershipPlan}
         isRentMode={false}
+        additionalCharges={resolvedAdditionalCharges}
       />
     </div>
   );

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CheckoutForm.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CheckoutForm.tsx
@@ -26,6 +26,11 @@ import axios from "axios";
 import { performFullAuthCycle } from "@/services/auth-cycle-service";
 import { loginEnrolledUser } from "@/services/signup-api";
 import { AddressForm, AddressFormHandle } from "./AddressForm";
+import {
+    ResolvedCharge,
+    buildChargeEnrollmentEntries,
+    sumChargeAmounts,
+} from "../../-utils/additional-charges-util";
 
 interface CheckoutFormProps {
     open: boolean;
@@ -35,6 +40,7 @@ interface CheckoutFormProps {
     items: any[];
     membershipPlan?: any;
     isRentMode?: boolean;
+    additionalCharges?: ResolvedCharge[];
 }
 
 export const CheckoutForm: React.FC<CheckoutFormProps> = ({
@@ -45,6 +51,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
     items,
     membershipPlan,
     isRentMode = false,
+    additionalCharges = [],
 }) => {
     const [email, setEmail] = useState("");
     const [fullName, setFullName] = useState("");
@@ -441,7 +448,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
 
                 // Build learner_package_session_enrollments array for each item
                 // Use per-item plan data resolved from each book's own enroll invite
-                const learnerPackageSessionEnrollments = items.map(item => {
+                const bookEnrollments = items.map(item => {
                     const itemPlan = perItemPlanData[item.enrollInviteId];
                     return {
                         package_session_id: item.packageSessionId || item.id,
@@ -451,11 +458,18 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
                     };
                 });
 
-                // Calculate total amount as sum of all package sessions
-                const calculatedTotalAmount = items.reduce(
+                // Append one enrollment entry per additional charge (e.g. shipping tier).
+                // Backend treats each entry identically — UserPlan + PaymentLog per entry,
+                // grouped under the same MP order ID. Amount is validated against the sum
+                // of each entry's PaymentPlan.actualPrice.
+                const chargeEnrollments = buildChargeEnrollmentEntries(additionalCharges);
+                const learnerPackageSessionEnrollments = [...bookEnrollments, ...chargeEnrollments];
+
+                const booksSubtotal = items.reduce(
                     (total, item) => total + (item.price * (item.quantity || 1)),
                     0
                 );
+                const calculatedTotalAmount = booksSubtotal + sumChargeAmounts(additionalCharges);
 
                 const buyPayload = {
                     user: userPayload,
@@ -776,18 +790,37 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
                                 <AddressForm ref={addressFormRef} initial={initialAddressInputs} />
 
                                 {/* Compact Summary */}
-                                <div className="bg-gray-50 rounded-xl p-3 border border-gray-100 flex items-center justify-between">
-                                    <div className="flex flex-col">
-                                        <span className="text-[10px] text-gray-500 font-bold uppercase tracking-tight">Order Total</span>
-                                        <span className="text-base font-black text-primary-600">₹{totalAmount.toFixed(0)}</span>
+                                {additionalCharges.length > 0 ? (
+                                    <div className="bg-gray-50 rounded-xl p-3 border border-gray-100 space-y-1">
+                                        <div className="flex justify-between text-xs text-gray-700">
+                                            <span>Subtotal ({items.length} {items.length === 1 ? "item" : "items"})</span>
+                                            <span className="font-medium">₹{(totalAmount - sumChargeAmounts(additionalCharges)).toFixed(2)}</span>
+                                        </div>
+                                        {additionalCharges.map((charge) => (
+                                            <div key={charge.key} className="flex justify-between text-xs text-gray-700">
+                                                <span>{charge.label}</span>
+                                                <span className="font-medium">₹{charge.amount.toFixed(2)}</span>
+                                            </div>
+                                        ))}
+                                        <div className="flex justify-between items-center pt-1.5 border-t border-gray-200">
+                                            <span className="text-[10px] text-gray-500 font-bold uppercase tracking-tight">Order Total</span>
+                                            <span className="text-base font-black text-primary-600">₹{totalAmount.toFixed(2)}</span>
+                                        </div>
                                     </div>
-                                    <div className="text-right">
-                                        <span className="text-[10px] text-gray-400 font-medium block">{items.length} Items</span>
-                                        <span className="text-[10px] text-green-600 font-bold flex items-center justify-end gap-1">
-                                            <span className="w-1 h-1 bg-green-500 rounded-full" /> Secure
-                                        </span>
+                                ) : (
+                                    <div className="bg-gray-50 rounded-xl p-3 border border-gray-100 flex items-center justify-between">
+                                        <div className="flex flex-col">
+                                            <span className="text-[10px] text-gray-500 font-bold uppercase tracking-tight">Order Total</span>
+                                            <span className="text-base font-black text-primary-600">₹{totalAmount.toFixed(0)}</span>
+                                        </div>
+                                        <div className="text-right">
+                                            <span className="text-[10px] text-gray-400 font-medium block">{items.length} Items</span>
+                                            <span className="text-[10px] text-green-600 font-bold flex items-center justify-end gap-1">
+                                                <span className="w-1 h-1 bg-green-500 rounded-full" /> Secure
+                                            </span>
+                                        </div>
                                     </div>
-                                </div>
+                                )}
                             </>
                         )}
                     </div>

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-types/course-catalogue-types.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-types/course-catalogue-types.ts
@@ -1,4 +1,42 @@
 // Updated to support layout configuration
+
+/**
+ * A single tier in a quantity-based additional charge (e.g. shipping).
+ * `maxQty: null` means unbounded (top tier — applies for all quantities >= minQty).
+ * Each tier is backed by its own PaymentPlan in the DB so the backend can verify
+ * `paid_amount == PaymentPlan.actualPrice`.
+ */
+export interface AdditionalChargeTier {
+  minQty: number;
+  maxQty: number | null;
+  planId: string;
+  amount: number;
+}
+
+/**
+ * Charge added to checkout beyond the items themselves — e.g. shipping, security deposit.
+ * Backed by a dedicated "internal" Package (`package_type` = `DELIVERY_CHARGE` /
+ * `SECURITY_DEPOSIT`) so it flows through the same enroll/payment/invoice plumbing
+ * as a regular purchase. Two pricing shapes:
+ *   - `tiers[]` — quantity-dependent (cart picks the matching tier by total qty)
+ *   - `planId + amount` — flat charge
+ * `applicableTo` gates which cart mode the charge appears in: "COURSE" = buy mode,
+ * "MEMBERSHIP" = rent mode. A charge can apply to one or both.
+ */
+export interface AdditionalCharge {
+  key: string;
+  label: string;
+  applicableTo: ("COURSE" | "MEMBERSHIP")[];
+  packageSessionId: string;
+  enrollInviteId: string;
+  paymentOptionId: string;
+  tiers?: AdditionalChargeTier[];
+  planId?: string;
+  amount?: number;
+  refundable?: boolean;
+  description?: string;
+}
+
 export interface GlobalSettings {
   courseCatalogeType: {
     enabled: boolean;
@@ -46,8 +84,9 @@ export interface GlobalSettings {
   };
   payment: {
     enabled: boolean;
-    provider: "razorpay" | "stripe" | "paypal";
+    provider: "razorpay" | "stripe" | "paypal" | "PHONEPE";
     fields: string[];
+    additionalCharges?: AdditionalCharge[];
   };
   communityJoinLink?: string;
   layout?: {
@@ -337,6 +376,7 @@ export interface CartComponentProps {
   showEmptyState?: boolean;
   emptyStateMessage?: string;
   instituteId?: string;
+  globalSettings?: GlobalSettings;
   styles?: {
     padding?: string;
     roundedEdges?: boolean;

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-utils/additional-charges-util.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-utils/additional-charges-util.ts
@@ -1,0 +1,114 @@
+import { AdditionalCharge, AdditionalChargeTier, GlobalSettings } from "../-types/course-catalogue-types";
+
+export type CartMode = "buy" | "rent";
+
+const MODE_TO_APPLICABLE: Record<CartMode, "COURSE" | "MEMBERSHIP"> = {
+  buy: "COURSE",
+  rent: "MEMBERSHIP",
+};
+
+/**
+ * A single resolved charge ready for display + enrollment:
+ *   - `amount` is what the user pays
+ *   - `planId` is the PaymentPlan whose `actualPrice` MUST equal `amount`
+ *     (backend verifies this; cart math and backend must agree)
+ *   - `tier` is the matched tier when the charge is qty-based, else null
+ */
+export interface ResolvedCharge {
+  key: string;
+  label: string;
+  amount: number;
+  planId: string;
+  packageSessionId: string;
+  enrollInviteId: string;
+  paymentOptionId: string;
+  tier: AdditionalChargeTier | null;
+}
+
+const isTiered = (charge: AdditionalCharge): boolean =>
+  Array.isArray(charge.tiers) && charge.tiers.length > 0;
+
+/**
+ * Picks the tier whose [minQty, maxQty] contains `qty`. `maxQty: null` is unbounded.
+ * If no tier matches (e.g. qty=0 and minQty starts at 1), returns null and the
+ * charge is skipped — empty cart should not be charged shipping.
+ */
+const matchTier = (tiers: AdditionalChargeTier[], qty: number): AdditionalChargeTier | null => {
+  for (const tier of tiers) {
+    const minOk = qty >= tier.minQty;
+    const maxOk = tier.maxQty === null || tier.maxQty === undefined || qty <= tier.maxQty;
+    if (minOk && maxOk) return tier;
+  }
+  return null;
+};
+
+const isApplicable = (charge: AdditionalCharge, mode: CartMode): boolean => {
+  if (!Array.isArray(charge.applicableTo) || charge.applicableTo.length === 0) return false;
+  return charge.applicableTo.includes(MODE_TO_APPLICABLE[mode]);
+};
+
+/**
+ * Returns charges (shipping etc.) resolved against the current cart for the given mode.
+ * A charge missing its DB linkage (packageSessionId / enrollInviteId / paymentOptionId
+ * / planId) is skipped — without those it cannot be enrolled, so displaying its amount
+ * would mislead the user. `qty = 0` returns [] for the same reason.
+ */
+export const resolveAdditionalCharges = (
+  globalSettings: GlobalSettings | undefined | null,
+  mode: CartMode,
+  qty: number,
+): ResolvedCharge[] => {
+  if (!globalSettings || qty <= 0) return [];
+  const charges = globalSettings.payment?.additionalCharges;
+  if (!Array.isArray(charges) || charges.length === 0) return [];
+
+  const resolved: ResolvedCharge[] = [];
+  for (const charge of charges) {
+    if (!isApplicable(charge, mode)) continue;
+    if (!charge.packageSessionId || !charge.enrollInviteId || !charge.paymentOptionId) continue;
+
+    if (isTiered(charge)) {
+      const tier = matchTier(charge.tiers!, qty);
+      if (!tier || !tier.planId) continue;
+      resolved.push({
+        key: charge.key,
+        label: charge.label,
+        amount: tier.amount,
+        planId: tier.planId,
+        packageSessionId: charge.packageSessionId,
+        enrollInviteId: charge.enrollInviteId,
+        paymentOptionId: charge.paymentOptionId,
+        tier,
+      });
+    } else if (charge.planId && typeof charge.amount === "number") {
+      resolved.push({
+        key: charge.key,
+        label: charge.label,
+        amount: charge.amount,
+        planId: charge.planId,
+        packageSessionId: charge.packageSessionId,
+        enrollInviteId: charge.enrollInviteId,
+        paymentOptionId: charge.paymentOptionId,
+        tier: null,
+      });
+    }
+  }
+  return resolved;
+};
+
+export const sumChargeAmounts = (charges: ResolvedCharge[]): number =>
+  charges.reduce((sum, c) => sum + c.amount, 0);
+
+/**
+ * Maps resolved charges to v2 `learner_package_session_enrollments[]` entries.
+ * Shape matches the existing entries CheckoutForm builds for books, so the backend
+ * treats them uniformly (creates UserPlan + PaymentLog per entry, sums per
+ * `PaymentPlan.actualPrice` for amount verification).
+ */
+export const buildChargeEnrollmentEntries = (charges: ResolvedCharge[]) =>
+  charges.map((c) => ({
+    package_session_id: c.packageSessionId,
+    plan_id: c.planId,
+    payment_option_id: c.paymentOptionId,
+    enroll_invite_id: c.enrollInviteId,
+  }));

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyOrdersWidget.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyOrdersWidget.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getInstituteId } from "@/constants/helper";
 import { getUserId } from "@/constants/getUserId";
-import { BASE_URL } from "@/constants/urls";
+import { PAYMENT_LOGS_URL } from "@/constants/urls";
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
 import { cn } from "@/lib/utils";
 import { ShoppingBag, ChevronLeft, ChevronRight, Package } from "lucide-react";
@@ -52,8 +52,6 @@ interface PaymentLogEntry {
         full_name: string;
     };
 }
-
-const PAYMENT_LOGS_URL = `${BASE_URL}/admin-core-service/v1/user-plan/payment-logs`;
 
 const ORDER_STATUS_STYLES: Record<string, string> = {
     ORDERED: "bg-gray-100 text-gray-700",


### PR DESCRIPTION
## Summary of Changes

Adds tiered shipping charges to ReadOnRent's buy-mode checkout. Shipping is modeled as a regular `PackageSession` (with `package.package_type = 'DELIVERY_CHARGE'` as the marker) so it flows through the existing v2 enroll / payment / invoice plumbing. Tiers — ₹40 (1 book), ₹50 (2–3), ₹80 (4–8), ₹100 (9+) — live as four `PaymentPlan` rows so the backend can verify each enrollment's paid amount against `PaymentPlan.actualPrice`.

Also closes the v2 amount-trust gap: backend now asserts `paymentInitiationRequest.amount == sum(plan.actualPrice)` across all enrollment items before initiating payment, rejecting tampered payloads with a clear error.

Internal package types (`DELIVERY_CHARGE`, `SECURITY_DEPOSIT`) are filtered out at every learner-facing data-access point — catalogue search, My Books / dashboard widgets, tag chips, and the My Orders widget — so the delivery PackageSession is invisible everywhere except the invoice line items.

Rent mode is intentionally untouched. Security deposit + rent-mode shipping is a follow-up PR.

**Backend:**
- `MultiPackageLearnerEnrollService.enrollMultiPackage`: amount-verification guard that walks `learner_package_session_enrollments[]`, sums each item's `PaymentPlan.actualPrice`, and rejects mismatches with `VacademyException`. `MANUAL` enrollment type and `amount <= 0` paths are explicitly skipped.
- `PackageRepository`: adds `(p.package_type IS NULL OR p.package_type NOT IN ('DELIVERY_CHARGE', 'SECURITY_DEPOSIT'))` to the catalogue queries (via the existing `packageTypes` SpEL clause), `findDistinctPackagesByUserIdAndInstituteId` + count variant (My Books / dashboard), and `findAllDistinctTagsByInstituteId` (genre chips). Pre-V53 `NULL`-typed rows still pass through.
- `PaymentLogRepository.findPaymentLogsByFiltersNative`: `NOT EXISTS` clause that excludes any payment_log whose enroll_invite is linked to an internal package_type. Keeps "Delivery Charges" out of the My Orders widget while still letting it appear as an invoice line item.

**Frontend (`frontend-learner-dashboard-app`):**
- `course-catalogue-types.ts`: new `AdditionalCharge` + `AdditionalChargeTier` interfaces; `payment` block of `GlobalSettings` extended with `additionalCharges?: AdditionalCharge[]`. `CartComponentProps` accepts `globalSettings`.
- `additional-charges-util.ts` (new): `resolveAdditionalCharges(globalSettings, mode, qty)` picks the right tier per cart mode/qty; `buildChargeEnrollmentEntries` shapes them into v2 enrollment entries; `sumChargeAmounts` for display.
- `JsonRenderer.tsx`: passes `globalSettings` down to `CartComponent`.
- `CartComponent.tsx` (buy mode only): replaces the single "Total" row with Subtotal + per-charge line(s) + Total breakdown; passes resolved charges to `CheckoutForm`.
- `CheckoutForm.tsx`: accepts `additionalCharges` prop, renders the same breakdown in the order summary, appends one shipping enrollment entry per resolved charge to `learner_package_session_enrollments`, and sums `books_subtotal + shipping` for `payment_initiation_request.amount`.
- `urls.ts`: new `PAYMENT_LOGS_URL` constant (was previously hardcoded inline in `MyOrdersWidget`).
- `MyOrdersWidget.tsx`: imports `PAYMENT_LOGS_URL` from `urls.ts` instead of constructing it inline.

## Manual setup required (per institute)

1. Seed one `Package` (`package_type='DELIVERY_CHARGE'`) + `PackageInstitute` + **two** `PackageSession` rows (one ACTIVE for enrollment, one with `level_id='INVITED'`, `session_id='INVITED'`, `status='INVITED'` as the invitation placeholder the enroll path expects) + `EnrollInvite` + `PaymentOption` + `package_session_learner_invitation_to_payment_option` bridge + four `PaymentPlan` rows (₹40 / ₹50 / ₹80 / ₹100). Done for ReadOnRent via direct INSERTs.
2. Update the institute's `course_catalogue.catalogue_json → globalSettings.payment.additionalCharges` with a `SHIPPING` entry pointing to the seeded `packageSessionId`, `enrollInviteId`, `paymentOptionId`, and the four `planId`s. Done for ReadOnRent.

## Related Issue

<link or leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- 5 books + tiered shipping (4–8 tier @ ₹80) end-to-end against local `admin_core_service`. Cart shows Subtotal ₹1440 / Shipping ₹80 / Total ₹1520, breakdown updates live as qty changes
- CheckoutForm order summary shows the same breakdown
- Backend `[AMOUNT_GUARD]` logs (added during testing) confirmed all 6 plan lookups: `Plan e7f9f083 actualPrice=240, db6a2cdc=160, 754cbbaf=480, 142676bd=240, 54e9e027=320, 9a15f3e3=80` → `expectedSum=1520.0 == clientAmount=1520.0 → MATCH`
- v2 enroll completed all 6 child enrollments creating 6 UserPlan + 6 PaymentLog rows linked under the same `MP...` order ID
- `DELIVERY_CHARGE` package does not appear in learner book catalogue, "My Books" widget, genre/tag chips, or "My Orders" widget
- Rent-mode cart unchanged — no shipping line appears
- Final payment confirmation + invoice line-item rendering pending verification on a real Razorpay/PhonePe completion

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
