### PR TITLE
fix(leads): fix prod build break in LeadStatusSelect (TS2322)

### DIFF
--- a/frontend-admin-dashboard/src/components/shared/lead-status-select.tsx
+++ b/frontend-admin-dashboard/src/components/shared/lead-status-select.tsx
@@ -9,7 +9,7 @@ const normalize = (v: string) => v.trim().toUpperCase().replace(/\s+/g, '_');
 
 interface LeadStatusSelectProps {
     /** Audience response id of the lead whose status is being changed. */
-    responseId: string;
+    responseId?: string;
     /** Current status (key or label) shown on the chip. */
     currentStatus?: string | null;
     /** Institute's configured statuses (with ids, for the update call). */
@@ -38,6 +38,7 @@ export function LeadStatusSelect({
         key: s.status_key,
         label: s.label,
         color: s.color,
+        order: s.display_order,
     }));
 
     const norm = currentStatus ? normalize(currentStatus) : null;


### PR DESCRIPTION
## Why
The Cloudflare Pages build on `main` is failing (introduced by #1748) with two TS2322 errors in `LeadStatusSelect`:

```
src/components/shared/lead-status-select.tsx(86,29): Property 'order' is missing ... CustomLeadStatus
src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx(801,29): Type 'string | undefined' is not assignable to type 'string'
```

## Fix
- Add `order` (`display_order`) to the chip statuses passed to `LeadStatusChip` (satisfies `CustomLeadStatus`).
- Make `responseId` optional — recent-leads' `response_id` is `string | undefined`; it's already guarded at runtime.

2-line change. Verified locally with a full `tsc --noEmit` → 0 errors (the same step CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)