### PR TITLE
db: add score_scaled + progress_measure to scorm_learner_progress

### DIFF
--- a/admin_core_service/src/main/resources/db/migration/V307__Add_scorm_progress_columns.sql
+++ b/admin_core_service/src/main/resources/db/migration/V307__Add_scorm_progress_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE scorm_learner_progress
+    ADD COLUMN IF NOT EXISTS score_scaled DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS progress_measure DOUBLE PRECISION;


### PR DESCRIPTION
## Summary
- Adds two nullable columns to `scorm_learner_progress` — `score_scaled` (DOUBLE PRECISION) and `progress_measure` (DOUBLE PRECISION)
- These back the upcoming SCORM completion-cascade fix (closes B1 in the progress-tracking audit ledger), which needs typed columns to compute the chapter % per the SCORM 2004 spec precedence (`progress_measure` > `score.scaled` > `score.raw/max` > status-only)
- Shipped as a standalone migration PR so the version number is claimed safely on `main` before the feature code lands in a follow-up PR

## Why separate from the code
Single shared DB; once V307's checksum is recorded by Flyway, any concurrent V307 grab by another branch would cause boot failures. Merging the migration alone is safe — adding nullable columns is purely additive and backward-compatible with current code that doesn't reference them.

## Test plan
- [ ] CI green
- [ ] Flyway applies `V307__Add_scorm_progress_columns.sql` cleanly on deploy
- [ ] Verify after deploy: `\d scorm_learner_progress` shows the two new columns
- [ ] Verify idempotency: re-running the SQL via `IF NOT EXISTS` is a no-op
- [ ] Feature code that consumes these columns ships in the follow-up PR on this same branch
