### PR TITLE
add methods for sending notification to  assigned counsellor and to a…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorAssignmentService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.admin_core_service.features.audience.entity.Audience;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceRepository;
 import vacademy.io.admin_core_service.features.counselor_pool.entity.CounselorPool;
 import vacademy.io.admin_core_service.features.counselor_pool.entity.CounselorPoolAudience;
 import vacademy.io.admin_core_service.features.counselor_pool.entity.CounselorPoolMember;
@@ -17,6 +19,7 @@ import vacademy.io.admin_core_service.features.counselor_pool.repository.Counsel
 import vacademy.io.admin_core_service.features.counselor_pool.repository.CounselorPoolRepository;
 import vacademy.io.admin_core_service.features.counselor_pool.repository.CounselorPoolShiftMemberRepository;
 import vacademy.io.admin_core_service.features.counselor_pool.repository.CounselorPoolShiftRepository;
+import vacademy.io.admin_core_service.features.notification_service.service.NotificationService;
 
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -60,6 +63,8 @@ public class CounselorAssignmentService {
     private final CounselorPoolMemberRepository poolMemberRepository;
     private final CounselorPoolShiftRepository shiftRepository;
     private final CounselorPoolShiftMemberRepository shiftMemberRepository;
+    private final AudienceRepository audienceRepository;        // for resolving campaign name in alert text
+    private final NotificationService notificationService;      // existing helper that wraps notification_service HTTP call
 
     /**
      * Pick a counselor for a lead that just arrived on the given audience.
@@ -100,6 +105,7 @@ public class CounselorAssignmentService {
         List<CounselorPoolMember> orderedMembers = buildCandidateMembers(pool, audienceId, mode);
         if (orderedMembers.isEmpty()) {
             log.info("No candidate counselors for audience={} in pool={}", audienceId, poolId);
+            sendUnassignedAlertToPoolAdmin(pool, audienceId);
             return Optional.empty();
         }
 
@@ -107,7 +113,7 @@ public class CounselorAssignmentService {
         CounselorPoolAudience locked = poolAudienceRepository.findByAudienceIdForUpdate(audienceId)
                 .orElse(null);
         if (locked == null) {
-            // Race: audience was removed between resolution and lock. Bail.
+            // Race: audience was removed between resolution and lock. Bail (transient — no alert).
             return Optional.empty();
         }
 
@@ -119,6 +125,7 @@ public class CounselorAssignmentService {
         ResolvedAssignment resolved = resolveWithBackup(picked, orderedMembers, locked.getLastAssignedCounselorId());
         if (resolved == null) {
             log.info("All candidates inactive (no usable backup) for audience={} pool={}", audienceId, poolId);
+            sendUnassignedAlertToPoolAdmin(pool, audienceId);
             return Optional.empty();
         }
 
@@ -129,7 +136,84 @@ public class CounselorAssignmentService {
                 resolved.pickedOriginalUserId,
                 new Timestamp(System.currentTimeMillis()));
 
+        // Step 8: bell-icon notification to the assigned counselor.
+        sendNewLeadNotificationToCounsellor(pool, audienceId, resolved.resolvedUserId);
+
         return Optional.of(resolved.resolvedUserId);
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // System alert dispatch (best-effort; failures don't break assignment)
+    // ────────────────────────────────────────────────────────────────
+
+    /** Bell-icon notification for a counselor who just got a new lead. */
+    private void sendNewLeadNotificationToCounsellor(CounselorPool pool, String audienceId, String counselorUserId) {
+        if (counselorUserId == null || counselorUserId.isBlank()) {
+            return;
+        }
+        String campaignName = resolveCampaignName(audienceId);
+        try {
+            notificationService.createSystemAlertAnnouncement(
+                    pool.getInstituteId(),
+                    List.of(counselorUserId),
+                    "New lead assigned",
+                    "You have a new lead from campaign \"" + campaignName + "\".",
+                    "system",
+                    "System",
+                    "ADMIN",
+                    Map.of(
+                            "priority", 2,
+                            "isDismissible", true,
+                            "showBadge", true,
+                            "isActive", true
+                    )
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send new-lead notification to counselor={} for audience={}: {}",
+                    counselorUserId, audienceId, e.getMessage());
+        }
+    }
+
+    /**
+     * Alert the pool's creator that a lead which SHOULD have been auto-assigned
+     * (mode != MANUAL) could not be routed. Lead is unassigned; admin needs to
+     * either fix counselor configuration or assign manually.
+     */
+    private void sendUnassignedAlertToPoolAdmin(CounselorPool pool, String audienceId) {
+        String adminUserId = pool.getCreatedBy();
+        if (adminUserId == null || adminUserId.isBlank()) {
+            log.warn("Pool {} has no created_by; cannot route unassigned-lead alert", pool.getId());
+            return;
+        }
+        String campaignName = resolveCampaignName(audienceId);
+        try {
+            notificationService.createSystemAlertAnnouncement(
+                    pool.getInstituteId(),
+                    List.of(adminUserId),
+                    "Lead could not be auto-assigned",
+                    "A lead in pool \"" + pool.getName() + "\" (campaign: " + campaignName + ") could not be auto-assigned. "
+                            + "Either all counselors are inactive, or the audience has no members. Please assign manually.",
+                    "system",
+                    "System",
+                    "ADMIN",
+                    Map.of(
+                            "priority", 3,
+                            "isDismissible", true,
+                            "showBadge", true,
+                            "isActive", true
+                    )
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send unassigned-lead alert to admin={} for pool={}: {}",
+                    adminUserId, pool.getId(), e.getMessage());
+        }
+    }
+
+    private String resolveCampaignName(String audienceId) {
+        return audienceRepository.findById(audienceId)
+                .map(Audience::getCampaignName)
+                .filter(name -> name != null && !name.isBlank())
+                .orElse("Untitled campaign");
     }
 
     // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary of Changes

Adds two bell-icon system alerts on the counsellor-pool auto-assignment flow. When a lead is auto-assigned, the counsellor gets a notification. When the assignment fails for a pool that should have auto-routed (`ROUND_ROBIN` or `TIME_BASED`), the pool's creator gets an alert so they can intervene manually.

Reuses the existing `recipient_messages` (`mode_type = SYSTEM_ALERT`) plumbing — no new tables, no new endpoints, no frontend changes.

**Backend:**
- Modified `CounselorAssignmentService.java` (+86 lines, no behavior change to existing assignment algorithm)
- Injected `NotificationService` (existing helper that wraps the notification-service HTTP call) and `AudienceRepository` (to resolve campaign name for the message text)
- Added 3 private helpers: `sendNewLeadNotificationToCounsellor`, `sendUnassignedAlertToPoolAdmin`, `resolveCampaignName`
- Counsellor notification fires on the success path (priority 2, dismissible)
- Admin alert fires when `orderedMembers.isEmpty()` OR `resolved == null` AND the pool's mode is not MANUAL (priority 3, dismissible, recipient = `pool.created_by`)
- All notification dispatches are wrapped in try/catch — failures log a warning and never break lead submission
- No alerts fire for MANUAL pools, audiences not in any pool, or the transient race-condition path (`locked == null`)

**Frontend:**
- None. The existing admin/learner dashboards already render `mode_type = SYSTEM_ALERT` rows in the bell icon

## Related Issue



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Submit a lead to a campaign whose pool is ROUND_ROBIN with active members → assigned counsellor sees a new bell notification within polling interval
- Submit a lead to a campaign whose pool is TIME_BASED and a shift is active → on-shift counsellor sees the notification
- Submit a lead to a campaign whose pool has every member set INACTIVE (no working backup) → pool creator sees the admin alert; lead remains unassigned
- Submit a lead to a campaign in a pool with no members for that audience → pool creator sees the admin alert
- Submit a lead to a MANUAL-mode pool → no notifications, no alerts (as intended)
- Submit a lead to a campaign that is NOT in any pool → no notifications, no alerts (as intended)
- Verify `recipient_messages` row is inserted with `mode_type='SYSTEM_ALERT'`, correct `user_id`, and expected priority (2 for counsellor, 3 for admin)
- Force a notification-service outage → verify lead-submission still succeeds (best-effort dispatch)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
