### PR TITLE
fix: add logic to end the trigger when is_end_node field of workflow_…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowEngineService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowEngineService.java
@@ -245,6 +245,19 @@ public class WorkflowEngineService {
                                     "node.type", nodeType, "layer", "2-workflow-engine"));
                 }
 
+                // is_end_node terminates ONLY this branch — not the entire workflow.
+                // Other paths already on the execution stack (from multi-goto fan-out
+                // or diamond DAGs) will still run. The handler above has already
+                // executed for this node, so any final side-effects (e.g. a closing
+                // SEND_EMAIL or UPDATE_RECORD) are honored before the path ends.
+                // To stop a whole workflow run, every terminal leaf must be marked
+                // is_end_node = true.
+                if (Boolean.TRUE.equals(current.getIsEndNode())) {
+                    log.info("Node {} has is_end_node=true — terminating this path (other branches, if any, continue)",
+                            current.getId());
+                    continue;
+                }
+
                 // Evaluate routing to find next nodes and push them to stack
                 List<String> nextNodeIds = evaluateRoutingNextNodeIds(effectiveConfig, ctx);
                 log.info("Routing evaluation for node {} returned: {}", current.getId(), nextNodeIds);


### PR DESCRIPTION
## Summary of Changes

Honor `workflow_node_mapping.is_end_node` in the workflow engine. The column was being persisted by the builder and round-tripped to the frontend, but the runtime engine never read it — so a node marked as the end in the UI would still execute downstream nodes if its `config_json.routing` had a `goto`.

Now, after a node's handler runs, the engine checks `current.getIsEndNode()` and `continue`s if true — terminating just that branch without evaluating routing or pushing successors. The handler still executes for the end node so any final side-effect (closing email, status update, etc.) is honored.

Path-only semantics: other branches already on the execution stack (multi-goto fan-out / diamond DAGs) keep running. To end an entire workflow, every terminal leaf must be marked `is_end_node = true`. Rationale is documented inline so this isn't misread as a kill-switch later.

**Backend:**
- Add `is_end_node` check in `WorkflowEngineService.run()` between the handler invocation and `evaluateRoutingNextNodeIds()` — uses `Boolean.TRUE.equals(...)` so legacy `null` rows behave as `false` and need no migration
- Add block comment documenting the path-only termination semantics and why we use `continue` (preserves diamond-DAG support) over clearing the stack
- Existing termination signals preserved unchanged: empty `routing` array, `{"type": "end"}` route, and literal `targetNodeId == "end"` string

**Frontend:**
- None

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Linear workflow with the last node marked `is_end_node=true`: handler runs, path ends, no further nodes processed
- Linear workflow with `is_end_node=true` mid-chain and a downstream `goto`: confirmed downstream node is NOT executed (previously was)
- Node with `is_end_node=false`/`null` and routing present: existing behavior unchanged — successors still pushed
- Diamond DAG sanity check: a path terminating via `is_end_node` does not affect other branches already on the execution stack

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
