### PR TITLE
ci(electron): enable git long paths on Windows store build

### DIFF
--- a/.github/workflows/electron-store-build.yml
+++ b/.github/workflows/electron-store-build.yml
@@ -37,6 +37,15 @@ jobs:
         shell: bash
         working-directory: ./frontend-learner-dashboard-app
     steps:
+      # Some frontend-admin-dashboard route paths exceed Windows' 260-char MAX_PATH,
+      # which makes `git checkout` fail with "Filename too long" (exit 128) on the
+      # windows-latest runner. Enabling git long-path support before checkout fixes it.
+      # Runs from ${{ github.workspace }} because the default working-directory
+      # (./frontend-learner-dashboard-app) does not exist until after checkout.
+      - name: Enable git long paths (Windows MAX_PATH workaround)
+        working-directory: ${{ github.workspace }}
+        run: git config --system core.longpaths true
+
       - name: Checkout source
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The windows-latest checkout failed (git exit 128, "Filename too long") because some frontend-admin-dashboard route paths exceed Windows MAX_PATH. Set core.longpaths=true before actions/checkout so the full repo checks out.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
