### PR TITLE
fix: fieldKey mismatch , use prefix match for fieldKey instead of exa…

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/sub-org-learners/-components/SubOrgLearnersComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/sub-org-learners/-components/SubOrgLearnersComponent.tsx
@@ -156,43 +156,58 @@ export function SubOrgLearnersComponent({ adminMappings, instituteDetails }: Sub
     let mobile_number = '';
     let username = '';
 
-    // Helper to find field by name (case-insensitive)
-    const findFieldByName = (names: string[]) => {
-      return instituteCustomFields.find(f => 
-        names.some(name => f.custom_field.fieldName.toLowerCase() === name.toLowerCase())
-      );
+    // Match core identity fields by `fieldKey` (the stable machine ID set at
+    // field creation by the backend's CustomFieldKeyGenerator) — NOT by the
+    // freeform display label `fieldName`, which admins can rename freely
+    // (e.g. "Full Name (First Name & Last Name)") and which breaks string match.
+    // Two key patterns coexist in production:
+    //   - Legacy seeded defaults:  "full_name" / "email" / "phone_number"
+    //   - Admin-created via UI:    "<slug>_inst_<instituteId>"
+    const matchKey = (prefix: string) => (f: InstituteCustomField) => {
+      const k = f.custom_field.fieldKey;
+      return k === prefix || k.startsWith(prefix + '_inst_');
     };
 
-    // Name field - could be 'name', 'Name', 'Full Name', 'full_name'
-    const nameField = findFieldByName(['name', 'full name', 'full_name']);
-    if (nameField) {
-      full_name = formData[nameField.custom_field.fieldKey] || '';
-    }
+    const nameField  = instituteCustomFields.find(matchKey('full_name'));
+    const emailField = instituteCustomFields.find(matchKey('email'));
+    const phoneField = instituteCustomFields.find(matchKey('phone_number'));
 
-    // If no single name field, try First Name + Last Name combination
+    if (nameField)  full_name     = formData[nameField.custom_field.fieldKey] || '';
+    if (emailField) email         = formData[emailField.custom_field.fieldKey] || '';
+    if (phoneField) mobile_number = formData[phoneField.custom_field.fieldKey] || '';
+
+    // Fallback for split-name forms (institutes using First Name + Last Name
+    // instead of a single combined Full Name field).
     if (!full_name) {
-      const firstNameField = findFieldByName(['first name', 'firstname']);
-      const lastNameField = findFieldByName(['last name', 'lastname']);
-      const firstName = firstNameField ? formData[firstNameField.custom_field.fieldKey] : '';
-      const lastName = lastNameField ? formData[lastNameField.custom_field.fieldKey] : '';
-      full_name = `${firstName || ''} ${lastName || ''}`.trim();
+      const firstNameField = instituteCustomFields.find(matchKey('first_name'));
+      const lastNameField  = instituteCustomFields.find(matchKey('last_name'));
+      const firstName = firstNameField ? formData[firstNameField.custom_field.fieldKey] || '' : '';
+      const lastName  = lastNameField ? formData[lastNameField.custom_field.fieldKey] || '' : '';
+      full_name = `${firstName} ${lastName}`.trim();
     }
 
-    // Email field - could be 'email', 'Email'
-    const emailField = findFieldByName(['email']);
-    email = emailField ? formData[emailField.custom_field.fieldKey] : '';
-
-    // Phone field - could be 'phone', 'Phone', 'Mobile', 'mobile_number'
-    const phoneField = findFieldByName(['phone', 'mobile', 'mobile_number']);
-    mobile_number = phoneField ? formData[phoneField.custom_field.fieldKey] : '';
-
-    // If standard fields form fallback (if custom fields didn't cover them or failed to load)
+    // Fallback for institutes whose invite form has no custom fields configured.
+    // The hardcoded Email/Full Name/Mobile inputs render in that branch (see the
+    // `instituteCustomFields.length === 0` body of the dialog below).
     if (!email && formData.email) email = formData.email;
     if (!full_name && formData.full_name) full_name = formData.full_name;
     if (!mobile_number && formData.mobile_number) mobile_number = formData.mobile_number;
 
     if (!email || !full_name) {
-      toast.error('Email and Name are required fields.');
+      // Distinguish "user left a visible input blank" from "this invite form
+      // has no recognizable email/name field configured" — the latter is an
+      // admin/config problem and needs a different message so the user doesn't
+      // think they're missing an input that doesn't exist.
+      const hasFormFields = instituteCustomFields.length > 0;
+      const isConfigProblem =
+        hasFormFields && (!emailField || (!nameField && !full_name));
+      if (isConfigProblem) {
+        toast.error(
+          "This institute's invite form is missing a recognizable Email or Full Name field. Ask an admin to verify the invite form configuration."
+        );
+      } else {
+        toast.error('Email and Name are required fields.');
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary of Changes

Fix "Add Learner" silent failure on the sub-org learners page (`/sub-org-learners`). Users on institutes whose Full Name field uses any non-canonical display label (e.g. `"Full Name (First Name & Last Name)"`) were blocked from adding learners — the submit handler toasted `"Email and Name are required fields."` and never POSTed, even though all fields were filled correctly.

Root cause: `handleAddMember` resolved core identity fields (full_name / email / phone) by **strict case-insensitive equality** against the admin-editable `fieldName` display label. Admins can freely rename labels (parenthetical clarifications, translations, alternative phrasings), so the matcher missed perfectly valid fields and the form bailed.

Fix: match by `fieldKey` — the stable machine identifier set server-side by `CustomFieldKeyGenerator`. Accepts both legacy seeded keys (`"full_name"`, `"email"`, `"phone_number"`) and admin-created keys (`"<slug>_inst_<instituteId>"`). Also added a distinct error message for "invite form has no recognizable Email/Full Name field" so misconfigured invite forms surface as an admin/config issue instead of being blamed on user input.

**Backend:**
- None.

**Frontend:**
- Replace `findFieldByName` (display-label string-match) with `matchKey(prefix)` (fieldKey-based) in `SubOrgLearnersComponent.tsx`
- Re-key the First Name + Last Name split-form fallback to use `matchKey('first_name')` / `matchKey('last_name')`
- Preserve the `formData.email/full_name/mobile_number` fallback path for institutes with zero custom fields configured (where the modal renders hardcoded inputs)
- Add a separate toast message for the "invite form missing core field" config case
- Inline comments documenting the two fieldKey patterns coexisting in production (legacy seeded vs admin-created) so future devs don't fall into the same name-matching trap

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Add Learner on letstalkvet (institute whose Full Name label is `"Full Name (First Name & Last Name)"`): confirmed form now submits and learner is added
- Add Learner on an institute with combined Full Name field using canonical label: still works
- Add Learner on an institute with split First Name + Last Name fields: combined name path still works via the same matcher
- Fallback for institutes with zero custom fields (`instituteCustomFields.length === 0` renders hardcoded inputs): still works
- Misconfigured form (no recognizable email or full_name field via fieldKey): now shows a distinct admin-targeted error instead of the generic required-fields message
- design-lint clean on the changed file

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
