### PR TITLE
devops: route u.readonrent.com short-link host to media-service + add…

### DIFF
--- a/vacademy_devops/vacademy-services/templates/ingress.yaml
+++ b/vacademy_devops/vacademy-services/templates/ingress.yaml
@@ -110,6 +110,7 @@ spec:
         - backend-stage.vacademy.io
         - u.vacademy.io
         - u.aanandham.uk
+        - u.readonrent.com
       secretName: vacademy-tls-secret
   rules:
     - host: backend-stage.vacademy.io
@@ -182,6 +183,16 @@ spec:
                 port:
                   number: {{ .Values.services.media_service.port }}
     - host: u.aanandham.uk
+      http:
+        paths:
+          - path: /s
+            pathType: Prefix
+            backend:
+              service:
+                name: media-service
+                port:
+                  number: {{ .Values.services.media_service.port }}
+    - host: u.readonrent.com
       http:
         paths:
           - path: /s


### PR DESCRIPTION
## Summary of Changes

Adds `u.readonrent.com` as a branded short-link domain so ReadOnRent share links resolve as `https://u.readonrent.com/s/{slug}` instead of the default `https://u.vacademy.io/s/{slug}`. This is an infra-only change — the short-link service already resolves the host per-institute from the `backend_base_url` table, so no application code was touched. Mirrors the existing `u.aanandham.uk` setup.

**Backend:**
- No code changes. Per-institute host resolution already exists in `ShortLinkService.resolveBaseUrl`. The ReadOnRent host is enabled via a `backend_base_url` row (`institute_id = 91a5ad98-…`, `base_url = readonrent.com`) applied separately to the media_service DB.

**DevOps:**
- `ingress.yaml`: added `u.readonrent.com` to the `vacademy-tls-secret` TLS hosts list so cert-manager issues a Let's Encrypt cert for it.
- `ingress.yaml`: added a `u.readonrent.com` host rule routing `/s` → `media-service` (clone of the `u.aanandham.uk` block).
- DNS: `u.readonrent.com` A record → `5.223.55.238` (DNS only / grey cloud), matching `u.vacademy.io`. Already created in Cloudflare.

## Related Issue

<leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Confirmed DNS: `dig +short u.readonrent.com` returns `5.223.55.238`, identical to `u.vacademy.io`.
- Verified pre-deploy state matches expectation: `http://u.readonrent.com/s/...` returns ingress default-backend 404 and HTTPS serves the fake cert (no host rule / cert yet).
- Post-deploy verification: `curl -I https://u.readonrent.com/s/<code>` returns a valid cert and a `302` redirect (same behavior as `u.vacademy.io`).
- Existing `u.vacademy.io/s/...` links for ReadOnRent continue to work and auto-upgrade to the new host on next share (`absoluteUrl` is recomputed per request).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
