### PR TITLE
chore: pgbouncer YAML fix + chart memory limits sync

### DIFF
--- a/.github/workflows/deploy-pgbouncer.yml
+++ b/.github/workflows/deploy-pgbouncer.yml
@@ -58,8 +58,24 @@ jobs:
 
       - name: Apply PgBouncer Deployment and Service
         run: |
-          kubectl apply -f vacademy_devops/vacademy-services/templates/pgbouncer-deployment.yaml
-          kubectl apply -f vacademy_devops/vacademy-services/templates/pgbouncer-service.yaml
+          helm template vacademy-services \
+            ./vacademy_devops/vacademy-services \
+            --set pgbouncer.dbHost=${{ secrets.PGBOUNCER_DB_HOST }} \
+            --set pgbouncer.dbReadHost=${{ secrets.PGBOUNCER_DB_READ_HOST }} \
+            --set pgbouncer.dbPort=26754 \
+            --set pgbouncer.dbUsername=${{ secrets.DB_USERNAME }} \
+            --set pgbouncer.dbPassword=${{ secrets.DB_PASSWORD }} \
+            --show-only templates/pgbouncer-deployment.yaml \
+            | kubectl apply -f -
+          helm template vacademy-services \
+            ./vacademy_devops/vacademy-services \
+            --set pgbouncer.dbHost=${{ secrets.PGBOUNCER_DB_HOST }} \
+            --set pgbouncer.dbReadHost=${{ secrets.PGBOUNCER_DB_READ_HOST }} \
+            --set pgbouncer.dbPort=26754 \
+            --set pgbouncer.dbUsername=${{ secrets.DB_USERNAME }} \
+            --set pgbouncer.dbPassword=${{ secrets.DB_PASSWORD }} \
+            --show-only templates/pgbouncer-service.yaml \
+            | kubectl apply -f -
 
       - name: Restart PgBouncer to pick up config changes
         run: |

--- a/vacademy_devops/vacademy-services/templates/admin-core-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/admin-core-service-deployment.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             requests:
               cpu: "250m"
-              memory: "1Gi"
+              memory: "1536Mi"
             limits:
               cpu: "1000m"
-              memory: "2Gi"
+              memory: "3Gi"
           livenessProbe:
             httpGet:
               path: /admin-core-service/actuator/health

--- a/vacademy_devops/vacademy-services/templates/notification-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/notification-service-deployment.yaml
@@ -33,10 +33,10 @@ spec:
           resources:
             requests:
               cpu: "200m"
-              memory: "512Mi"
+              memory: "768Mi"
             limits:
               cpu: "350m"
-              memory: "1Gi"
+              memory: "2Gi"
           livenessProbe:
             httpGet:
               path: /notification-service/actuator/health


### PR DESCRIPTION
## Summary

Two post-cutover follow-ups identified during CI/CD validation on the Hetzner k3s cluster:

1. **pgbouncer workflow fix** — `.github/workflows/deploy-pgbouncer.yml` was running `kubectl apply -f` directly on Helm template files (`templates/pgbouncer-deployment.yaml` and `pgbouncer-service.yaml`), which start with `{{- if .Values.pgbouncer.enabled }}`. kubectl interpreted the leading `{{` as JSON and failed with `invalid character '{' looking for beginning of object key string`. Fixed by rendering via `helm template --show-only ... | kubectl apply -f -`, mirroring the existing (working) ConfigMap step in the same workflow. No template edits, no Helm release relocation.

2. **Chart memory limits drift** — Resources are hardcoded inline in `templates/<service>-deployment.yaml` (not parameterized via `values.yaml`). After the Hetzner migration, live memory was bumped on two services via `kubectl set resources`. Synced chart back to match live so future `helm upgrade` won't undo the bumps:
   - admin-core-service: requests 1Gi -> 1536Mi, limits 2Gi -> 3Gi
   - notification-service: requests 512Mi -> 768Mi, limits 1Gi -> 2Gi
   - All other services unchanged.

## Verification

- `helm template` renders cleanly post-edit; rendered manifests match live cluster values for both services.
- `kubectl apply --dry-run=client` against live Hetzner k3s reports `deployment.apps/pgbouncer configured (dry run)` and `service/pgbouncer configured (dry run)` for the rendered pgbouncer manifests.
- Other 5 services (auth, ai, media, assessment, community) unchanged in render output — no regressions.

## Test plan

- [ ] Trigger `deploy-pgbouncer.yml` workflow on this branch (or merge to main) and confirm it now succeeds end-to-end.
- [ ] Next `vac` Helm release upgrade preserves admin-core 3Gi / notification 2Gi memory limits (no rollback to old values).

Reference: Hetzner migration cutover follow-ups.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>