### PR TITLE
devops: JVM heap pinning + CPU/mem bumps (slowness fixes batch 1)

### DIFF
--- a/vacademy_devops/vacademy-services/templates/admin-core-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/admin-core-service-deployment.yaml
@@ -1,3 +1,12 @@
+{{- /*
+  JVM heap is pinned via JAVA_TOOL_OPTIONS below because the Hetzner
+  Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2
+  container-support detection: every Java pod read the node's full
+  memory (~11.4 GiB) as its heap budget on a 1-2 GiB pod limit, which
+  caused OOMKill cascades (migration day + media-service OOMKill).
+  Explicit -Xms/-Xmx via JAVA_TOOL_OPTIONS sidesteps the broken
+  auto-detection. See memory/jvm-cgroup-detection-broken-hetzner.md.
+*/ -}}
 {{- if .Values.services.admin_core_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -39,13 +48,17 @@ spec:
                 name: myconfigmapv1.0
             - secretRef:
                 name: vacademy-secrets
+          env:
+            # Pin heap explicitly; cgroup-v2 auto-detection is broken on this kernel.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms512m -Xmx2560m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
           resources:
             requests:
               cpu: "250m"
               memory: "1536Mi"
             limits:
-              cpu: "1000m"
-              memory: "3Gi"
+              cpu: "2000m"
+              memory: "4Gi"
           # startupProbe gates startup: it polls until the app first answers OK,
           # then liveness/readiness take over. With initialDelaySeconds=30 we
           # detect a ready pod ~150s earlier per pod vs the old 180-300s wait,

--- a/vacademy_devops/vacademy-services/templates/assessment-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/assessment-service-deployment.yaml
@@ -1,3 +1,12 @@
+{{- /*
+  JVM heap is pinned via JAVA_TOOL_OPTIONS below because the Hetzner
+  Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2
+  container-support detection: every Java pod read the node's full
+  memory (~11.4 GiB) as its heap budget on a 1-2 GiB pod limit, which
+  caused OOMKill cascades (migration day + media-service OOMKill).
+  Explicit -Xms/-Xmx via JAVA_TOOL_OPTIONS sidesteps the broken
+  auto-detection. See memory/jvm-cgroup-detection-broken-hetzner.md.
+*/ -}}
 {{- if .Values.services.assessment_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,13 +39,17 @@ spec:
                 name: myconfigmapv1.0
             - secretRef:
                 name: vacademy-secrets
+          env:
+            # Pin heap explicitly; cgroup-v2 auto-detection is broken on this kernel.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms256m -Xmx1024m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
           resources:
             requests:
               cpu: "100m"
-              memory: "512Mi"
+              memory: "1Gi"
             limits:
-              cpu: "500m"
-              memory: "1536Mi"
+              cpu: "750m"
+              memory: "2Gi"
           livenessProbe:
             httpGet:
               path: /assessment-service/actuator/health

--- a/vacademy_devops/vacademy-services/templates/auth-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/auth-service-deployment.yaml
@@ -1,3 +1,12 @@
+{{- /*
+  JVM heap is pinned via JAVA_TOOL_OPTIONS below because the Hetzner
+  Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2
+  container-support detection: every Java pod read the node's full
+  memory (~11.4 GiB) as its heap budget on a 1-2 GiB pod limit, which
+  caused OOMKill cascades (migration day + media-service OOMKill).
+  Explicit -Xms/-Xmx via JAVA_TOOL_OPTIONS sidesteps the broken
+  auto-detection. See memory/jvm-cgroup-detection-broken-hetzner.md.
+*/ -}}
 {{- if .Values.services.auth_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,6 +39,10 @@ spec:
                 name: myconfigmapv1.0
             - secretRef:
                 name: vacademy-secrets
+          env:
+            # Pin heap explicitly; cgroup-v2 auto-detection is broken on this kernel.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms256m -Xmx1024m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
           resources:
             requests:
               cpu: "200m"

--- a/vacademy_devops/vacademy-services/templates/media-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/media-service-deployment.yaml
@@ -1,3 +1,12 @@
+{{- /*
+  JVM heap is pinned via JAVA_TOOL_OPTIONS below because the Hetzner
+  Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2
+  container-support detection: every Java pod read the node's full
+  memory (~11.4 GiB) as its heap budget on a 1-2 GiB pod limit, which
+  caused OOMKill cascades (migration day + media-service OOMKill).
+  Explicit -Xms/-Xmx via JAVA_TOOL_OPTIONS sidesteps the broken
+  auto-detection. See memory/jvm-cgroup-detection-broken-hetzner.md.
+*/ -}}
 {{- if .Values.services.media_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,13 +39,17 @@ spec:
                 name: myconfigmapv1.0
             - secretRef:
                 name: vacademy-secrets
+          env:
+            # Pin heap explicitly; cgroup-v2 auto-detection is broken on this kernel.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms256m -Xmx1280m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
           resources:
             requests:
-              cpu: "200m"
-              memory: "512Mi"
-            limits:
-              cpu: "400m"
+              cpu: "300m"
               memory: "1Gi"
+            limits:
+              cpu: "1000m"
+              memory: "2Gi"
           livenessProbe:
             httpGet:
               path: /media-service/actuator/health

--- a/vacademy_devops/vacademy-services/templates/notification-service-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/notification-service-deployment.yaml
@@ -1,3 +1,12 @@
+{{- /*
+  JVM heap is pinned via JAVA_TOOL_OPTIONS below because the Hetzner
+  Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2
+  container-support detection: every Java pod read the node's full
+  memory (~11.4 GiB) as its heap budget on a 1-2 GiB pod limit, which
+  caused OOMKill cascades (migration day + media-service OOMKill).
+  Explicit -Xms/-Xmx via JAVA_TOOL_OPTIONS sidesteps the broken
+  auto-detection. See memory/jvm-cgroup-detection-broken-hetzner.md.
+*/ -}}
 {{- if .Values.services.notification_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,12 +39,16 @@ spec:
                 name: myconfigmapv1.0
             - secretRef:
                 name: vacademy-secrets
+          env:
+            # Pin heap explicitly; cgroup-v2 auto-detection is broken on this kernel.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms256m -Xmx1280m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
           resources:
             requests:
-              cpu: "200m"
+              cpu: "300m"
               memory: "768Mi"
             limits:
-              cpu: "350m"
+              cpu: "1000m"
               memory: "2Gi"
           livenessProbe:
             httpGet:

--- a/vacademy_devops/vacademy-services/templates/pgbouncer-deployment.yaml
+++ b/vacademy_devops/vacademy-services/templates/pgbouncer-deployment.yaml
@@ -33,11 +33,11 @@ spec:
               readOnly: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "64Mi"
+              cpu: "200m"
+              memory: "96Mi"
             limits:
-              cpu: "250m"
-              memory: "128Mi"
+              cpu: "1000m"
+              memory: "256Mi"
           livenessProbe:
             tcpSocket:
               port: 6432


### PR DESCRIPTION
## Summary

- Pin JVM heap explicitly via `JAVA_TOOL_OPTIONS` on every Java service deployment (auth, admin_core, assessment, media, notification). The Hetzner Ubuntu 26.04 / Linux 7.0.0 kernel breaks the JVM's cgroup-v2 container-support detection, so every Java pod was reading the node's full memory (~11.4 GiB) as its max-heap budget on a 1-2 GiB pod limit. Result: OOMKill cascade on migration day + media-service OOMKill ~22h ago.
- Bump CPU limits on the most-throttled pods: pgbouncer `250m -> 1000m`, notification `350m -> 1000m`, media `400m -> 1000m`, admin-core `1000m -> 2000m`, assessment `500m -> 750m`.
- Bump memory limits where the JVM needs more headroom for non-heap: media `1Gi -> 2Gi`, assessment `1.5Gi -> 2Gi`, admin-core `3Gi -> 4Gi`, pgbouncer `128Mi -> 256Mi`.
- Bump memory requests to match what we patched live (no scheduling regressions expected; the cluster has been running with these values for the last few hours).
- Add a top `{{- /* ... */ -}}` comment in each affected deployment template explaining why the heap pin exists, pointing at `memory/jvm-cgroup-detection-broken-hetzner.md`.

These exact values were applied live first via `kubectl set env` + `kubectl patch`, then verified healthy on the cluster. This PR syncs the source chart so the next `helm upgrade` doesn't undo them.

## Files

- `vacademy_devops/vacademy-services/templates/admin-core-service-deployment.yaml`
- `vacademy_devops/vacademy-services/templates/assessment-service-deployment.yaml`
- `vacademy_devops/vacademy-services/templates/auth-service-deployment.yaml`
- `vacademy_devops/vacademy-services/templates/media-service-deployment.yaml`
- `vacademy_devops/vacademy-services/templates/notification-service-deployment.yaml`
- `vacademy_devops/vacademy-services/templates/pgbouncer-deployment.yaml` (CPU/mem only — no JVM)

## Heap pin values (matches live patches)

| Service       | mem limit | -Xms | -Xmx   |
| ------------- | --------- | ---- | ------ |
| auth          | 1536Mi    | 256m | 1024m  |
| admin_core    | 4Gi       | 512m | 2560m  |
| assessment    | 2Gi       | 256m | 1024m  |
| media         | 2Gi       | 256m | 1280m  |
| notification  | 2Gi       | 256m | 1280m  |

All Java services also get `-XX:+UseG1GC -XX:MaxGCPauseMillis=200` so the GC mode is explicit and won't flip if the JDK base image bumps.

## Test plan

- [x] `helm template` renders all six templates cleanly with no YAML errors.
- [x] Live cluster healthy post-patch, no 5xx surge observed.
- [ ] After merge: run a `helm upgrade` against stage and verify each Java pod comes up with `JAVA_TOOL_OPTIONS` in its env and the new resource limits in its spec.
- [ ] On stage, `kubectl exec` into one Java pod and confirm `jcmd 1 VM.flags | grep MaxHeapSize` matches the pinned `-Xmx`, not the node's memory.
- [ ] Watch admin-core, media, notification for ~24h post-merge for OOMKill recurrence.

## Follow-ups (not in this PR)

- Track the Hetzner / Ubuntu kernel fix for cgroup-v2 container detection; once that ships we can revert the explicit heap pin and let `-XX:+UseContainerSupport` work normally again.
- ai_service (Python) is unaffected — Python doesn't read cgroup for heap sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)