### PR TITLE
devops: let workflow_dispatch also deploy across all 7 service workflows

### DIFF
--- a/.github/workflows/docker-publish-ai-service.yml
+++ b/.github/workflows/docker-publish-ai-service.yml
@@ -52,7 +52,7 @@ jobs:
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -60,7 +60,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG }}
 
       - name: Restart deployment if it exists
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         env:
           DEPLOYMENT_NAME: ai-service
           NAMESPACE: default

--- a/.github/workflows/maven-publish-admin-core-service.yml
+++ b/.github/workflows/maven-publish-admin-core-service.yml
@@ -107,7 +107,7 @@ jobs:
       # replace global kubeconfig with service account's kubeconfig
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -115,7 +115,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/admin-core-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -148,7 +148,7 @@ jobs:
             ZOOM_OAUTH_FRONTEND_CALLBACK_URL=${{ secrets.ZOOM_OAUTH_FRONTEND_CALLBACK_URL }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: admin-core-service

--- a/.github/workflows/maven-publish-assessment-service.yml
+++ b/.github/workflows/maven-publish-assessment-service.yml
@@ -90,7 +90,7 @@ jobs:
       # replace global kubeconfig with service account's kubeconfig
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -98,7 +98,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/assessment-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -115,7 +115,7 @@ jobs:
             INTERNAL_SERVICE_TOKEN=${{ secrets.INTERNAL_SERVICE_TOKEN }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: assessment-service

--- a/.github/workflows/maven-publish-auth-service.yml
+++ b/.github/workflows/maven-publish-auth-service.yml
@@ -82,14 +82,14 @@ jobs:
           echo "Docker Image Link = $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: Azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG }}
 
       - name: Set Environment Variables in Deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/auth-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -108,7 +108,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: auth-service

--- a/.github/workflows/maven-publish-community-service.yml
+++ b/.github/workflows/maven-publish-community-service.yml
@@ -94,7 +94,7 @@ jobs:
       # replace global kubeconfig with service account's kubeconfig
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -102,7 +102,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/community-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -121,7 +121,7 @@ jobs:
             GH_ACTION_TOKEN=${{ secrets.GH_ACTION_TOKEN }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: community-service

--- a/.github/workflows/maven-publish-media-service.yml
+++ b/.github/workflows/maven-publish-media-service.yml
@@ -99,7 +99,7 @@ jobs:
       # replace global kubeconfig with service account's kubeconfig
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -107,7 +107,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/media-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -132,7 +132,7 @@ jobs:
             CLOUD_CONVERT_KEY=${{ secrets.CLOUD_CONVERT_KEY }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: media-service

--- a/.github/workflows/maven-publish-notification-service.yml
+++ b/.github/workflows/maven-publish-notification-service.yml
@@ -110,7 +110,7 @@ jobs:
       # replace global kubeconfig with service account's kubeconfig
       # https://nicwortel.nl/blog/2022/continuous-deployment-to-kubernetes-with-github-actions
       - name: Connect to Hetzner k3s kubernetes cluster
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: connect-to-k8s-cluster
         uses: Azure/k8s-set-context@v4.0.0
         with:
@@ -118,7 +118,7 @@ jobs:
           kubeconfig: ${{ secrets.VACADEMY_PROD_KUBECONFIG}}
 
       - name: Deploy to Kubernetes
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           kubectl set env deployment/notification-service \
             DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
@@ -154,7 +154,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Restart deployment
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: restart-deployment
         env:
           DEPLOYMENT_NAME: notification-service


### PR DESCRIPTION
## Summary
Today's symptom: notification-service was running an older image even though a newer one had been pushed to ECR. Root cause: the maven-publish (and docker-publish-ai-service) workflows had

\`\`\`yaml
if: github.event_name == 'push'
\`\`\`

on the **Connect to k3s / Deploy / Restart** steps. So when someone manually clicks "Run workflow" in the Actions UI (which sends \`workflow_dispatch\`), the workflow builds and pushes \`:latest\` to ECR, but the cluster never gets the rolling restart. Result: the new image sits on ECR while the cluster runs an old digest.

## The fix
Widen the gate to also include \`workflow_dispatch\`:

\`\`\`yaml
if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
\`\`\`

Applied to:
- maven-publish-auth-service.yml
- maven-publish-admin-core-service.yml
- maven-publish-assessment-service.yml
- maven-publish-community-service.yml
- maven-publish-media-service.yml
- maven-publish-notification-service.yml
- docker-publish-ai-service.yml

## ⚠️ Side effect at merge time
The path filter on these workflows includes the workflow file itself, so merging this PR will trigger ALL 7 deploys on push to main simultaneously. That's a lot of rolling restarts in one window. If you want to avoid that, either:
1. Merge during a quiet window (the rollouts are zero-downtime per maxUnavailable=0, so just noisy)
2. OR cancel the runs from the Actions UI right after merge (the change is already in main)

## Test plan
- [ ] Merge this PR
- [ ] Verify all 7 service rollouts complete cleanly
- [ ] Next time someone clicks "Run workflow" manually on any of these → cluster gets the new image automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)