### PR TITLE
chore(ci): rename VACADEMY_STAGE_KUBECONFIG to VACADEMY_PROD_KUBECONFIG

### DIFF
--- a/.github/workflows/deploy-pgbouncer.yml
+++ b/.github/workflows/deploy-pgbouncer.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG }}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG }}
 
       - name: Create PgBouncer userlist secret
         run: |

--- a/.github/workflows/docker-publish-ai-service.yml
+++ b/.github/workflows/docker-publish-ai-service.yml
@@ -51,13 +51,13 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG }}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG }}
 
       - name: Restart deployment if it exists
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-admin-core-service.yml
+++ b/.github/workflows/maven-publish-admin-core-service.yml
@@ -99,21 +99,20 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      # Get the KUBECONFIG from : https://cloud.linode.com/kubernetes/clusters/189301/summary
+      # KUBECONFIG is sourced from the Hetzner k3s prod cluster (see /etc/rancher/k3s/k3s.yaml on the control-plane node)
 
       # TODO: This kubeconfig is global kubeconfig with access to whole cluster
       # In production refrain from using this and use k8s service account with limited access
       # Each service account has permissions like IAM and each has its own kubeconfig
       # replace global kubeconfig with service account's kubeconfig
-      # https://www.linode.com/content/terraforming-kubernetes-github-actions/
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG}}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-assessment-service.yml
+++ b/.github/workflows/maven-publish-assessment-service.yml
@@ -82,21 +82,20 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      # Get the KUBECONFIG from : https://cloud.linode.com/kubernetes/clusters/189301/summary
+      # KUBECONFIG is sourced from the Hetzner k3s prod cluster (see /etc/rancher/k3s/k3s.yaml on the control-plane node)
 
       # TODO: This kubeconfig is global kubeconfig with access to whole cluster
       # In production refrain from using this and use k8s service account with limited access
       # Each service account has permissions like IAM and each has its own kubeconfig
       # replace global kubeconfig with service account's kubeconfig
-      # https://www.linode.com/content/terraforming-kubernetes-github-actions/
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG}}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-auth-service.yml
+++ b/.github/workflows/maven-publish-auth-service.yml
@@ -81,12 +81,12 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG }}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG }}
 
       - name: Set Environment Variables in Deployment
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-community-service.yml
+++ b/.github/workflows/maven-publish-community-service.yml
@@ -86,21 +86,20 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      # Get the KUBECONFIG from : https://cloud.linode.com/kubernetes/clusters/189301/summary
+      # KUBECONFIG is sourced from the Hetzner k3s prod cluster (see /etc/rancher/k3s/k3s.yaml on the control-plane node)
 
       # TODO: This kubeconfig is global kubeconfig with access to whole cluster
       # In production refrain from using this and use k8s service account with limited access
       # Each service account has permissions like IAM and each has its own kubeconfig
       # replace global kubeconfig with service account's kubeconfig
-      # https://www.linode.com/content/terraforming-kubernetes-github-actions/
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG}}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-media-service.yml
+++ b/.github/workflows/maven-publish-media-service.yml
@@ -91,21 +91,20 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      # Get the KUBECONFIG from : https://cloud.linode.com/kubernetes/clusters/189301/summary
+      # KUBECONFIG is sourced from the Hetzner k3s prod cluster (see /etc/rancher/k3s/k3s.yaml on the control-plane node)
 
       # TODO: This kubeconfig is global kubeconfig with access to whole cluster
       # In production refrain from using this and use k8s service account with limited access
       # Each service account has permissions like IAM and each has its own kubeconfig
       # replace global kubeconfig with service account's kubeconfig
-      # https://www.linode.com/content/terraforming-kubernetes-github-actions/
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG}}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
         if: github.event_name == 'push'

--- a/.github/workflows/maven-publish-notification-service.yml
+++ b/.github/workflows/maven-publish-notification-service.yml
@@ -102,21 +102,20 @@ jobs:
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
-      # Get the KUBECONFIG from : https://cloud.linode.com/kubernetes/clusters/189301/summary
+      # KUBECONFIG is sourced from the Hetzner k3s prod cluster (see /etc/rancher/k3s/k3s.yaml on the control-plane node)
 
       # TODO: This kubeconfig is global kubeconfig with access to whole cluster
       # In production refrain from using this and use k8s service account with limited access
       # Each service account has permissions like IAM and each has its own kubeconfig
       # replace global kubeconfig with service account's kubeconfig
-      # https://www.linode.com/content/terraforming-kubernetes-github-actions/
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
-      - name: Connect to LKE kubernetes cluster
+      - name: Connect to Hetzner k3s kubernetes cluster
         if: github.event_name == 'push'
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.VACADEMY_STAGE_KUBECONFIG}}
+          kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Renames `secrets.VACADEMY_STAGE_KUBECONFIG` to `secrets.VACADEMY_PROD_KUBECONFIG` across all 8 deploy workflow references. The legacy "STAGE" name dates back to the LKE-era stage cluster; the secret value has been repointed at the Hetzner k3s prod cluster post-cutover, so the name was misleading.
- Updates the `Connect to LKE kubernetes cluster` step names to `Connect to Hetzner k3s kubernetes cluster` and replaces dead `cloud.linode.com` / `linode.com` comment links with a pointer to the Hetzner control-plane `/etc/rancher/k3s/k3s.yaml`.
- Pure CI rename — no service code, no helm chart, no infra changes.

## Files touched (8)

- `.github/workflows/docker-publish-ai-service.yml`
- `.github/workflows/deploy-pgbouncer.yml`
- `.github/workflows/maven-publish-auth-service.yml`
- `.github/workflows/maven-publish-admin-core-service.yml`
- `.github/workflows/maven-publish-assessment-service.yml`
- `.github/workflows/maven-publish-community-service.yml`
- `.github/workflows/maven-publish-media-service.yml`
- `.github/workflows/maven-publish-notification-service.yml`

## Cutover note (read before merging)

The repo is at the GitHub per-repo Actions-secret cap (100/100), so `VACADEMY_PROD_KUBECONFIG` cannot be created until `VACADEMY_STAGE_KUBECONFIG` is deleted. Order of operations at merge time:

1. Confirm no in-flight Actions runs.
2. ``gh secret delete VACADEMY_STAGE_KUBECONFIG -R Vacademy-io/vacademy_platform``
3. ``gh secret set VACADEMY_PROD_KUBECONFIG -R Vacademy-io/vacademy_platform < /tmp/vacademy-stage-kubeconfig.yaml``
4. Merge this PR.
5. Verify with a manual ``workflow_dispatch`` on ``Deploy PgBouncer`` (low-risk job).

Steps 2 and 3 should be back-to-back; the gap window is the only period where any kubectl-step would fail, and ``paths``-gated deploy workflows only fire on push to main.

## Test plan

- [ ] Confirm ``grep -rn 'VACADEMY_STAGE_KUBECONFIG' .github/workflows/`` returns zero matches on this branch
- [ ] After merge + secret swap, trigger ``Deploy PgBouncer`` via workflow_dispatch and confirm the ``Connect to Hetzner k3s kubernetes cluster`` step authenticates successfully