### PR TITLE
feat: terminate learner from selected package sessions and fire LEARN…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentOperationController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentOperationController.java
@@ -25,7 +25,7 @@ public class InstituteStudentOperationController {
 
     @PostMapping("/update")
     public void updateStudentStatus(@RequestAttribute("user") CustomUserDetails user, @RequestBody StudentStatusUpdateRequestWrapper requestWrapper) {
-        manager.updateStudentStatus(requestWrapper.getRequests(), requestWrapper.getOperation());
+        manager.updateStudentStatus(requestWrapper.getRequests(), requestWrapper.getOperation(), user);
     }
 
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/dto/StudentStatusUpdateRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/dto/StudentStatusUpdateRequest.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,4 +21,12 @@ public class StudentStatusUpdateRequest {
     private String newState;
     private String instituteId;
     private String currentPackageSessionId;
+
+    /**
+     * Optional list of package sessions to act on in a single call (MAKE_INACTIVE).
+     * When present and non-empty, MAKE_INACTIVE deactivates the learner from every
+     * package session in this list with one UPDATE. When absent, the operation
+     * falls back to the single {@link #currentPackageSessionId}.
+     */
+    private List<String> packageSessionIds;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/LearnerTerminationWorkflowHelper.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/LearnerTerminationWorkflowHelper.java
@@ -1,0 +1,91 @@
+package vacademy.io.admin_core_service.features.institute_learner.manager;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.packages.repository.PackageSessionRepository;
+import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
+import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
+import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.institute.entity.session.PackageSession;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fires the {@link WorkflowTriggerEvent#LEARNER_TERMINATION} workflow when a learner
+ * is made INACTIVE in one or more package sessions via the institute_learner
+ * MAKE_INACTIVE operation.
+ *
+ * <p>Lives in its own bean (separate from {@code StudentSessionManager}) so the
+ * {@code @Async} firing actually runs on a different thread — Spring's async proxy
+ * is bypassed on self-invocation. The caller registers an afterCommit callback so
+ * this only runs once the status UPDATE is durable; workflow QUERY nodes then see
+ * the now-INACTIVE rows.
+ */
+@Service
+@Slf4j
+public class LearnerTerminationWorkflowHelper {
+
+    @Autowired
+    private WorkflowTriggerService workflowTriggerService;
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private PackageSessionRepository packageSessionRepository;
+
+    /**
+     * Fire one LEARNER_TERMINATION trigger per package session the learner was
+     * terminated from. Best-effort: a failure for one package session is logged
+     * and does not stop the others, and never propagates (the DB write already
+     * committed before this runs).
+     */
+    @Async
+    public void fireTerminationWorkflows(String userId, List<String> packageSessionIds,
+                                         String instituteId, String adminUserId) {
+        if (userId == null || packageSessionIds == null || packageSessionIds.isEmpty()) {
+            return;
+        }
+
+        UserDTO member = fetchUser(userId);
+        UserDTO admin = adminUserId == null ? null : fetchUser(adminUserId);
+
+        for (String packageSessionId : packageSessionIds) {
+            try {
+                Optional<PackageSession> optionalPackageSession = packageSessionRepository.findById(packageSessionId);
+                String packageId = optionalPackageSession
+                        .map(ps -> ps.getPackageEntity() != null ? ps.getPackageEntity().getId() : null)
+                        .orElse(null);
+
+                Map<String, Object> contextData = new HashMap<>();
+                contextData.put("member", member);
+                contextData.put("packageSessionIds", packageSessionId);
+                contextData.put("packageId", packageId);
+                contextData.put("admin", admin);
+
+                workflowTriggerService.handleTriggerEvents(
+                        WorkflowTriggerEvent.LEARNER_TERMINATION.name(),
+                        packageSessionId, instituteId, contextData);
+            } catch (Exception e) {
+                log.error("Failed to fire LEARNER_TERMINATION workflow for userId={}, packageSessionId={}: {}",
+                        userId, packageSessionId, e.getMessage(), e);
+            }
+        }
+    }
+
+    private UserDTO fetchUser(String userId) {
+        try {
+            List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(userId));
+            return users.isEmpty() ? null : users.get(0);
+        } catch (Exception e) {
+            log.error("Failed to fetch user {} for LEARNER_TERMINATION context: {}", userId, e.getMessage(), e);
+            return null;
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentSessionManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentSessionManager.java
@@ -1,23 +1,41 @@
 package vacademy.io.admin_core_service.features.institute_learner.manager;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import vacademy.io.admin_core_service.features.institute_learner.dto.StudentStatusUpdateRequest;
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionRepository;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.VacademyException;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 @Service
+@Slf4j
 public class StudentSessionManager {
 
     @Autowired
     private StudentSessionRepository studentSessionRepository;
 
+    @Autowired
+    private LearnerTerminationWorkflowHelper learnerTerminationWorkflowHelper;
+
     @Transactional
-    public void updateStudentStatus(List<StudentStatusUpdateRequest> requests, String operation) {
+    public void updateStudentStatus(List<StudentStatusUpdateRequest> requests, String operation,
+                                    CustomUserDetails adminDetails) {
+        String adminUserId = adminDetails != null ? adminDetails.getUserId() : null;
+
+        // MAKE_INACTIVE terminations to fire workflows for, collected during the
+        // loop and fired only AFTER the transaction commits (see below).
+        List<TerminationFiring> terminations = new ArrayList<>();
+        List<String> failures = new ArrayList<>();
+
         for (StudentStatusUpdateRequest request : requests) {
             try {
                 switch (operation) {
@@ -30,7 +48,7 @@ public class StudentSessionManager {
                         studentSessionRepository.updateExpiryDate(request.getUserId(), request.getCurrentPackageSessionId(), request.getInstituteId(), expiryDate);
                         break;
                     case "MAKE_INACTIVE":
-                        studentSessionRepository.updateStatus(request.getUserId(), request.getCurrentPackageSessionId(), request.getInstituteId(), request.getNewState());
+                        handleMakeInactive(request, terminations);
                         break;
                     case "MAKE_ACTIVE":
                         studentSessionRepository.updateStatus(request.getUserId(), request.getCurrentPackageSessionId(), request.getInstituteId(), "ACTIVE");
@@ -45,9 +63,71 @@ public class StudentSessionManager {
                         throw new IllegalArgumentException("Invalid operation: " + operation);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                // Do NOT swallow silently: record the failure so it surfaces to the
+                // caller (and rolls back the transaction) instead of returning 200.
+                log.error("Failed '{}' for userId={}, packageSessionId={}: {}",
+                        operation, request.getUserId(), request.getCurrentPackageSessionId(), e.getMessage(), e);
+                failures.add(request.getUserId() + ":" + e.getMessage());
             }
         }
 
+        if (!failures.isEmpty()) {
+            // Rolls back the whole transaction (and skips workflow firing below,
+            // since the afterCommit callback was never registered).
+            throw new VacademyException("Failed to update status for " + failures.size()
+                    + " learner(s): " + String.join("; ", failures));
+        }
+
+        fireTerminationWorkflowsAfterCommit(terminations, adminUserId);
+    }
+
+    private void handleMakeInactive(StudentStatusUpdateRequest request, List<TerminationFiring> terminations) {
+        List<String> packageSessionIds = request.getPackageSessionIds();
+        if (packageSessionIds != null && !packageSessionIds.isEmpty()) {
+            // Approach B: one atomic UPDATE across every chosen package session.
+            studentSessionRepository.updateStatusForPackageSessions(
+                    request.getUserId(), packageSessionIds, request.getInstituteId(), request.getNewState());
+            terminations.add(new TerminationFiring(request.getUserId(),
+                    new ArrayList<>(packageSessionIds), request.getInstituteId()));
+        } else {
+            // Back-compat: callers that still send a single currentPackageSessionId.
+            studentSessionRepository.updateStatus(
+                    request.getUserId(), request.getCurrentPackageSessionId(), request.getInstituteId(), request.getNewState());
+            if (request.getCurrentPackageSessionId() != null) {
+                terminations.add(new TerminationFiring(request.getUserId(),
+                        List.of(request.getCurrentPackageSessionId()), request.getInstituteId()));
+            }
+        }
+    }
+
+    /**
+     * Fire LEARNER_TERMINATION workflows after the status UPDATE commits, so the
+     * workflow's QUERY nodes see the now-INACTIVE rows. The helper method is
+     * {@code @Async}, so firing also runs off the request thread. Falls back to a
+     * direct (still async) call when there's no active transaction.
+     */
+    private void fireTerminationWorkflowsAfterCommit(List<TerminationFiring> terminations, String adminUserId) {
+        if (terminations.isEmpty()) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    for (TerminationFiring t : terminations) {
+                        learnerTerminationWorkflowHelper.fireTerminationWorkflows(
+                                t.userId(), t.packageSessionIds(), t.instituteId(), adminUserId);
+                    }
+                }
+            });
+        } else {
+            for (TerminationFiring t : terminations) {
+                learnerTerminationWorkflowHelper.fireTerminationWorkflows(
+                        t.userId(), t.packageSessionIds(), t.instituteId(), adminUserId);
+            }
+        }
+    }
+
+    private record TerminationFiring(String userId, List<String> packageSessionIds, String instituteId) {
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionRepository.java
@@ -76,6 +76,24 @@ public interface StudentSessionRepository extends CrudRepository<StudentSessionI
                    @Param("instituteId") String instituteId,
                    @Param("status") String status);
 
+  /**
+   * Update the status for a learner across MULTIPLE package sessions in one query.
+   * Used by MAKE_INACTIVE when an admin terminates a learner from several package
+   * sessions at once — collapses what would otherwise be N single-PS updates into
+   * a single atomic UPDATE.
+   */
+  @Modifying
+  @Transactional
+  @Query(value = "UPDATE student_session_institute_group_mapping " +
+          "SET status = :status " +
+          "WHERE user_id = :userId " +
+          "AND package_session_id IN (:packageSessionIds) " +
+          "AND institute_id = :instituteId", nativeQuery = true)
+  int updateStatusForPackageSessions(@Param("userId") String userId,
+                                     @Param("packageSessionIds") List<String> packageSessionIds,
+                                     @Param("instituteId") String instituteId,
+                                     @Param("status") String status);
+
   List<StudentSessionInstituteGroupMapping> findAllByInstituteIdAndUserId(String instituteId, String userId);
 
   List<StudentSessionInstituteGroupMapping> findAllByInstituteIdAndUserIdAndStatusIn(String instituteId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/enums/WorkflowTriggerEvent.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/enums/WorkflowTriggerEvent.java
@@ -31,6 +31,10 @@ public enum WorkflowTriggerEvent {
     SUBSCRIPTION_TERMINATED,
     LEARNER_RE_ENROLLMENT,
 
+    // Fired when an admin makes a learner INACTIVE in a package session
+    // (institute_learner MAKE_INACTIVE operation). Keyed by eventId = packageSessionId.
+    LEARNER_TERMINATION,
+
     // LMS / content / engagement
     COURSE_CREATED,
     DOUBT_RAISED,

--- a/frontend-admin-dashboard/src/components/design-system/table-components/student-menu-options/terminate-registration-dialog.tsx
+++ b/frontend-admin-dashboard/src/components/design-system/table-components/student-menu-options/terminate-registration-dialog.tsx
@@ -1,9 +1,15 @@
 import { MyDialog } from '../../dialog';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useDialogStore } from '../../../../routes/manage-students/students-list/-hooks/useDialogStore';
 import { MyButton } from '../../button';
 import { useTerminateStudentMutation } from '@/routes/manage-students/students-list/-services/useStudentOperations';
 import { useBulkTerminateStudentsMutation } from '@/routes/manage-students/students-list/-services/useBulkOperations';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
+import { removeDefaultPrefix } from '@/utils/helpers/removeDefaultPrefix';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
 interface TerminateRegistrationDialogProps {
     trigger: ReactNode;
@@ -13,10 +19,52 @@ interface TerminateRegistrationDialogProps {
 
 const TerminateRegistrationDialogContent = () => {
     const { selectedStudent, bulkActionInfo, isBulkAction, closeAllDialogs } = useDialogStore();
+    const { getDetailsFromPackageSessionId } = useInstituteDetailsStore();
+    const batchTerm = getTerminology(ContentTerms.Batch, SystemTerms.Batch);
     const displayText = isBulkAction ? bulkActionInfo?.displayText : selectedStudent?.full_name;
 
     const { mutate: terminateSingle, isPending: isSinglePending } = useTerminateStudentMutation();
     const { mutate: terminateBulk, isPending: isBulkPending } = useBulkTerminateStudentsMutation();
+
+    // Every package session the (single) selected learner is enrolled in. Falls back
+    // to the row's current package_session_id when the fan-out list isn't present.
+    const enrolledPsIds = useMemo(() => {
+        if (isBulkAction || !selectedStudent) return [];
+        const all = selectedStudent.all_package_session_ids;
+        if (all && all.length > 0) return all;
+        return selectedStudent.package_session_id ? [selectedStudent.package_session_id] : [];
+    }, [isBulkAction, selectedStudent]);
+
+    const psOptions = useMemo(() => {
+        return enrolledPsIds.map((psId) => {
+            const details = getDetailsFromPackageSessionId({ packageSessionId: psId });
+            const packageName = removeDefaultPrefix(details?.package_dto?.package_name || '');
+            const levelName = details?.level?.level_name;
+            const cleanedLevel =
+                levelName && levelName !== 'DEFAULT' ? removeDefaultPrefix(levelName) : '';
+            const composed = cleanedLevel
+                ? `${packageName} - ${cleanedLevel}`.trim()
+                : packageName || psId;
+            return { id: psId, label: composed || psId };
+        });
+    }, [enrolledPsIds, getDetailsFromPackageSessionId]);
+
+    // Default the row's current package session selected (preserves prior behavior),
+    // and let the admin add/remove others when the learner has multiple enrollments.
+    const [selectedPsIds, setSelectedPsIds] = useState<string[]>([]);
+    useEffect(() => {
+        if (isBulkAction || !selectedStudent) return;
+        const fallback = selectedStudent.package_session_id;
+        setSelectedPsIds(fallback ? [fallback] : enrolledPsIds.slice(0, 1));
+    }, [isBulkAction, selectedStudent, enrolledPsIds]);
+
+    const showPicker = !isBulkAction && psOptions.length > 1;
+
+    const togglePs = (psId: string, checked: boolean) => {
+        setSelectedPsIds((prev) =>
+            checked ? [...new Set([...prev, psId])] : prev.filter((id) => id !== psId)
+        );
+    };
 
     const handleSubmit = () => {
         if (isBulkAction && bulkActionInfo?.selectedStudents) {
@@ -40,13 +88,13 @@ const TerminateRegistrationDialogContent = () => {
                     onSuccess: closeAllDialogs,
                 }
             );
-        } else if (selectedStudent?.user_id && selectedStudent?.package_session_id) {
+        } else if (selectedStudent?.user_id && selectedPsIds.length > 0) {
             terminateSingle(
                 {
                     students: [
                         {
                             userId: selectedStudent.user_id,
-                            currentPackageSessionId: selectedStudent.package_session_id,
+                            packageSessionIds: selectedPsIds,
                         },
                     ],
                 },
@@ -58,18 +106,48 @@ const TerminateRegistrationDialogContent = () => {
     };
 
     const isLoading = isSinglePending || isBulkPending;
+    const submitDisabled = isLoading || (!isBulkAction && selectedPsIds.length === 0);
 
     return (
         <div className="flex flex-col gap-6 p-6 text-neutral-600">
             <div>
                 Registration for <span className="text-primary-500">{displayText}</span> will be
                 terminated
+                {showPicker
+                    ? ` from the selected ${getTerminology(
+                          ContentTerms.Batch,
+                          SystemTerms.Batch
+                      ).toLowerCase()}(es)`
+                    : ''}
             </div>
+
+            {showPicker && (
+                <div className="flex flex-col gap-3">
+                    <Label className="text-xs text-neutral-500">Select {batchTerm}(es)</Label>
+                    <div className="flex flex-col gap-2">
+                        {psOptions.map((option) => (
+                            <label
+                                key={option.id}
+                                className="flex cursor-pointer items-center gap-2 text-sm"
+                            >
+                                <Checkbox
+                                    checked={selectedPsIds.includes(option.id)}
+                                    onCheckedChange={(checked) =>
+                                        togglePs(option.id, checked === true)
+                                    }
+                                />
+                                <span>{option.label}</span>
+                            </label>
+                        ))}
+                    </div>
+                </div>
+            )}
+
             <MyButton
                 buttonType="primary"
                 scale="large"
                 layoutVariant="default"
-                disable={isLoading}
+                disable={submitDisabled}
                 onClick={handleSubmit}
             >
                 {isLoading ? 'Terminating...' : 'Terminate'}

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-services/useStudentOperations.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-services/useStudentOperations.ts
@@ -105,7 +105,9 @@ export const useExtendSessionMutation = () => {
 interface TerminateStudentRequest {
     students: {
         userId: string;
-        currentPackageSessionId: string;
+        // The package session(s) to terminate the learner from. The first entry is
+        // also sent as current_package_session_id for backend back-compat.
+        packageSessionIds: string[];
     }[];
 }
 
@@ -115,11 +117,12 @@ const terminateStudent = async ({ students }: TerminateStudentRequest) => {
     const INSTITUTE_ID = tokenData && Object.keys(tokenData.authorities)[0];
     const response = await authenticatedAxiosInstance.post(STUDENT_UPDATE_OPERATION, {
         operation: 'MAKE_INACTIVE',
-        requests: students.map(({ userId, currentPackageSessionId }) => ({
+        requests: students.map(({ userId, packageSessionIds }) => ({
             user_id: userId,
             new_state: 'INACTIVE',
             institute_id: INSTITUTE_ID,
-            current_package_session_id: currentPackageSessionId,
+            current_package_session_id: packageSessionIds[0],
+            package_session_ids: packageSessionIds,
         })),
     });
     return response.data;


### PR DESCRIPTION
## Summary of Changes

Lets an admin choose **which package session(s)** to terminate a learner from, and fires a workflow per terminated package session. Previously, "Terminate Registration" (`MAKE_INACTIVE`) always deactivated the learner from the single `package_session_id` collapsed onto the table row (the "latest active" enrollment), so admins couldn't target a specific enrollment when a learner was in multiple package sessions — and no workflow ran on termination.

**Backend:**
- `StudentStatusUpdateRequest` DTO: added optional `package_session_ids` list (back-compat with `current_package_session_id`).
- `StudentSessionRepository`: new `updateStatusForPackageSessions(...)` — one atomic `UPDATE ... WHERE package_session_id IN (:ids)` instead of N single-PS updates.
- `StudentSessionManager`: `MAKE_INACTIVE` uses the IN-clause when a list is sent (else single-PS fallback); now takes the acting admin; **fixed silent error-swallowing** (failures are collected and thrown as `VacademyException` → rolls back the tx, instead of `printStackTrace()` + HTTP 200).
- New `LearnerTerminationWorkflowHelper` (`@Async`): after the status UPDATE commits, fires `WorkflowTriggerService.handleTriggerEvents(LEARNER_TERMINATION, packageSessionId, instituteId, ctx)` once per terminated package session (afterCommit so workflow QUERY nodes see the now-INACTIVE rows). Context: `member`, `packageSessionIds`, `packageId`, `admin`.
- New `WorkflowTriggerEvent.LEARNER_TERMINATION` (keyed by `eventId = packageSessionId`).
- `InstituteStudentOperationController`: passes the authenticated admin into the manager.

**Frontend:**
- Terminate dialog: multi-select package-session picker (checkboxes) shown when the learner has more than one enrollment (`all_package_session_ids`), labels resolved via `getDetailsFromPackageSessionId` (same pattern as `BatchPicker`); the row's current package session is checked by default. Bulk terminate unchanged.
- `useTerminateStudentMutation`: sends `package_session_ids` in the request payload.

## Related Issue

<leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Terminated a learner enrolled in multiple package sessions from two selected sessions; verified both rows flipped to `INACTIVE` in `student_session_institute_group_mapping` via SQL, and the learner's other enrollments were untouched (correctly scoped).
- Verified the single-enrollment case still shows the plain confirm dialog (no picker) and terminates correctly.
- Backend compiles cleanly (`mvnw compile`); frontend typechecks cleanly (`tsc --noEmit`) for changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
