### PR TITLE
feat(counselor-pool): schedule_pattern column + per-day and same-hour…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CounselorPoolDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CounselorPoolDTO.java
@@ -34,6 +34,10 @@ public class CounselorPoolDTO {
     @JsonProperty("assignment_mode")
     private String assignmentMode;
 
+    /** PER_DAY | SAME_HOURS_ALL_DAYS — drives which schedule editor the UI renders. */
+    @JsonProperty("schedule_pattern")
+    private String schedulePattern;
+
     @JsonProperty("created_by")
     private String createdBy;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CreatePoolRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CreatePoolRequest.java
@@ -33,6 +33,14 @@ public class CreatePoolRequest {
     @JsonProperty("assignment_mode")
     private String assignmentMode;
 
+    /**
+     * Optional: PER_DAY | SAME_HOURS_ALL_DAYS. Drives the schedule editor used
+     * by the UI. Defaults to PER_DAY when omitted. Only meaningful for
+     * TIME_BASED pools but accepted on any pool for forward compatibility.
+     */
+    @JsonProperty("schedule_pattern")
+    private String schedulePattern;
+
     /** Optional: campaigns to link at creation. */
     @JsonProperty("audience_ids")
     private List<String> audienceIds;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/UpdatePoolRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/UpdatePoolRequest.java
@@ -20,4 +20,13 @@ public class UpdatePoolRequest {
     /** MANUAL | ROUND_ROBIN | TIME_BASED. Switching modes does NOT clear shifts or members. */
     @JsonProperty("assignment_mode")
     private String assignmentMode;
+
+    /**
+     * PER_DAY | SAME_HOURS_ALL_DAYS. Frontend sends this when admin picks a
+     * schedule pattern from the empty state. Changing pattern with existing
+     * shift rows in the pool is rejected at the service layer — admin must
+     * clear the schedule first.
+     */
+    @JsonProperty("schedule_pattern")
+    private String schedulePattern;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/entity/CounselorPool.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/entity/CounselorPool.java
@@ -36,6 +36,15 @@ public class CounselorPool {
     @Column(name = "assignment_mode", nullable = false, length = 50)
     private String assignmentMode; // AssignmentMode enum value
 
+    /**
+     * How the admin authored the weekly schedule (TIME_BASED pools only).
+     * Drives which editor the UI renders when the pool is reopened. NULL
+     * means the admin hasn't picked yet — UI shows the empty-state chooser.
+     * Routing engine ignores this field — it reads flat shift rows.
+     */
+    @Column(name = "schedule_pattern", length = 50)
+    private String schedulePattern; // SchedulePattern enum value, or null
+
     @Column(name = "created_by")
     private String createdBy;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/enums/SchedulePattern.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/enums/SchedulePattern.java
@@ -1,0 +1,14 @@
+package vacademy.io.admin_core_service.features.counselor_pool.enums;
+
+/**
+ * How the admin authored a pool's weekly schedule. Affects only the UI editor
+ * that loads when the pool is reopened; the routing engine reads flat
+ * counselor_pool_shift rows regardless of which pattern produced them.
+ */
+public enum SchedulePattern {
+    /** Shifts authored independently per day (the original editor). */
+    PER_DAY,
+
+    /** One set of blocks applied to all 7 days. Frontend expands to per-day rows on save. */
+    SAME_HOURS_ALL_DAYS
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
@@ -7,6 +7,7 @@ import vacademy.io.admin_core_service.features.counselor_pool.dto.*;
 import vacademy.io.admin_core_service.features.counselor_pool.entity.*;
 import vacademy.io.admin_core_service.features.counselor_pool.enums.AssignmentMode;
 import vacademy.io.admin_core_service.features.counselor_pool.enums.PoolStatus;
+import vacademy.io.admin_core_service.features.counselor_pool.enums.SchedulePattern;
 import vacademy.io.admin_core_service.features.counselor_pool.repository.*;
 import vacademy.io.common.exceptions.VacademyException;
 
@@ -42,11 +43,14 @@ public class CounselorPoolService {
             throw new VacademyException("A pool with this name already exists in the institute");
         }
 
+        String schedulePattern = resolveSchedulePattern(request.getSchedulePattern());
+
         CounselorPool pool = CounselorPool.builder()
                 .instituteId(request.getInstituteId())
                 .name(request.getName())
                 .description(request.getDescription())
                 .assignmentMode(request.getAssignmentMode())
+                .schedulePattern(schedulePattern)
                 .createdBy(createdByUserId)
                 .build();
         pool = poolRepository.save(pool);
@@ -84,6 +88,16 @@ public class CounselorPoolService {
         if (request.getAssignmentMode() != null) {
             validateAssignmentMode(request.getAssignmentMode());
             pool.setAssignmentMode(request.getAssignmentMode());
+        }
+        if (request.getSchedulePattern() != null) {
+            String newPattern = resolveSchedulePattern(request.getSchedulePattern());
+            // Switching pattern with shifts already configured would silently break the
+            // editor's "trust the column" load path. Force admin to clear the schedule first.
+            if (!newPattern.equals(pool.getSchedulePattern())
+                    && poolShiftRepository.findByPoolIdOrderByDayOfWeekAscStartTimeAsc(poolId).size() > 0) {
+                throw new VacademyException("Cannot change schedule_pattern while shifts exist. Clear the schedule first.");
+            }
+            pool.setSchedulePattern(newPattern);
         }
         poolRepository.save(pool);
 
@@ -336,6 +350,22 @@ public class CounselorPoolService {
         }
     }
 
+    /**
+     * Validates the schedule_pattern string. Returns null when input is null
+     * or blank — the column is nullable so the UI can distinguish "not picked
+     * yet" (NULL) from "explicitly picked X".
+     */
+    private static String resolveSchedulePattern(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return SchedulePattern.valueOf(raw).name();
+        } catch (IllegalArgumentException e) {
+            throw new VacademyException("schedule_pattern must be one of PER_DAY, SAME_HOURS_ALL_DAYS");
+        }
+    }
+
     private static void requireNonBlank(String value, String message) {
         if (value == null || value.isBlank()) {
             throw new VacademyException(message);
@@ -356,6 +386,7 @@ public class CounselorPoolService {
                 .name(p.getName())
                 .description(p.getDescription())
                 .assignmentMode(p.getAssignmentMode())
+                .schedulePattern(p.getSchedulePattern())
                 .createdBy(p.getCreatedBy())
                 .createdAt(p.getCreatedAt())
                 .updatedAt(p.getUpdatedAt())

--- a/admin_core_service/src/main/resources/db/migration/V270__Add_schedule_pattern_to_counselor_pool.sql
+++ b/admin_core_service/src/main/resources/db/migration/V270__Add_schedule_pattern_to_counselor_pool.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- V270: Add schedule_pattern to counselor_pool
+--
+-- Distinguishes how the admin authored the pool's TIME_BASED
+-- weekly schedule, so the UI can render the right editor when
+-- the pool is reopened:
+--
+--   PER_DAY              — admin authored shifts independently per day
+--                          (current behaviour; default for pre-existing pools)
+--   SAME_HOURS_ALL_DAYS  — admin authored one set of blocks that applies
+--                          to all 7 days; on save the frontend expands them
+--                          to 7-day rows so the routing engine stays unchanged
+--
+-- Routing engine and shift validation read flat counselor_pool_shift rows
+-- and remain unaffected.
+--
+-- The column is nullable so the UI can distinguish "admin hasn't explicitly
+-- picked a pattern yet" (NULL) from "admin picked X" (PER_DAY|SAME_HOURS_ALL_DAYS).
+-- That lets the empty-state chooser appear for fresh TIME_BASED pools, and
+-- legacy data (pre-migration shifts) gracefully falls back to PER_DAY on the UI.
+-- ============================================================
+
+ALTER TABLE counselor_pool
+    ADD COLUMN IF NOT EXISTS schedule_pattern VARCHAR(50);

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/ScheduleTab.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/ScheduleTab.tsx
@@ -1,194 +1,51 @@
 /**
- * Weekly shift schedule editor. Active only when the pool's assignment_mode
- * is TIME_BASED. Admin draws shift blocks for each of the 7 days, assigning
- * one or more counselors to each block.
+ * Schedule tab — routes between three views for a TIME_BASED pool:
  *
- * On save, the entire schedule is sent as one replacement (PUT /schedule).
- * Backend validates 24/7 coverage across all days; this UI also runs the same
- * validation client-side and surfaces gaps before the request goes out.
+ *   1. ScheduleEmptyState        — pool has no shifts AND no pattern picked yet
+ *   2. PerDayScheduleEditor      — pattern = PER_DAY (or legacy data without pattern)
+ *   3. SameHoursAllDaysEditor    — pattern = SAME_HOURS_ALL_DAYS
+ *
+ * Pattern decision rules:
+ *   - If schedule has saved shifts AND pool.schedule_pattern is null → fall
+ *     back to PER_DAY (legacy data created before the schedule_pattern
+ *     column existed).
+ *   - If shifts exist, the pattern is effectively locked. The backend
+ *     rejects pattern changes while shifts are present.
+ *   - If no shifts AND no pattern → show the empty-state chooser.
+ *   - If no shifts AND pattern set (admin picked but hasn't saved) → show
+ *     the matching editor; admin can click "Change pattern" to go back.
  */
 
-import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
-import { GET_INSTITUTE_USERS } from '@/constants/urls';
-import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
+import { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
 import { MyButton } from '@/components/design-system/button';
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
-import {
     CounselorPoolDTO,
-    DAYS_OF_WEEK,
-    DayOfWeek,
-    ShiftBlockRequest,
-    useSetWeeklySchedule,
+    SchedulePattern,
     useWeeklySchedule,
 } from '@/services/counselor-pool';
+import PerDayScheduleEditor from './schedule/PerDayScheduleEditor';
+import SameHoursAllDaysEditor from './schedule/SameHoursAllDaysEditor';
+import ScheduleEmptyState from './schedule/ScheduleEmptyState';
 
 interface ScheduleTabProps {
     pool: CounselorPoolDTO;
 }
 
-const DAY_LABEL: Record<DayOfWeek, string> = {
-    MON: 'Monday',
-    TUE: 'Tuesday',
-    WED: 'Wednesday',
-    THU: 'Thursday',
-    FRI: 'Friday',
-    SAT: 'Saturday',
-    SUN: 'Sunday',
-};
-
-interface EditableShift {
-    /** Local-only client id for React keys. */
-    localId: string;
-    startTime: string; // "HH:mm:ss"
-    endTime: string;
-    label?: string;
-    counselorUserIds: string[];
-}
-
-interface InstituteUser {
-    id: string;
-    full_name: string;
-}
-
-const fetchCounselors = async (): Promise<InstituteUser[]> => {
-    const instituteId = getCurrentInstituteId();
-    const response = await authenticatedAxiosInstance({
-        method: 'POST',
-        url: GET_INSTITUTE_USERS,
-        params: { instituteId, pageNumber: 0, pageSize: 500 },
-        data: { roles: ['COUNSELLOR', 'ADMIN'], status: ['ACTIVE'] },
-    });
-    const raw = Array.isArray(response.data) ? response.data : response.data?.content || [];
-    return raw.map((u: Record<string, unknown>) => ({
-        id: u.id as string,
-        full_name: u.full_name as string,
-    }));
-};
-
 export default function ScheduleTab({ pool }: ScheduleTabProps) {
-    const { data: serverSchedule, isLoading } = useWeeklySchedule(pool.id);
-    const { mutate: saveSchedule, isPending: saving } = useSetWeeklySchedule(pool.id);
+    const { data: serverSchedule = [], isLoading } = useWeeklySchedule(pool.id);
 
-    const { data: instituteUsers = [] } = useQuery({
-        queryKey: ['institute-counselors-for-schedule'],
-        queryFn: fetchCounselors,
-        staleTime: 60 * 1000,
-    });
-    const userNameById = useMemo(() => {
-        const map = new Map<string, string>();
-        instituteUsers.forEach((u) => map.set(u.id, u.full_name));
-        return map;
-    }, [instituteUsers]);
-
-    /** Counselors selectable for shifts: those who are members of this pool. */
-    const poolCounselorOptions = useMemo(() => {
-        const ids = new Set((pool.members ?? []).map((m) => m.counselor_user_id));
-        return [...ids].map((id) => ({ id, name: userNameById.get(id) ?? id.slice(0, 8) + '…' }));
-    }, [pool.members, userNameById]);
-
-    /** Editable schedule: day → list of shift blocks. */
-    const [schedule, setSchedule] = useState<Record<DayOfWeek, EditableShift[]>>(() =>
-        emptySchedule()
-    );
-
-    useEffect(() => {
-        if (!serverSchedule) return;
-        const next = emptySchedule();
-        for (const s of serverSchedule) {
-            next[s.day_of_week].push({
-                localId: s.id,
-                startTime: s.start_time,
-                endTime: s.end_time,
-                label: s.label,
-                counselorUserIds: (s.members ?? []).map((m) => m.counselor_user_id),
-            });
-        }
-        for (const day of DAYS_OF_WEEK) {
-            next[day].sort((a, b) => a.startTime.localeCompare(b.startTime));
-        }
-        setSchedule(next);
-    }, [serverSchedule]);
-
-    const updateDay = (day: DayOfWeek, mutate: (shifts: EditableShift[]) => EditableShift[]) => {
-        setSchedule((prev) => ({ ...prev, [day]: mutate([...prev[day]]) }));
-    };
-
-    const addShift = (day: DayOfWeek) =>
-        updateDay(day, (shifts) => [
-            ...shifts,
-            {
-                localId: cryptoRandom(),
-                startTime: '09:00:00',
-                endTime: '12:00:00',
-                counselorUserIds: [],
-            },
-        ]);
-
-    const removeShift = (day: DayOfWeek, idx: number) =>
-        updateDay(day, (shifts) => shifts.filter((_, i) => i !== idx));
-
-    const updateShift = (day: DayOfWeek, idx: number, patch: Partial<EditableShift>) =>
-        updateDay(day, (shifts) => shifts.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
-
-    const validation = useMemo(() => validateCoverage(schedule), [schedule]);
-
-    const handleSave = () => {
-        if (!validation.ok) {
-            toast.error('Fix the schedule before saving: ' + validation.errors[0]);
-            return;
-        }
-        const flatShifts: ShiftBlockRequest[] = [];
-        for (const day of DAYS_OF_WEEK) {
-            for (const s of schedule[day]) {
-                flatShifts.push({
-                    day_of_week: day,
-                    start_time: s.startTime,
-                    end_time: s.endTime,
-                    label: s.label,
-                    counselor_user_ids: s.counselorUserIds,
-                });
-            }
-        }
-        saveSchedule(
-            { shifts: flatShifts },
-            {
-                onSuccess: () => toast.success('Schedule saved'),
-                onError: (err) =>
-                    toast.error(extractError(err) ?? 'Failed to save schedule'),
-            }
-        );
-    };
+    // Local toggle that lets admin reopen the chooser BEFORE any shifts are
+    // saved. Once shifts exist, this is ignored — pattern is locked.
+    const [forceChooser, setForceChooser] = useState(false);
 
     if (pool.assignment_mode !== 'TIME_BASED') {
         return (
             <Card>
                 <CardContent className="py-8 text-sm text-muted-foreground">
-                    This tab is only used when the pool's assignment mode is{' '}
-                    <strong>Time-based</strong>. Switch the mode in the Overview tab to configure
-                    a weekly shift schedule.
-                </CardContent>
-            </Card>
-        );
-    }
-
-    if (poolCounselorOptions.length === 0) {
-        return (
-            <Card>
-                <CardContent className="py-8 text-sm text-muted-foreground">
-                    Add at least one counselor to this pool before configuring the schedule.
+                    This tab is only used when the pool&apos;s assignment mode is{' '}
+                    <strong>Time-based</strong>. Switch the mode in the Overview tab to
+                    configure a weekly shift schedule.
                 </CardContent>
             </Card>
         );
@@ -198,277 +55,50 @@ export default function ScheduleTab({ pool }: ScheduleTabProps) {
         return <div className="p-4 text-sm text-muted-foreground">Loading schedule…</div>;
     }
 
-    return (
-        <div className="space-y-4">
-            <Card className={validation.ok ? 'border-green-300' : 'border-red-300'}>
-                <CardHeader>
-                    <CardTitle>Coverage Status</CardTitle>
-                    <CardDescription>
-                        The schedule must cover every minute of every day. Overlapping shifts are
-                        allowed.
-                    </CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {validation.ok ? (
-                        <p className="text-sm text-green-700">
-                            ✓ All 7 days are covered 24/7
-                        </p>
-                    ) : (
-                        <ul className="space-y-1 text-sm text-red-700">
-                            {validation.errors.map((e, i) => (
-                                <li key={i}>• {e}</li>
-                            ))}
-                        </ul>
-                    )}
-                </CardContent>
-            </Card>
+    const hasShifts = serverSchedule.length > 0;
+    const pattern: SchedulePattern | null =
+        (pool.schedule_pattern as SchedulePattern | undefined) ?? null;
 
-            {DAYS_OF_WEEK.map((day) => (
-                <DayCard
-                    key={day}
-                    day={day}
-                    shifts={schedule[day]}
-                    counselorOptions={poolCounselorOptions}
-                    onAdd={() => addShift(day)}
-                    onRemove={(idx) => removeShift(day, idx)}
-                    onUpdate={(idx, patch) => updateShift(day, idx, patch)}
-                />
-            ))}
-
-            <div className="flex justify-end">
-                <MyButton
-                    buttonType="primary"
-                    scale="medium"
-                    onClick={handleSave}
-                    disable={saving || !validation.ok}
-                >
-                    {saving ? 'Saving…' : 'Save Schedule'}
-                </MyButton>
-            </div>
-        </div>
-    );
-}
-
-interface DayCardProps {
-    day: DayOfWeek;
-    shifts: EditableShift[];
-    counselorOptions: { id: string; name: string }[];
-    onAdd: () => void;
-    onRemove: (idx: number) => void;
-    onUpdate: (idx: number, patch: Partial<EditableShift>) => void;
-}
-
-function DayCard({ day, shifts, counselorOptions, onAdd, onRemove, onUpdate }: DayCardProps) {
-    return (
-        <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-                <CardTitle className="text-base">{DAY_LABEL[day]}</CardTitle>
-                <MyButton buttonType="secondary" scale="small" onClick={onAdd}>
-                    + Add Shift
-                </MyButton>
-            </CardHeader>
-            <CardContent className="space-y-3">
-                {shifts.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">
-                        No shifts configured. Add a shift to cover this day.
-                    </p>
-                ) : (
-                    shifts.map((s, idx) => (
-                        <ShiftBlockEditor
-                            key={s.localId}
-                            shift={s}
-                            counselorOptions={counselorOptions}
-                            onRemove={() => onRemove(idx)}
-                            onUpdate={(patch) => onUpdate(idx, patch)}
-                        />
-                    ))
-                )}
-            </CardContent>
-        </Card>
-    );
-}
-
-interface ShiftBlockEditorProps {
-    shift: EditableShift;
-    counselorOptions: { id: string; name: string }[];
-    onRemove: () => void;
-    onUpdate: (patch: Partial<EditableShift>) => void;
-}
-
-function ShiftBlockEditor({ shift, counselorOptions, onRemove, onUpdate }: ShiftBlockEditorProps) {
-    const availableToAdd = counselorOptions.filter(
-        (c) => !shift.counselorUserIds.includes(c.id)
-    );
-
-    return (
-        <div className="rounded border bg-neutral-50 p-3">
-            <div className="flex items-end gap-3">
-                <div className="space-y-1">
-                    <Label className="text-xs">Start</Label>
-                    <Input
-                        type="time"
-                        step={1}
-                        value={trimToHM(shift.startTime)}
-                        onChange={(e) =>
-                            onUpdate({ startTime: padToFullTime(e.target.value) })
-                        }
-                        className="w-32"
-                    />
-                </div>
-                <div className="space-y-1">
-                    <Label className="text-xs">End</Label>
-                    <Input
-                        type="time"
-                        step={1}
-                        value={trimToHM(shift.endTime)}
-                        onChange={(e) =>
-                            onUpdate({ endTime: padToFullTime(e.target.value) })
-                        }
-                        className="w-32"
-                    />
-                </div>
-                <div className="flex-1 space-y-1">
-                    <Label className="text-xs">Label (optional)</Label>
-                    <Input
-                        value={shift.label ?? ''}
-                        onChange={(e) => onUpdate({ label: e.target.value })}
-                        placeholder="e.g. Morning shift"
-                    />
-                </div>
-                <button
-                    type="button"
-                    className="self-end pb-2 text-xs text-red-600 hover:underline"
-                    onClick={onRemove}
-                >
-                    Remove
-                </button>
-            </div>
-
-            <div className="mt-3 space-y-2">
-                <Label className="text-xs">Counselors on this shift</Label>
-                <div className="flex flex-wrap gap-2">
-                    {shift.counselorUserIds.length === 0 && (
-                        <span className="text-xs text-muted-foreground">
-                            None selected — add at least one
-                        </span>
-                    )}
-                    {shift.counselorUserIds.map((id) => (
-                        <Badge
-                            key={id}
-                            className="cursor-pointer bg-blue-100 text-blue-700 hover:bg-red-100 hover:text-red-700"
-                            onClick={() =>
-                                onUpdate({
-                                    counselorUserIds: shift.counselorUserIds.filter((c) => c !== id),
-                                })
-                            }
-                        >
-                            {counselorOptions.find((c) => c.id === id)?.name ?? id} ×
-                        </Badge>
-                    ))}
-                </div>
-                {availableToAdd.length > 0 && (
-                    <Select
-                        value=""
-                        onValueChange={(v) =>
-                            onUpdate({ counselorUserIds: [...shift.counselorUserIds, v] })
-                        }
-                    >
-                        <SelectTrigger className="w-64">
-                            <SelectValue placeholder="+ Add counselor" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {availableToAdd.map((c) => (
-                                <SelectItem key={c.id} value={c.id}>
-                                    {c.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                )}
-            </div>
-        </div>
-    );
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────
-
-function emptySchedule(): Record<DayOfWeek, EditableShift[]> {
-    return {
-        MON: [],
-        TUE: [],
-        WED: [],
-        THU: [],
-        FRI: [],
-        SAT: [],
-        SUN: [],
-    };
-}
-
-const START_OF_DAY = '00:00:00';
-const END_OF_DAY = '23:59:59';
-
-function validateCoverage(schedule: Record<DayOfWeek, EditableShift[]>): {
-    ok: boolean;
-    errors: string[];
-} {
-    const errors: string[] = [];
-    for (const day of DAYS_OF_WEEK) {
-        const dayShifts = schedule[day];
-        if (dayShifts.length === 0) {
-            errors.push(`${DAY_LABEL[day]} has no shifts.`);
-            continue;
-        }
-
-        // Validate each shift: counsellor count, start < end
-        for (const s of dayShifts) {
-            if (s.counselorUserIds.length === 0) {
-                errors.push(`${DAY_LABEL[day]} ${s.startTime}–${s.endTime}: needs at least one counselor.`);
-            }
-            if (s.startTime >= s.endTime) {
-                errors.push(`${DAY_LABEL[day]} ${s.startTime}–${s.endTime}: end must be after start.`);
-            }
-        }
-
-        // Coverage walk
-        const sorted = [...dayShifts].sort((a, b) => a.startTime.localeCompare(b.startTime));
-        const first = sorted[0]!;
-        if (first.startTime !== START_OF_DAY) {
-            errors.push(`${DAY_LABEL[day]} does not start at 00:00:00 (first block: ${first.startTime}).`);
-        }
-        let coveredUntil = first.endTime;
-        for (let i = 1; i < sorted.length; i++) {
-            const next = sorted[i]!;
-            if (next.startTime > coveredUntil) {
-                errors.push(
-                    `${DAY_LABEL[day]} has a gap between ${coveredUntil} and ${next.startTime}.`
-                );
-            }
-            if (next.endTime > coveredUntil) coveredUntil = next.endTime;
-        }
-        if (coveredUntil < END_OF_DAY) {
-            errors.push(`${DAY_LABEL[day]} does not cover up to 23:59:59 (covered until ${coveredUntil}).`);
-        }
+    // Empty state: shown when nothing is saved and admin hasn't picked, OR
+    // when admin clicks "Change pattern" before saving shifts.
+    if (!hasShifts && (pattern === null || forceChooser)) {
+        return (
+            <ScheduleEmptyState
+                poolId={pool.id}
+                onPatternChosen={() => setForceChooser(false)}
+            />
+        );
     }
-    return { ok: errors.length === 0, errors };
-}
 
-function trimToHM(t: string): string {
-    // "HH:mm:ss" → "HH:mm" for <input type="time"> default render
-    return t?.slice(0, 5) ?? '';
-}
+    // Pattern set (either explicitly or legacy fallback to PER_DAY).
+    const effectivePattern: SchedulePattern = pattern ?? 'PER_DAY';
 
-function padToFullTime(hm: string): string {
-    // "HH:mm" → "HH:mm:00"
-    return hm.length === 5 ? `${hm}:00` : hm;
-}
-
-function cryptoRandom(): string {
-    return Math.random().toString(36).slice(2, 10);
-}
-
-function extractError(err: unknown): string | undefined {
     return (
-        (err as { response?: { data?: { ex?: string; message?: string } } })?.response?.data?.ex ??
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message
+        <div className="space-y-3">
+            {!hasShifts && (
+                <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 p-3 text-xs text-muted-foreground">
+                    <span>
+                        Authoring as <strong>{prettyPattern(effectivePattern)}</strong>. Save
+                        below to lock this choice.
+                    </span>
+                    <MyButton
+                        buttonType="secondary"
+                        scale="small"
+                        onClick={() => setForceChooser(true)}
+                    >
+                        Change pattern
+                    </MyButton>
+                </div>
+            )}
+            {effectivePattern === 'SAME_HOURS_ALL_DAYS' ? (
+                <SameHoursAllDaysEditor pool={pool} />
+            ) : (
+                <PerDayScheduleEditor pool={pool} />
+            )}
+        </div>
     );
+}
+
+function prettyPattern(p: SchedulePattern): string {
+    return p === 'SAME_HOURS_ALL_DAYS' ? 'Same hours every day' : 'Custom per day';
 }

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/PerDayScheduleEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/PerDayScheduleEditor.tsx
@@ -1,0 +1,396 @@
+/**
+ * UI A — "Custom per day" editor. Authors each weekday independently.
+ *
+ * For each day, the admin picks one of two layouts:
+ *   - "Whole day" — one block 00:00:00–23:59:59, ≥1 counsellor
+ *   - "Multiple shifts" — N blocks tiling the 24h with no gaps, each ≥1 counsellor
+ *
+ * Every day must be filled (no empty days), every shift must have ≥1
+ * counsellor, and gaps surface inline per-day. Save is disabled until all 7
+ * days validate.
+ *
+ * "Reset schedule" wipes all shifts (POST empty list is rejected by backend
+ * for safety; we instead need to send a placeholder that's clearly invalid OR
+ * unlock the pattern selector by deleting the saved schedule via a separate
+ * flow). For now Reset rewinds the local edits to the saved server state.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { MyButton } from '@/components/design-system/button';
+import {
+    CounselorPoolDTO,
+    DAYS_OF_WEEK,
+    DayOfWeek,
+    PoolShiftDTO,
+    ShiftBlockRequest,
+    useSetWeeklySchedule,
+    useWeeklySchedule,
+} from '@/services/counselor-pool';
+import ScheduleReadView from './ScheduleReadView';
+import ShiftBlockEditor from './ShiftBlockEditor';
+import ShiftCountPicker from './ShiftCountPicker';
+import {
+    DAY_LABEL,
+    END_OF_DAY,
+    START_OF_DAY,
+    cryptoRandom,
+    extractError,
+    fetchCounselors,
+    normalizeEndOfDay,
+    validateDayCoverage,
+    type EditableShift,
+} from './shared';
+
+interface Props {
+    pool: CounselorPoolDTO;
+}
+
+type DayLayout = 'WHOLE_DAY' | 'MULTIPLE_SHIFTS';
+
+export default function PerDayScheduleEditor({ pool }: Props) {
+    const { data: serverSchedule, isLoading } = useWeeklySchedule(pool.id);
+    const { mutate: saveSchedule, isPending: saving } = useSetWeeklySchedule(pool.id);
+
+    const { data: instituteUsers = [] } = useQuery({
+        queryKey: ['institute-counselors-for-schedule'],
+        queryFn: fetchCounselors,
+        staleTime: 60 * 1000,
+    });
+    const userNameById = useMemo(() => {
+        const map = new Map<string, string>();
+        instituteUsers.forEach((u) => map.set(u.id, u.full_name));
+        return map;
+    }, [instituteUsers]);
+
+    const poolCounselorOptions = useMemo(() => {
+        const ids = new Set((pool.members ?? []).map((m) => m.counselor_user_id));
+        return [...ids].map((id) => ({
+            id,
+            name: userNameById.get(id) ?? id.slice(0, 8) + '…',
+        }));
+    }, [pool.members, userNameById]);
+
+    const [schedule, setSchedule] = useState<Record<DayOfWeek, EditableShift[]>>(() =>
+        emptySchedule()
+    );
+    /** Read/edit mode toggle — mirrors OverviewTab. Auto-starts in edit when nothing's saved. */
+    const [editing, setEditing] = useState(false);
+
+    const hydrateFromServer = useCallback((rows: PoolShiftDTO[]) => {
+        const next = emptySchedule();
+        for (const s of rows) {
+            next[s.day_of_week].push({
+                localId: s.id,
+                startTime: s.start_time,
+                endTime: s.end_time,
+                label: s.label,
+                counselorUserIds: (s.members ?? []).map((m) => m.counselor_user_id),
+            });
+        }
+        for (const day of DAYS_OF_WEEK) {
+            next[day].sort((a, b) => a.startTime.localeCompare(b.startTime));
+        }
+        setSchedule(next);
+    }, []);
+
+    useEffect(() => {
+        if (!serverSchedule) return;
+        hydrateFromServer(serverSchedule);
+        // If nothing's saved yet, drop the admin straight into the editor.
+        setEditing((curr) => curr || serverSchedule.length === 0);
+    }, [serverSchedule, hydrateFromServer]);
+
+    const updateDay = (day: DayOfWeek, mutate: (shifts: EditableShift[]) => EditableShift[]) => {
+        setSchedule((prev) => ({ ...prev, [day]: mutate([...prev[day]]) }));
+    };
+
+    /** Switch a day to Whole-day layout: collapse to one 00:00–23:59 block, preserving the union of counsellors. */
+    const setWholeDay = (day: DayOfWeek) =>
+        updateDay(day, (shifts) => {
+            const unionIds = Array.from(
+                new Set(shifts.flatMap((s) => s.counselorUserIds))
+            );
+            return [
+                {
+                    localId: cryptoRandom(),
+                    startTime: START_OF_DAY,
+                    endTime: END_OF_DAY,
+                    counselorUserIds: unionIds,
+                },
+            ];
+        });
+
+    /**
+     * Switch a day to Multiple-shifts layout. If it was a whole-day block, drop it
+     * so the ShiftCountPicker shows. If it was already multi-shift, leave existing
+     * shifts in place.
+     */
+    const setMultipleShifts = (day: DayOfWeek) =>
+        updateDay(day, (shifts) => {
+            if (shifts.length === 0) return shifts;
+            const onlyWholeDay =
+                shifts.length === 1 &&
+                shifts[0]!.startTime === START_OF_DAY &&
+                shifts[0]!.endTime === END_OF_DAY;
+            return onlyWholeDay ? [] : shifts;
+        });
+
+    /** Replace a day's shifts wholesale — used by ShiftCountPicker. */
+    const replaceDayShifts = (day: DayOfWeek, shifts: EditableShift[]) =>
+        updateDay(day, () => shifts);
+
+    const addShift = (day: DayOfWeek) =>
+        updateDay(day, (shifts) => [...shifts, defaultShift()]);
+
+    const removeShift = (day: DayOfWeek, idx: number) =>
+        updateDay(day, (shifts) => shifts.filter((_, i) => i !== idx));
+
+    const updateShift = (day: DayOfWeek, idx: number, patch: Partial<EditableShift>) =>
+        updateDay(day, (shifts) => shifts.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+
+    const dayValidations = useMemo(() => {
+        const out: Record<DayOfWeek, ReturnType<typeof validateDayCoverage>> = {} as never;
+        for (const day of DAYS_OF_WEEK) {
+            out[day] = validateDayCoverage(schedule[day]);
+        }
+        return out;
+    }, [schedule]);
+
+    const allValid = DAYS_OF_WEEK.every((d) => dayValidations[d].ok);
+
+    const handleSave = () => {
+        if (!allValid) {
+            toast.error('Fix the highlighted days before saving.');
+            return;
+        }
+        const flatShifts: ShiftBlockRequest[] = [];
+        for (const day of DAYS_OF_WEEK) {
+            for (const s of schedule[day]) {
+                flatShifts.push({
+                    day_of_week: day,
+                    start_time: s.startTime,
+                    // Bump minute-precision EOD (23:59:00) to second-precision so the
+                    // backend's coverage rule and routing engine see full coverage.
+                    end_time: normalizeEndOfDay(s.endTime),
+                    label: s.label,
+                    counselor_user_ids: s.counselorUserIds,
+                });
+            }
+        }
+        saveSchedule(
+            { shifts: flatShifts },
+            {
+                onSuccess: () => {
+                    toast.success('Schedule saved');
+                    setEditing(false);
+                },
+                onError: (err) => toast.error(extractError(err) ?? 'Failed to save schedule'),
+            }
+        );
+    };
+
+    const handleCancel = () => {
+        if (serverSchedule) hydrateFromServer(serverSchedule);
+        setEditing(false);
+    };
+
+    if (poolCounselorOptions.length === 0) {
+        return (
+            <Card>
+                <CardContent className="py-8 text-sm text-muted-foreground">
+                    Add at least one counsellor to this pool before configuring the schedule.
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (isLoading) {
+        return <div className="p-4 text-sm text-muted-foreground">Loading schedule…</div>;
+    }
+
+    // Read mode: compact view, with "Edit" button. Only when there's something saved.
+    if (!editing && serverSchedule && serverSchedule.length > 0) {
+        return (
+            <ScheduleReadView
+                schedule={serverSchedule}
+                pattern="PER_DAY"
+                userNameById={userNameById}
+                onEdit={() => setEditing(true)}
+            />
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <Card className={allValid ? 'border-green-300' : 'border-red-300'}>
+                <CardHeader>
+                    <CardTitle>Coverage Status</CardTitle>
+                    <CardDescription>
+                        Each day must cover 00:00–23:59 with no gaps, and every shift must have
+                        at least one counsellor.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {allValid ? (
+                        <p className="text-sm text-green-700">✓ All 7 days are valid</p>
+                    ) : (
+                        <ul className="space-y-1 text-sm text-red-700">
+                            {DAYS_OF_WEEK.filter((d) => !dayValidations[d].ok).map((d) => (
+                                <li key={d}>• {DAY_LABEL[d]} — see errors below</li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+
+            {DAYS_OF_WEEK.map((day) => {
+                const shifts = schedule[day];
+                const layout: DayLayout =
+                    shifts.length === 1 &&
+                    shifts[0]!.startTime === START_OF_DAY &&
+                    shifts[0]!.endTime === END_OF_DAY
+                        ? 'WHOLE_DAY'
+                        : 'MULTIPLE_SHIFTS';
+                const validation = dayValidations[day];
+
+                return (
+                    <Card
+                        key={day}
+                        className={validation.ok ? undefined : 'border-red-300'}
+                    >
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+                            <CardTitle className="text-base">{DAY_LABEL[day]}</CardTitle>
+                            <div className="flex items-center gap-2">
+                                <LayoutToggle
+                                    layout={layout}
+                                    onChange={(next) =>
+                                        next === 'WHOLE_DAY'
+                                            ? setWholeDay(day)
+                                            : setMultipleShifts(day)
+                                    }
+                                />
+                                {layout === 'MULTIPLE_SHIFTS' && (
+                                    <MyButton
+                                        buttonType="secondary"
+                                        scale="small"
+                                        onClick={() => addShift(day)}
+                                    >
+                                        + Add Shift
+                                    </MyButton>
+                                )}
+                            </div>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {shifts.length === 0 && layout === 'MULTIPLE_SHIFTS' && (
+                                <ShiftCountPicker
+                                    onPick={(generated) => replaceDayShifts(day, generated)}
+                                />
+                            )}
+                            {shifts.length === 0 && layout === 'WHOLE_DAY' && (
+                                <p className="text-xs text-red-700">
+                                    No shifts configured. Add one to cover this day.
+                                </p>
+                            )}
+                            {shifts.map((s, idx) => {
+                                const shiftErr = validation.shiftErrors.find(
+                                    (e) => e.localId === s.localId
+                                );
+                                return (
+                                    <ShiftBlockEditor
+                                        key={s.localId}
+                                        shift={s}
+                                        counselorOptions={poolCounselorOptions}
+                                        error={shiftErr?.message}
+                                        canRemove={layout === 'MULTIPLE_SHIFTS' && shifts.length > 1}
+                                        onRemove={() => removeShift(day, idx)}
+                                        onUpdate={(patch) => updateShift(day, idx, patch)}
+                                    />
+                                );
+                            })}
+                            {validation.coverageErrors.length > 0 && (
+                                <ul className="space-y-1 text-xs text-red-700">
+                                    {validation.coverageErrors.map((e, i) => (
+                                        <li key={i}>• {e}</li>
+                                    ))}
+                                </ul>
+                            )}
+                        </CardContent>
+                    </Card>
+                );
+            })}
+
+            <div className="flex justify-end gap-2">
+                {serverSchedule && serverSchedule.length > 0 && (
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={handleCancel}
+                        disable={saving}
+                    >
+                        Cancel
+                    </MyButton>
+                )}
+                <MyButton
+                    buttonType="primary"
+                    scale="medium"
+                    onClick={handleSave}
+                    disable={saving || !allValid}
+                >
+                    {saving ? 'Saving…' : 'Save Schedule'}
+                </MyButton>
+            </div>
+        </div>
+    );
+}
+
+interface LayoutToggleProps {
+    layout: DayLayout;
+    onChange: (next: DayLayout) => void;
+}
+
+function LayoutToggle({ layout, onChange }: LayoutToggleProps) {
+    const opt = (value: DayLayout, label: string) => (
+        <button
+            type="button"
+            onClick={() => onChange(value)}
+            className={
+                'rounded-sm px-3 py-1 text-xs transition ' +
+                (layout === value
+                    ? 'bg-primary-100 text-primary-700'
+                    : 'text-neutral-600 hover:bg-neutral-100')
+            }
+        >
+            {label}
+        </button>
+    );
+    return (
+        <div className="inline-flex rounded-md border border-neutral-200 p-0.5">
+            {opt('WHOLE_DAY', 'Whole day')}
+            {opt('MULTIPLE_SHIFTS', 'Multiple shifts')}
+        </div>
+    );
+}
+
+function emptySchedule(): Record<DayOfWeek, EditableShift[]> {
+    return {
+        MON: [],
+        TUE: [],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: [],
+    };
+}
+
+function defaultShift(): EditableShift {
+    return {
+        localId: cryptoRandom(),
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        counselorUserIds: [],
+    };
+}

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/SameHoursAllDaysEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/SameHoursAllDaysEditor.tsx
@@ -1,0 +1,320 @@
+/**
+ * UI B — "Same hours every day" editor.
+ *
+ * Admin defines one canonical 24h template (N blocks tiling 00:00–23:59:59).
+ * That template is applied to all 7 days on save: the frontend emits N × 7
+ * shift rows, expanding overnight blocks (start > end) into two halves at
+ * midnight per day so the backend's strict start < end check is satisfied.
+ *
+ * On load, we read Monday's shifts (the schedule_pattern column told the
+ * Schedule tab to render this editor, so we trust that all 7 days are
+ * identical) and merge any (00:00–T) + (T'–23:59:59) pair with the same
+ * member set back into one overnight block.
+ *
+ * Every block must have ≥1 counsellor; the canonical template must tile 24h.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { MyButton } from '@/components/design-system/button';
+import {
+    CounselorPoolDTO,
+    DAYS_OF_WEEK,
+    PoolShiftDTO,
+    ShiftBlockRequest,
+    useSetWeeklySchedule,
+    useWeeklySchedule,
+} from '@/services/counselor-pool';
+import ScheduleReadView from './ScheduleReadView';
+import ShiftBlockEditor from './ShiftBlockEditor';
+import ShiftCountPicker from './ShiftCountPicker';
+import {
+    END_OF_DAY,
+    START_OF_DAY,
+    cryptoRandom,
+    extractError,
+    fetchCounselors,
+    normalizeEndOfDay,
+    reconstructSameHoursTemplate,
+    validateDayCoverage,
+    type EditableShift,
+    type ShiftError,
+} from './shared';
+
+interface Props {
+    pool: CounselorPoolDTO;
+}
+
+export default function SameHoursAllDaysEditor({ pool }: Props) {
+    const { data: serverSchedule, isLoading } = useWeeklySchedule(pool.id);
+    const { mutate: saveSchedule, isPending: saving } = useSetWeeklySchedule(pool.id);
+
+    const { data: instituteUsers = [] } = useQuery({
+        queryKey: ['institute-counselors-for-schedule'],
+        queryFn: fetchCounselors,
+        staleTime: 60 * 1000,
+    });
+    const userNameById = useMemo(() => {
+        const map = new Map<string, string>();
+        instituteUsers.forEach((u) => map.set(u.id, u.full_name));
+        return map;
+    }, [instituteUsers]);
+
+    const poolCounselorOptions = useMemo(() => {
+        const ids = new Set((pool.members ?? []).map((m) => m.counselor_user_id));
+        return [...ids].map((id) => ({
+            id,
+            name: userNameById.get(id) ?? id.slice(0, 8) + '…',
+        }));
+    }, [pool.members, userNameById]);
+
+    /**
+     * The single canonical 24h template. Each block applies to all 7 days.
+     * Overnight blocks (start > end) are stored as one logical row here and
+     * split at midnight on save.
+     */
+    const [template, setTemplate] = useState<EditableShift[]>([]);
+    /** Read/edit mode toggle — auto-starts in edit when nothing's saved. */
+    const [editing, setEditing] = useState(false);
+
+    const hydrateFromServer = useCallback((rows: PoolShiftDTO[]) => {
+        setTemplate(reconstructSameHoursTemplate(rows));
+    }, []);
+
+    useEffect(() => {
+        if (!serverSchedule) return;
+        hydrateFromServer(serverSchedule);
+        setEditing((curr) => curr || serverSchedule.length === 0);
+    }, [serverSchedule, hydrateFromServer]);
+
+    const updateTemplate = (mutate: (rows: EditableShift[]) => EditableShift[]) =>
+        setTemplate((prev) => mutate([...prev]));
+
+    const addBlock = () =>
+        updateTemplate((rows) => [
+            ...rows,
+            {
+                localId: cryptoRandom(),
+                startTime: '09:00:00',
+                endTime: '12:00:00',
+                counselorUserIds: [],
+            },
+        ]);
+
+    const removeBlock = (idx: number) =>
+        updateTemplate((rows) => rows.filter((_, i) => i !== idx));
+
+    const updateBlock = (idx: number, patch: Partial<EditableShift>) =>
+        updateTemplate((rows) => rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+
+    const validation = useMemo(() => validateTemplate(template), [template]);
+
+    const handleSave = () => {
+        if (!validation.ok) {
+            toast.error('Fix the highlighted blocks before saving.');
+            return;
+        }
+        const flatShifts: ShiftBlockRequest[] = [];
+        const expanded = expandOvernight(template);
+        for (const day of DAYS_OF_WEEK) {
+            for (const block of expanded) {
+                flatShifts.push({
+                    day_of_week: day,
+                    start_time: block.startTime,
+                    // Bump minute-precision EOD (23:59:00) to second-precision so the
+                    // backend's coverage rule and routing engine see full coverage.
+                    end_time: normalizeEndOfDay(block.endTime),
+                    label: block.label,
+                    counselor_user_ids: block.counselorUserIds,
+                });
+            }
+        }
+        saveSchedule(
+            { shifts: flatShifts },
+            {
+                onSuccess: () => {
+                    toast.success('Schedule saved');
+                    setEditing(false);
+                },
+                onError: (err) => toast.error(extractError(err) ?? 'Failed to save schedule'),
+            }
+        );
+    };
+
+    const handleCancel = () => {
+        if (serverSchedule) hydrateFromServer(serverSchedule);
+        setEditing(false);
+    };
+
+    if (poolCounselorOptions.length === 0) {
+        return (
+            <Card>
+                <CardContent className="py-8 text-sm text-muted-foreground">
+                    Add at least one counsellor to this pool before configuring the schedule.
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (isLoading) {
+        return <div className="p-4 text-sm text-muted-foreground">Loading schedule…</div>;
+    }
+
+    if (!editing && serverSchedule && serverSchedule.length > 0) {
+        return (
+            <ScheduleReadView
+                schedule={serverSchedule}
+                pattern="SAME_HOURS_ALL_DAYS"
+                userNameById={userNameById}
+                onEdit={() => setEditing(true)}
+            />
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <Card className={validation.ok ? 'border-green-300' : 'border-red-300'}>
+                <CardHeader>
+                    <CardTitle>Coverage Status</CardTitle>
+                    <CardDescription>
+                        Define blocks that tile 24 hours. The same set of blocks is applied to
+                        Monday through Sunday. Blocks crossing midnight (e.g. 18:00–09:00) are
+                        allowed.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {validation.ok ? (
+                        <p className="text-sm text-green-700">✓ 24h covered, all blocks valid</p>
+                    ) : (
+                        <ul className="space-y-1 text-sm text-red-700">
+                            {validation.coverageErrors.map((e, i) => (
+                                <li key={i}>• {e}</li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+                    <div>
+                        <CardTitle className="text-base">Daily Template</CardTitle>
+                        <CardDescription>Applied to all 7 days</CardDescription>
+                    </div>
+                    <MyButton buttonType="secondary" scale="small" onClick={addBlock}>
+                        + Add Block
+                    </MyButton>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    {template.length === 0 && (
+                        <ShiftCountPicker onPick={(generated) => setTemplate(generated)} />
+                    )}
+                    {template.map((b, idx) => {
+                        const shiftErr = validation.shiftErrors.find((e) => e.localId === b.localId);
+                        const isOvernight = b.startTime > b.endTime;
+                        return (
+                            <ShiftBlockEditor
+                                key={b.localId}
+                                shift={b}
+                                counselorOptions={poolCounselorOptions}
+                                error={shiftErr?.message}
+                                endLabel={isOvernight ? 'next day' : undefined}
+                                onRemove={() => removeBlock(idx)}
+                                onUpdate={(patch) => updateBlock(idx, patch)}
+                            />
+                        );
+                    })}
+                </CardContent>
+            </Card>
+
+            <div className="flex justify-end gap-2">
+                {serverSchedule && serverSchedule.length > 0 && (
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={handleCancel}
+                        disable={saving}
+                    >
+                        Cancel
+                    </MyButton>
+                )}
+                <MyButton
+                    buttonType="primary"
+                    scale="medium"
+                    onClick={handleSave}
+                    disable={saving || !validation.ok}
+                >
+                    {saving ? 'Saving…' : 'Save Schedule'}
+                </MyButton>
+            </div>
+        </div>
+    );
+}
+
+// ─── Validation ────────────────────────────────────────────────────────────
+
+function validateTemplate(template: EditableShift[]): {
+    ok: boolean;
+    coverageErrors: string[];
+    shiftErrors: ShiftError[];
+} {
+    const shiftErrors: ShiftError[] = [];
+
+    for (const b of template) {
+        if (b.counselorUserIds.length === 0) {
+            shiftErrors.push({ localId: b.localId, message: 'Add at least one counsellor.' });
+        }
+        if (b.startTime === b.endTime) {
+            shiftErrors.push({ localId: b.localId, message: 'Duration must be greater than zero.' });
+        }
+    }
+
+    if (template.length === 0) {
+        return { ok: false, coverageErrors: ['No blocks configured.'], shiftErrors };
+    }
+
+    // Reuse the per-day coverage validator on the midnight-expanded view.
+    // It checks gaps and "first block must start at 00:00" / "must reach 23:59:59".
+    const expanded = expandOvernight(template);
+    const { coverageErrors } = validateDayCoverage(expanded);
+
+    return {
+        ok: coverageErrors.length === 0 && shiftErrors.length === 0,
+        coverageErrors,
+        shiftErrors,
+    };
+}
+
+// ─── Overnight expansion / template reconstruction ──────────────────────────
+
+/**
+ * Split overnight blocks (start > end) into two halves: [start, 23:59:59] and
+ * [00:00, end]. Non-overnight blocks pass through. Both halves carry the same
+ * label and counsellors. The localId is suffixed so the halves don't collide
+ * if the caller looks them up.
+ */
+function expandOvernight(blocks: EditableShift[]): EditableShift[] {
+    const out: EditableShift[] = [];
+    for (const b of blocks) {
+        if (b.startTime > b.endTime) {
+            out.push({
+                ...b,
+                localId: `${b.localId}:eve`,
+                startTime: b.startTime,
+                endTime: END_OF_DAY,
+            });
+            out.push({
+                ...b,
+                localId: `${b.localId}:morn`,
+                startTime: START_OF_DAY,
+                endTime: b.endTime,
+            });
+        } else {
+            out.push(b);
+        }
+    }
+    return out;
+}
+

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ScheduleEmptyState.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ScheduleEmptyState.tsx
@@ -1,0 +1,108 @@
+/**
+ * Empty state for the Schedule tab: shows when the pool has TIME_BASED mode
+ * but no shifts saved yet. Admin picks one of two authoring patterns. The
+ * pattern is persisted to counselor_pool.schedule_pattern via PATCH and the
+ * Schedule tab then renders the matching editor.
+ *
+ * Once any shift is saved, the pattern is locked. To change it, admin must
+ * clear the schedule first (handled inside each editor).
+ */
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { MyButton } from '@/components/design-system/button';
+import { useUpdatePool, type SchedulePattern } from '@/services/counselor-pool';
+import { extractError } from './shared';
+
+interface Props {
+    poolId: string;
+    /** Called after pattern is saved so parent can switch to the matching editor. */
+    onPatternChosen: (pattern: SchedulePattern) => void;
+}
+
+export default function ScheduleEmptyState({ poolId, onPatternChosen }: Props) {
+    const { mutate: updatePool, isPending } = useUpdatePool(poolId);
+    const [pending, setPending] = useState<SchedulePattern | null>(null);
+
+    const pick = (pattern: SchedulePattern) => {
+        setPending(pattern);
+        updatePool(
+            { schedule_pattern: pattern },
+            {
+                onSuccess: () => {
+                    setPending(null);
+                    onPatternChosen(pattern);
+                },
+                onError: (err) => {
+                    setPending(null);
+                    toast.error(extractError(err) ?? 'Failed to set schedule pattern');
+                },
+            }
+        );
+    };
+
+    return (
+        <div className="space-y-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Choose a schedule pattern</CardTitle>
+                    <CardDescription>
+                        Pick how you want to author this pool&apos;s weekly schedule. You can
+                        change this later, but only after clearing the schedule.
+                    </CardDescription>
+                </CardHeader>
+            </Card>
+
+            <div className="grid gap-4 md:grid-cols-2">
+                <PatternCard
+                    title="Custom per day"
+                    description="Each day of the week is authored independently. Each day can be one whole-day block or split into multiple shifts."
+                    example="Mon 09:00–18:00 Amit, Tue 09:00–13:00 Bhavna + 13:00–18:00 Charlie, Wed 09:00–18:00 Diya, …"
+                    onChoose={() => pick('PER_DAY')}
+                    isPending={isPending && pending === 'PER_DAY'}
+                />
+                <PatternCard
+                    title="Same hours every day"
+                    description="Define one set of blocks that repeats across all 7 days. Useful when shifts don't vary by day."
+                    example="09:00–12:00 Amit, 12:00–18:00 Bhavna, 18:00–09:00 Charlie — applied to Mon through Sun."
+                    onChoose={() => pick('SAME_HOURS_ALL_DAYS')}
+                    isPending={isPending && pending === 'SAME_HOURS_ALL_DAYS'}
+                />
+            </div>
+        </div>
+    );
+}
+
+interface PatternCardProps {
+    title: string;
+    description: string;
+    example: string;
+    onChoose: () => void;
+    isPending: boolean;
+}
+
+function PatternCard({ title, description, example, onChoose, isPending }: PatternCardProps) {
+    return (
+        <Card className="flex h-full flex-col">
+            <CardHeader>
+                <CardTitle className="text-base">{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col justify-between gap-4">
+                <p className="rounded bg-neutral-50 p-3 text-xs text-muted-foreground">
+                    <span className="block font-medium text-neutral-700">Example</span>
+                    {example}
+                </p>
+                <MyButton
+                    buttonType="primary"
+                    scale="medium"
+                    onClick={onChoose}
+                    disable={isPending}
+                >
+                    {isPending ? 'Setting…' : `Use ${title}`}
+                </MyButton>
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ScheduleReadView.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ScheduleReadView.tsx
@@ -1,0 +1,189 @@
+/**
+ * Compact, read-only view of a pool's saved weekly schedule. Renders one
+ * screen without scrolling for a typical schedule. Mirrors the OverviewTab
+ * pattern: read mode by default once data exists, "Edit" button flips the
+ * parent into edit mode.
+ *
+ * Two shapes depending on schedule_pattern:
+ *   - PER_DAY              → 7-column grid, one column per day
+ *   - SAME_HOURS_ALL_DAYS  → single column "Same hours every day" with the
+ *                            canonical template (overnight blocks merged)
+ */
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { MyButton } from '@/components/design-system/button';
+import {
+    DAYS_OF_WEEK,
+    DayOfWeek,
+    PoolShiftDTO,
+    SchedulePattern,
+} from '@/services/counselor-pool';
+import {
+    DAY_LABEL,
+    END_OF_DAY,
+    groupShiftsByDay,
+    reconstructSameHoursTemplate,
+    trimToHM,
+    type EditableShift,
+} from './shared';
+
+interface Props {
+    schedule: PoolShiftDTO[];
+    pattern: SchedulePattern;
+    userNameById: Map<string, string>;
+    onEdit: () => void;
+}
+
+export default function ScheduleReadView({ schedule, pattern, userNameById, onEdit }: Props) {
+    if (pattern === 'SAME_HOURS_ALL_DAYS') {
+        const template = reconstructSameHoursTemplate(schedule);
+        return (
+            <Card>
+                <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                    <div>
+                        <CardTitle>Weekly Schedule</CardTitle>
+                        <CardDescription>Same hours every day</CardDescription>
+                    </div>
+                    <MyButton buttonType="secondary" scale="small" onClick={onEdit}>
+                        Edit
+                    </MyButton>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    {template.map((b) => (
+                        <TemplateBlockRow
+                            key={b.localId}
+                            block={b}
+                            userNameById={userNameById}
+                        />
+                    ))}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    // PER_DAY
+    const byDay = groupShiftsByDay(schedule);
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle>Weekly Schedule</CardTitle>
+                    <CardDescription>Custom per day</CardDescription>
+                </div>
+                <MyButton buttonType="secondary" scale="small" onClick={onEdit}>
+                    Edit
+                </MyButton>
+            </CardHeader>
+            <CardContent>
+                <div className="grid grid-cols-2 gap-2 md:grid-cols-4 lg:grid-cols-7">
+                    {DAYS_OF_WEEK.map((day) => (
+                        <DayColumn
+                            key={day}
+                            day={day}
+                            shifts={byDay[day]}
+                            userNameById={userNameById}
+                        />
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+interface DayColumnProps {
+    day: DayOfWeek;
+    shifts: PoolShiftDTO[];
+    userNameById: Map<string, string>;
+}
+
+function DayColumn({ day, shifts, userNameById }: DayColumnProps) {
+    return (
+        <div className="space-y-1.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-neutral-600">
+                {DAY_LABEL[day]}
+            </p>
+            {shifts.length === 0 && (
+                <p className="rounded border border-dashed border-neutral-200 p-2 text-xs text-muted-foreground">
+                    —
+                </p>
+            )}
+            {shifts.map((s) => (
+                <ShiftCell key={s.id} shift={s} userNameById={userNameById} />
+            ))}
+        </div>
+    );
+}
+
+interface ShiftCellProps {
+    shift: PoolShiftDTO;
+    userNameById: Map<string, string>;
+}
+
+function ShiftCell({ shift, userNameById }: ShiftCellProps) {
+    const end = shift.end_time === END_OF_DAY ? '23:59' : trimToHM(shift.end_time);
+    const memberIds = (shift.members ?? []).map((m) => m.counselor_user_id);
+    return (
+        <div className="rounded border border-neutral-200 bg-neutral-50 p-2">
+            <p className="text-xs font-medium text-neutral-700">
+                {trimToHM(shift.start_time)} – {end}
+            </p>
+            {shift.label && (
+                <p className="text-xs text-muted-foreground">{shift.label}</p>
+            )}
+            <div className="mt-1 flex flex-wrap gap-1">
+                {memberIds.length === 0 ? (
+                    <span className="text-xs text-muted-foreground">No counsellor</span>
+                ) : (
+                    memberIds.map((id) => (
+                        <Badge
+                            key={id}
+                            className="bg-blue-100 text-blue-700 hover:bg-blue-100"
+                        >
+                            {userNameById.get(id) ?? id.slice(0, 8) + '…'}
+                        </Badge>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}
+
+interface TemplateBlockRowProps {
+    block: EditableShift;
+    userNameById: Map<string, string>;
+}
+
+function TemplateBlockRow({ block, userNameById }: TemplateBlockRowProps) {
+    const end = block.endTime === END_OF_DAY ? '23:59' : trimToHM(block.endTime);
+    const isOvernight = block.startTime > block.endTime;
+    return (
+        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-2">
+            <div className="flex items-baseline gap-3">
+                <p className="text-sm font-medium text-neutral-700">
+                    {trimToHM(block.startTime)} – {end}
+                    {isOvernight && (
+                        <span className="ml-1 text-xs text-muted-foreground">(next day)</span>
+                    )}
+                </p>
+                {block.label && (
+                    <p className="text-xs text-muted-foreground">{block.label}</p>
+                )}
+            </div>
+            <div className="flex flex-wrap justify-end gap-1">
+                {block.counselorUserIds.length === 0 ? (
+                    <span className="text-xs text-muted-foreground">No counsellor</span>
+                ) : (
+                    block.counselorUserIds.map((id) => (
+                        <Badge
+                            key={id}
+                            className="bg-blue-100 text-blue-700 hover:bg-blue-100"
+                        >
+                            {userNameById.get(id) ?? id.slice(0, 8) + '…'}
+                        </Badge>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ShiftBlockEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ShiftBlockEditor.tsx
@@ -1,0 +1,144 @@
+/**
+ * Renders one shift block row: start time, end time, optional label, the
+ * multi-counsellor picker, and a remove button. Used by both editors
+ * (per-day and same-hours-all-days) so the look-and-feel is identical.
+ */
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { type EditableShift, padToFullTime, trimToHM } from './shared';
+
+interface Props {
+    shift: EditableShift;
+    counselorOptions: { id: string; name: string }[];
+    /** Optional inline error message shown under the block. */
+    error?: string;
+    /** Optional inline-removal flag for the only-block case (e.g. UI B with one block). */
+    canRemove?: boolean;
+    onRemove: () => void;
+    onUpdate: (patch: Partial<EditableShift>) => void;
+    /** Optional override for the "End" label tooltip; UI B uses it to explain midnight wrap. */
+    endLabel?: string;
+}
+
+export default function ShiftBlockEditor({
+    shift,
+    counselorOptions,
+    error,
+    canRemove = true,
+    onRemove,
+    onUpdate,
+    endLabel,
+}: Props) {
+    const availableToAdd = counselorOptions.filter(
+        (c) => !shift.counselorUserIds.includes(c.id)
+    );
+
+    return (
+        <div
+            className={
+                'rounded border p-3 ' +
+                (error ? 'border-red-300 bg-red-50' : 'border-neutral-200 bg-neutral-50')
+            }
+        >
+            <div className="flex flex-wrap items-end gap-3">
+                <div className="space-y-1">
+                    <Label className="text-xs">Start</Label>
+                    <Input
+                        type="time"
+                        step={60}
+                        value={trimToHM(shift.startTime)}
+                        onChange={(e) =>
+                            onUpdate({ startTime: padToFullTime(e.target.value) })
+                        }
+                        className="w-32"
+                    />
+                </div>
+                <div className="space-y-1">
+                    <Label className="text-xs">End{endLabel ? ` (${endLabel})` : ''}</Label>
+                    <Input
+                        type="time"
+                        step={60}
+                        value={trimToHM(shift.endTime)}
+                        onChange={(e) =>
+                            onUpdate({ endTime: padToFullTime(e.target.value) })
+                        }
+                        className="w-32"
+                    />
+                </div>
+                <div className="flex-1 space-y-1">
+                    <Label className="text-xs">Label (optional)</Label>
+                    <Input
+                        value={shift.label ?? ''}
+                        onChange={(e) => onUpdate({ label: e.target.value })}
+                        placeholder="e.g. Morning shift"
+                    />
+                </div>
+                {canRemove && (
+                    <button
+                        type="button"
+                        className="self-end pb-2 text-xs text-red-600 hover:underline"
+                        onClick={onRemove}
+                    >
+                        Remove
+                    </button>
+                )}
+            </div>
+
+            <div className="mt-3 space-y-2">
+                <Label className="text-xs">Counsellors on this shift</Label>
+                <div className="flex flex-wrap gap-2">
+                    {shift.counselorUserIds.length === 0 && (
+                        <span className="text-xs text-muted-foreground">
+                            None selected — add at least one
+                        </span>
+                    )}
+                    {shift.counselorUserIds.map((id) => (
+                        <Badge
+                            key={id}
+                            className="cursor-pointer bg-blue-100 text-blue-700 hover:bg-red-100 hover:text-red-700"
+                            onClick={() =>
+                                onUpdate({
+                                    counselorUserIds: shift.counselorUserIds.filter(
+                                        (c) => c !== id
+                                    ),
+                                })
+                            }
+                        >
+                            {counselorOptions.find((c) => c.id === id)?.name ?? id} ×
+                        </Badge>
+                    ))}
+                </div>
+                {availableToAdd.length > 0 && (
+                    <Select
+                        value=""
+                        onValueChange={(v) =>
+                            onUpdate({ counselorUserIds: [...shift.counselorUserIds, v] })
+                        }
+                    >
+                        <SelectTrigger className="w-64">
+                            <SelectValue placeholder="+ Add counsellor" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {availableToAdd.map((c) => (
+                                <SelectItem key={c.id} value={c.id}>
+                                    {c.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                )}
+            </div>
+
+            {error && <p className="mt-2 text-xs text-red-700">{error}</p>}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ShiftCountPicker.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/ShiftCountPicker.tsx
@@ -1,0 +1,84 @@
+/**
+ * Quick-create picker for shift blocks. Shown when a multi-shift day (UI A)
+ * or the daily template (UI B) is empty. Admin picks 2/3/4 evenly-spaced
+ * shifts or "Custom" to fall back to the manual + Add Shift flow.
+ *
+ * The generated blocks have empty counsellor lists and the last block always
+ * ends at 23:59:59 — so the admin never has to figure out the second-precision
+ * end-of-day trap by hand.
+ */
+
+import { MyButton } from '@/components/design-system/button';
+import { END_OF_DAY, cryptoRandom, type EditableShift } from './shared';
+
+interface Props {
+    onPick: (shifts: EditableShift[]) => void;
+}
+
+export default function ShiftCountPicker({ onPick }: Props) {
+    return (
+        <div className="rounded border border-dashed border-neutral-300 bg-neutral-50 p-4">
+            <p className="mb-3 text-sm text-neutral-700">
+                How many shifts on this day?
+            </p>
+            <div className="flex flex-wrap gap-2">
+                {[2, 3, 4].map((n) => (
+                    <MyButton
+                        key={n}
+                        buttonType="secondary"
+                        scale="small"
+                        onClick={() => onPick(evenlyDividedBlocks(n))}
+                    >
+                        {n} shifts
+                    </MyButton>
+                ))}
+                <MyButton
+                    buttonType="secondary"
+                    scale="small"
+                    onClick={() => onPick([customBlock()])}
+                >
+                    Custom
+                </MyButton>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+                You can adjust the times and add counsellors after picking.
+            </p>
+        </div>
+    );
+}
+
+/**
+ * Generate `n` evenly-spaced shift blocks tiling 24h. Hours divide evenly
+ * for n ∈ {2, 3, 4} (the only options exposed); the last block always ends
+ * at 23:59:59 so the schedule reaches end-of-day cleanly.
+ */
+export function evenlyDividedBlocks(n: number): EditableShift[] {
+    if (n < 1) return [];
+    const blocks: EditableShift[] = [];
+    for (let i = 0; i < n; i++) {
+        const startHour = Math.floor((i * 24) / n);
+        const endHour = Math.floor(((i + 1) * 24) / n);
+        const isLast = i === n - 1;
+        blocks.push({
+            localId: cryptoRandom(),
+            startTime: `${pad2(startHour)}:00:00`,
+            endTime: isLast ? END_OF_DAY : `${pad2(endHour)}:00:00`,
+            counselorUserIds: [],
+        });
+    }
+    return blocks;
+}
+
+/** Single empty block for the "Custom" path — same default as the previous + Add Shift. */
+function customBlock(): EditableShift {
+    return {
+        localId: cryptoRandom(),
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        counselorUserIds: [],
+    };
+}
+
+function pad2(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+}

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/shared.ts
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/schedule/shared.ts
@@ -1,0 +1,233 @@
+/**
+ * Shared types and helpers for the two TIME_BASED schedule editors:
+ *   - PerDayScheduleEditor          (schedule_pattern = PER_DAY)
+ *   - SameHoursAllDaysEditor        (schedule_pattern = SAME_HOURS_ALL_DAYS)
+ *
+ * Both editors produce the same backend payload (flat ShiftBlockRequest[])
+ * and read from the same flat PoolShiftDTO[]. The pattern only affects how
+ * the admin authors / reads the data — storage is identical.
+ */
+
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { GET_INSTITUTE_USERS } from '@/constants/urls';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+import type { DayOfWeek, PoolShiftDTO } from '@/services/counselor-pool';
+
+export const DAY_LABEL: Record<DayOfWeek, string> = {
+    MON: 'Monday',
+    TUE: 'Tuesday',
+    WED: 'Wednesday',
+    THU: 'Thursday',
+    FRI: 'Friday',
+    SAT: 'Saturday',
+    SUN: 'Sunday',
+};
+
+export const START_OF_DAY = '00:00:00';
+export const END_OF_DAY = '23:59:59';
+
+export interface EditableShift {
+    /** Local-only client id for React keys. */
+    localId: string;
+    startTime: string; // "HH:mm:ss"
+    endTime: string;
+    label?: string;
+    counselorUserIds: string[];
+}
+
+export interface InstituteUser {
+    id: string;
+    full_name: string;
+}
+
+export const fetchCounselors = async (): Promise<InstituteUser[]> => {
+    const instituteId = getCurrentInstituteId();
+    const response = await authenticatedAxiosInstance({
+        method: 'POST',
+        url: GET_INSTITUTE_USERS,
+        params: { instituteId, pageNumber: 0, pageSize: 500 },
+        data: { roles: ['COUNSELLOR', 'ADMIN'], status: ['ACTIVE'] },
+    });
+    const raw = Array.isArray(response.data) ? response.data : response.data?.content || [];
+    return raw.map((u: Record<string, unknown>) => ({
+        id: u.id as string,
+        full_name: u.full_name as string,
+    }));
+};
+
+/** "HH:mm:ss" → "HH:mm" for <input type="time"> default render. */
+export function trimToHM(t: string): string {
+    return t?.slice(0, 5) ?? '';
+}
+
+/** "HH:mm" → "HH:mm:00". */
+export function padToFullTime(hm: string): string {
+    return hm.length === 5 ? `${hm}:00` : hm;
+}
+
+/**
+ * The HTML <input type="time"> with step=60 emits "HH:mm" which we pad to
+ * "HH:mm:00". For end-of-day, that produces "23:59:00" — but the backend's
+ * coverage rule and the routing engine want "23:59:59" exactly. Snap any
+ * end-of-day-shaped value up to ":59" so the validator and save mapper
+ * agree with the backend.
+ */
+export function normalizeEndOfDay(t: string): string {
+    return t === '23:59:00' ? END_OF_DAY : t;
+}
+
+// ─── Compact-view helpers ──────────────────────────────────────────────────
+
+/**
+ * Reconstruct the canonical 24h template (for SAME_HOURS_ALL_DAYS) from the
+ * flat shift rows the backend returned. Trusts that all 7 days are
+ * structurally identical (the schedule_pattern column guarantees this), so it
+ * reads Monday's rows. Any pair of (00:00–T) + (T'–23:59:59) with the same
+ * counsellor set is merged into one overnight block.
+ *
+ * Used by SameHoursAllDaysEditor on load and by ScheduleReadView for the
+ * compact view.
+ */
+export function reconstructSameHoursTemplate(server: PoolShiftDTO[]): EditableShift[] {
+    const mondays = server
+        .filter((s) => s.day_of_week === ('MON' as DayOfWeek))
+        .sort((a, b) => a.start_time.localeCompare(b.start_time));
+
+    if (mondays.length === 0) return [];
+
+    const blocks: EditableShift[] = mondays.map((s) => ({
+        localId: s.id,
+        startTime: s.start_time,
+        endTime: s.end_time,
+        label: s.label,
+        counselorUserIds: (s.members ?? []).map((m) => m.counselor_user_id),
+    }));
+
+    const morningIdx = blocks.findIndex((b) => b.startTime === START_OF_DAY);
+    const eveningIdx = blocks.findIndex((b) => b.endTime === END_OF_DAY);
+    if (
+        morningIdx >= 0 &&
+        eveningIdx >= 0 &&
+        morningIdx !== eveningIdx &&
+        sameMemberSet(blocks[morningIdx]!.counselorUserIds, blocks[eveningIdx]!.counselorUserIds)
+    ) {
+        const morning = blocks[morningIdx]!;
+        const evening = blocks[eveningIdx]!;
+        const merged: EditableShift = {
+            localId: cryptoRandom(),
+            startTime: evening.startTime,
+            endTime: morning.endTime,
+            label: evening.label ?? morning.label,
+            counselorUserIds: evening.counselorUserIds,
+        };
+        const remaining = blocks.filter((_, i) => i !== morningIdx && i !== eveningIdx);
+        return [...remaining, merged].sort((a, b) =>
+            a.startTime.localeCompare(b.startTime)
+        );
+    }
+
+    return blocks;
+}
+
+/** Group flat shift rows by day for the PER_DAY compact view. */
+export function groupShiftsByDay(server: PoolShiftDTO[]): Record<DayOfWeek, PoolShiftDTO[]> {
+    const out: Record<DayOfWeek, PoolShiftDTO[]> = {
+        MON: [], TUE: [], WED: [], THU: [], FRI: [], SAT: [], SUN: [],
+    };
+    for (const s of server) {
+        out[s.day_of_week].push(s);
+    }
+    for (const day of Object.keys(out) as DayOfWeek[]) {
+        out[day].sort((a, b) => a.start_time.localeCompare(b.start_time));
+    }
+    return out;
+}
+
+function sameMemberSet(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) return false;
+    const setA = new Set(a);
+    return b.every((x) => setA.has(x));
+}
+
+export function cryptoRandom(): string {
+    return Math.random().toString(36).slice(2, 10);
+}
+
+export function extractError(err: unknown): string | undefined {
+    return (
+        (err as { response?: { data?: { ex?: string; message?: string } } })?.response?.data?.ex ??
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message
+    );
+}
+
+// ─── Validation ────────────────────────────────────────────────────────────
+
+export interface ShiftError {
+    localId: string;
+    message: string;
+}
+
+/**
+ * Validate one day's worth of shifts (or the canonical 24h template used by
+ * the same-hours-all-days editor). Checks:
+ *   - every block has ≥1 counsellor
+ *   - every block has start < end (no overnight; if overnight is allowed by the
+ *     caller, split it at midnight before calling this)
+ *   - blocks tile [00:00:00, 23:59:59] with no gaps
+ *
+ * Returns top-level coverage errors plus per-shift errors keyed by localId.
+ */
+export function validateDayCoverage(shifts: EditableShift[]): {
+    ok: boolean;
+    coverageErrors: string[];
+    shiftErrors: ShiftError[];
+} {
+    const coverageErrors: string[] = [];
+    const shiftErrors: ShiftError[] = [];
+
+    if (shifts.length === 0) {
+        return { ok: false, coverageErrors: ['No shifts configured.'], shiftErrors };
+    }
+
+    for (const s of shifts) {
+        if (s.counselorUserIds.length === 0) {
+            shiftErrors.push({ localId: s.localId, message: 'Add at least one counsellor.' });
+        }
+        if (s.startTime >= s.endTime) {
+            shiftErrors.push({
+                localId: s.localId,
+                message: 'End time must be after start time.',
+            });
+        }
+    }
+
+    // Snap minute-precision end-of-day (23:59:00) to second-precision
+    // before walking coverage, so admins entering "11:59 PM" don't trip a
+    // 1-second-gap error that gets re-mapped to 23:59:59 at save anyway.
+    const sorted = [...shifts]
+        .map((s) => ({ ...s, endTime: normalizeEndOfDay(s.endTime) }))
+        .sort((a, b) => a.startTime.localeCompare(b.startTime));
+    const first = sorted[0]!;
+    if (first.startTime !== START_OF_DAY) {
+        coverageErrors.push(
+            `Schedule must start at 00:00 (first block: ${first.startTime}).`
+        );
+    }
+    let coveredUntil = first.endTime;
+    for (let i = 1; i < sorted.length; i++) {
+        const next = sorted[i]!;
+        if (next.startTime > coveredUntil) {
+            coverageErrors.push(`Gap between ${coveredUntil} and ${next.startTime}.`);
+        }
+        if (next.endTime > coveredUntil) coveredUntil = next.endTime;
+    }
+    if (coveredUntil < END_OF_DAY) {
+        coverageErrors.push(`Schedule must cover up to end of day (covered until ${coveredUntil}).`);
+    }
+
+    return {
+        ok: coverageErrors.length === 0 && shiftErrors.length === 0,
+        coverageErrors,
+        shiftErrors,
+    };
+}

--- a/frontend-admin-dashboard/src/services/counselor-pool.ts
+++ b/frontend-admin-dashboard/src/services/counselor-pool.ts
@@ -27,6 +27,11 @@ import {
 export type AssignmentMode = 'MANUAL' | 'ROUND_ROBIN' | 'TIME_BASED';
 export type PoolStatus = 'ACTIVE' | 'INACTIVE';
 export type DayOfWeek = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
+/**
+ * How the admin authored a pool's weekly schedule. Drives which editor the
+ * Schedule tab renders. Routing engine ignores this — it reads flat shift rows.
+ */
+export type SchedulePattern = 'PER_DAY' | 'SAME_HOURS_ALL_DAYS';
 
 export const DAYS_OF_WEEK: DayOfWeek[] = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
@@ -81,6 +86,8 @@ export interface CounselorPoolDTO {
     name: string;
     description?: string;
     assignment_mode: AssignmentMode;
+    /** PER_DAY | SAME_HOURS_ALL_DAYS — drives which Schedule editor renders. */
+    schedule_pattern?: SchedulePattern;
     created_by?: string;
     created_at?: string;
     updated_at?: string;
@@ -94,6 +101,8 @@ export interface CreatePoolRequest {
     name: string;
     description?: string;
     assignment_mode: AssignmentMode;
+    /** Optional: defaults to PER_DAY on the backend. */
+    schedule_pattern?: SchedulePattern;
     audience_ids?: string[];
     counselor_user_ids?: string[];
 }
@@ -102,6 +111,11 @@ export interface UpdatePoolRequest {
     name?: string;
     description?: string;
     assignment_mode?: AssignmentMode;
+    /**
+     * Changing pattern with shifts already configured is rejected backend-side.
+     * Admin must clear the schedule (delete all shifts) before switching.
+     */
+    schedule_pattern?: SchedulePattern;
 }
 
 export interface UpdateMemberStatusRequest {


### PR DESCRIPTION
## Summary of Changes

Adds a new `schedule_pattern` column to counselor pools so admins can choose between two authoring styles for TIME_BASED schedules, and adds compact read/edit views for the Schedule tab that fit on one screen.

**Backend:**
- New `counselor_pool.schedule_pattern` column (`PER_DAY` | `SAME_HOURS_ALL_DAYS`), nullable so the UI can show an empty-state chooser for fresh pools
- `V270__Add_schedule_pattern_to_counselor_pool.sql` migration — backwards compatible, existing pools get `NULL` and the frontend falls back to PER_DAY rendering
- `SchedulePattern` enum + wiring through `CreatePoolRequest`, `UpdatePoolRequest`, `CounselorPoolDTO`, entity, and service
- `updatePool` rejects pattern changes while shifts exist ("Cannot change schedule_pattern while shifts exist")
- Routing engine untouched — it reads flat shift rows regardless of pattern

**Frontend:**
- Schedule tab routes between three views: chooser (no shifts + no pattern), `PerDayScheduleEditor`, `SameHoursAllDaysEditor`
- `ScheduleEmptyState` — two-card chooser that PATCHes the pattern on pick
- `PerDayScheduleEditor` — per-day "Whole day / Multiple shifts" toggle, inline gap errors, save-disabled-until-all-7-days-valid
- `SameHoursAllDaysEditor` — single 24h template applied to all 7 days, overnight blocks auto-split at midnight on save and re-merged on load
- `ShiftCountPicker` — quick-create 2 / 3 / 4 / Custom evenly-divided blocks, last block always ends at `23:59:59`
- `ScheduleReadView` — compact read mode (7-column grid for PER_DAY, single-list for SAME_HOURS) with Edit toggle, mirrors OverviewTab pattern
- Time inputs now minute-precision (`step={60}`); save mapper bumps `23:59:00` → `23:59:59` so backend coverage is honoured
- Reused canonical components: `MyButton`, `Card`, `Badge`, design tokens only

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Migration V270 applied against the local DB; `schedule_pattern` column exists and is nullable
- Existing TIME_BASED pool with saved shifts opens directly into PerDayScheduleEditor (legacy fallback) without UI regressions
- Fresh TIME_BASED pool → chooser appears → picked "Custom per day" → editor loads with picker per day
- ShiftCountPicker → picked "2 shifts" → 00:00–12:00 and 12:00–23:59 generated, save succeeds with no `Schedule must cover up to 23:59:59` error
- Saved schedule → compact read view shows the 7-column grid on one screen, no scrolling
- Edit → revealed editor with Cancel button → Cancel reverts local edits → Save collapses back to read mode
- Submitted a real lead on a Friday at 19:33 IST → assignment landed on the correct counsellor (`amit counsellor`); `counselor_pool_audience.last_assigned_counselor_id` updated; `user_lead_profile.assigned_counselor_id` + `assigned_counselor_name` set
- `design-lint.mjs` clean on all changed frontend files
- Backend `mvn compile` clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
