### PR TITLE
fix(audience): wire missing lead-status repos and pass leadStatusId i…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -149,6 +149,12 @@ public class AudienceService {
     private vacademy.io.admin_core_service.features.audience.repository.LeadScoreRepository leadScoreRepository;
 
     @Autowired
+    private vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository userLeadProfileRepository;
+
+    @Autowired
+    private vacademy.io.admin_core_service.features.audience.repository.LeadStatusRepository leadStatusRepository;
+
+    @Autowired
     private vacademy.io.admin_core_service.features.counselor_pool.service.CounselorAssignmentService counselorAssignmentService;
 
     @Autowired
@@ -1579,6 +1585,7 @@ public class AudienceService {
                 && !filterDTO.getInstituteId().isBlank()) {
             Page<AudienceResponse> all = audienceResponseRepository.findInstituteLeadsWithFilters(
                     filterDTO.getInstituteId(),
+                    filterDTO.getLeadStatusId(),
                     filterDTO.getSubmittedFromLocal(),
                     filterDTO.getSubmittedToLocal(),
                     filterDTO.getSearchQuery(),
@@ -1598,6 +1605,7 @@ public class AudienceService {
 
         Page<AudienceResponse> responses = audienceResponseRepository.findLeadsWithFilters(
                 filterDTO.getAudienceId(),
+                filterDTO.getLeadStatusId(),
                 filterDTO.getSourceType(),
                 filterDTO.getSourceId(),
                 filterDTO.getSubmittedFromLocal(),


### PR DESCRIPTION
## Summary of Changes

Fixes 5 compile errors in `AudienceService` introduced when the lead-status feature added a `leadStatusId` predicate and `user_lead_profile` / `lead_status` lookups to the repository queries without updating the service layer.

**Backend:**
- Inject `UserLeadProfileRepository` and `LeadStatusRepository` into `AudienceService` (were referenced at lines 1716 and 1732 but never autowired).
- Pass `filterDTO.getLeadStatusId()` as the 2nd argument to `AudienceResponseRepository.findInstituteLeadsWithFilters(...)`. The query declares 11 params but the call site was supplying only 10, which also caused a `Timestamp → String` type error because every following arg landed in the wrong slot.
- Pass `filterDTO.getLeadStatusId()` as the 2nd argument to `AudienceResponseRepository.findLeadsWithFilters(...)`. Same shape of bug — query expected 20 params, call site supplied 19.

**Frontend:**
- None.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `./mvnw compile` on `admin_core_service` — BUILD SUCCESS (was failing with 5 errors before this change).
- Read the repository query bodies to confirm `leadStatusId` is the new 2nd named param in both queries and that the existing `LeadFilterDTO.leadStatusId` field is the correct source.
- Verified `UserLeadProfileRepository.findByUserIdIn(List<String>)` and `LeadStatusRepository` (extends `JpaRepository<LeadStatus, String>`, so `findAllById` is inherited) expose the methods the service calls.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
