### PR TITLE
Fix/completed chapter ux

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/ScormTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/ScormTrackingService.java
@@ -11,6 +11,8 @@ import vacademy.io.admin_core_service.features.slide.dto.ScormTrackingDTO;
 import vacademy.io.admin_core_service.features.slide.entity.ScormLearnerProgress;
 import vacademy.io.admin_core_service.features.slide.repository.ScormLearnerProgressRepository;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.Optional;
 
@@ -30,6 +32,7 @@ public class ScormTrackingService {
                 .findTopByUserIdAndSlideIdOrderByAttemptNumberDesc(userId, slideId);
 
         ScormLearnerProgress progress;
+        boolean isResume;
         if (progressOpt.isPresent()) {
             progress = progressOpt.get();
             // Optional: Logic to decide if we need a new attempt (e.g., if previous was
@@ -37,6 +40,7 @@ public class ScormTrackingService {
             // For simplicity, we reuse the attempt if not strictly completed/finalized, or
             // create new if needed.
             // Here we just return the latest state to resume.
+            isResume = true;
         } else {
             // Create first attempt
             progress = new ScormLearnerProgress();
@@ -47,9 +51,30 @@ public class ScormTrackingService {
             progress.setCompletionStatus("not attempted");
             progress.setSuccessStatus("unknown");
             progress = scormLearnerProgressRepository.save(progress);
+            isResume = false;
         }
 
-        return mapToDTO(progress);
+        ScormTrackingDTO dto = mapToDTO(progress);
+        // Inject cmi.entry per SCORM 2004 spec. Tells the lesson runtime
+        // whether to treat this launch as a fresh attempt (ab-initio) or a
+        // continuation that should attempt to restore cmi.suspend_data /
+        // cmi.location. Without this, well-authored packages that strictly
+        // check cmi.entry before reading suspend_data start fresh on every
+        // launch — even when valid resume state exists on the server.
+        //
+        // Permissive interpretation: emit "resume" whenever an existing row
+        // is found, regardless of the previous cmi.exit value. Strict spec
+        // would require cmi.exit == "suspend"; in practice many lessons
+        // never set cmi.exit on close (tab close, navigation away), so
+        // strict mode would miss the common case. Packages that don't write
+        // suspend_data themselves will see "resume" but have nothing to
+        // restore — they fall back to fresh start. No harm.
+        Map<String, Object> cmi = dto.getCmiJson() != null
+                ? new HashMap<>(dto.getCmiJson())
+                : new HashMap<>();
+        cmi.put("cmi.entry", isResume ? "resume" : "ab-initio");
+        dto.setCmiJson(cmi);
+        return dto;
     }
 
     @Transactional

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/index.tsx
@@ -400,8 +400,12 @@ function Slides() {
 
       const completion = calculateOverallCompletion(accessibleSlides);
 
-      // Priority 1: If course is 100% completed
-      if (completion === 100) {
+      // Priority 1: If course is 100% completed AND the user hasn't explicitly
+      // asked for a specific slide via URL. The !slideId gate matters because
+      // this effect re-runs on every slideId change — without the gate, every
+      // Next / Previous / sidebar click on a completed chapter would re-route
+      // back to the first slide (or feedback), making the chapter feel locked.
+      if (completion === 100 && !slideId) {
         // Check if user has already seen feedback for this course
         const feedbackSeenKey = `feedback_seen_${courseId}_${chapterId}`;
         const hasSeenFeedback = localStorage.getItem(feedbackSeenKey);


### PR DESCRIPTION
## Summary of Changes

Two small post-merge follow-ups surfaced by the SCORM cascade work (PR #1803).

The first is a navigation regression on any chapter that reaches 100% completion: clicking Next / Previous / sidebar items briefly mounts the requested slide then bounces back to the first slide. This pre-existed in the codebase but was effectively dormant — before the SCORM cascade landed, SCORM slides reported `percentage_completed: null` so chapters containing SCORM could never reach 100%. Now that SCORM correctly reports 100%, the bouncing branch became reachable in real use.

The second is a SCORM-spec gap on the backend: `ScormTrackingService.initializeSession` returns the saved CMI state on re-init but never sets `cmi.entry`, so well-authored SCORM 2004 packages that strictly check `cmi.entry` before reading `cmi.suspend_data` start fresh on every launch — even when valid resume state exists on the server. This affects all SCORM slides on the platform, not just ones authored after this PR.

**Frontend:**
- `slides/index.tsx`: gate the "redirect to first slide / feedback when chapter is 100%" branch on `!slideId`. The branch was originally written for the page-load case (`?slideId` absent in URL) but the effect re-runs on every `slideId` change, so without the gate it ran on every Next click and overrode the requested slide. Adding `&& !slideId` preserves the friendly first-time-feedback / return-to-top UX when a learner re-opens a completed chapter cold, and respects explicit URL navigation when the learner clicks within.

**Backend:**
- `ScormTrackingService.initializeSession`: inject `cmi.entry` into the returned DTO's `cmi_json` map. Value is `"resume"` when an existing `scorm_learner_progress` row is found, `"ab-initio"` for a fresh attempt. Permissive interpretation — strict SCORM 2004 spec would require previous `cmi.exit = "suspend"`, but many lessons never set `cmi.exit` on close (tab close, navigation away, browser crash) so strict mode would miss the common case. Packages that don't write `cmi.suspend_data` themselves will see `"resume"` but have nothing to restore — they fall back to fresh-start. No harm.

## Related Issue

Surfaced during PR #1803 testing — neither was introduced by that PR; both were latent and made reachable by it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- **Navigation fix:** verified the bounce scenario locally — chapter with Quiz + 2 SCORM slides all at 100%. Before fix: clicking Next from slide 1/3 briefly mounts slide 2/3 then bounces back to 1/3. After fix: clicking Next stays on slide 2/3 as expected.
- Verified the cold-open UX is preserved: opening the chapter URL without a `slideId` param still triggers the first-time-feedback page on initial completion, and shows the first slide on subsequent cold opens.
- Verified direct deep-links (`?slideId=<specific-slide>`) are honored regardless of chapter completion state.
- **SCORM cmi.entry:** verified the LKG_Alphabets_DragDrop_SCORM2004_v2 package — confirmed it doesn't write `cmi.suspend_data` (author didn't enable resume), so the lesson still starts fresh on re-launch even with `cmi.entry: "resume"` — expected behavior, no harm. Backend log shows `cmi.entry` correctly emitted on every re-init.
- Manual DevTools check on the initialize response: the returned `cmi_json` now contains `"cmi.entry": "resume"` for existing-attempt re-opens and `"cmi.entry": "ab-initio"` for first-time opens.
- Maven compile + frontend `tsc --noEmit` + `design-lint` all clean (2 pre-existing inline-style warnings on the iframe wrapper, untouched).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
