### PR TITLE
fix(ppt-to-pdf): upload presentations via pre-signed S3 URL to avoid 413

### DIFF
--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -212,6 +212,7 @@ export const REFRESH_TOKEN_URL = `${BASE_URL}/auth-service/v1/refresh-token`;
 
 export const UPLOAD_DOCS_FILE_URL = `${BASE_URL}/media-service/convert/doc-to-html`;
 export const CONVERT_PPT_TO_PDF_URL = `${BASE_URL}/media-service/convert/ppt-to-pdf`;
+export const CONVERT_PPT_TO_PDF_BY_ID_URL = `${BASE_URL}/media-service/convert/ppt-to-pdf-by-id`;
 export const SUBMIT_RATING_URL = `${BASE_URL}/admin-core-service/rating`;
 export const GET_ALL_USER_RATINGS = `${BASE_URL}/admin-core-service/rating/get-source-ratings-admin`;
 export const GET_ALL_RATING_SUMMARY = `${BASE_URL}/admin-core-service/rating/summary`;

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-ppt-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-ppt-dialog.tsx
@@ -15,9 +15,10 @@ import * as pdfjs from 'pdfjs-dist';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import { CheckCircle, PresentationChart } from '@phosphor-icons/react';
 import { getSlideStatusForUser } from '../../non-admin/hooks/useNonAdminSlides';
-import { CONVERT_PPT_TO_PDF_URL } from '@/constants/urls';
+import { CONVERT_PPT_TO_PDF_BY_ID_URL } from '@/constants/urls';
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { useFileUpload } from '@/hooks/use-file-upload';
+import { UploadFileInS3 } from '@/services/upload_file';
 import {
     buildAppendReorderPayload,
     getNextSlideOrder,
@@ -33,19 +34,31 @@ interface FormData {
 /**
  * Converts a PPT/PPTX file to PDF using the media-service API.
  * Returns the PDF as a File object.
+ *
+ * The presentation is uploaded directly to S3 via a pre-signed URL and only its
+ * fileId is sent to media-service for conversion. This keeps the large upload off
+ * the nginx/Spring request path, which otherwise rejects big decks with a 413.
  */
 export async function convertPptToPdf(file: File): Promise<File> {
-    const formData = new globalThis.FormData();
-    formData.append('file', file);
-
     try {
+        // 1. Upload the presentation straight to S3 (bypasses the request-size limit).
+        const accessToken = getTokenFromCookie(TokenKey.accessToken);
+        const decoded = getTokenDecodedData(accessToken) as
+            | { userId?: string; sub?: string; authorities?: Record<string, unknown> }
+            | undefined;
+        const userId = decoded?.userId || decoded?.sub || '';
+        const instituteId = (decoded?.authorities && Object.keys(decoded.authorities)[0]) || 'STUDENTS';
+
+        const fileId = await UploadFileInS3(file, () => {}, userId, 'PPT_TO_PDF', instituteId, false);
+        if (!fileId) {
+            throw new Error('Failed to upload presentation for conversion.');
+        }
+
+        // 2. Convert the uploaded file by id (tiny request body, no 413).
         const response = await authenticatedAxiosInstance.post(
-            `${CONVERT_PPT_TO_PDF_URL}?quality=high`,
-            formData,
-            {
-                headers: { 'Content-Type': 'multipart/form-data' },
-                responseType: 'blob',
-            }
+            `${CONVERT_PPT_TO_PDF_BY_ID_URL}?quality=high`,
+            { file_id: fileId, file_name: file.name },
+            { responseType: 'blob' }
         );
 
         const pdfBlob = new Blob([response.data], { type: 'application/pdf' });

--- a/media_service/src/main/java/vacademy/io/media_service/controller/PptToPdfController.java
+++ b/media_service/src/main/java/vacademy/io/media_service/controller/PptToPdfController.java
@@ -6,10 +6,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.media_service.dto.PptToPdfByIdRequest;
 import vacademy.io.media_service.service.PptToPdfService;
 
 @RestController
@@ -45,6 +49,40 @@ public class PptToPdfController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_PDF);
         String filename = file.getOriginalFilename();
+        if (filename != null && filename.lastIndexOf('.') > 0) {
+            filename = filename.substring(0, filename.lastIndexOf('.'));
+        } else {
+            filename = "converted";
+        }
+        headers.setContentDisposition(ContentDisposition.attachment().filename(filename + ".pdf").build());
+
+        return new ResponseEntity<>(pdfContent, headers, HttpStatus.OK);
+    }
+
+    /**
+     * Convert an already-uploaded PowerPoint file (referenced by its media-service
+     * fileId) to PDF.
+     *
+     * <p>The client uploads the presentation straight to S3 via a pre-signed URL,
+     * then calls this endpoint with the resulting fileId. The request body is tiny
+     * (just the id), so it is not subject to the nginx/Spring request-size limit
+     * that the multipart {@link #convertPptToPdf} endpoint runs into for large decks.
+     *
+     * @param request fileId (required) + original fileName (for format detection)
+     * @param quality Optional quality setting (kept for API compatibility)
+     * @return PDF file
+     */
+    @PostMapping("/ppt-to-pdf-by-id")
+    public ResponseEntity<byte[]> convertPptToPdfById(
+            @RequestAttribute("user") CustomUserDetails userDetails,
+            @RequestBody PptToPdfByIdRequest request,
+            @RequestParam(value = "quality", required = false, defaultValue = "standard") String quality) {
+
+        byte[] pdfContent = pptToPdfService.convertPptToPdfByFileId(request.getFileId(), request.getFileName());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        String filename = request.getFileName();
         if (filename != null && filename.lastIndexOf('.') > 0) {
             filename = filename.substring(0, filename.lastIndexOf('.'));
         } else {

--- a/media_service/src/main/java/vacademy/io/media_service/dto/PptToPdfByIdRequest.java
+++ b/media_service/src/main/java/vacademy/io/media_service/dto/PptToPdfByIdRequest.java
@@ -1,0 +1,24 @@
+package vacademy.io.media_service.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request for converting an already-uploaded presentation (referenced by its
+ * media-service fileId) to PDF. The file is uploaded directly to S3 via a
+ * pre-signed URL, so the bytes never pass through nginx/Spring — this avoids the
+ * request-body size limit that the multipart {@code /convert/ppt-to-pdf} endpoint hits.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PptToPdfByIdRequest {
+    /** media-service file id returned by {@code /get-signed-url}. */
+    private String fileId;
+    /** Original file name (used to detect the input format, e.g. .ppt/.pptx/.odp). */
+    private String fileName;
+}

--- a/media_service/src/main/java/vacademy/io/media_service/service/PptToPdfService.java
+++ b/media_service/src/main/java/vacademy/io/media_service/service/PptToPdfService.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import vacademy.io.common.exceptions.VacademyException;
@@ -22,9 +24,15 @@ public class PptToPdfService {
     private static final String CLOUD_CONVERT_BASE_URL = "https://api.cloudconvert.com/v2";
     private static final int MAX_POLL_ATTEMPTS = 60;
     private static final long POLL_INTERVAL_MS = 3000;
+    // Pre-signed GET URL lifetime handed to CloudConvert. A conversion completes in
+    // seconds/minutes; 1 day is ample headroom while keeping the link short-lived.
+    private static final int SOURCE_URL_EXPIRY_DAYS = 1;
 
     @Value("${CLOUD_CONVERT_KEY:}")
     private String cloudConvertApiKey;
+
+    @Autowired
+    private FileService fileService;
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -35,6 +43,34 @@ public class PptToPdfService {
 
     public byte[] convertPptToPdfHighQuality(MultipartFile file, double scaleFactor) {
         return convertUsingCloudConvert(file);
+    }
+
+    /**
+     * Converts an already-uploaded presentation (identified by its media-service
+     * fileId) to PDF. A pre-signed GET URL is generated for the S3 object and handed
+     * to CloudConvert via an {@code import/url} task, so the presentation bytes are
+     * pulled directly from S3 and never stream through this service.
+     *
+     * @param fileId   media-service file id of the uploaded presentation
+     * @param fileName original file name, used to detect the input format
+     * @return converted PDF bytes
+     */
+    public byte[] convertPptToPdfByFileId(String fileId, String fileName) {
+        if (!StringUtils.hasText(fileId)) {
+            throw new VacademyException("fileId is required for conversion");
+        }
+
+        String sourceUrl;
+        try {
+            sourceUrl = fileService.getUrlWithExpiryAndId(fileId, SOURCE_URL_EXPIRY_DAYS);
+        } catch (Exception e) {
+            throw new VacademyException("Could not resolve uploaded file for conversion: " + e.getMessage());
+        }
+        if (!StringUtils.hasText(sourceUrl)) {
+            throw new VacademyException("Uploaded file not found for fileId: " + fileId);
+        }
+
+        return convertUsingCloudConvertFromUrl(sourceUrl, getInputFormat(fileName));
     }
 
     private byte[] convertUsingCloudConvert(MultipartFile file) {
@@ -80,6 +116,83 @@ public class PptToPdfService {
             logger.error("CloudConvert conversion failed", e);
             throw new VacademyException("PPT to PDF conversion failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * Same conversion pipeline as {@link #convertUsingCloudConvert}, but the source
+     * presentation is pulled by CloudConvert from a pre-signed S3 URL ({@code import/url})
+     * instead of being uploaded from this service ({@code import/upload}).
+     */
+    private byte[] convertUsingCloudConvertFromUrl(String sourceUrl, String inputFormat) {
+        if (cloudConvertApiKey == null || cloudConvertApiKey.isBlank()) {
+            throw new VacademyException("CloudConvert API key is not configured");
+        }
+
+        logger.info("Starting CloudConvert conversion from URL: format={}", inputFormat);
+
+        try {
+            // Step 1: Create a job with import/url + convert + export/url tasks
+            JsonNode jobData = createJobFromUrl(inputFormat, sourceUrl);
+            String jobId = jobData.path("id").asText();
+
+            // Step 2: Poll for job completion (CloudConvert fetches the file itself)
+            JsonNode completedJob = pollForCompletion(jobId);
+
+            // Step 3: Download the exported PDF
+            JsonNode exportTask = findTaskByName(completedJob.path("tasks"), "export-file");
+            String downloadUrl = exportTask.path("result").path("files").get(0).path("url").asText();
+
+            byte[] pdfBytes = downloadFile(downloadUrl);
+            logger.info("PDF conversion complete: {} bytes", pdfBytes.length);
+            return pdfBytes;
+
+        } catch (VacademyException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.error("CloudConvert conversion from URL failed", e);
+            throw new VacademyException("PPT to PDF conversion failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Creates a CloudConvert job that imports the source from a URL:
+     * 1. import/url - CloudConvert downloads the file from the given URL
+     * 2. convert - to convert PPT to PDF
+     * 3. export/url - to get a download URL for the result
+     */
+    private JsonNode createJobFromUrl(String inputFormat, String sourceUrl) throws IOException {
+        Map<String, Object> job = Map.of(
+                "tasks", Map.of(
+                        "import-file", Map.of(
+                                "operation", "import/url",
+                                "url", sourceUrl),
+                        "convert-file", Map.of(
+                                "operation", "convert",
+                                "input", "import-file",
+                                "input_format", inputFormat,
+                                "output_format", "pdf",
+                                "optimize_print", true),
+                        "export-file", Map.of(
+                                "operation", "export/url",
+                                "input", "convert-file")));
+
+        HttpHeaders headers = createHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String requestBody = objectMapper.writeValueAsString(job);
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                CLOUD_CONVERT_BASE_URL + "/jobs",
+                HttpMethod.POST,
+                request,
+                String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new VacademyException("Failed to create CloudConvert job: " + response.getBody());
+        }
+
+        return objectMapper.readTree(response.getBody()).path("data");
     }
 
     /**


### PR DESCRIPTION
Large PPT/PPTX uploads were rejected at the nginx ingress with 413 (default 1MB body limit) before reaching media-service. The deck now uploads directly to S3 via a pre-signed URL and only the fileId is sent to the converter, which hands a pre-signed GET URL to CloudConvert (import/url), so the presentation bytes never traverse the gateway.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
