### PR TITLE
cpo invoice: add sendEmail overload + installment line items

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -276,6 +276,18 @@ public class InvoiceService {
      */
     @Transactional
     public Invoice generateInvoice(UserPlan userPlan, PaymentLog paymentLog, String instituteId) {
+        return generateInvoice(userPlan, paymentLog, instituteId, true);
+    }
+
+    /**
+     * Overload that controls whether the invoice email is sent. The online CPO/SCHOOL payment
+     * webhook generates the invoice purely so a real, downloadable {@code INV-} record exists,
+     * but it already sends its own fee receipt — so it passes {@code sendEmail=false} to avoid a
+     * duplicate learner email. All existing callers use the 3-arg overload and keep emailing.
+     *
+     * @param sendEmail whether to email the generated invoice PDF to the learner
+     */
+    public Invoice generateInvoice(UserPlan userPlan, PaymentLog paymentLog, String instituteId, boolean sendEmail) {
         try {
             log.info("Starting invoice generation for userPlanId: {}, paymentLogId: {}, instituteId: {}",
                     userPlan.getId(), paymentLog.getId(), instituteId);
@@ -317,11 +329,13 @@ public class InvoiceService {
                     paymentLogs, instituteId);
 
             // 8. Send email with PDF attached (don't fail if email fails)
-            try {
-                sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId, pdfBytes);
-            } catch (Exception e) {
-                log.error("Failed to send invoice email for invoice: {}. Invoice generation will continue.",
-                        invoiceNumber, e);
+            if (sendEmail) {
+                try {
+                    sendInvoiceEmail(invoice, invoiceData.getUser(), instituteId, pdfBytes);
+                } catch (Exception e) {
+                    log.error("Failed to send invoice email for invoice: {}. Invoice generation will continue.",
+                            invoiceNumber, e);
+                }
             }
 
             log.info("Invoice generated successfully: {} with {} payment log(s)",


### PR DESCRIPTION
Fixes CI build break: RazorpayWebHookService.handleSchoolPayment calls generateInvoice(userPlan, paymentLog, instituteId, sendEmail=false) but the 4-arg overload was not committed. Adds the overload (3-arg delegates with sendEmail=true; email gated on the flag) plus the CPO installment line-item builder so school-fee invoices itemize installments instead of the course name.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
