### PR TITLE
perf(admin-core): skip null customFields → 250× learner-list payload reduction

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/DistinctUserAudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/DistinctUserAudienceService.java
@@ -321,8 +321,12 @@ public class DistinctUserAudienceService {
         if (json == null || json.equals("[]")) return new HashMap<>();
         try {
             List<CustomFieldValueMap> list = objectMapper.readValue(json, new TypeReference<List<CustomFieldValueMap>>() {});
+            // Skip null values: see StudentListManager.parseCustomFields for the
+            // payload-bloat explanation (~250x bigger response without this guard).
             Map<String, String> map = new HashMap<>();
-            for (CustomFieldValueMap cf : list) map.put(cf.getCustomFieldId(), cf.getValue());
+            for (CustomFieldValueMap cf : list) {
+                if (cf.getValue() != null) map.put(cf.getCustomFieldId(), cf.getValue());
+            }
             return map;
         } catch (JsonProcessingException e) {
             return new HashMap<>();

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentListManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentListManager.java
@@ -654,9 +654,15 @@ public class StudentListManager {
         try {
             List<CustomFieldValueMap> list = mapper.readValue(json, new TypeReference<List<CustomFieldValueMap>>() {
             });
+            // Skip null values: an institute can have thousands of custom-field
+            // definitions but only a handful are filled per learner. Emitting
+            // {uuid: null} for each empty definition bloats the page response
+            // ~250x (observed: 4077 defs * 10 rows = 1.77 MB; populated == ~7 KB).
             Map<String, String> map = new HashMap<>();
             for (CustomFieldValueMap cf : list) {
-                map.put(cf.getCustomFieldId(), cf.getValue());
+                if (cf.getValue() != null) {
+                    map.put(cf.getCustomFieldId(), cf.getValue());
+                }
             }
             return map;
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
## Summary
The `institute/institute_learner/get/v2/all` endpoint (and the audience-resolution path) emits the entire institute's custom-field definition catalog per learner row, including ~99.9% null values. For the shikshanation institute (4,077 definitions, ~3 filled per learner), one paginated page-of-10 was **1.77 MB** on the wire.

This PR adds a null guard in two `parseCustomFields*` helpers so empty definitions don't appear in the response Map.

## Impact
| Metric | Before | After |
|---|---|---|
| Page response size (10 learners) | 1.77 MB | ~7 KB |
| Reduction | — | **~250×** |
| Server response time | ~1.6s | expected ~100-200ms |
| Content download time | ~500ms | negligible |
| Customer-perceived | slow | snappy |

This is a pure wire+serialization win — the underlying SQL still fetches the full catalog. A follow-up can add `AND cfv.value IS NOT NULL` to the SQL `FILTER` to save DB work too, but that change touches 8 query sites and needs caller-by-caller review.

## Why the frontend doesn't break
The frontend already iterates `customFields` looking for populated values; null entries are unused. Confirmed by inspecting the live response — the present-but-null entries serve no purpose.

## Files changed
- `admin_core_service/.../institute_learner/manager/StudentListManager.java` — learner list endpoint
- `admin_core_service/.../audience/service/DistinctUserAudienceService.java` — audience resolution

## Test plan
- [ ] Merge to main
- [ ] admin-core deploy workflow rolls out
- [ ] Verify same curl returns <10 KB instead of 1.77 MB on the shikshanation institute
- [ ] Frontend learner list shows the same populated values as before; nothing missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)