### PR TITLE
fix(leads): multi-select bulk add for pool counselors/audiences + fix…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
@@ -62,13 +62,17 @@ public class CounselorPoolController {
     // Audience attachment
     // ────────────────────────────────────────────────────────────────
 
-    @PostMapping("/{poolId}/audiences/{audienceId}")
-    public ResponseEntity<String> addAudienceToPool(
+    /**
+     * Attach one or more audiences (campaigns) to the pool atomically.
+     * Body: { audience_ids: [...] }. If any id fails, nothing is added.
+     */
+    @PostMapping("/{poolId}/audiences")
+    public ResponseEntity<String> addAudiencesToPool(
             @PathVariable String poolId,
-            @PathVariable String audienceId,
+            @RequestBody AddAudiencesRequest request,
             @RequestAttribute("user") CustomUserDetails user) {
-        poolService.addAudienceToPool(poolId, audienceId, user.getUserId());
-        return ResponseEntity.ok("Audience attached");
+        poolService.addAudiencesToPool(poolId, request.getAudienceIds(), user.getUserId());
+        return ResponseEntity.ok("Audiences attached");
     }
 
     @DeleteMapping("/{poolId}/audiences/{audienceId}")
@@ -97,13 +101,17 @@ public class CounselorPoolController {
     // Counselor (member) management
     // ────────────────────────────────────────────────────────────────
 
-    @PostMapping("/{poolId}/counselors/{counselorUserId}")
-    public ResponseEntity<String> addCounselorToPool(
+    /**
+     * Add one or more counselors to the pool atomically.
+     * Body: { counselor_user_ids: [...] }. If any id fails, nothing is added.
+     */
+    @PostMapping("/{poolId}/counselors")
+    public ResponseEntity<String> addCounselorsToPool(
             @PathVariable String poolId,
-            @PathVariable String counselorUserId,
+            @RequestBody AddCounselorsRequest request,
             @RequestAttribute("user") CustomUserDetails user) {
-        poolService.addCounselorToPool(poolId, counselorUserId, user.getUserId());
-        return ResponseEntity.ok("Counselor added to pool");
+        poolService.addCounselorsToPool(poolId, request.getCounselorUserIds(), user.getUserId());
+        return ResponseEntity.ok("Counselors added to pool");
     }
 
     @DeleteMapping("/{poolId}/counselors/{counselorUserId}")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/AddAudiencesRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/AddAudiencesRequest.java
@@ -1,0 +1,25 @@
+package vacademy.io.admin_core_service.features.counselor_pool.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Attach one or more audiences (campaigns) to a pool in a single call. Each
+ * audience seeds member rows for every existing pool member. The whole batch is
+ * atomic — if any id fails (e.g. already attached to another pool), nothing is
+ * added.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddAudiencesRequest {
+
+    @JsonProperty("audience_ids")
+    private List<String> audienceIds;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/AddCounselorsRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/dto/AddCounselorsRequest.java
@@ -1,0 +1,24 @@
+package vacademy.io.admin_core_service.features.counselor_pool.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Add one or more counselors to a pool in a single call. Each counselor is
+ * appended to the bottom of the rotation for every audience in the pool. The
+ * whole batch is atomic — if any id fails, nothing is added.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddCounselorsRequest {
+
+    @JsonProperty("counselor_user_ids")
+    private List<String> counselorUserIds;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/service/CounselorPoolService.java
@@ -184,9 +184,23 @@ public class CounselorPoolService {
     // Audience membership
     // ────────────────────────────────────────────────────────────────
 
+    /**
+     * Attach one or more audiences to the pool atomically. If any id fails
+     * (e.g. already attached to another pool), the whole batch rolls back.
+     */
     @Transactional
-    public void addAudienceToPool(String poolId, String audienceId, String addedByUserId) {
+    public void addAudiencesToPool(String poolId, List<String> audienceIds, String addedByUserId) {
         ensurePoolExists(poolId);
+        if (audienceIds == null || audienceIds.isEmpty()) {
+            throw new VacademyException("audience_ids must be a non-empty list");
+        }
+        // De-dupe while preserving order so a repeated id can't double-seed rows.
+        for (String audienceId : new LinkedHashSet<>(audienceIds)) {
+            attachAudienceToPoolInternal(poolId, audienceId, addedByUserId);
+        }
+    }
+
+    private void attachAudienceToPoolInternal(String poolId, String audienceId, String addedByUserId) {
         attachAudienceInternal(poolId, audienceId);
 
         // Seed member rows for the new audience using existing pool members.
@@ -220,9 +234,17 @@ public class CounselorPoolService {
     // Counselor membership
     // ────────────────────────────────────────────────────────────────
 
+    /**
+     * Add one or more counselors to the pool atomically. Each counselor is
+     * appended to the bottom of the rotation for every audience. If any id
+     * fails, the whole batch rolls back.
+     */
     @Transactional
-    public void addCounselorToPool(String poolId, String counselorUserId, String addedByUserId) {
+    public void addCounselorsToPool(String poolId, List<String> counselorUserIds, String addedByUserId) {
         ensurePoolExists(poolId);
+        if (counselorUserIds == null || counselorUserIds.isEmpty()) {
+            throw new VacademyException("counselor_user_ids must be a non-empty list");
+        }
 
         List<CounselorPoolAudience> audiences = poolAudienceRepository.findByPoolId(poolId);
         if (audiences.isEmpty()) {
@@ -230,6 +252,14 @@ public class CounselorPoolService {
             throw new VacademyException("Add at least one audience to the pool before adding counselors.");
         }
 
+        // De-dupe while preserving order so a repeated id can't shift ordering.
+        for (String counselorUserId : new LinkedHashSet<>(counselorUserIds)) {
+            addCounselorToAudiences(poolId, audiences, counselorUserId, addedByUserId);
+        }
+    }
+
+    private void addCounselorToAudiences(String poolId, List<CounselorPoolAudience> audiences,
+                                         String counselorUserId, String addedByUserId) {
         // For each audience, append this counselor at the bottom of the rotation.
         for (CounselorPoolAudience pa : audiences) {
             String audienceId = pa.getAudienceId();

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -141,10 +141,14 @@ export const COUNSELOR_POOL_BY_ID = (poolId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}`;
 export const COUNSELOR_POOL_AUDIENCE = (poolId: string, audienceId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/audiences/${audienceId}`;
+export const COUNSELOR_POOL_AUDIENCES = (poolId: string) =>
+    `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/audiences`;
 export const COUNSELOR_POOL_AUDIENCE_ORDER = (poolId: string, audienceId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/audiences/${audienceId}/order`;
 export const COUNSELOR_POOL_COUNSELOR = (poolId: string, counselorUserId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/counselors/${counselorUserId}`;
+export const COUNSELOR_POOL_COUNSELORS = (poolId: string) =>
+    `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/counselors`;
 export const COUNSELOR_POOL_COUNSELOR_STATUS = (poolId: string, counselorUserId: string) =>
     `${BASE_URL}/admin-core-service/v1/counselor-pool/${poolId}/counselors/${counselorUserId}/status`;
 export const COUNSELOR_POOL_COUNSELOR_MEMBERSHIPS = (counselorUserId: string) =>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step2CourseSelector.tsx
@@ -268,14 +268,14 @@ export const Step2CourseSelector = ({
                             <FunnelSimple size={13} />
                             {levelTerm}
                             {selectedLevelIds.length > 0 && (
-                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-[10px] leading-none">
+                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-caption leading-none">
                                     {selectedLevelIds.length}
                                 </Badge>
                             )}
                             <CaretDown size={11} className="text-neutral-400" />
                         </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="max-h-60 w-48 overflow-y-auto">
+                    <DropdownMenuContent align="start" className="z-popover-above-modal max-h-60 w-48 overflow-y-auto">
                         <DropdownMenuLabel className="text-xs text-neutral-500">
                             Filter by {levelTerm}
                         </DropdownMenuLabel>
@@ -324,14 +324,14 @@ export const Step2CourseSelector = ({
                             <FunnelSimple size={13} />
                             {sessionTerm}
                             {selectedSessionIds.length > 0 && (
-                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-[10px] leading-none">
+                                <Badge className="ml-0.5 h-4 min-w-4 rounded-full px-1 py-0 text-caption leading-none">
                                     {selectedSessionIds.length}
                                 </Badge>
                             )}
                             <CaretDown size={11} className="text-neutral-400" />
                         </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="max-h-60 w-48 overflow-y-auto">
+                    <DropdownMenuContent align="start" className="z-popover-above-modal max-h-60 w-48 overflow-y-auto">
                         <DropdownMenuLabel className="text-xs text-neutral-500">
                             Filter by {sessionTerm}
                         </DropdownMenuLabel>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step3EnrollConfig.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step3EnrollConfig.tsx
@@ -17,7 +17,7 @@ import { BookOpen, Lightning } from '@phosphor-icons/react';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarBlank as CalendarIcon } from '@phosphor-icons/react';
 import { format, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
@@ -103,12 +103,12 @@ const CourseConfigRow = ({ instituteId, ps, onUpdate }: CourseConfigRowProps) =>
             </div>
 
             {resolved?.paymentOption && (
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-neutral-600">
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-caption text-neutral-600">
                     <span className="rounded-full bg-neutral-100 px-2 py-0.5 font-medium text-neutral-700">
                         {resolved.paymentOption.name}
                     </span>
                     <span
-                        className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                        className={`rounded-full px-2 py-0.5 text-caption font-semibold ${
                             resolved.paymentOption.type === 'FREE'
                                 ? 'bg-emerald-100 text-emerald-700'
                                 : resolved.paymentOption.type === 'CPO'
@@ -119,7 +119,7 @@ const CourseConfigRow = ({ instituteId, ps, onUpdate }: CourseConfigRowProps) =>
                         {resolved.paymentOption.type}
                     </span>
                     {resolved.resolvedFromDefault && (
-                        <span className="text-[10px] text-neutral-400">
+                        <span className="text-caption text-neutral-400">
                             (auto-resolved from DEFAULT invite)
                         </span>
                     )}
@@ -246,7 +246,7 @@ export const Step3EnrollConfig = ({
                             <SelectTrigger>
                                 <SelectValue />
                             </SelectTrigger>
-                            <SelectContent>
+                            <SelectContent className="z-popover-above-modal">
                                 <SelectItem value="SKIP">Skip silently (recommended)</SelectItem>
                                 <SelectItem value="RE_ENROLL">
                                     Re-enroll (reactivate expired/terminated)
@@ -286,7 +286,7 @@ export const Step3EnrollConfig = ({
                                     )}
                                 </Button>
                             </PopoverTrigger>
-                            <PopoverContent className="w-auto p-0" align="start">
+                            <PopoverContent className="z-popover-above-modal w-auto p-0" align="start">
                                 <Calendar
                                     mode="single"
                                     selected={

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/AudiencesTab.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/AudiencesTab.tsx
@@ -4,26 +4,19 @@
  * institute's full campaign list. Backend enforces "one campaign per pool".
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { MyButton } from '@/components/design-system/button';
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
+import MultiSelectAddList from './MultiSelectAddList';
 import {
     handleFetchCampaignsList,
     type CampaignItem,
 } from '@/routes/audience-manager/list/-services/get-campaigns-list';
 import {
     CounselorPoolDTO,
-    useAddAudienceToPool,
+    useAddAudiencesToPool,
     useRemoveAudienceFromPool,
 } from '@/services/counselor-pool';
 
@@ -32,8 +25,6 @@ interface AudiencesTabProps {
 }
 
 export default function AudiencesTab({ pool }: AudiencesTabProps) {
-    const [pendingAudienceId, setPendingAudienceId] = useState<string>('');
-
     // Reuse the existing campaign-list service from audience-manager. Pull a wide page
     // (size 500) so we get every campaign in the institute regardless of pagination.
     const instituteId = getCurrentInstituteId() ?? '';
@@ -45,7 +36,7 @@ export default function AudiencesTab({ pool }: AudiencesTabProps) {
     const { data: campaignsPage, isLoading } = useQuery(campaignsQuery);
     const allCampaigns: CampaignItem[] = campaignsPage?.content ?? [];
 
-    const { mutate: addAudience, isPending: adding } = useAddAudienceToPool(pool.id);
+    const { mutateAsync: addAudiencesAsync } = useAddAudiencesToPool(pool.id);
     const { mutate: removeAudience, isPending: removing } = useRemoveAudienceFromPool(pool.id);
 
     const attachedIds = useMemo(
@@ -71,15 +62,19 @@ export default function AudiencesTab({ pool }: AudiencesTabProps) {
         [allCampaigns, attachedIds]
     );
 
-    const handleAdd = () => {
-        if (!pendingAudienceId) return;
-        addAudience(pendingAudienceId, {
-            onSuccess: () => {
-                toast.success('Campaign attached to pool');
-                setPendingAudienceId('');
-            },
-            onError: (err) => toast.error(extractError(err) ?? 'Failed to attach campaign'),
-        });
+    // One atomic bulk attach. On failure the whole batch is rejected, so we keep
+    // every checked id selected for retry; on success we clear them all.
+    const handleAddAudiences = async (ids: string[]): Promise<string[]> => {
+        try {
+            await addAudiencesAsync(ids);
+            toast.success(
+                ids.length === 1 ? 'Campaign attached' : `${ids.length} campaigns attached`
+            );
+            return [];
+        } catch (err) {
+            toast.error(extractError(err) ?? 'Failed to attach campaigns');
+            return ids;
+        }
     };
 
     const handleRemove = (audienceId: string, campaignName: string) => {
@@ -101,40 +96,19 @@ export default function AudiencesTab({ pool }: AudiencesTabProps) {
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                    <div className="flex items-center gap-3">
-                        <Select value={pendingAudienceId} onValueChange={setPendingAudienceId}>
-                            <SelectTrigger className="w-full max-w-md">
-                                <SelectValue
-                                    placeholder={
-                                        isLoading
-                                            ? 'Loading campaigns…'
-                                            : available.length === 0
-                                              ? 'No unattached campaigns available'
-                                              : 'Select a campaign'
-                                    }
-                                />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {available.map((c) => (
-                                    <SelectItem key={c.id} value={c.id!}>
-                                        {c.campaign_name}
-                                        <span className="ml-2 text-xs text-muted-foreground">
-                                            ({c.status})
-                                        </span>
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                        <MyButton
-                            buttonType="primary"
-                            scale="small"
-                            onClick={handleAdd}
-                            disable={!pendingAudienceId || adding}
-                        >
-                            {adding ? 'Adding…' : 'Add'}
-                        </MyButton>
-                    </div>
-                    <p className="text-xs text-muted-foreground">
+                    <MultiSelectAddList
+                        items={available.map((c) => ({
+                            id: c.id!,
+                            label: c.campaign_name ?? '(unnamed campaign)',
+                            sublabel: c.status,
+                        }))}
+                        loading={isLoading}
+                        onAdd={handleAddAudiences}
+                        searchPlaceholder="Search campaigns…"
+                        emptyText="No unattached campaigns available."
+                        itemNoun="campaign"
+                    />
+                    <p className="text-caption text-neutral-400">
                         A campaign already in another pool will be rejected — remove it from there
                         first.
                     </p>

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/CounselorsTab.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/CounselorsTab.tsx
@@ -37,6 +37,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import MultiSelectAddList from './MultiSelectAddList';
 import {
     handleFetchCampaignsList,
     type CampaignItem,
@@ -45,7 +46,7 @@ import {
     CounselorPoolDTO,
     type MonthlyTargetEntry,
     PoolMemberDTO,
-    useAddCounselorToPool,
+    useAddCounselorsToPool,
     useBulkUpdateMemberStatus,
     useCounselorMemberships,
     useRemoveCounselorFromPool,
@@ -109,7 +110,6 @@ const fetchBackupEligibleCounsellors = async (): Promise<InstituteUser[]> => {
 };
 
 export default function CounselorsTab({ pool }: CounselorsTabProps) {
-    const [pendingUserId, setPendingUserId] = useState<string>('');
     const [statusDialog, setStatusDialog] = useState<{
         counselorUserId: string;
         counselorName: string;
@@ -154,7 +154,7 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
         [instituteUsers, counselorsInPool]
     );
 
-    const { mutate: addCounselor, isPending: adding } = useAddCounselorToPool(pool.id);
+    const { mutateAsync: addCounselorsAsync } = useAddCounselorsToPool(pool.id);
     const { mutate: removeCounselor, isPending: removing } = useRemoveCounselorFromPool(pool.id);
     const { mutate: updateStatus, isPending: updatingStatus } = useUpdateMemberStatus(pool.id);
     const { mutate: bulkUpdateStatus, isPending: bulkUpdatingStatus } = useBulkUpdateMemberStatus();
@@ -182,19 +182,21 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
     const { data: memberships = [], isLoading: membershipsLoading } =
         useCounselorMemberships(membershipsCounselorId);
 
-    const handleAdd = () => {
-        if (!pendingUserId) return;
+    // One atomic bulk add. On failure the whole batch is rejected, so we keep
+    // every checked id selected for retry; on success we clear them all.
+    const handleAddCounselors = async (ids: string[]): Promise<string[]> => {
         if ((pool.audiences ?? []).length === 0) {
             toast.error('Add at least one campaign to the pool before adding counselors');
-            return;
+            return ids; // keep all checked — nothing was attempted
         }
-        addCounselor(pendingUserId, {
-            onSuccess: () => {
-                toast.success('Counselor added');
-                setPendingUserId('');
-            },
-            onError: (err) => toast.error(extractError(err) ?? 'Failed to add counselor'),
-        });
+        try {
+            await addCounselorsAsync(ids);
+            toast.success(ids.length === 1 ? 'Counselor added' : `${ids.length} counselors added`);
+            return [];
+        } catch (err) {
+            toast.error(extractError(err) ?? 'Failed to add counselors');
+            return ids;
+        }
     };
 
     const handleRemove = (counselorUserId: string, name: string) => {
@@ -361,41 +363,17 @@ export default function CounselorsTab({ pool }: CounselorsTabProps) {
                     </CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <div className="flex items-center gap-3">
-                        <Select value={pendingUserId} onValueChange={setPendingUserId}>
-                            <SelectTrigger className="w-full max-w-md">
-                                <SelectValue
-                                    placeholder={
-                                        usersLoading
-                                            ? 'Loading counselors…'
-                                            : availableUsers.length === 0
-                                              ? 'All eligible counselors already in pool'
-                                              : 'Select a counselor'
-                                    }
-                                />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {availableUsers.map((u) => (
-                                    <SelectItem key={u.id} value={u.id}>
-                                        {u.full_name}
-                                        {u.email && (
-                                            <span className="ml-2 text-xs text-muted-foreground">
-                                                {u.email}
-                                            </span>
-                                        )}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                        <MyButton
-                            buttonType="primary"
-                            scale="small"
-                            onClick={handleAdd}
-                            disable={!pendingUserId || adding}
-                        >
-                            {adding ? 'Adding…' : 'Add'}
-                        </MyButton>
-                    </div>
+                    <MultiSelectAddList
+                        items={availableUsers.map((u) => ({
+                            id: u.id,
+                            label: u.full_name,
+                        }))}
+                        loading={usersLoading}
+                        onAdd={handleAddCounselors}
+                        searchPlaceholder="Search counselors…"
+                        emptyText="All eligible counselors are already in this pool."
+                        itemNoun="counselor"
+                    />
                 </CardContent>
             </Card>
 

--- a/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/MultiSelectAddList.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/leads/pools/-components/MultiSelectAddList.tsx
@@ -1,0 +1,174 @@
+/**
+ * Reusable "pick many, add in one go" control for pool settings.
+ *
+ * Replaces the single-select dropdown + Add button used when attaching
+ * counselors or campaigns to a pool. Shows a searchable, scrollable checklist
+ * with a select-all toggle and an "Add Selected (N)" action.
+ *
+ * The backend has no bulk-add endpoint, so `onAdd` is expected to fan out one
+ * request per id. It returns the ids that FAILED — this component then keeps
+ * those checked (so the admin can retry) and clears the ones that succeeded.
+ */
+
+import { useMemo, useState } from 'react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { MyButton } from '@/components/design-system/button';
+
+export interface MultiSelectItem {
+    id: string;
+    label: string;
+    /** Optional muted suffix, e.g. a status or email. */
+    sublabel?: string;
+}
+
+interface MultiSelectAddListProps {
+    items: MultiSelectItem[];
+    loading?: boolean;
+    /** Fan out the adds; resolve with the ids that failed (empty = all ok). */
+    onAdd: (ids: string[]) => Promise<string[]>;
+    searchPlaceholder?: string;
+    emptyText?: string;
+    /** Singular noun for the button, e.g. "counselor" → "Add 2 counselors". */
+    itemNoun?: string;
+}
+
+export default function MultiSelectAddList({
+    items,
+    loading = false,
+    onAdd,
+    searchPlaceholder = 'Search…',
+    emptyText = 'Nothing to add.',
+    itemNoun = 'item',
+}: MultiSelectAddListProps) {
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [submitting, setSubmitting] = useState(false);
+
+    const filtered = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        if (!q) return items;
+        return items.filter(
+            (it) =>
+                it.label.toLowerCase().includes(q) ||
+                (it.sublabel?.toLowerCase().includes(q) ?? false)
+        );
+    }, [items, search]);
+
+    // Selection can only ever include ids that still exist in `items` (an add
+    // removes succeeded ids from the parent's available list).
+    const selectedCount = useMemo(
+        () => items.reduce((n, it) => (selected.has(it.id) ? n + 1 : n), 0),
+        [items, selected]
+    );
+
+    const allFilteredSelected =
+        filtered.length > 0 && filtered.every((it) => selected.has(it.id));
+
+    const toggle = (id: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const toggleAllFiltered = () => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (allFilteredSelected) {
+                for (const it of filtered) next.delete(it.id);
+            } else {
+                for (const it of filtered) next.add(it.id);
+            }
+            return next;
+        });
+    };
+
+    const handleAdd = async () => {
+        const ids = items.filter((it) => selected.has(it.id)).map((it) => it.id);
+        if (ids.length === 0) return;
+        setSubmitting(true);
+        try {
+            const failed = await onAdd(ids);
+            // Keep failed ids checked for retry; clear the rest.
+            setSelected(new Set(failed));
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="space-y-3">
+            <div className="relative">
+                <MagnifyingGlass
+                    size={16}
+                    className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
+                />
+                <Input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder={searchPlaceholder}
+                    className="pl-9"
+                />
+            </div>
+
+            <div className="flex items-center justify-between">
+                <button
+                    type="button"
+                    className="text-caption font-medium text-primary-500 hover:underline disabled:opacity-50"
+                    onClick={toggleAllFiltered}
+                    disabled={filtered.length === 0 || submitting}
+                >
+                    {allFilteredSelected ? 'Clear all' : 'Select all'}
+                </button>
+                <span className="text-caption text-neutral-400">{selectedCount} selected</span>
+            </div>
+
+            <div className="max-h-72 divide-y overflow-y-auto rounded-md border">
+                {loading ? (
+                    <p className="px-3 py-6 text-center text-body text-neutral-400">Loading…</p>
+                ) : filtered.length === 0 ? (
+                    <p className="px-3 py-6 text-center text-body text-neutral-400">
+                        {items.length === 0 ? emptyText : 'No matches.'}
+                    </p>
+                ) : (
+                    filtered.map((it) => (
+                        <label
+                            key={it.id}
+                            className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-neutral-50"
+                        >
+                            <Checkbox
+                                checked={selected.has(it.id)}
+                                onCheckedChange={() => toggle(it.id)}
+                            />
+                            <span className="flex-1 truncate text-body text-neutral-700">
+                                {it.label}
+                                {it.sublabel && (
+                                    <span className="ml-2 text-caption text-neutral-400">
+                                        {it.sublabel}
+                                    </span>
+                                )}
+                            </span>
+                        </label>
+                    ))
+                )}
+            </div>
+
+            <MyButton
+                buttonType="primary"
+                scale="small"
+                onClick={handleAdd}
+                disable={selectedCount === 0 || submitting}
+            >
+                {submitting
+                    ? 'Adding…'
+                    : selectedCount === 0
+                      ? `Add ${itemNoun}s`
+                      : `Add ${selectedCount} ${itemNoun}${selectedCount === 1 ? '' : 's'}`}
+            </MyButton>
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/services/counselor-pool.ts
+++ b/frontend-admin-dashboard/src/services/counselor-pool.ts
@@ -14,10 +14,12 @@ import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import {
     COUNSELOR_POOL_AUDIENCE,
+    COUNSELOR_POOL_AUDIENCES,
     COUNSELOR_POOL_AUDIENCE_ORDER,
     COUNSELOR_POOL_BASE,
     COUNSELOR_POOL_BY_ID,
     COUNSELOR_POOL_COUNSELOR,
+    COUNSELOR_POOL_COUNSELORS,
     COUNSELOR_POOL_COUNSELOR_MEMBERSHIPS,
     COUNSELOR_POOL_COUNSELOR_MONTHLY_TARGET,
     COUNSELOR_POOL_COUNSELOR_STATUS,
@@ -219,16 +221,28 @@ export const deletePool = async (poolId: string): Promise<void> => {
     await authenticatedAxiosInstance.delete(COUNSELOR_POOL_BY_ID(poolId));
 };
 
-export const addAudienceToPool = async (poolId: string, audienceId: string): Promise<void> => {
-    await authenticatedAxiosInstance.post(COUNSELOR_POOL_AUDIENCE(poolId, audienceId));
+// Atomic bulk attach — backend rolls back the whole batch if any id fails.
+export const addAudiencesToPool = async (
+    poolId: string,
+    audienceIds: string[]
+): Promise<void> => {
+    await authenticatedAxiosInstance.post(COUNSELOR_POOL_AUDIENCES(poolId), {
+        audience_ids: audienceIds,
+    });
 };
 
 export const removeAudienceFromPool = async (poolId: string, audienceId: string): Promise<void> => {
     await authenticatedAxiosInstance.delete(COUNSELOR_POOL_AUDIENCE(poolId, audienceId));
 };
 
-export const addCounselorToPool = async (poolId: string, counselorUserId: string): Promise<void> => {
-    await authenticatedAxiosInstance.post(COUNSELOR_POOL_COUNSELOR(poolId, counselorUserId));
+// Atomic bulk add — backend rolls back the whole batch if any id fails.
+export const addCounselorsToPool = async (
+    poolId: string,
+    counselorUserIds: string[]
+): Promise<void> => {
+    await authenticatedAxiosInstance.post(COUNSELOR_POOL_COUNSELORS(poolId), {
+        counselor_user_ids: counselorUserIds,
+    });
 };
 
 export const removeCounselorFromPool = async (
@@ -378,10 +392,10 @@ export const useDeletePool = () => {
     });
 };
 
-export const useAddAudienceToPool = (poolId: string) => {
+export const useAddAudiencesToPool = (poolId: string) => {
     const invalidate = useInvalidatePool();
     return useMutation({
-        mutationFn: (audienceId: string) => addAudienceToPool(poolId, audienceId),
+        mutationFn: (audienceIds: string[]) => addAudiencesToPool(poolId, audienceIds),
         onSuccess: () => invalidate(poolId),
     });
 };
@@ -394,10 +408,10 @@ export const useRemoveAudienceFromPool = (poolId: string) => {
     });
 };
 
-export const useAddCounselorToPool = (poolId: string) => {
+export const useAddCounselorsToPool = (poolId: string) => {
     const invalidate = useInvalidatePool();
     return useMutation({
-        mutationFn: (counselorUserId: string) => addCounselorToPool(poolId, counselorUserId),
+        mutationFn: (counselorUserIds: string[]) => addCounselorsToPool(poolId, counselorUserIds),
         onSuccess: () => invalidate(poolId),
     });
 };


### PR DESCRIPTION
## Summary of Changes

Improves the lead-pool settings UI and fixes recurring "popup hidden behind the modal" bugs in the Enroll Learner wizard. Also replaces the per-item add endpoints for pool counselors/audiences with atomic bulk endpoints, since the frontend now adds many at once.

**Backend:**
- Replaced the single-item add endpoints with list-body bulk variants: `POST /counselor-pool/{poolId}/counselors` (`{ counselor_user_ids: [...] }`) and `POST /counselor-pool/{poolId}/audiences` (`{ audience_ids: [...] }`). The `DELETE .../{id}` (remove) endpoints are unchanged.
- Added request DTOs `AddCounselorsRequest` and `AddAudiencesRequest`.
- Refactored `CounselorPoolService`: the old per-item logic became private helpers; new `addCounselorsToPool` / `addAudiencesToPool` are `@Transactional` and loop over a de-duped id set. The batch is atomic — if any id fails, the whole batch rolls back.

**Frontend:**
- Lead-pool **Counselors** and **Audiences** tabs: replaced the single-select dropdown + Add with a new shared `MultiSelectAddList` component (search + checkbox list + "Select all" + "Add N …"). On failure the selection is kept for retry; on success it clears.
- Counselor dropdown now shows the name only (removed the email suffix).
- Service layer + URL constants updated to the new bulk endpoints (`addCounselorsToPool` / `addAudiencesToPool` hooks now take `string[]`).
- Fixed popups rendering behind the Enroll Learner modal (`DialogContent` is `z-[1100]`, popups defaulted to `z-50`) by applying the existing `z-popover-above-modal` (1200) token to: Step 2 Level/Session filters (`DropdownMenuContent`), and Step 3 "If Learner is Already Enrolled" `SelectContent` + "Payment Date" `PopoverContent`.
- Minor design-system cleanups required by the lint gate: lucide `CalendarIcon` → phosphor `CalendarBlank`; arbitrary `text-[10px]/[11px]` → `text-caption` token.

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran the admin dashboard against a local `admin_core_service` (port 8072) and exercised both tabs end-to-end.
- Multi-selected several counselors and several campaigns and confirmed they were added in one call and appear in the pool.
- Verified the atomic behaviour and that the selection is retained on failure.
- Confirmed the Level/Session filter dropdowns and the duplicate-handling dropdown + payment-date calendar all render above the Enroll Learner modal.
- `mvn compile` (backend) passes; `tsc --noEmit` and `design-lint` (frontend) pass clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
