### PR TITLE
fix(pgbouncer): unbreak prod — drop stale Linode port 26754

### DIFF
--- a/.github/workflows/deploy-pgbouncer.yml
+++ b/.github/workflows/deploy-pgbouncer.yml
@@ -1,4 +1,4 @@
-name: Deploy PgBouncer to LKE
+name: Deploy PgBouncer to k3s
 
 on:
   push:
@@ -50,7 +50,6 @@ jobs:
             ./vacademy_devops/vacademy-services \
             --set pgbouncer.dbHost=${{ secrets.PGBOUNCER_DB_HOST }} \
             --set pgbouncer.dbReadHost=${{ secrets.PGBOUNCER_DB_READ_HOST }} \
-            --set pgbouncer.dbPort=26754 \
             --set pgbouncer.dbUsername=${{ secrets.DB_USERNAME }} \
             --set pgbouncer.dbPassword=${{ secrets.DB_PASSWORD }} \
             --show-only templates/pgbouncer-configmap.yaml \
@@ -62,7 +61,6 @@ jobs:
             ./vacademy_devops/vacademy-services \
             --set pgbouncer.dbHost=${{ secrets.PGBOUNCER_DB_HOST }} \
             --set pgbouncer.dbReadHost=${{ secrets.PGBOUNCER_DB_READ_HOST }} \
-            --set pgbouncer.dbPort=26754 \
             --set pgbouncer.dbUsername=${{ secrets.DB_USERNAME }} \
             --set pgbouncer.dbPassword=${{ secrets.DB_PASSWORD }} \
             --show-only templates/pgbouncer-deployment.yaml \
@@ -71,7 +69,6 @@ jobs:
             ./vacademy_devops/vacademy-services \
             --set pgbouncer.dbHost=${{ secrets.PGBOUNCER_DB_HOST }} \
             --set pgbouncer.dbReadHost=${{ secrets.PGBOUNCER_DB_READ_HOST }} \
-            --set pgbouncer.dbPort=26754 \
             --set pgbouncer.dbUsername=${{ secrets.DB_USERNAME }} \
             --set pgbouncer.dbPassword=${{ secrets.DB_PASSWORD }} \
             --show-only templates/pgbouncer-service.yaml \

--- a/vacademy_devops/vacademy-services/values.yaml
+++ b/vacademy_devops/vacademy-services/values.yaml
@@ -139,11 +139,11 @@ ingress:
 # ---------------------------------------------------------------------------
 pgbouncer:
   enabled: true                   # cloud prod = true; standalone overlay sets false
-  dbHost: "REPLACE_WITH_LINODE_DB_HOST"
-  dbReadHost: "REPLACE_WITH_LINODE_READ_REPLICA_HOST"
-  dbPort: 26754
+  dbHost: "REPLACE_WITH_DB_HOST"
+  dbReadHost: "REPLACE_WITH_DB_READ_HOST"
+  dbPort: 5432
   dbUsername: "postgres"
-  dbPassword: "REPLACE_WITH_LINODE_DB_PASSWORD"
+  dbPassword: "REPLACE_WITH_DB_PASSWORD"
 
 # ---------------------------------------------------------------------------
 # FULL ENVIRONMENT — source of truth for every service's runtime config.


### PR DESCRIPTION
## What broke

After PR #1847 was merged, the `deploy-pgbouncer.yml` workflow re-rendered the pgbouncer `ConfigMap` (it now uses `helm template --show-only … | kubectl apply`). But the workflow still hardcoded `--set pgbouncer.dbPort=26754` — the **Linode managed-DB port**. On Hetzner, Postgres listens on `5432`.

Pgbouncer accepted client connections but every backend dial to `10.0.0.4:26754` timed out:

```
WARNING C-...: admin_core_service/vacademy@10.42.x.x: pooler error: client_login_timeout (server down)
```

All 6 services lost DB access for ~5 minutes until I patched the live ConfigMap and restarted pgbouncer.

## What this PR changes

| File | Change |
|---|---|
| `.github/workflows/deploy-pgbouncer.yml` | Remove `--set pgbouncer.dbPort=26754` from all 3 `helm template` steps. Rename workflow display "to LKE" → "to k3s". |
| `vacademy_devops/vacademy-services/values.yaml` | `pgbouncer.dbPort` default `26754` → `5432`. Rename `REPLACE_WITH_LINODE_*` placeholders → `REPLACE_WITH_DB_*`. |

Port is not a secret and is the chart's natural default — no new GitHub secret needed.

## Verification

```
$ helm template vacademy-services ./vacademy_devops/vacademy-services \
    --set pgbouncer.dbHost=10.0.0.4 --set pgbouncer.dbReadHost=10.0.0.5 \
    --set pgbouncer.dbUsername=vacademy --set pgbouncer.dbPassword=xxx \
    --show-only templates/pgbouncer-configmap.yaml | grep "port="
    admin_core_service   = host=10.0.0.4 port=5432 dbname=admin_core_service
    auth_service         = host=10.0.0.4 port=5432 dbname=auth_service
    assessment_service   = host=10.0.0.4 port=5432 dbname=assessment_service pool_size=15
    community_service    = host=10.0.0.4 port=5432 dbname=community_service
    ...
```

## Prod state right now

Already hotfixed live (kubectl-edited ConfigMap + `rollout restart deployment/pgbouncer`). Pgbouncer is healthy and serving traffic. This PR just keeps the next workflow run from undoing that.

## Test plan

- [ ] Merge to main
- [ ] Workflow will auto-trigger (touches deploy-pgbouncer.yml path) — watch it succeed
- [ ] After workflow finishes: `kubectl get cm pgbouncer-config -o yaml | grep port=` should still show `port=5432`
- [ ] All 6 services remain healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)