### PR TITLE
feat(counselor-pool): multi-pool inactivate with optional open-lead r…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/UserLeadProfileRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/UserLeadProfileRepository.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.audience.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -38,4 +39,39 @@ public interface UserLeadProfileRepository extends JpaRepository<UserLeadProfile
      */
     @Query("SELECT p.userId FROM UserLeadProfile p WHERE p.instituteId = :instituteId")
     List<String> findUserIdsByInstituteId(@Param("instituteId") String instituteId);
+
+    /**
+     * Bulk move OPEN leads (conversion_status = 'LEAD') currently assigned to
+     * {@code fromCounselorId} over to {@code backupId}, scoped to the audiences
+     * that belong to the given pool. Used when an admin marks a counselor
+     * INACTIVE in a pool and opts to also transfer their existing leads.
+     *
+     * Scoping rule: a lead is "in this pool" if its user has any
+     * audience_response row whose audience belongs to the pool. Pool A going
+     * inactive does NOT touch leads tied only to pool B's audiences.
+     *
+     * Native SQL because the scoping join goes through two non-trivial tables
+     * (audience_response, counselor_pool_audience) that aren't worth modeling
+     * as JPA associations for this one query.
+     */
+    @Modifying
+    @Query(value = "UPDATE user_lead_profile " +
+                   "   SET assigned_counselor_id = :backupId, " +
+                   "       assigned_counselor_name = :backupName, " +
+                   "       updated_at = NOW() " +
+                   " WHERE assigned_counselor_id = :fromCounselorId " +
+                   "   AND institute_id = :instituteId " +
+                   "   AND conversion_status = 'LEAD' " +
+                   "   AND EXISTS (" +
+                   "       SELECT 1 FROM audience_response ar " +
+                   "         JOIN counselor_pool_audience cpa ON cpa.audience_id = ar.audience_id " +
+                   "        WHERE ar.user_id = user_lead_profile.user_id " +
+                   "          AND cpa.pool_id = :poolId" +
+                   "   )",
+           nativeQuery = true)
+    int reassignOpenLeadsInPool(@Param("poolId") String poolId,
+                                @Param("fromCounselorId") String fromCounselorId,
+                                @Param("backupId") String backupId,
+                                @Param("backupName") String backupName,
+                                @Param("instituteId") String instituteId);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
@@ -127,6 +127,31 @@ public class CounselorPoolController {
         return ResponseEntity.ok("Status updated");
     }
 
+    /**
+     * List the pools (within the institute) where this counselor is currently
+     * ACTIVE. Powers the multi-pool selector in the "Mark Inactive" dialog.
+     * Pools where the counselor is already INACTIVE are excluded.
+     */
+    @GetMapping("/counselors/{counselorUserId}/memberships")
+    public ResponseEntity<List<CounselorPoolMembershipDTO>> listCounselorMemberships(
+            @PathVariable String counselorUserId,
+            @RequestParam("instituteId") String instituteId) {
+        return ResponseEntity.ok(poolService.listActiveMembershipsForCounselor(instituteId, counselorUserId));
+    }
+
+    /**
+     * Flip a counselor's status across MULTIPLE pools at once. All-or-nothing
+     * — any per-pool failure rolls back the whole batch. Body carries the
+     * pool_ids plus the same status/backup/reassign flag applied to each.
+     */
+    @PatchMapping("/counselors/{counselorUserId}/status-multi")
+    public ResponseEntity<String> bulkUpdateMemberStatus(
+            @PathVariable String counselorUserId,
+            @RequestBody BulkUpdateMemberStatusRequest request) {
+        poolService.bulkUpdateMemberStatusAcrossPools(counselorUserId, request);
+        return ResponseEntity.ok("Status updated");
+    }
+
     // ────────────────────────────────────────────────────────────────
     // Weekly schedule (TIME_BASED mode)
     // ────────────────────────────────────────────────────────────────

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/BulkUpdateMemberStatusRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/BulkUpdateMemberStatusRequest.java
@@ -1,0 +1,43 @@
+package vacademy.io.admin_core_service.features.counselor_pool.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Flip a counselor's status across MULTIPLE pools in one transactional call.
+ *
+ * Same backup_counselor_user_id and reassign_existing_leads apply to every
+ * pool in pool_ids. Any per-pool failure rolls back the whole batch
+ * (all-or-nothing semantics — admin sees a single error toast and nothing
+ * changed server-side).
+ *
+ * The lead-reassign scope stays per-pool: a lead is moved to the backup only
+ * if it belongs to that specific pool's audiences, even when several pools
+ * are updated in one request.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkUpdateMemberStatusRequest {
+
+    @JsonProperty("pool_ids")
+    private List<String> poolIds;
+
+    /** ACTIVE | INACTIVE */
+    private String status;
+
+    /** Required when status = INACTIVE. Same backup is applied to every pool. */
+    @JsonProperty("backup_counselor_user_id")
+    private String backupCounselorUserId;
+
+    /** INACTIVE only. Scoped per-pool: only this pool's open leads move. */
+    @JsonProperty("reassign_existing_leads")
+    @Builder.Default
+    private Boolean reassignExistingLeads = false;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CounselorPoolMembershipDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/CounselorPoolMembershipDTO.java
@@ -1,0 +1,31 @@
+package vacademy.io.admin_core_service.features.counselor_pool.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One pool that a counselor belongs to, for the "manage this counselor across
+ * pools" admin flow. The status is the pool-level status (ACTIVE iff every
+ * audience row for this counselor in that pool is ACTIVE) — matches the
+ * same rollup the CounselorsTab UI computes today.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CounselorPoolMembershipDTO {
+
+    @JsonProperty("pool_id")
+    private String poolId;
+
+    @JsonProperty("pool_name")
+    private String poolName;
+
+    /** ACTIVE | INACTIVE — rollup across the counselor's rows in this pool. */
+    private String status;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/UpdateMemberStatusRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/UpdateMemberStatusRequest.java
@@ -12,6 +12,11 @@ import lombok.NoArgsConstructor;
  *
  * When marking INACTIVE, a backup_counselor_user_id is required so the routing
  * engine knows where to redirect leads. When marking ACTIVE, backup is cleared.
+ *
+ * reassign_existing_leads (INACTIVE only) controls whether existing OPEN leads
+ * already assigned to this counselor — scoped to the audiences in THIS pool —
+ * are also moved to the backup. When the counselor later becomes ACTIVE again,
+ * the transferred leads stay with the backup; no rollback or history.
  */
 @Data
 @Builder
@@ -25,4 +30,13 @@ public class UpdateMemberStatusRequest {
     /** Required when status = INACTIVE. Ignored when status = ACTIVE. */
     @JsonProperty("backup_counselor_user_id")
     private String backupCounselorUserId;
+
+    /**
+     * INACTIVE only. When true, also reassign the counselor's currently open
+     * (conversion_status = LEAD) leads, scoped to this pool's audiences, to
+     * the backup. Default false → only NEW leads will route to the backup.
+     */
+    @JsonProperty("reassign_existing_leads")
+    @Builder.Default
+    private Boolean reassignExistingLeads = false;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
@@ -1,14 +1,18 @@
 package vacademy.io.admin_core_service.features.counselor_pool.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
 import vacademy.io.admin_core_service.features.counselor_pool.dto.*;
 import vacademy.io.admin_core_service.features.counselor_pool.entity.*;
 import vacademy.io.admin_core_service.features.counselor_pool.enums.AssignmentMode;
 import vacademy.io.admin_core_service.features.counselor_pool.enums.PoolStatus;
 import vacademy.io.admin_core_service.features.counselor_pool.enums.SchedulePattern;
 import vacademy.io.admin_core_service.features.counselor_pool.repository.*;
+import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.*;
@@ -19,6 +23,7 @@ import java.util.stream.Collectors;
  * Shift management lives in CounselorPoolShiftService.
  * Assignment-time logic (round-robin / time-based) lives in CounselorAssignmentService.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CounselorPoolService {
@@ -28,6 +33,8 @@ public class CounselorPoolService {
     private final CounselorPoolMemberRepository poolMemberRepository;
     private final CounselorPoolShiftRepository poolShiftRepository;
     private final CounselorPoolShiftMemberRepository poolShiftMemberRepository;
+    private final UserLeadProfileRepository userLeadProfileRepository;
+    private final AuthService authService;
 
     // ────────────────────────────────────────────────────────────────
     // Pool CRUD
@@ -286,6 +293,7 @@ public class CounselorPoolService {
         }
 
         String backupId = request.getBackupCounselorUserId();
+        boolean reassignExistingLeads = Boolean.TRUE.equals(request.getReassignExistingLeads());
         if (PoolStatus.INACTIVE.name().equals(status)) {
             requireNonBlank(backupId, "backup_counselor_user_id is required when marking INACTIVE");
             if (counselorUserId.equals(backupId)) {
@@ -298,12 +306,124 @@ public class CounselorPoolService {
             // we trust the id and rely on app-layer rules upstream.
         } else {
             backupId = null; // clear backup when going back to ACTIVE
+            reassignExistingLeads = false; // flag only meaningful on the INACTIVE path
         }
 
         int updated = poolMemberRepository.bulkUpdateStatusForCounselorInPool(poolId, counselorUserId, status, backupId);
         if (updated == 0) {
             throw new VacademyException("Counselor is not in this pool");
         }
+
+        if (reassignExistingLeads) {
+            CounselorPool pool = poolRepository.findById(poolId)
+                    .orElseThrow(() -> new VacademyException("Pool not found: " + poolId));
+            String backupName = resolveCounselorDisplayName(backupId);
+            int moved = userLeadProfileRepository.reassignOpenLeadsInPool(
+                    poolId, counselorUserId, backupId, backupName, pool.getInstituteId());
+            log.info("Reassigned {} open leads from counselor={} to backup={} in pool={} (institute={})",
+                    moved, counselorUserId, backupId, poolId, pool.getInstituteId());
+        }
+    }
+
+    /**
+     * List every pool (in the given institute) where this counselor currently
+     * has at least one ACTIVE row. Pools where they're already INACTIVE are
+     * excluded — the multi-pool "mark inactive" UI only lets admin act on
+     * pools where the counselor is still operational.
+     *
+     * Pool-level status mirrors the UI's rollup: ACTIVE iff every member row
+     * in that pool is ACTIVE.
+     */
+    @Transactional(readOnly = true)
+    public List<CounselorPoolMembershipDTO> listActiveMembershipsForCounselor(String instituteId,
+                                                                              String counselorUserId) {
+        requireNonBlank(instituteId, "instituteId is required");
+        requireNonBlank(counselorUserId, "counselorUserId is required");
+
+        List<CounselorPoolMember> rows = poolMemberRepository
+                .findByInstituteAndCounselor(instituteId, counselorUserId);
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+
+        // Group by pool, roll up status
+        Map<String, List<CounselorPoolMember>> rowsByPool = rows.stream()
+                .collect(Collectors.groupingBy(CounselorPoolMember::getPoolId));
+
+        List<String> activePoolIds = rowsByPool.entrySet().stream()
+                .filter(e -> e.getValue().stream()
+                        .allMatch(m -> PoolStatus.ACTIVE.name().equals(m.getStatus())))
+                .map(Map.Entry::getKey)
+                .toList();
+        if (activePoolIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, String> poolNameById = poolRepository.findAllById(activePoolIds).stream()
+                .collect(Collectors.toMap(CounselorPool::getId, CounselorPool::getName));
+
+        return activePoolIds.stream()
+                .map(poolId -> CounselorPoolMembershipDTO.builder()
+                        .poolId(poolId)
+                        .poolName(poolNameById.getOrDefault(poolId, poolId))
+                        .status(PoolStatus.ACTIVE.name())
+                        .build())
+                .toList();
+    }
+
+    /**
+     * Flip the counselor's status across several pools in one transactional
+     * call. Per pool, the same per-pool logic runs (validate, write member
+     * rows, optionally reassign open leads). If any pool fails, the whole
+     * transaction rolls back — admin sees one error and nothing changed.
+     *
+     * Backup is one id for all pools — a backup is just any institute
+     * counsellor and not pool-membership-bound.
+     */
+    @Transactional
+    public void bulkUpdateMemberStatusAcrossPools(String counselorUserId, BulkUpdateMemberStatusRequest request) {
+        requireNonBlank(counselorUserId, "counselorUserId is required");
+        if (request == null || request.getPoolIds() == null || request.getPoolIds().isEmpty()) {
+            throw new VacademyException("pool_ids must contain at least one pool");
+        }
+        // De-dup but preserve insertion order so log lines are deterministic.
+        List<String> poolIds = request.getPoolIds().stream()
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isBlank())
+                .distinct()
+                .toList();
+        if (poolIds.isEmpty()) {
+            throw new VacademyException("pool_ids must contain at least one pool");
+        }
+
+        UpdateMemberStatusRequest perPool = UpdateMemberStatusRequest.builder()
+                .status(request.getStatus())
+                .backupCounselorUserId(request.getBackupCounselorUserId())
+                .reassignExistingLeads(request.getReassignExistingLeads())
+                .build();
+        for (String poolId : poolIds) {
+            // Each iteration is part of the outer @Transactional — any throw
+            // from updateMemberStatus rolls back the work done for earlier pools.
+            updateMemberStatus(poolId, counselorUserId, perPool);
+        }
+    }
+
+    /**
+     * Best-effort display-name lookup via auth-service. Name is a denormalized
+     * cache on user_lead_profile; failure to resolve is non-fatal — the leads
+     * still get repointed, the cached name just becomes null and the UI falls
+     * back to "Unassigned"-style rendering until the next assignment refreshes it.
+     */
+    private String resolveCounselorDisplayName(String counselorUserId) {
+        try {
+            List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(counselorUserId));
+            if (!users.isEmpty() && users.get(0) != null) {
+                return users.get(0).getFullName();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve display name for counselor={}: {}", counselorUserId, e.getMessage());
+        }
+        return null;
     }
 
     // ────────────────────────────────────────────────────────────────

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -123,6 +123,10 @@ export const COUNSELOR_POOL_COUNSELOR = (poolId: string, counselorUserId: string
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/counselors/${counselorUserId}`;
 export const COUNSELOR_POOL_COUNSELOR_STATUS = (poolId: string, counselorUserId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/counselors/${counselorUserId}/status`;
+export const COUNSELOR_POOL_COUNSELOR_MEMBERSHIPS = (counselorUserId: string) =>
+    `${BASE_URL}/admin-core-service/v1/counselor-pool/counselors/${counselorUserId}/memberships`;
+export const COUNSELOR_POOL_COUNSELOR_STATUS_MULTI = (counselorUserId: string) =>
+    `${BASE_URL}/admin-core-service/v1/counselor-pool/counselors/${counselorUserId}/status-multi`;
 export const COUNSELOR_POOL_SCHEDULE = (poolId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/schedule`;
 

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/CounselorsTab.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/CounselorsTab.tsx
@@ -19,6 +19,7 @@ import { GET_INSTITUTE_USERS } from '@/constants/urls';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import { MyButton } from '@/components/design-system/button';
 import {
     Select,
@@ -39,6 +40,8 @@ import {
     CounselorPoolDTO,
     PoolMemberDTO,
     useAddCounselorToPool,
+    useBulkUpdateMemberStatus,
+    useCounselorMemberships,
     useRemoveCounselorFromPool,
     useUpdateMemberStatus,
 } from '@/services/counselor-pool';
@@ -106,6 +109,10 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
         action: 'INACTIVE' | 'ACTIVE';
     } | null>(null);
     const [pendingBackupId, setPendingBackupId] = useState<string>('');
+    const [reassignExistingLeads, setReassignExistingLeads] = useState<boolean>(false);
+    // Pool IDs the admin has checked for the INACTIVE batch. Seeded with the
+    // current pool when the dialog opens; admin can add/remove.
+    const [selectedPoolIds, setSelectedPoolIds] = useState<string[]>([]);
 
     const { data: instituteUsers = [], isLoading: usersLoading } = useQuery({
         queryKey: ['institute-counselors'],
@@ -136,6 +143,14 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
     const { mutate: addCounselor, isPending: adding } = useAddCounselorToPool(pool.id);
     const { mutate: removeCounselor, isPending: removing } = useRemoveCounselorFromPool(pool.id);
     const { mutate: updateStatus, isPending: updatingStatus } = useUpdateMemberStatus(pool.id);
+    const { mutate: bulkUpdateStatus, isPending: bulkUpdatingStatus } = useBulkUpdateMemberStatus();
+
+    // Fetch memberships only when the INACTIVE dialog is open. Reactivation
+    // doesn't need this — it stays per-pool.
+    const membershipsCounselorId =
+        statusDialog?.action === 'INACTIVE' ? statusDialog.counselorUserId : undefined;
+    const { data: memberships = [], isLoading: membershipsLoading } =
+        useCounselorMemberships(membershipsCounselorId);
 
     const handleAdd = () => {
         if (!pendingUserId) return;
@@ -164,35 +179,78 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
     const openStatusDialog = (counselorUserId: string, currentStatus: 'ACTIVE' | 'INACTIVE') => {
         const user = userById.get(counselorUserId);
         const name = user?.full_name ?? counselorUserId;
+        const action = currentStatus === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
         setStatusDialog({
             counselorUserId,
             counselorName: name,
-            action: currentStatus === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE',
+            action,
         });
         setPendingBackupId('');
+        setReassignExistingLeads(false);
+        // For inactivation we seed with the current pool; admin can add the
+        // counsellor's other ACTIVE pools once the memberships fetch returns.
+        setSelectedPoolIds(action === 'INACTIVE' ? [pool.id] : []);
+    };
+
+    const togglePoolSelection = (poolId: string) => {
+        setSelectedPoolIds((prev) =>
+            prev.includes(poolId) ? prev.filter((id) => id !== poolId) : [...prev, poolId]
+        );
     };
 
     const confirmStatusChange = () => {
         if (!statusDialog) return;
         const { counselorUserId, action } = statusDialog;
-        if (action === 'INACTIVE' && !pendingBackupId) {
+
+        if (action === 'ACTIVE') {
+            // Reactivate stays per-pool — the admin clicked it from this pool view.
+            updateStatus(
+                {
+                    counselorUserId,
+                    request: { status: 'ACTIVE', backup_counselor_user_id: null },
+                },
+                {
+                    onSuccess: () => {
+                        toast.success('Counselor reactivated');
+                        setStatusDialog(null);
+                    },
+                    onError: (err) =>
+                        toast.error(extractError(err) ?? 'Failed to update status'),
+                }
+            );
+            return;
+        }
+
+        // INACTIVE path — multi-pool, all-or-nothing.
+        if (selectedPoolIds.length === 0) {
+            toast.error('Pick at least one pool');
+            return;
+        }
+        if (!pendingBackupId) {
             toast.error('Pick a backup counselor');
             return;
         }
-        updateStatus(
+        bulkUpdateStatus(
             {
                 counselorUserId,
                 request: {
-                    status: action,
-                    backup_counselor_user_id: action === 'INACTIVE' ? pendingBackupId : null,
+                    pool_ids: selectedPoolIds,
+                    status: 'INACTIVE',
+                    backup_counselor_user_id: pendingBackupId,
+                    reassign_existing_leads: reassignExistingLeads,
                 },
             },
             {
                 onSuccess: () => {
-                    toast.success(action === 'INACTIVE' ? 'Counselor marked inactive' : 'Counselor reactivated');
+                    toast.success(
+                        selectedPoolIds.length === 1
+                            ? 'Counselor marked inactive'
+                            : `Counselor marked inactive in ${selectedPoolIds.length} pools`
+                    );
                     setStatusDialog(null);
                 },
-                onError: (err) => toast.error(extractError(err) ?? 'Failed to update status'),
+                onError: (err) =>
+                    toast.error(extractError(err) ?? 'Failed to update status'),
             }
         );
     };
@@ -349,31 +407,102 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
                         </DialogTitle>
                         <DialogDescription>
                             {statusDialog?.action === 'INACTIVE'
-                                ? 'Pick a backup counselor. All leads that would go to this counselor will be redirected to the backup until they are reactivated.'
+                                ? 'Choose which pools to mark inactive in and pick one backup counselor. Leads that would go to this counselor in those pools will route to the backup until they are reactivated.'
                                 : 'Reactivating clears the backup. New leads will route to this counselor normally.'}
                         </DialogDescription>
                     </DialogHeader>
 
                     {statusDialog?.action === 'INACTIVE' && (
-                        <div className="space-y-2 py-2">
-                            <Select value={pendingBackupId} onValueChange={setPendingBackupId}>
-                                <SelectTrigger>
-                                    <SelectValue placeholder="Select backup counselor" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {backupCandidates.length === 0 ? (
-                                        <div className="px-3 py-2 text-xs text-muted-foreground">
-                                            No other active counselors available
-                                        </div>
-                                    ) : (
-                                        backupCandidates.map((c) => (
-                                            <SelectItem key={c.id} value={c.id}>
-                                                {c.name}
-                                            </SelectItem>
-                                        ))
-                                    )}
-                                </SelectContent>
-                            </Select>
+                        <div className="space-y-4 py-2">
+                            <div className="space-y-2">
+                                <p className="text-sm font-medium">
+                                    Pools to mark inactive in
+                                </p>
+                                {membershipsLoading ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        Loading pools…
+                                    </p>
+                                ) : memberships.length === 0 ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        No active pool memberships found for this counselor.
+                                    </p>
+                                ) : (
+                                    <ul className="space-y-1 rounded-md border p-2">
+                                        {memberships.map((m) => (
+                                            <li key={m.pool_id}>
+                                                <label className="flex items-center gap-2 text-sm">
+                                                    <Checkbox
+                                                        checked={selectedPoolIds.includes(
+                                                            m.pool_id
+                                                        )}
+                                                        onCheckedChange={() =>
+                                                            togglePoolSelection(m.pool_id)
+                                                        }
+                                                    />
+                                                    <span className="flex-1">
+                                                        {m.pool_name}
+                                                        {m.pool_id === pool.id && (
+                                                            <span className="ml-2 text-xs text-muted-foreground">
+                                                                (this pool)
+                                                            </span>
+                                                        )}
+                                                    </span>
+                                                </label>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+
+                            <div className="space-y-2">
+                                <p className="text-sm font-medium">Backup counselor</p>
+                                <Select
+                                    value={pendingBackupId}
+                                    onValueChange={setPendingBackupId}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select backup counselor" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {backupCandidates.length === 0 ? (
+                                            <div className="px-3 py-2 text-xs text-muted-foreground">
+                                                No other active counselors available
+                                            </div>
+                                        ) : (
+                                            backupCandidates.map((c) => (
+                                                <SelectItem key={c.id} value={c.id}>
+                                                    {c.name}
+                                                </SelectItem>
+                                            ))
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                                <p className="text-xs text-muted-foreground">
+                                    Applies to every selected pool.
+                                </p>
+                            </div>
+
+                            <label className="flex items-start gap-2 text-sm">
+                                <Checkbox
+                                    checked={reassignExistingLeads}
+                                    onCheckedChange={(c) =>
+                                        setReassignExistingLeads(c === true)
+                                    }
+                                    disabled={!pendingBackupId}
+                                    className="mt-0.5"
+                                />
+                                <span className="leading-snug">
+                                    <span className="font-medium">
+                                        Also move existing open leads to the backup
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        For each selected pool, leads from that pool&apos;s
+                                        campaigns that are still open (not converted or
+                                        lost) move to the backup. If the counselor is
+                                        reactivated later, these leads stay with the backup.
+                                    </span>
+                                </span>
+                            </label>
                         </div>
                     )}
 
@@ -382,7 +511,7 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
                             buttonType="secondary"
                             scale="medium"
                             onClick={() => setStatusDialog(null)}
-                            disable={updatingStatus}
+                            disable={updatingStatus || bulkUpdatingStatus}
                         >
                             Cancel
                         </MyButton>
@@ -392,10 +521,14 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
                             onClick={confirmStatusChange}
                             disable={
                                 updatingStatus ||
-                                (statusDialog?.action === 'INACTIVE' && !pendingBackupId)
+                                bulkUpdatingStatus ||
+                                (statusDialog?.action === 'INACTIVE' &&
+                                    (!pendingBackupId ||
+                                        selectedPoolIds.length === 0 ||
+                                        membershipsLoading))
                             }
                         >
-                            {updatingStatus
+                            {updatingStatus || bulkUpdatingStatus
                                 ? 'Saving…'
                                 : statusDialog?.action === 'INACTIVE'
                                   ? 'Mark Inactive'

--- a/frontend-admin-dashboard/src/services/counselor-pool.ts
+++ b/frontend-admin-dashboard/src/services/counselor-pool.ts
@@ -18,7 +18,9 @@ import {
     COUNSELOR_POOL_BASE,
     COUNSELOR_POOL_BY_ID,
     COUNSELOR_POOL_COUNSELOR,
+    COUNSELOR_POOL_COUNSELOR_MEMBERSHIPS,
     COUNSELOR_POOL_COUNSELOR_STATUS,
+    COUNSELOR_POOL_COUNSELOR_STATUS_MULTI,
     COUNSELOR_POOL_SCHEDULE,
 } from '@/constants/urls';
 
@@ -122,6 +124,37 @@ export interface UpdateMemberStatusRequest {
     status: PoolStatus;
     /** Required when status = INACTIVE. */
     backup_counselor_user_id?: string | null;
+    /**
+     * INACTIVE only. When true, also move the counselor's currently open
+     * (conversion_status = LEAD) leads — scoped to this pool's audiences —
+     * over to the backup. Leads stay with the backup after reactivation
+     * (no rollback, no history).
+     */
+    reassign_existing_leads?: boolean;
+}
+
+/**
+ * One pool the counselor currently belongs to (powered by GET
+ * /counselors/{id}/memberships). Backend filters to pools where status =
+ * ACTIVE — pools where they're already inactive aren't returned.
+ */
+export interface CounselorPoolMembershipDTO {
+    pool_id: string;
+    pool_name: string;
+    status: PoolStatus;
+}
+
+/**
+ * Body for PATCH /counselors/{id}/status-multi — flips a counselor across
+ * multiple pools at once. Same backup + reassign flag apply to every pool.
+ * Backend wraps the whole batch in one @Transactional: any failure rolls
+ * back all the pools.
+ */
+export interface BulkUpdateMemberStatusRequest {
+    pool_ids: string[];
+    status: PoolStatus;
+    backup_counselor_user_id?: string | null;
+    reassign_existing_leads?: boolean;
 }
 
 export interface ShiftBlockRequest {
@@ -197,6 +230,28 @@ export const updateMemberStatus = async (
 ): Promise<void> => {
     await authenticatedAxiosInstance.patch(
         COUNSELOR_POOL_COUNSELOR_STATUS(poolId, counselorUserId),
+        request
+    );
+};
+
+export const fetchCounselorMemberships = async (
+    counselorUserId: string
+): Promise<CounselorPoolMembershipDTO[]> => {
+    const instituteId = getCurrentInstituteId();
+    const response = await authenticatedAxiosInstance({
+        method: 'GET',
+        url: COUNSELOR_POOL_COUNSELOR_MEMBERSHIPS(counselorUserId),
+        params: { instituteId },
+    });
+    return response.data ?? [];
+};
+
+export const bulkUpdateMemberStatus = async (
+    counselorUserId: string,
+    request: BulkUpdateMemberStatusRequest
+): Promise<void> => {
+    await authenticatedAxiosInstance.patch(
+        COUNSELOR_POOL_COUNSELOR_STATUS_MULTI(counselorUserId),
         request
     );
 };
@@ -339,6 +394,43 @@ export const useUpdateMemberStatus = (poolId: string) => {
         mutationFn: (args: { counselorUserId: string; request: UpdateMemberStatusRequest }) =>
             updateMemberStatus(poolId, args.counselorUserId, args.request),
         onSuccess: () => invalidate(poolId),
+    });
+};
+
+/**
+ * Fetch a counselor's ACTIVE pool memberships. Pools where the counselor is
+ * already INACTIVE are filtered out backend-side and won't appear here.
+ *
+ * Disabled when {@code counselorUserId} is falsy so the hook can sit in a
+ * component that opens its dialog on demand without firing a wasted request.
+ */
+export const useCounselorMemberships = (counselorUserId: string | undefined) =>
+    useQuery({
+        queryKey: ['counselor-pool-memberships', counselorUserId ?? ''],
+        queryFn: () => fetchCounselorMemberships(counselorUserId!),
+        enabled: !!counselorUserId,
+        staleTime: 30 * 1000,
+    });
+
+/**
+ * Multi-pool status flip. On success, invalidates every pool the call touched
+ * so member lists refresh — plus the institute-wide pool list. Both the
+ * current pool view and any sibling pool detail caches are kept in sync.
+ */
+export const useBulkUpdateMemberStatus = () => {
+    const invalidate = useInvalidatePool();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (args: { counselorUserId: string; request: BulkUpdateMemberStatusRequest }) =>
+            bulkUpdateMemberStatus(args.counselorUserId, args.request),
+        onSuccess: (_data, variables) => {
+            for (const poolId of variables.request.pool_ids) {
+                invalidate(poolId);
+            }
+            qc.invalidateQueries({
+                queryKey: ['counselor-pool-memberships', variables.counselorUserId],
+            });
+        },
     });
 };
 


### PR DESCRIPTION
## Summary of Changes

Marking a counsellor inactive used to be a per-pool action with no option for the existing leads they were already handling — those leads just sat there pointed at someone who's paused. This PR adds two things to that flow:

1. **Multi-pool selection.** A counsellor often belongs to several pools. The "Mark Inactive" dialog now lists every pool where they're currently ACTIVE in the institute, with the current pool pre-checked. Admin picks one or more, one backup counsellor, and confirms. The backend processes the whole batch in one transaction — all-or-nothing, so if anything fails admin sees one error and nothing changed.
2. **Optional reassignment of existing open leads.** A new checkbox lets admin also move the counsellor's currently open leads (conversion_status = LEAD) to the backup. Scope is per-pool: a lead only moves if it belongs to that specific pool's audiences. Reactivating later doesn't pull leads back — no history, no rollback.

**Backend:**
- New `GET /v1/counselor-pool/counselors/{id}/memberships?instituteId=…` returns the counsellor's currently-ACTIVE pool memberships, name included. Pools where they're already INACTIVE are filtered out (rollup matches the UI: ACTIVE iff every audience row is ACTIVE).
- New `PATCH /v1/counselor-pool/counselors/{id}/status-multi` — body carries `pool_ids`, `status`, `backup_counselor_user_id`, `reassign_existing_leads`. Wraps the existing per-pool method in a single `@Transactional` so any per-pool failure rolls back the entire batch.
- `UpdateMemberStatusRequest` gains `reassign_existing_leads` (INACTIVE-only). When true, `CounselorPoolService.updateMemberStatus` looks up the backup's display name once and calls a new repo method to bulk-update `user_lead_profile`.
- `UserLeadProfileRepository.reassignOpenLeadsInPool` — native UPDATE that moves only `conversion_status = 'LEAD'` rows whose user has an `audience_response` belonging to the given pool. Updates both `assigned_counselor_id` and the cached `assigned_counselor_name`.
- Old per-pool `PATCH .../{poolId}/counselors/{id}/status` left untouched — "Reactivate" still uses it.

**Frontend:**
- Updated dialog in `CounselorsTab` (INACTIVE path): fetches the counsellor's memberships on open, renders a pool checkbox list (current pool pre-checked and labelled), single backup picker labelled "Applies to every selected pool", reassign-leads checkbox with explanatory copy. Confirm calls the multi-pool endpoint. Toast says "marked inactive in N pools" when N > 1.
- New types `CounselorPoolMembershipDTO`, `BulkUpdateMemberStatusRequest` and hooks `useCounselorMemberships`, `useBulkUpdateMemberStatus` in `services/counselor-pool.ts`. Success invalidates every touched pool's cache so sibling pool views refresh.
- 2 new URL constants in `constants/urls.ts`.
- Reactivate path stays single-pool as before.

## Related Issue

<link or leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Marked a counsellor inactive in one pool with backup picked and reassign checkbox **off** — only new leads route to backup; existing assigned leads stay with the original counsellor (verified in DB).
- Same flow with reassign checkbox **on** — open leads (`conversion_status = LEAD`) in that pool's audiences move to the backup with the cached name updated; closed/converted leads in the same pool are left alone.
- Counsellor in multiple pools — opened the dialog, confirmed the list shows all ACTIVE pools (the current pool pre-checked, others unchecked, INACTIVE ones absent). Selected two pools, confirmed both flipped together and lead reassignment happened scoped per-pool.
- Forced a backend validation error mid-batch (e.g. removed the counsellor from one of the selected pools in another tab before confirming) — verified the whole transaction rolled back; no pool ended up partially updated.
- Reactivating a counsellor still uses the old per-pool endpoint and clears the backup as before. Leads that were transferred to the backup stay with the backup.
- Backend `mvn compile` clean, frontend `tsc --noEmit` clean, design-lint clean on modified files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
