### PR TITLE
feat(counselor-pool): expose Order tab for TIME_BASED pools as tie-br…

### DIFF
--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/OrderTab.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/OrderTab.tsx
@@ -1,7 +1,10 @@
 /**
- * Rotation order editor for ROUND_ROBIN mode. Two render modes (matching
- * OverviewTab's UX pattern):
+ * Rotation order editor. Used by ROUND_ROBIN and TIME_BASED pools — the same
+ * `display_order` column drives both. For TIME_BASED, order only matters
+ * when multiple counsellors are on the same shift block (it tie-breaks the
+ * pick within that intersection). Copy below adapts to the pool's mode.
  *
+ * Two render modes (matching OverviewTab's UX pattern):
  *   - Read-only (default) — shows the current order(s) as plain numbered
  *     lists. Header has an Edit button.
  *   - Editing — toggle + up/down arrows + Save/Cancel. Two operating
@@ -67,6 +70,14 @@ const fetchUsers = async (): Promise<InstituteUser[]> => {
 export default function OrderTab({ pool }: OrderTabProps) {
     const audiences = pool.audiences ?? [];
     const members = pool.members ?? [];
+    const isTimeBased = pool.assignment_mode === 'TIME_BASED';
+
+    const readOnlyDescription = isTimeBased
+        ? 'Used as a tie-breaker when multiple counsellors are on the same shift. The lower-numbered counsellor goes first.'
+        : 'Round-robin cycles counsellors in this order.';
+    const editDescription = isTimeBased
+        ? 'Set the order in which on-shift counsellors are tried. Only matters when more than one is on the same shift.'
+        : 'Use the same order for every campaign, or customise it per campaign.';
 
     const { data: users = [] } = useQuery({
         queryKey: ['institute-counselors-order'],
@@ -192,9 +203,7 @@ export default function OrderTab({ pool }: OrderTabProps) {
                     <CardHeader className="flex flex-row items-start justify-between space-y-0">
                         <div>
                             <CardTitle>Rotation Order</CardTitle>
-                            <CardDescription>
-                                Round-robin cycles counselors in this order.
-                            </CardDescription>
+                            <CardDescription>{readOnlyDescription}</CardDescription>
                         </div>
                         <MyButton buttonType="secondary" scale="small" onClick={startEdit}>
                             Edit
@@ -256,9 +265,7 @@ export default function OrderTab({ pool }: OrderTabProps) {
             <Card>
                 <CardHeader>
                     <CardTitle>Rotation Order</CardTitle>
-                    <CardDescription>
-                        Use the same order for every campaign, or customize it per campaign.
-                    </CardDescription>
+                    <CardDescription>{editDescription}</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-2">
                     <div className="flex items-center gap-3">

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/PoolEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/PoolEditor.tsx
@@ -4,12 +4,14 @@
  *   - Overview    name, description, mode  (only tab visible during create)
  *   - Audiences   add/remove campaigns
  *   - Counselors  add/remove + status + backup
- *   - Order       rotation order editor       (only when mode = ROUND_ROBIN)
+ *   - Order       rotation order editor       (ROUND_ROBIN and TIME_BASED)
  *   - Schedule    weekly shift editor         (only when mode = TIME_BASED)
  *
- * The 4th tab swaps between Order and Schedule based on the pool's mode.
- * MANUAL mode shows neither — there's nothing to configure beyond audiences
- * and counselors.
+ * Order is shown for both rotation modes because the routing engine sorts
+ * candidate counsellors by display_order in both: for ROUND_ROBIN it drives
+ * the rotation itself; for TIME_BASED it tie-breaks when multiple counsellors
+ * are on the same shift block. MANUAL mode shows neither — there's nothing
+ * to configure beyond audiences and counselors.
  */
 
 import { useNavigate } from '@tanstack/react-router';
@@ -51,9 +53,10 @@ export default function PoolEditor({ poolId, initialTab }: PoolEditorProps) {
     //   1. URL search param ?tab=... (e.g. after create, we redirect to ?tab=audiences)
     //   2. fall back to 'overview'
     // During create or when the requested tab is hidden for the current mode, bounce to 'overview'.
+    const orderVisible = isRoundRobin || isTimeBased;
     let landingTab: EditorTab = initialTab ?? 'overview';
     if (isCreating && landingTab !== 'overview') landingTab = 'overview';
-    if (landingTab === 'order' && !isRoundRobin) landingTab = 'overview';
+    if (landingTab === 'order' && !orderVisible) landingTab = 'overview';
     if (landingTab === 'schedule' && !isTimeBased) landingTab = 'overview';
 
     return (
@@ -76,9 +79,9 @@ export default function PoolEditor({ poolId, initialTab }: PoolEditorProps) {
                     <TabsTrigger value="counselors" disabled={isCreating}>
                         Counselors
                     </TabsTrigger>
-                    {/* Dynamic 4th tab: Order for ROUND_ROBIN, Schedule for TIME_BASED,
-                        nothing for MANUAL (no rotation config to set). */}
-                    {!isCreating && isRoundRobin && (
+                    {/* Order tab: ROUND_ROBIN and TIME_BASED. For TIME_BASED it tie-breaks
+                        when multiple counsellors are on the same shift. */}
+                    {!isCreating && orderVisible && (
                         <TabsTrigger value="order">Order</TabsTrigger>
                     )}
                     {!isCreating && isTimeBased && (
@@ -98,7 +101,7 @@ export default function PoolEditor({ poolId, initialTab }: PoolEditorProps) {
                         <TabsContent value="counselors">
                             <CounselorsTab pool={pool} />
                         </TabsContent>
-                        {isRoundRobin && (
+                        {orderVisible && (
                             <TabsContent value="order">
                                 <OrderTab pool={pool} />
                             </TabsContent>


### PR DESCRIPTION
## Summary of Changes

For TIME_BASED counselor pools, the Order tab was hidden by the UI even though the routing engine actually does sort candidate counsellors by `display_order` (it tie-breaks the pick when two or more counsellors are on the same shift). This exposes the existing Order tab to TIME_BASED pools too, with mode-aware copy so admins know when the order actually matters.

**Backend:**
- No changes — the `PUT /v1/counselor-pool/{poolId}/audiences/{audienceId}/order` endpoint and `display_order` logic in `CounselorAssignmentService.buildCandidateMembers` already work the same for both modes.

**Frontend:**
- `PoolEditor.tsx` — Order tab visibility computed as `orderVisible = isRoundRobin || isTimeBased`; Schedule tab still TIME_BASED-only; landing-tab guard updated to match
- `OrderTab.tsx` — header descriptions adapt to `pool.assignment_mode`:
    - ROUND_ROBIN (unchanged): "Round-robin cycles counsellors in this order."
    - TIME_BASED: "Used as a tie-breaker when multiple counsellors are on the same shift. The lower-numbered counsellor goes first."

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Opened a TIME_BASED pool — Order tab now appears alongside Schedule
- Opened a ROUND_ROBIN pool — Order tab still appears with the original "Round-robin cycles..." copy
- Opened a MANUAL pool — no Order, no Schedule (unchanged)
- Reordered counsellors via the Order tab on a TIME_BASED pool, saved → `counselor_pool_member.display_order` updated; the engine picks the lower-order counsellor first when two are on the same shift
- `design-lint.mjs` clean on both changed files

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
