### PR TITLE
render-worker: switch buildx cache to GHA cache (fix 403 on GHCR)

### DIFF
--- a/.github/workflows/docker-publish-render-worker.yml
+++ b/.github/workflows/docker-publish-render-worker.yml
@@ -72,8 +72,11 @@ jobs:
           tags: |
             ghcr.io/vacademy-io/render-worker:${{ env.TAG }}
             ghcr.io/vacademy-io/render-worker:latest
-          cache-from: type=registry,ref=ghcr.io/vacademy-io/render-worker:cache
-          cache-to:   type=registry,ref=ghcr.io/vacademy-io/render-worker:cache,mode=max
+          # Use GitHub Actions cache (built into the runner). Avoids the GHCR
+          # auth dance the registry cache backend required and is typically
+          # a bit faster. 10 GB cache quota per repo, free.
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
 
       - name: Connect to k3s
         uses: Azure/k8s-set-context@v4.0.0


### PR DESCRIPTION
## Summary
Last night's render-worker deploy run hit `403 Forbidden` writing the cache image to GHCR (`ghcr.io/vacademy-io/render-worker:cache`). The package was created manually with a PAT and the `Vacademy-io/vacademy_platform` repo wasn't yet on the package's "Manage Actions access" list — so `GITHUB_TOKEN` couldn't even HEAD blobs on it.

This PR sidesteps that for the cache by using GitHub Actions cache (`type=gha,mode=max`) instead of a registry-backed cache.

## What's NOT in this PR
The image push itself still uses GHCR, so it still needs the package to grant the repo write access. That's a one-click UI change:

https://github.com/orgs/Vacademy-io/packages/container/render-worker/settings → Manage Actions access → Add Repository → `vacademy_platform` → Write

## Test plan
- [ ] Grant the repo write access on the GHCR package (link above)
- [ ] Merge this PR
- [ ] Workflow auto-runs on the path filter — should now: cache pushes to GHA cache (no GHCR auth needed), image pushes to GHCR (works after the package access grant)
- [ ] Verify pod gets the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)