### PR TITLE
fix(learner-progress): refresh course progress instantly after slide …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_study_library/controller/LearnerStudyLibraryController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_study_library/controller/LearnerStudyLibraryController.java
@@ -27,7 +27,7 @@ public class LearnerStudyLibraryController {
     private StudyLibraryService studyLibraryService;
 
     @GetMapping("/init-details")
-    @ClientCacheable(maxAgeSeconds = 60, scope = CacheScope.PRIVATE, varyHeaders = {"X-User-Id", "X-Package-Session-Id"})
+    @ClientCacheable(maxAgeSeconds = 0, scope = CacheScope.NO_STORE, varyHeaders = {"X-User-Id", "X-Package-Session-Id"})
     public ResponseEntity<List<LearnerSubjectProjection>> getLearnerStudyLibraryInitDetails(
             @RequestParam String packageSessionId,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -35,19 +35,19 @@ public class LearnerStudyLibraryController {
     }
 
     @GetMapping("/modules-with-chapters")
-    @ClientCacheable(maxAgeSeconds = 300, scope = CacheScope.PRIVATE, varyHeaders = {"X-User-Id", "X-Package-Session-Id"})
+    @ClientCacheable(maxAgeSeconds = 0, scope = CacheScope.NO_STORE, varyHeaders = {"X-User-Id", "X-Package-Session-Id"})
     public ResponseEntity<List<LearnerModuleDTOWithDetails>> modulesWithChapters(@RequestParam("subjectId") String subjectId, @RequestParam("packageSessionId") String packageSessionId, @RequestAttribute("user") CustomUserDetails user) {
         return ResponseEntity.ok(learnerStudyLibraryService.getModulesDetailsWithChapters(subjectId, packageSessionId, user));
     }
 
     @GetMapping("/get-slides/{chapterId}")
-    @ClientCacheable(maxAgeSeconds = 60, scope = CacheScope.PRIVATE, varyHeaders = {"X-User-Id"})
+    @ClientCacheable(maxAgeSeconds = 0, scope = CacheScope.NO_STORE, varyHeaders = {"X-User-Id"})
     public ResponseEntity<List<SlideDetailProjection>> getSlidesByChapterId(@PathVariable String chapterId, @RequestAttribute("user") CustomUserDetails user) {
         return ResponseEntity.ok(learnerStudyLibraryService.getSlidesByChapterId(chapterId, user));
     }
 
     @GetMapping("/slides")
-    @ClientCacheable(maxAgeSeconds = 300, scope = CacheScope.PRIVATE, varyHeaders = {"X-User-Id"})
+    @ClientCacheable(maxAgeSeconds = 0, scope = CacheScope.NO_STORE, varyHeaders = {"X-User-Id"})
     public ResponseEntity<List<LearnerSlidesDetailDTO>> getLearnerSlidesByChapterId(@RequestParam String chapterId, @RequestAttribute("user") CustomUserDetails user) {
         return ResponseEntity.ok(learnerStudyLibraryService.getLearnerSlides(chapterId, user));
     }

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/assignment-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/assignment-slide.tsx
@@ -14,6 +14,7 @@ import { SUBMIT_ASSIGNMENT_SLIDE_ANSWERS, GET_ASSIGNMENT_ACTIVITY_LOGS } from "@
 import { getPublicUrl } from "@/services/upload_file";
 import { v4 as uuidv4 } from "uuid";
 import { getUserId } from "@/constants/getUserId";
+import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 import { MyInput } from "@/components/design-system/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
@@ -1039,6 +1040,14 @@ const AssignmentSlide = ({
     onSuccess: () => {
       toast.success("Assignment submitted successfully!");
       queryClient.invalidateQueries({ queryKey: ['ASSIGNMENT_GRADING_RESULTS'] });
+      // Reconcile progress UI (chapter/module/course %) after the async
+      // completion cascade lands. chapterId comes from the slide route URL,
+      // same source the submit uses for slideId.
+      const chapterId =
+        new URLSearchParams(window.location.search).get("chapterId") || "";
+      if (chapterId) {
+        void refreshProgressAfterSubmit(queryClient, chapterId);
+      }
     },
     onError: (error: unknown) => {
       // Backend returns ErrorInfo { message } via GlobalExceptionHandler when

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/question-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/question-slide.tsx
@@ -6,7 +6,7 @@ import { MyInput } from "@/components/design-system/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 // import { MyButton } from "@/components/design-system/button";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
 import { SUBMIT_QUESTION_SLIDE_ANSWERS } from "@/constants/urls";
 import { v4 as uuidv4 } from "uuid";
@@ -14,6 +14,7 @@ import { getUserId } from "@/constants/getUserId";
 import { Textarea } from "@/components/ui/textarea";
 import { useRouter } from "@tanstack/react-router";
 import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
+import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 
 interface Option {
     id: string;
@@ -68,6 +69,7 @@ interface QuestionResponseMap {
 
 const QuestionSlide = ({ questionData, onSubmit }: QuestionSlideProps) => {
     const router = useRouter();
+    const queryClient = useQueryClient();
     const { chapterId, moduleId, subjectId } = router.state.location.search;
     // const { activeItem } = useContentStore();
     const [selectedOptionsMap, setSelectedOptionsMap] = useState<
@@ -439,6 +441,12 @@ const QuestionSlide = ({ questionData, onSubmit }: QuestionSlideProps) => {
 
             // Call the onSubmit function passed from parent
             await onSubmit(slideId, submissionValue);
+
+            // Reconcile progress UI (chapter/module/course %) after the
+            // async completion cascade lands. chapterId is from the route.
+            if (chapterId) {
+                void refreshProgressAfterSubmit(queryClient, chapterId);
+            }
 
             // Reset inputs after submission
             if (questionType === "MCQS" || questionType === "TRUE_FALSE") {

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useSlidesRefresh.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useSlidesRefresh.ts
@@ -1,40 +1,22 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
+import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 
 export const useSlidesRefresh = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { chapterId } = router.state.location.search;
 
-  // Refresh every progress-bearing cache after a slide-tracking POST. The
-  // backend cascade (slide → chapter → module → subject → package_session)
-  // runs @Async, so we wait briefly before invalidating; otherwise the
-  // refetch races the cascade and reads stale data. Same pattern is used in
-  // QuizViewer's refreshProgressAfterSubmit.
+  // Thin wrapper around the shared refresh util so slide-sync hooks
+  // (PDF / video / audio / presentation) and submit-based slides
+  // (quiz / scorm / question / assignment …) all use the SAME backoff
+  // reconciliation logic. chapterId comes from the active route here.
   const refreshSlides = async () => {
     if (!chapterId) {
       console.warn("⚠️ [useSlidesRefresh] No chapter ID available, skipping refresh");
       return;
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 600));
-
-    try {
-      await queryClient.invalidateQueries({
-        predicate: (q) => {
-          const k = q.queryKey;
-          if (!Array.isArray(k)) return false;
-          return (
-            k[0] === "MODULES_WITH_CHAPTERS" ||
-            k[0] === "GET_MODULES_WITH_CHAPTERS" ||
-            k[0] === "GET_COURSE_INIT" ||
-            (k[0] === "slides" && k[1] === chapterId)
-          );
-        },
-      });
-    } catch (error) {
-      console.error("❌ [useSlidesRefresh] Failed to refresh progress caches:", error);
-    }
+    await refreshProgressAfterSubmit(queryClient, chapterId);
   };
 
   return {

--- a/frontend-learner-dashboard-app/src/utils/study-library/tracking/refreshProgressAfterSubmit.ts
+++ b/frontend-learner-dashboard-app/src/utils/study-library/tracking/refreshProgressAfterSubmit.ts
@@ -1,32 +1,72 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-// Invalidate every React Query cache that feeds a progress UI after a slide
-// submit. The backend cascade (slide → chapter → module → subject →
-// package_session) runs @Async, so we wait briefly before invalidating so the
-// refetch sees the new rows. Keys covered:
-//   - ["slides", chapterId]            — chapter sidebar (per-slide %)
-//   - ["MODULES_WITH_CHAPTERS", ...]   — module list (rollup chapter %)
-//   - ["GET_MODULES_WITH_CHAPTERS",...] — alternate naming used in this codebase
-//   - ["GET_COURSE_INIT", ...]         — course-overall % tile
+// Refresh every React Query cache that feeds a progress UI after a slide submit.
 //
-// The 600ms delay is the empirical settle window for the @Async cascade
-// (see 2026-05-09 work in .samar/). Shorter risks invalidating before the
-// backend has written; longer makes the UI feel laggy.
+// The backend rollup cascade (slide → chapter → module → subject →
+// package_session) runs @Async and commits AFTER the submit response, with
+// variable latency. A single fixed-delay refetch can therefore race the cascade
+// and read a stale value. Instead of guessing one settle time, we reconcile
+// across a few backoff waves: the first wave is awaited (so callers that await
+// still get an immediate refresh), and later waves run in the background so the
+// rollup tiles land on the authoritative value once the cascade finishes — even
+// under load — without blocking the caller's submit/sync flow.
+//
+// We deliberately do NOT try to detect "the value changed". A genuine completion
+// can legitimately leave a rollup unchanged (re-opening an already-complete
+// slide, averaging absorption, or MAX across multiple package_sessions of the
+// same course), so treating "unchanged" as failure would false-time-out. We just
+// re-invalidate a bounded number of times and stop.
+//
+// Keys covered:
+//   - ["slides", chapterId]              — chapter sidebar (per-slide %)
+//   - ["MODULES_WITH_CHAPTERS", ...]     — module list (rollup chapter %)
+//   - ["GET_MODULES_WITH_CHAPTERS", ...] — alternate naming used in this codebase
+//   - ["GET_COURSE_INIT", ...]           — course-overall % tile
+
+const ROLLUP_KEYS = [
+  "MODULES_WITH_CHAPTERS",
+  "GET_MODULES_WITH_CHAPTERS",
+  "GET_COURSE_INIT",
+];
+
+// First wave (awaited) ~matches the previous 600ms behaviour; later waves are
+// background-only reconciliation for slower cascades.
+const FIRST_WAVE_MS = 500;
+const BACKGROUND_WAVES_MS = [1500, 3000];
+
+const invalidateProgress = (
+  queryClient: QueryClient,
+  chapterId: string,
+  includeSlides: boolean
+): Promise<void> =>
+  queryClient
+    .invalidateQueries({
+      predicate: (q) => {
+        const k = q.queryKey;
+        if (!Array.isArray(k)) return false;
+        if (ROLLUP_KEYS.includes(k[0] as string)) return true;
+        // Per-slide % is optimistically set + monotonic-guarded server-side, so
+        // we only refetch it on the first wave to avoid re-flickering it.
+        if (includeSlides && k[0] === "slides" && k[1] === chapterId) return true;
+        return false;
+      },
+    })
+    .catch((error) => {
+      console.error("[refreshProgressAfterSubmit] invalidation failed:", error);
+    });
+
 export const refreshProgressAfterSubmit = async (
   queryClient: QueryClient,
   chapterId: string
 ): Promise<void> => {
-  await new Promise((resolve) => setTimeout(resolve, 600));
-  await queryClient.invalidateQueries({
-    predicate: (q) => {
-      const k = q.queryKey;
-      if (!Array.isArray(k)) return false;
-      return (
-        k[0] === "MODULES_WITH_CHAPTERS" ||
-        k[0] === "GET_MODULES_WITH_CHAPTERS" ||
-        k[0] === "GET_COURSE_INIT" ||
-        (k[0] === "slides" && k[1] === chapterId)
-      );
-    },
-  });
+  // First wave: awaited, includes the per-slide cache.
+  await new Promise((resolve) => setTimeout(resolve, FIRST_WAVE_MS));
+  await invalidateProgress(queryClient, chapterId, true);
+
+  // Background waves: rollups only, fire-and-forget so we don't block the caller.
+  for (const delay of BACKGROUND_WAVES_MS) {
+    setTimeout(() => {
+      void invalidateProgress(queryClient, chapterId, false);
+    }, delay);
+  }
 };


### PR DESCRIPTION
## Summary of Changes

Learner course-progress (the overall % tile and the chapter/module/slide
sidebar) was not updating promptly after a learner completed a slide — it
could stay stale for up to ~5 minutes. Root cause was a caching layer the
frontend could not invalidate: the learner-study-library read endpoints
sent `Cache-Control: private, max-age=60/300`, which both the browser HTTP
cache and the app-level in-memory cache (`src/lib/http/clientCache.ts`)
honour. So the post-submit React Query invalidation refetched, but the
refetch was served the stale cached body and never reached the server.
Two slide types (standalone Question, Assignment) also never triggered any
progress refresh at all.

This change makes progress reconcile within a couple of seconds, keeps the
async completion cascade untouched, and does not increase steady-state
server load (React Query in-memory caching still de-dupes navigation).

**Backend:**
- `LearnerStudyLibraryController`: set `@ClientCacheable` to
  `CacheScope.NO_STORE` on the four per-user, progress-bearing reads
  (`/init-details`, `/modules-with-chapters`, `/get-slides/{chapterId}`,
  `/slides`) — previously `private, max-age=60/300`. These caches were
  keyed off `Cache-Control` and could not be invalidated from JS, silently
  defeating the post-submit refetch. Header-only change — no write-path,
  transaction, or cascade impact. All other `@ClientCacheable` endpoints
  (catalog, institute, domain-routing, etc.) are unchanged.

**Frontend (learner-dashboard):**
- Consolidated the two duplicate refresh helpers — `refreshProgressAfterSubmit`
  (util) and `useSlidesRefresh` (hook) invalidated identical keys; the hook
  now delegates to the util.
- Replaced the single fixed 600ms-then-invalidate with bounded backoff
  reconciliation: first wave awaited (~500ms, incl. per-slide cache), then
  two background waves (1.5s, 3s) that reconcile rollup tiles only (so the
  optimistic per-slide % isn't re-flickered). Deliberately does NOT gate on
  "value changed" — a genuine completion can legitimately leave a rollup
  unchanged (re-opening a complete slide, averaging absorption, or MAX
  across multiple package_sessions of the same course). Same helper
  signature, so all existing call sites are unaffected.
- Wired the standalone Question and Assignment submit paths into the refresh
  (previously they invalidated no progress caches).

## Related Issue



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `tsc --noEmit`: no TypeScript errors in any changed file.
- `design-lint.mjs`: 0 errors on the changed `.tsx` files.
- Manual end-to-end on stage/preview (real data, real writes — local
  write-path testing is not feasible: prod DB access is read-only):
  - Complete each slide type (PDF, video, audio, quiz, SCORM, code editor,
    Question, Assignment) and confirm the overall-% tile and chapter/module
    rollups update within ~3s.
  - `curl -I` the four endpoints and confirm `Cache-Control: no-store`.
  - Confirm via read-replica SQL that the learner's
    `PERCENTAGE_PACKAGE_SESSION_COMPLETED` row moved.
  - Re-test the already-wired types (PDF/video/quiz/SCORM) to confirm the
    helper consolidation didn't regress them.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
