### PR TITLE
added structured address form with india post pincode auto-fill to ch…

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/AddressForm.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/AddressForm.tsx
@@ -1,0 +1,318 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { Loader2, MapPin } from "lucide-react";
+
+/**
+ * Backend-shaped output. Parent reads this via getValue() at submit time.
+ * UserDTO only has columns for these four fields (addressLine max 512 chars,
+ * city max 255, region max 255, pinCode regex \d{6}), so granular UI inputs
+ * (house no, landmark, district, post office) are concatenated into
+ * addressLine — backend doesn't store them separately.
+ */
+export interface AddressFormValue {
+  addressLine: string;
+  city: string;
+  region: string;
+  pinCode: string;
+}
+
+export interface AddressFormHandle {
+  validate: () => boolean;
+  getValue: () => AddressFormValue;
+}
+
+interface AddressFormProps {
+  /**
+   * Pre-fill values from the logged-in user's StudentDetails. Only the four
+   * backend-indexed fields are restored — granular fields stay blank because
+   * we can't reliably parse them back out of the stored addressLine.
+   */
+  initial?: { city?: string; region?: string; pinCode?: string };
+}
+
+const INDIAN_STATES = [
+  "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chhattisgarh",
+  "Goa", "Gujarat", "Haryana", "Himachal Pradesh", "Jharkhand",
+  "Karnataka", "Kerala", "Madhya Pradesh", "Maharashtra", "Manipur",
+  "Meghalaya", "Mizoram", "Nagaland", "Odisha", "Punjab",
+  "Rajasthan", "Sikkim", "Tamil Nadu", "Telangana", "Tripura",
+  "Uttar Pradesh", "Uttarakhand", "West Bengal",
+  "Andaman and Nicobar Islands", "Chandigarh",
+  "Dadra and Nagar Haveli and Daman and Diu", "Delhi",
+  "Jammu and Kashmir", "Ladakh", "Lakshadweep", "Puducherry",
+];
+
+const PINCODE_API = "https://api.postalpincode.in/pincode";
+
+const labelCls = "text-[11px] font-bold text-gray-900 uppercase flex items-center gap-1.5";
+const inputBase =
+  "w-full px-3 py-2 bg-gray-50 border rounded-lg transition-all focus:bg-white focus:ring-2 text-sm font-medium";
+const inputDefault = "border-gray-200 focus:ring-primary-50 focus:border-primary-400";
+const inputError = "border-red-300 focus:ring-red-50";
+const errorText = "text-red-500 text-[10px] font-semibold";
+
+export const AddressForm = forwardRef<AddressFormHandle, AddressFormProps>(({ initial }, ref) => {
+  const [houseNo, setHouseNo] = useState("");
+  const [area, setArea] = useState("");
+  const [landmark, setLandmark] = useState("");
+  const [pinCode, setPinCode] = useState("");
+  const [stateName, setStateName] = useState("");
+  const [district, setDistrict] = useState("");
+  const [postOffice, setPostOffice] = useState("");
+  const [postOfficeOptions, setPostOfficeOptions] = useState<string[]>([]);
+  const [city, setCity] = useState("");
+
+  const [pinLookupLoading, setPinLookupLoading] = useState(false);
+  const [pinLookupError, setPinLookupError] = useState<string | null>(null);
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Pre-fill on initial mount / when StudentDetails loads after open. We don't
+  // guard against overwriting user edits because, in this modal's lifecycle,
+  // `initial` only flips from undefined → defined once per open.
+  useEffect(() => {
+    if (initial?.city) setCity(initial.city);
+  }, [initial?.city]);
+  useEffect(() => {
+    if (initial?.region) setStateName(initial.region);
+  }, [initial?.region]);
+  useEffect(() => {
+    if (initial?.pinCode) setPinCode(initial.pinCode);
+  }, [initial?.pinCode]);
+
+  // Debounced India Post lookup. Fires once `pinCode` is a clean 6-digit
+  // string. Auto-fills state + district + Post Office list. User can still
+  // override the state dropdown manually if the API picks the wrong one.
+  useEffect(() => {
+    if (!/^\d{6}$/.test(pinCode)) {
+      setPostOfficeOptions([]);
+      setPinLookupError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setPinLookupLoading(true);
+      setPinLookupError(null);
+      try {
+        const res = await fetch(`${PINCODE_API}/${pinCode}`, { signal: controller.signal });
+        const data = await res.json();
+        const first = Array.isArray(data) ? data[0] : null;
+        if (
+          first?.Status === "Success" &&
+          Array.isArray(first.PostOffice) &&
+          first.PostOffice.length > 0
+        ) {
+          const offices: string[] = first.PostOffice
+            .map((po: { Name?: string }) => po.Name)
+            .filter((n: string | undefined): n is string => !!n);
+          setPostOfficeOptions(offices);
+          const firstPO = first.PostOffice[0];
+          if (firstPO?.State) setStateName(firstPO.State);
+          if (firstPO?.District) setDistrict(firstPO.District);
+          setPostOffice((current) =>
+            current && offices.includes(current) ? current : offices[0] || ""
+          );
+        } else {
+          setPostOfficeOptions([]);
+          setPinLookupError("Pincode not found — please enter address manually");
+        }
+      } catch (e) {
+        if ((e as { name?: string }).name !== "AbortError") {
+          setPinLookupError("Couldn't reach India Post. Enter address manually.");
+        }
+      } finally {
+        setPinLookupLoading(false);
+      }
+    }, 400);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [pinCode]);
+
+  const buildAddressLine = (): string => {
+    const parts: string[] = [];
+    if (houseNo.trim()) parts.push(houseNo.trim());
+    if (area.trim()) parts.push(area.trim());
+    if (landmark.trim()) parts.push(`Near ${landmark.trim()}`);
+    if (postOffice.trim()) parts.push(`PO ${postOffice.trim()}`);
+    if (district.trim()) parts.push(`Dist ${district.trim()}`);
+    return parts.join(", ");
+  };
+
+  const runValidation = (): Record<string, string> => {
+    const next: Record<string, string> = {};
+    if (!houseNo.trim()) next.houseNo = "Required";
+    if (!area.trim()) next.area = "Required";
+    if (!pinCode.trim()) next.pinCode = "Pincode is required";
+    else if (!/^\d{6}$/.test(pinCode.trim())) next.pinCode = "Must be 6 digits";
+    if (!stateName.trim()) next.stateName = "Select a state";
+    if (!district.trim()) next.district = "Required";
+    if (!postOffice.trim()) next.postOffice = "Required";
+    if (!city.trim()) next.city = "Required";
+    return next;
+  };
+
+  useImperativeHandle(ref, () => ({
+    validate: () => {
+      const next = runValidation();
+      setErrors(next);
+      return Object.keys(next).length === 0;
+    },
+    getValue: () => ({
+      addressLine: buildAddressLine(),
+      city: city.trim(),
+      region: stateName.trim(),
+      pinCode: pinCode.trim(),
+    }),
+  }));
+
+  const handleBlur = (field: string) => {
+    const next = runValidation();
+    setErrors((prev) => ({ ...prev, [field]: next[field] || "" }));
+  };
+
+  const onPincodeChange = (raw: string) => {
+    const cleaned = raw.replace(/\D/g, "").slice(0, 6);
+    setPinCode(cleaned);
+    if (errors.pinCode) setErrors((prev) => ({ ...prev, pinCode: "" }));
+  };
+
+  return (
+    <div className="space-y-3">
+      <label className={labelCls}>
+        <MapPin className="h-3 w-3" /> Delivery Address
+      </label>
+
+      {/* House / Flat / Building No. */}
+      <div className="space-y-1">
+        <input
+          type="text"
+          value={houseNo}
+          onChange={(e) => { setHouseNo(e.target.value); if (errors.houseNo) setErrors((p) => ({ ...p, houseNo: "" })); }}
+          onBlur={() => handleBlur("houseNo")}
+          placeholder="House / Flat / Building No."
+          className={`${inputBase} ${errors.houseNo ? inputError : inputDefault}`}
+        />
+        {errors.houseNo && <p className={errorText}>{errors.houseNo}</p>}
+      </div>
+
+      {/* Area / Street / Locality */}
+      <div className="space-y-1">
+        <input
+          type="text"
+          value={area}
+          onChange={(e) => { setArea(e.target.value); if (errors.area) setErrors((p) => ({ ...p, area: "" })); }}
+          onBlur={() => handleBlur("area")}
+          placeholder="Area / Street / Locality"
+          className={`${inputBase} ${errors.area ? inputError : inputDefault}`}
+        />
+        {errors.area && <p className={errorText}>{errors.area}</p>}
+      </div>
+
+      {/* Landmark (optional) */}
+      <input
+        type="text"
+        value={landmark}
+        onChange={(e) => setLandmark(e.target.value)}
+        placeholder="Landmark (optional)"
+        className={`${inputBase} ${inputDefault}`}
+      />
+
+      {/* Pincode + City */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <div className="relative">
+            <input
+              type="text"
+              inputMode="numeric"
+              value={pinCode}
+              onChange={(e) => onPincodeChange(e.target.value)}
+              onBlur={() => handleBlur("pinCode")}
+              placeholder="Pincode"
+              maxLength={6}
+              className={`${inputBase} pr-8 ${errors.pinCode ? inputError : inputDefault}`}
+            />
+            {pinLookupLoading && (
+              <Loader2 className="absolute right-2.5 top-2.5 h-4 w-4 text-gray-400 animate-spin" />
+            )}
+          </div>
+          {errors.pinCode && <p className={errorText}>{errors.pinCode}</p>}
+          {!errors.pinCode && pinLookupError && <p className={errorText}>{pinLookupError}</p>}
+        </div>
+
+        <div className="space-y-1">
+          <input
+            type="text"
+            value={city}
+            onChange={(e) => { setCity(e.target.value); if (errors.city) setErrors((p) => ({ ...p, city: "" })); }}
+            onBlur={() => handleBlur("city")}
+            placeholder="City / Town / Village"
+            className={`${inputBase} ${errors.city ? inputError : inputDefault}`}
+          />
+          {errors.city && <p className={errorText}>{errors.city}</p>}
+        </div>
+      </div>
+
+      {/* State + District */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <select
+            value={stateName}
+            onChange={(e) => { setStateName(e.target.value); if (errors.stateName) setErrors((p) => ({ ...p, stateName: "" })); }}
+            onBlur={() => handleBlur("stateName")}
+            className={`${inputBase} ${errors.stateName ? inputError : inputDefault}`}
+          >
+            <option value="">Select State</option>
+            {INDIAN_STATES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          {errors.stateName && <p className={errorText}>{errors.stateName}</p>}
+        </div>
+
+        <div className="space-y-1">
+          <input
+            type="text"
+            value={district}
+            onChange={(e) => { setDistrict(e.target.value); if (errors.district) setErrors((p) => ({ ...p, district: "" })); }}
+            onBlur={() => handleBlur("district")}
+            placeholder="District"
+            className={`${inputBase} ${errors.district ? inputError : inputDefault}`}
+          />
+          {errors.district && <p className={errorText}>{errors.district}</p>}
+        </div>
+      </div>
+
+      {/* Post Office */}
+      <div className="space-y-1">
+        {postOfficeOptions.length > 0 ? (
+          <select
+            value={postOffice}
+            onChange={(e) => { setPostOffice(e.target.value); if (errors.postOffice) setErrors((p) => ({ ...p, postOffice: "" })); }}
+            onBlur={() => handleBlur("postOffice")}
+            className={`${inputBase} ${errors.postOffice ? inputError : inputDefault}`}
+          >
+            <option value="">Select Post Office</option>
+            {postOfficeOptions.map((po) => (
+              <option key={po} value={po}>{po}</option>
+            ))}
+          </select>
+        ) : (
+          <input
+            type="text"
+            value={postOffice}
+            onChange={(e) => { setPostOffice(e.target.value); if (errors.postOffice) setErrors((p) => ({ ...p, postOffice: "" })); }}
+            onBlur={() => handleBlur("postOffice")}
+            placeholder="Post Office"
+            className={`${inputBase} ${errors.postOffice ? inputError : inputDefault}`}
+          />
+        )}
+        {errors.postOffice && <p className={errorText}>{errors.postOffice}</p>}
+      </div>
+    </div>
+  );
+});
+
+AddressForm.displayName = "AddressForm";

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CheckoutForm.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CheckoutForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { MyButton } from "@/components/design-system/button";
-import { Loader2, MapPin, User, Mail, Phone, CreditCard, ChevronRight, CheckCircle2 } from "lucide-react";
+import { Loader2, User, Mail, Phone, ChevronRight, CheckCircle2 } from "lucide-react";
 import PhoneInput from "react-phone-input-2";
 import "react-phone-input-2/lib/bootstrap.css";
 import { getCachedPreferredCountries } from "@/services/domain-routing";
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import axios from "axios";
 import { performFullAuthCycle } from "@/services/auth-cycle-service";
 import { loginEnrolledUser } from "@/services/signup-api";
+import { AddressForm, AddressFormHandle } from "./AddressForm";
 
 interface CheckoutFormProps {
     open: boolean;
@@ -48,8 +49,16 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
     const [email, setEmail] = useState("");
     const [fullName, setFullName] = useState("");
     const [phone, setPhone] = useState("");
-    const [address, setAddress] = useState("");
     const [otp, setOtp] = useState("");
+    // Pre-fill source for AddressForm — only the 4 backend-indexed fields are
+    // restored from StudentDetails; granular UI fields stay blank because the
+    // stored addressLine is a single concatenated string we can't reliably split.
+    const [initialAddressInputs, setInitialAddressInputs] = useState<{
+        city?: string;
+        region?: string;
+        pinCode?: string;
+    }>({});
+    const addressFormRef = React.useRef<AddressFormHandle>(null);
     const [loading, setLoading] = useState(false);
     const [isInitializing, setIsInitializing] = useState(false);
     const [phoneOtpSent, setPhoneOtpSent] = useState(false);
@@ -70,7 +79,6 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
     }, []);
     const defaultPhoneCountry = preferredCountries[0] ?? "in";
     const [nameError, setNameError] = useState("");
-    const [addressError, setAddressError] = useState("");
 
     const [paymentPlanData, setPaymentPlanData] = useState<any>(null);
     // Per-item plan data: maps enrollInviteId -> { planId, paymentOptionId }
@@ -123,7 +131,11 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
                                 setEmail(studentDetails.email || studentDetails.username || "");
                                 const phoneNum = studentDetails.mobile_number || studentDetails.phone_number || "";
                                 setPhone(phoneNum);
-                                setAddress(studentDetails.address_line || studentDetails.address || "");
+                                setInitialAddressInputs({
+                                    city: studentDetails.city || undefined,
+                                    region: studentDetails.region || undefined,
+                                    pinCode: studentDetails.pin_code || undefined,
+                                });
                                 
                                 const hasPhone = !!(phoneNum && phoneNum.replace(/\D/g, "").length >= 10);
                                 if (hasPhone) {
@@ -294,7 +306,6 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
         setEmailError("");
         setPhoneError("");
         setNameError("");
-        setAddressError("");
 
         if (showFullForm) {
             if (!fullName.trim()) {
@@ -315,12 +326,14 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
             setPhoneError("Phone verification is required");
             hasErrors = true;
         }
-        if (!address.trim()) {
-            setAddressError("Delivery address is required");
+        // AddressForm renders its own field-level errors when validate() runs.
+        if (!addressFormRef.current?.validate()) {
             hasErrors = true;
         }
 
         if (hasErrors) return;
+
+        const addressValue = addressFormRef.current!.getValue();
 
         setLoading(true);
         try {
@@ -336,10 +349,10 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
                     getTerminology(RoleTerms.Learner, SystemTerms.Learner),
                 email: email.trim() || "student@example.com",
                 mobileNumber: phone,
-                address_line: address,
-                city: "",
-                region: "",
-                pin_code: "",
+                address_line: addressValue.addressLine,
+                city: addressValue.city,
+                region: addressValue.region,
+                pin_code: addressValue.pinCode,
                 date_of_birth: new Date().toISOString(),
                 gender: null,
                 password: "",
@@ -756,20 +769,11 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({
                                 </>
                                 )}
 
-                                {/* Address */}
-                                <div className="space-y-1">
-                                    <label className="text-[11px] font-bold text-gray-900 uppercase flex items-center gap-1.5">
-                                        <MapPin className="h-3 w-3" /> Delivery Address
-                                    </label>
-                                    <textarea
-                                        value={address}
-                                        onChange={(e) => setAddress(e.target.value)}
-                                        rows={2}
-                                        className={`w-full px-3 py-2 bg-gray-50 border rounded-lg transition-all focus:bg-white focus:ring-2 resize-none text-sm font-medium ${addressError ? "border-red-300 focus:ring-red-50" : "border-gray-200 focus:ring-primary-50 focus:border-primary-400"}`}
-                                        placeholder="Full address for delivery"
-                                    />
-                                    {addressError && <p className="text-red-500 text-[10px] font-semibold ml-1">{addressError}</p>}
-                                </div>
+                                {/* Structured address inputs — house no, area, landmark,
+                                    pincode (auto-fills state/district/post office via India
+                                    Post), city. Concats granular fields into addressLine for
+                                    the backend on submit. */}
+                                <AddressForm ref={addressFormRef} initial={initialAddressInputs} />
 
                                 {/* Compact Summary */}
                                 <div className="bg-gray-50 rounded-xl p-3 border border-gray-100 flex items-center justify-between">


### PR DESCRIPTION
## Summary of Changes

Replaces the single-textarea delivery address input in `CheckoutForm` with a structured `AddressForm` component. Eight fields (House/Flat, Area/Street, Landmark, Pincode, City, State, District, Post Office) capture proper Indian postal-address shape that ops can use for shipping labels without re-keying.

Pincode-driven auto-fill via the free public India Post API (`https://api.postalpincode.in/pincode/{code}`): once the user types a clean 6-digit pincode, State + District populate automatically and Post Office becomes a dropdown of matching offices. Lookup failures degrade gracefully — the form remains manually editable, including the state dropdown.

No backend changes. `UserDTO` already accepts the four backend-indexed fields (`addressLine` max 512 chars, `city` max 255, `region` max 255, `pinCode` `^\d{6}$`). The previous textarea only filled `addressLine` and sent `city / region / pinCode` as empty strings — those now carry real values. Granular UI inputs without dedicated columns (house no, landmark, district, post office) are concatenated into `addressLine` (well under the 512-char limit).

Both buy and rent checkout flows pick up the new component automatically since `CheckoutForm` is shared.

**Backend:**
- (no changes — `UserDTO` already supported the structured fields)

**Frontend (`frontend-learner-dashboard-app`):**
- `AddressForm.tsx` (new): `forwardRef` component exposing `validate()` and `getValue()` via `AddressFormHandle` so the parent drives submit-time validation without lifting child state. Renders 8 fields with per-field blur validation and full-form validation on submit. Debounced India Post lookup (400ms) populates State + District and lists matching Post Offices on valid 6-digit pincode. Pre-fills `city / region / pinCode` from an `initial` prop; granular inputs stay blank because the stored `addressLine` is a concatenated string that can't be reliably split back into structured fields.
- `CheckoutForm.tsx`: replaced the single-textarea block + `address` / `addressError` state with `<AddressForm ref={addressFormRef} initial={initialAddressInputs} />`. StudentDetails load now populates `initialAddressInputs` (city, region, pin_code) for returning-user pre-fill. `handleCheckout` calls `addressFormRef.current.validate()` and reads `getValue()` into the user payload so `address_line`, `city`, `region`, `pin_code` all carry real values (previously the last three were hardcoded `""`). Removed unused `MapPin` and `CreditCard` icon imports.

## Related Issue

<link or leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Cart → Checkout shows 8 structured inputs instead of the textarea
- Typing a valid 6-digit pincode (e.g. `560001`) auto-fills State (Karnataka) and District (Bangalore), populates the Post Office dropdown with the matching offices
- Invalid/unknown pincode (`999999`) shows "Pincode not found" hint; form remains fully editable
- Submitting with empty required fields surfaces inline field-level errors (House, Area, Pincode, City, State, District, Post Office)
- Successful submission posts the full structured payload — verified `user.address_line`, `user.city`, `user.region`, `user.pin_code` all carry real values (no empty strings) in the v2 enroll request body
- Returning logged-in user with saved address: City, State, Pincode pre-fill from StudentDetails; granular fields are blank as designed
- Both buy mode and rent mode paths exercise the same component (CheckoutForm is shared)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
