### PR TITLE
fix(learner): iOS App Store reader-app compliance (3.1.1, 4.8, 5.1.1,…

### DIFF
--- a/VACADEMY_IOS_COMPLIANCE_CHECKLIST.md
+++ b/VACADEMY_IOS_COMPLIANCE_CHECKLIST.md
@@ -1,0 +1,88 @@
+# Vacademy iOS — App Store Rejection-Risk Checklist
+
+What was hardened in code (this branch) vs. what **you must still do manually** in Xcode / App Store
+Connect. The manual items below are the most likely remaining rejection causes — none of them can be
+fixed from the codebase.
+
+---
+
+## ✅ Fixed in code (no action needed beyond build + OTA)
+
+| Guideline | Risk | Fix |
+|---|---|---|
+| 3.1.1 / 3.1.3 | Paid/commerce, membership, "Access Days", catalogue, prices visible on iOS | `shouldHidePaidPurchaseUI()` gates all of it on **native iOS only** — a pure runtime check (`Capacitor.getPlatform() === "ios"`), no setting and nothing to toggle. Web / Android / desktop keep full commerce. |
+| 3.1.1 | Enroll-by-invite "Upgrade Now" / "Complete Payment" → external gateways | Route guard on `/learner-invitation-response` + component gates (`enrollment-policy-dialog`, `payment-pending-step`, `enroll-form`). |
+| 4.8 | Google/GitHub login on iOS with **no Sign in with Apple** | Social login (+ signup) hidden on native iOS. Email-OTP / username-password / phone remain. |
+| 5.1.1(v) | In-app account deletion hidden by default | `useStudentPermissions` forces `canDeleteProfile = true` on iOS → Delete Account always reachable. |
+| 5.1.2 | Amplitude analytics auto-tracking with no ATT prompt | Amplitude disabled on native iOS (`analytics.ts`). |
+| 5.1.1 | Main `Info.plist` camera/mic strings said "property reviews and inspections" | Rewritten to learning-app wording. |
+| 5.x | Export-compliance prompt every upload | `ITSAppUsesNonExemptEncryption = false` added to `App/Info.plist`. |
+| 5.1.1 | Missing app-target privacy manifest (Capgo required-reason APIs) | `ios/App/App/PrivacyInfo.xcprivacy` created — **must be wired into targets, see #2 below**. |
+
+### How the gate works (no configuration)
+Hiding is driven entirely by `isIOSNative()` in `src/utils/ios-iap-compliance.ts` — there is **no admin
+toggle, no institute setting, no remote flag**. The native iOS app always hides commerce + social login;
+every other platform (web, Android, desktop) always shows them. This is deliberate: a remotely
+re-enabled commerce/login surface after approval is exactly what gets an app pulled under Guideline
+2.3.1. To legitimately sell or show social login on iOS later, implement StoreKit IAP / Sign in with
+Apple (see #5), don't flip a switch.
+
+---
+
+## ⛔ You MUST do these manually (cannot be done from code)
+
+### 1. Provide a demo account for App Review — **most common rejection (2.1)**
+The app is a login wall: a reviewer with no institute account sees only a login screen (the iOS
+reader-mode guard sends `/courses` back to login). App Review **will** reject unless you supply
+credentials.
+- App Store Connect → your app → **App Review Information → Sign-In Required → ON**.
+- Enter a working **demo learner** username + password (and the institute subdomain in the notes) that
+  lands on a **populated dashboard with real, free content**.
+- Add reviewer notes: "Institution-managed LMS. Use the demo account to sign in; enrollment and any
+  purchases are handled by the institute outside the app (reader app, Guideline 3.1.3)."
+
+### 2. Wire `PrivacyInfo.xcprivacy` into every target (5.1.1)
+The file exists but does nothing until it's in each target's build.
+- Open `ios/App/App.xcworkspace` in Xcode → select `PrivacyInfo.xcprivacy` → **File Inspector →
+  Target Membership**: check **App** and **all 7 per-institute targets** (the7cs, SSDC Horizon,
+  Five Sep, Uplift Teacher Training, Shiksha Nation, Chanakaya IAS Academy, Edzumo).
+- Archive and confirm there's no `ITMS-91053 Missing privacy manifest` warning.
+
+### 3. APNs environment = production (2.1)
+`ios/App/App/App.entitlements` commits `aps-environment = development`. A distribution build needs
+`production` or push silently dies for real users (a reviewer testing notifications = rejection).
+- Xcode **automatic signing usually rewrites this on archive** — but verify: after archiving, check the
+  `.ipa`'s embedded entitlements show `aps-environment = production`. If you do manual/CI signing, set a
+  Release entitlements file with `production`.
+
+### 4. App Store Connect Privacy "Nutrition" Labels (5.1.1 / 5.1.2)
+Declare data collection accurately and consistently with `PrivacyInfo.xcprivacy`:
+- Firebase push → **Device ID / push token**, used for **App Functionality**, **not** tracking.
+- Analytics is **off on iOS**, so do **not** declare tracking. (Keep it off, or you'll need an ATT prompt.)
+
+### 5. (Optional) To show Google/GitHub login on iOS later — implement Sign in with Apple (4.8)
+Social login is currently **hidden on iOS** because 4.8 requires Sign in with Apple parity. To bring it
+back: add the `Sign in with Apple` capability to each target, add `@capacitor-community/apple-sign-in`,
+render a "Continue with Apple" button, and wire backend Apple-token exchange. Then remove the
+`!isIOSNative()` gates in `login-form.tsx` / `ModularDynamicLoginContainer.tsx` /
+`ModularDynamicSignupContainer.tsx`.
+
+---
+
+## 🔧 Low-priority hygiene (won't reject, but worth cleaning)
+- `UIRequiredDeviceCapabilities = armv7` in the 7 brand `GoogleService-Info.plist` files → change to
+  `arm64` (the main target is already correct; iOS 15 is 64-bit only).
+- Remove stale duplicate plists in `ios/App/` root (`STEMx-Info.plist`, `ithinkersByFiveSep-Info.plist`,
+  `*copy-Info.plist`, `EnarkGoogleService-Info.plist`) — not used as any target's `INFOPLIST_FILE`;
+  two are still copied into the bundle as inert resources.
+- Strip the auth/institute `console.log` debug lines in `src/routes/__root.tsx` for release builds.
+
+---
+
+## Ship order
+1. `npm run build` + `npx cap copy ios` (and `npx cap sync ios` if pods changed), then archive in Xcode.
+2. Do manual items **#1–#4 above** before submitting.
+3. Publish the learner **OTA** (`scripts/publish-ota.sh`, bump `package.json` version first) so existing
+   installs pick up the JS-level gating.
+4. Nothing to configure — iOS hiding is automatic at runtime. The native binary you submit for review is
+   what matters (Info.plist + privacy manifest are native changes that OTA cannot deliver).

--- a/VACADEMY_IOS_READER_APP_IMPLEMENTATION.md
+++ b/VACADEMY_IOS_READER_APP_IMPLEMENTATION.md
@@ -1,0 +1,151 @@
+# Vacademy iOS — Reader-App Compliance Implementation
+
+**Date:** 2026-06-21
+**Scope:** `frontend-learner-dashboard-app` only (no backend, no DB migration)
+**Status:** Implemented & verified (tsc + design-lint clean), uncommitted in working tree.
+
+This document explains **what was changed and why** to get the learner iOS app past Apple
+App Review. For the remaining **manual** steps (Xcode / App Store Connect), see
+[`VACADEMY_IOS_COMPLIANCE_CHECKLIST.md`](./VACADEMY_IOS_COMPLIANCE_CHECKLIST.md).
+
+---
+
+## The problem
+
+The iOS app kept getting rejected for two reasons:
+
+| # | Apple Guideline | Why it was rejected |
+|---|---|---|
+| 1 | **3.1.1 — In-App Purchase** | Courses (digital content) were sold inside the app via external payment gateways (Stripe/Razorpay). Apple requires digital purchases to use Apple IAP, or not be sold in the app at all. |
+| 2 | **4.8 — Sign in with Apple** | The app offered Google/GitHub login without also offering Sign in with Apple. |
+
+Two secondary risks were fixed in the same pass: **5.1.1(v)** (in-app account deletion) and
+**5.1.2** (analytics tracking without an ATT prompt).
+
+---
+
+## The strategy: run iOS as a "reader app"
+
+Apple's "reader app" model: **don't sell anything inside the iOS app.** Users purchase on the
+**web**; the iOS app only unlocks content they already own. This avoids Apple's 15–30% IAP cut
+and is how most edtech apps comply.
+
+Concretely:
+- **iOS app** → all pricing, buying, and Google/GitHub login are **hidden**.
+- **Web + Android + desktop** → **completely unaffected** — full pricing, checkout, and social
+  login. This is critical: revenue still flows through the web, which is the whole point of the
+  reader-app model.
+
+### Why a pure runtime check (and not a setting/toggle)
+
+An earlier attempt put this behind a per-platform admin toggle so it could be flipped back on
+after approval. **That is dangerous** — re-enabling external payment / non-Apple social login
+after review is a **Guideline 2.3.1 violation** (hidden/post-review behavior change) and gets the
+**entire developer account terminated**, not just the app rejected.
+
+So the gate is a **pure runtime platform check with nothing to toggle**:
+
+```ts
+// src/utils/ios-iap-compliance.ts
+export const isIOSNative = () => Capacitor.getPlatform() === "ios";
+export const shouldHidePaidPurchaseUI = () => isIOSNative();
+```
+
+No institute setting, no admin tab, no remote flag, no localStorage cache. To legitimately sell
+or show social login on iOS later, implement **StoreKit IAP** / **Sign in with Apple** — don't
+flip a switch.
+
+---
+
+## What changed in code
+
+### Keystone
+- **`src/utils/ios-iap-compliance.ts`** — the single source of truth. Exports `isIOSNative()`,
+  `shouldHidePaidPurchaseUI()`, `useHidePaidPurchaseUI()`.
+
+### Payment / commerce hidden on iOS (Guideline 3.1.1)
+- **`components/common/price-with-mrp.tsx`** — `PriceWithMrp` + `OfferBadge` return `null`. This
+  is the global choke point that kills **every** price / MRP / "% off" in the app.
+- **`routes/__root.tsx`** — `beforeLoad` blocks marketplace/payment routes
+  (`/courses`, `/product-pages`, `/admission/payment`, `/pay`, `/payment-result`) before the
+  public-route bypass.
+- **`routes/$tagName/index.tsx`**, **`routes/$tagName/$courseId/index.tsx`**,
+  **`routes/learner-invitation-response/index.tsx`** — `beforeLoad` redirect to `/dashboard`.
+- **`routes/dashboard/-components/MyOrdersWidget.tsx`**, **`MyMembershipWidget.tsx`**,
+  **`MyBooksWidget.tsx`** — early `return null`.
+- **`routes/dashboard/index.tsx`** — "Explore Memberships/Books" commerce section hidden.
+- **`routes/study-library/courses/-component/CourseCatalougePage.tsx`** — "All Courses" (browse)
+  tab dropped; only In-Progress / Completed remain.
+- **`.../course-details/-components/course-enrollment.tsx`**, **`course-sidebar.tsx`** — Enroll/pay
+  CTAs hidden.
+- **`.../payment-dialogs/EnrollmentPaymentDialog.tsx`** — paid branches hidden (FREE path kept).
+- **`components/common/donation/DonationDialog.tsx`** — returns `null`.
+- **`components/common/enroll-by-invite/-components/enrollment-policy-dialog.tsx`**,
+  **`payment-pending-step.tsx`**, **`enroll-form.tsx`** — upgrade/complete-payment CTAs and
+  external-gateway redirects gated.
+- **`components/common/user-profile/user-page.tsx`** — "Membership Status" / Access Days card
+  hidden.
+
+### Social login hidden on iOS (Guideline 4.8)
+- **`.../auth/login/forms/page/login-form.tsx`**,
+  **`.../auth/login/components/modular/ModularDynamicLoginContainer.tsx`**,
+  **`.../auth/signup/components/ModularDynamicSignupContainer.tsx`** — Google/GitHub buttons +
+  divider wrapped in `!isIOSNative()`. Email + phone/OTP remain the iOS login methods.
+
+### Account deletion (Guideline 5.1.1(v))
+- **`hooks/use-student-permissions.ts`** — forces `canDeleteProfile = true` on iOS so the
+  Delete Account flow is always reachable (one change covers the route guard + all 3 menus).
+
+### Analytics (Guideline 5.1.2)
+- **`lib/analytics.ts`** — Amplitude disabled on native iOS (autocapture = tracking, and there's
+  no ATT prompt).
+
+### Native / iOS project files
+- **`ios/App/App/Info.plist`** — camera/mic usage strings rewritten to learning-app wording;
+  added `ITSAppUsesNonExemptEncryption = false`. (Plus two stale brand plists touched.)
+- **`ios/App/App/PrivacyInfo.xcprivacy`** — new privacy manifest (must be wired into Xcode
+  targets — see checklist #2).
+
+---
+
+## Verification
+
+```bash
+cd frontend-learner-dashboard-app
+node --max-old-space-size=8192 node_modules/typescript/bin/tsc --noEmit   # exit 0, no errors
+node ../scripts/design-lint.mjs <changed .tsx files>                       # design-lint: clean ✓
+```
+
+Both pass.
+
+---
+
+## How to ship
+
+> ⚠️ Info.plist + `PrivacyInfo.xcprivacy` are **native** changes — **OTA cannot deliver them.**
+> A fresh binary submitted to App Review is required.
+
+1. `cd frontend-learner-dashboard-app && npm run build && npx cap copy ios`
+   (`npx cap sync ios` if pods changed).
+2. Complete the **manual** items in
+   [`VACADEMY_IOS_COMPLIANCE_CHECKLIST.md`](./VACADEMY_IOS_COMPLIANCE_CHECKLIST.md) —
+   especially **#1 a demo account** in App Store Connect (the app is a login wall; missing
+   credentials is the most common rejection).
+3. Archive in Xcode → submit to App Review.
+4. (Optional) Publish the learner **OTA** (`scripts/publish-ota.sh`, bump `package.json` version
+   first) so existing installs pick up the JS-level gating too.
+
+No backend deploy and no DB migration are required.
+
+---
+
+## Future: bringing commerce / social login back to iOS (the legitimate way)
+
+- **Sell on iOS** → implement **StoreKit In-App Purchase** (Apple takes 15–30%): StoreKit
+  products, server-side receipt validation, IAP-product → course mapping.
+- **Google/GitHub on iOS** → add **Sign in with Apple** alongside them (capability +
+  `@capacitor-community/apple-sign-in` + backend Apple-token exchange), then remove the
+  `!isIOSNative()` gates in the three login files.
+
+Either path is a normal feature submitted through a normal review — **never** a post-approval
+remote flip.

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/controller/AppleNativeAuthController.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/controller/AppleNativeAuthController.java
@@ -1,0 +1,143 @@
+package vacademy.io.auth_service.feature.auth.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vacademy.io.auth_service.feature.auth.dto.AppleNativeLoginRequestDto;
+import vacademy.io.auth_service.feature.auth.dto.JwtResponseDto;
+import vacademy.io.auth_service.feature.auth.manager.LearnerOAuth2Manager;
+import vacademy.io.auth_service.feature.auth.service.AppleIdentityTokenVerifier;
+import vacademy.io.common.auth.service.OAuth2VendorToUserDetailService;
+import vacademy.io.common.exceptions.VacademyException;
+
+/**
+ * Native "Sign in with Apple" for the learner iOS app.
+ *
+ * <p>The web/Android social-login flow is a Spring OAuth2 server-side redirect
+ * (CustomOAuth2SuccessHandler). iOS instead uses the native ASAuthorization
+ * sheet, which returns an id_token directly to the app — so there is no browser
+ * round-trip and no Universal-Link callback. The app POSTs the id_token here;
+ * we verify it against Apple's JWKS and reuse the exact same token-minting path
+ * the redirect flow uses ({@link LearnerOAuth2Manager#loginUserByEmail}).
+ *
+ * <p>Lives under {@code /auth-service/learner/v1/**}, which is permit-all in
+ * {@code ApplicationSecurityConfig.ALLOWED_PATHS}.
+ */
+@RestController
+@RequestMapping("/auth-service/learner/v1/oauth/apple")
+public class AppleNativeAuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(AppleNativeAuthController.class);
+
+    private static final String VENDOR_APPLE = "apple";
+
+    @Autowired
+    private AppleIdentityTokenVerifier appleIdentityTokenVerifier;
+
+    @Autowired
+    private LearnerOAuth2Manager learnerOAuth2Manager;
+
+    @Autowired
+    private OAuth2VendorToUserDetailService oAuth2VendorToUserDetailService;
+
+    @PostMapping("/native")
+    public JwtResponseDto appleNativeLogin(@RequestBody AppleNativeLoginRequestDto request) throws Exception {
+        if (request == null || !StringUtils.hasText(request.getIdentityToken())) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "identityToken is required");
+        }
+        if (!StringUtils.hasText(request.getInstituteId())) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "instituteId is required");
+        }
+
+        Jwt jwt = appleIdentityTokenVerifier.verify(request.getIdentityToken());
+
+        String sub = jwt.getSubject();
+        if (!StringUtils.hasText(sub)) {
+            throw new VacademyException(HttpStatus.UNAUTHORIZED, "Apple identity token is missing a subject");
+        }
+
+        // Nonce: Apple echoes request.nonce VERBATIM into the id_token (OIDC), and
+        // the plugin forwards our raw value unhashed, so token nonce == body nonce.
+        // We do NOT hard-fail on a mismatch: the nonce is client-generated on both
+        // sides, so it adds no real replay protection (the actual controls are the
+        // RS256 signature + issuer + audience + exp checks in the verifier). A
+        // mismatch is logged for observability only. True single-use replay
+        // protection would require a server-issued nonce (tracked for P1).
+        if (StringUtils.hasText(request.getNonce())) {
+            String tokenNonce = jwt.getClaimAsString("nonce");
+            if (StringUtils.hasText(tokenNonce) && !tokenNonce.equals(request.getNonce())) {
+                log.warn("Apple id_token nonce did not match the request nonce (sub={}); continuing", sub);
+            }
+        }
+
+        // Email: prefer the verified id_token claim, then the first-sign-in body
+        // field (Apple only returns the convenience fields once).
+        String tokenEmail = jwt.getClaimAsString("email");
+        String email = StringUtils.hasText(tokenEmail) ? tokenEmail : request.getEmail();
+        Object isPrivateRelay = jwt.getClaims().get("is_private_email");
+
+        // ── Account-linking policy (keyed on the stable Apple subject) ──
+        // The Apple `sub` is the canonical identity for this user, independent of
+        // whether they share a real email or a stable "Hide My Email" relay
+        // address. We recover any email previously recorded for this sub so that:
+        //   • a returning user (incl. relay users) always lands on the SAME account;
+        //   • a first-time real (shared) email links to any existing account with
+        //     that address (cross-provider linking with a prior Google/email signup);
+        //   • a first-time relay address has no prior match, so a new account is
+        //     created and bound to this sub for next time.
+        // This call also upserts the (apple, sub, email) mapping — mirrors the
+        // GitHub private-email recovery in CustomOAuth2SuccessHandler.
+        String recoveredEmail = oAuth2VendorToUserDetailService
+                .getEmailByProviderIdAndSubject(VENDOR_APPLE, sub, email);
+        if (StringUtils.hasText(recoveredEmail)) {
+            email = recoveredEmail;
+        }
+
+        if (!StringUtils.hasText(email)) {
+            // Email-keyed matching: without any email we cannot match or create.
+            throw new VacademyException(HttpStatus.UNAUTHORIZED,
+                    "Apple did not return an email address for this account");
+        }
+
+        String fullName = resolveFullName(request, email);
+
+        log.info("Native Apple sign-in: institute={} sub={} privateRelay={}",
+                request.getInstituteId(), sub, isPrivateRelay);
+
+        JwtResponseDto response = learnerOAuth2Manager.loginUserByEmail(
+                fullName, email, request.getInstituteId(), sub, VENDOR_APPLE);
+
+        if (response == null) {
+            // null == no matching user and institute signup policy forbids auto-create
+            // (e.g. manual password strategy) or no policy configured.
+            throw new VacademyException(HttpStatus.UNAUTHORIZED,
+                    "We couldn't find or create an account for this Apple sign-in. Please contact your administrator.");
+        }
+        return response;
+    }
+
+    /**
+     * Composes a display name from the first-sign-in fields, falling back to the
+     * email local-part (Apple returns name only on the first authorization).
+     */
+    private String resolveFullName(AppleNativeLoginRequestDto request, String email) {
+        String given = request.getGivenName() == null ? "" : request.getGivenName().trim();
+        String family = request.getFamilyName() == null ? "" : request.getFamilyName().trim();
+        String composed = (given + " " + family).trim();
+        if (StringUtils.hasText(composed)) {
+            return composed;
+        }
+        if (StringUtils.hasText(request.getFullName())) {
+            return request.getFullName().trim();
+        }
+        int at = email.indexOf('@');
+        return at > 0 ? email.substring(0, at) : email;
+    }
+}

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/dto/AppleNativeLoginRequestDto.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/dto/AppleNativeLoginRequestDto.java
@@ -1,0 +1,55 @@
+package vacademy.io.auth_service.feature.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request body for the native iOS "Sign in with Apple" login.
+ *
+ * The learner app obtains these from the native ASAuthorization sheet via the
+ * {@code @capacitor-community/apple-sign-in} plugin and POSTs them to
+ * {@code /auth-service/learner/v1/oauth/apple/native}.
+ *
+ * Note: {@code givenName}/{@code familyName}/{@code email} are returned by Apple
+ * ONLY on the very first authorization per Apple ID per app — they are null on
+ * every subsequent sign-in. The {@code email} claim inside the verified
+ * {@code identityToken} is the source of truth; these convenience fields are a
+ * first-sign-in fallback only.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleNativeLoginRequestDto {
+
+    /** Apple-issued OIDC id_token (RS256 JWT) — verified server-side against Apple's JWKS. */
+    private String identityToken;
+
+    /** Short-lived Apple authorization code (unused for P0 JWKS-only verification). */
+    private String authorizationCode;
+
+    /** Stable Apple subject id as surfaced by the plugin ({@code user}); the id_token {@code sub} is authoritative. */
+    private String user;
+
+    /** First-sign-in convenience email (fallback when the id_token omits {@code email}). */
+    private String email;
+
+    /** First-sign-in given name (null afterwards). */
+    private String givenName;
+
+    /** First-sign-in family name (null afterwards). */
+    private String familyName;
+
+    /** Optional pre-composed full name. */
+    private String fullName;
+
+    /** Nonce echoed verbatim by Apple inside the id_token (OIDC session binding;
+     *  client-generated, so logged-not-enforced server-side — see controller). */
+    private String nonce;
+
+    /** Institute the learner is signing into (required — drives signup policy / session limits / theming). */
+    private String instituteId;
+
+    /** Originating platform, e.g. "ios" (informational). */
+    private String platform;
+}

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/service/AppleIdentityTokenVerifier.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/auth/service/AppleIdentityTokenVerifier.java
@@ -1,0 +1,104 @@
+package vacademy.io.auth_service.feature.auth.service;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Verifies a native "Sign in with Apple" identity token (OIDC id_token).
+ *
+ * <p>Apple signs id_tokens with <b>RS256</b> against the public keys published at
+ * {@code https://appleid.apple.com/auth/keys}. We verify signature + standard
+ * timestamps + issuer, and assert the audience is one of our iOS bundle ids
+ * (native {@code aud} == bundle id, unlike the web flow where {@code aud} == the
+ * Services ID).
+ *
+ * <p>The allowed-audience list is fail-closed: if {@code apple.native.audiences}
+ * is unset, every token is rejected.
+ */
+@Service
+public class AppleIdentityTokenVerifier {
+
+    private static final Logger log = LoggerFactory.getLogger(AppleIdentityTokenVerifier.class);
+
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final String APPLE_JWKS_URI = "https://appleid.apple.com/auth/keys";
+
+    private final List<String> allowedAudiences;
+    private final JwtDecoder jwtDecoder;
+
+    public AppleIdentityTokenVerifier(@Value("${apple.native.audiences:}") String audiencesCsv) {
+        this.allowedAudiences = Arrays.stream(audiencesCsv.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+
+        NimbusJwtDecoder decoder = NimbusJwtDecoder
+                .withJwkSetUri(APPLE_JWKS_URI)
+                .jwsAlgorithm(SignatureAlgorithm.RS256)
+                .build();
+
+        OAuth2TokenValidator<Jwt> defaultWithIssuer = JwtValidators.createDefaultWithIssuer(APPLE_ISSUER);
+        OAuth2TokenValidator<Jwt> audienceValidator = buildAudienceValidator();
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(defaultWithIssuer, audienceValidator));
+
+        this.jwtDecoder = decoder;
+    }
+
+    @PostConstruct
+    void warnIfUnconfigured() {
+        if (allowedAudiences.isEmpty()) {
+            log.warn("apple.native.audiences is empty — every native Apple sign-in will be REJECTED until "
+                    + "APPLE_NATIVE_AUDIENCES (comma-separated iOS bundle ids) is configured.");
+        } else {
+            log.info("Apple native sign-in configured for {} audience(s).", allowedAudiences.size());
+        }
+    }
+
+    /**
+     * Verifies the identity token and returns the parsed JWT, or throws
+     * {@link VacademyException} on any validation failure.
+     */
+    public Jwt verify(String identityToken) {
+        if (!StringUtils.hasText(identityToken)) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "Apple identity token is required");
+        }
+        try {
+            return jwtDecoder.decode(identityToken);
+        } catch (JwtException e) {
+            log.warn("Apple identity token verification failed: {}", e.getMessage());
+            throw new VacademyException(HttpStatus.UNAUTHORIZED, "Invalid Apple identity token");
+        }
+    }
+
+    private OAuth2TokenValidator<Jwt> buildAudienceValidator() {
+        return jwt -> {
+            List<String> aud = jwt.getAudience();
+            if (aud != null && aud.stream().anyMatch(allowedAudiences::contains)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(new OAuth2Error(
+                    "invalid_token",
+                    "Apple id_token audience " + aud + " is not in the allowed bundle-id list",
+                    null));
+        };
+    }
+}

--- a/auth_service/src/main/resources/application-dev.properties
+++ b/auth_service/src/main/resources/application-dev.properties
@@ -48,6 +48,11 @@ spring.security.oauth2.client.provider.github.token-uri=https://github.com/login
 spring.security.oauth2.client.provider.github.user-info-uri=https://api.github.com/user
 spring.security.oauth2.client.provider.github.user-name-attribute=login
 
+# Sign in with Apple (native iOS) — comma-separated iOS bundle ids accepted as the
+# id_token audience. Bundle ids are public + static, so they default in-line here
+# (one per iOS Xcode target); set APPLE_NATIVE_AUDIENCES to override.
+apple.native.audiences=${APPLE_NATIVE_AUDIENCES:io.vacademy.student.app,com.sevencs.learner,io.ssdc.student.app,io.fivesep.student.app,io.shikshanation.app,io.enarkuplift.app,io.chanakayaiasacademy.app,io.edzumo.app}
+
 
 # This tells Flyway to accept an existing schema and create a baseline
 spring.flyway.baseline-on-migrate=true

--- a/auth_service/src/main/resources/application-k8s-local.properties
+++ b/auth_service/src/main/resources/application-k8s-local.properties
@@ -49,6 +49,11 @@ spring.security.oauth2.client.provider.github.token-uri=https://github.com/login
 spring.security.oauth2.client.provider.github.user-info-uri=https://api.github.com/user
 spring.security.oauth2.client.provider.github.user-name-attribute=login
 
+# Sign in with Apple (native iOS) — comma-separated iOS bundle ids accepted as the
+# id_token audience. Bundle ids are public + static, so they default in-line here
+# (one per iOS Xcode target); set APPLE_NATIVE_AUDIENCES to override.
+apple.native.audiences=${APPLE_NATIVE_AUDIENCES:io.vacademy.student.app,com.sevencs.learner,io.ssdc.student.app,io.fivesep.student.app,io.shikshanation.app,io.enarkuplift.app,io.chanakayaiasacademy.app,io.edzumo.app}
+
 ## Logging - More verbose for local development
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG

--- a/auth_service/src/main/resources/application-stage.properties
+++ b/auth_service/src/main/resources/application-stage.properties
@@ -50,6 +50,12 @@ spring.security.oauth2.client.provider.github.token-uri=https://github.com/login
 spring.security.oauth2.client.provider.github.user-info-uri=https://api.github.com/user
 spring.security.oauth2.client.provider.github.user-name-attribute=login
 
+# Sign in with Apple (native iOS) — comma-separated iOS bundle ids accepted as the
+# id_token audience. Bundle ids are public + static, so they default in-line here
+# (one per iOS Xcode target); set APPLE_NATIVE_AUDIENCES to override. Adding a new
+# white-label iOS target == add its bundle id here (or to the env var).
+apple.native.audiences=${APPLE_NATIVE_AUDIENCES:io.vacademy.student.app,com.sevencs.learner,io.ssdc.student.app,io.fivesep.student.app,io.shikshanation.app,io.enarkuplift.app,io.chanakayaiasacademy.app,io.edzumo.app,io.sadbhavana.com}
+
 
 # This tells Flyway to accept an existing schema and create a baseline
 spring.flyway.baseline-on-migrate=true

--- a/docs/signup/SIGN_IN_WITH_APPLE.md
+++ b/docs/signup/SIGN_IN_WITH_APPLE.md
@@ -1,0 +1,236 @@
+# Sign in with Apple — Learner App (iOS)
+
+**Status:** P0 shipped (native iOS). P1 (Android/web redirect) not started.
+**Scope:** `auth_service` + `frontend-learner-dashboard-app` (Capacitor iOS).
+**Last updated:** 2026-06-21
+
+---
+
+## 1. Why this exists
+
+The learner app offers Google + GitHub social login. **Apple App Store Guideline 4.8** requires that any iOS app offering third-party social login also offer **Sign in with Apple** as an equivalent, peer option. Before this work, Google/GitHub were *hidden on native iOS* (`!isIOSNative()` gates) precisely to avoid a 4.8 rejection.
+
+This feature adds native Sign in with Apple on iOS, which let us **remove those gates** — so iOS now shows **Google, GitHub, and Apple together**. This is one coupled change: never ship the gate-lift without the Apple button, or vice-versa.
+
+---
+
+## 2. Architecture
+
+Two different mechanisms, by platform:
+
+| Platform | Mechanism | Status |
+|---|---|---|
+| **iOS (native)** | Native `ASAuthorization` sheet via `@capacitor-community/apple-sign-in` → identityToken POSTed to a backend verify endpoint | ✅ P0 (this doc) |
+| **Android / web / PWA** | The existing Spring OAuth2 server-side redirect, adding `apple` as a 3rd provider | ⏳ P1 (not built) |
+
+The native plugin has **no Android support**, which is why Android/web stay on the redirect path.
+
+### Native iOS flow (P0)
+
+```
+[Apple button] ──> SignInWithApple.authorize({ clientId=<bundleId>, scopes, nonce })
+                        │  (native Face/Touch ID sheet; no browser, no redirect)
+                        ▼
+   { identityToken (RS256 JWT), authorizationCode, user(sub), email?, givenName?, familyName? }
+                        │
+                        ▼  POST /auth-service/learner/v1/oauth/apple/native
+                           { identityToken, nonce, instituteId, email?, names?, ... }
+                        ▼
+   AppleIdentityTokenVerifier ── verify RS256 sig vs Apple JWKS, iss, aud∈bundleIds, exp
+                        │
+                        ▼  reuse the SAME token-minting as Google/GitHub
+   LearnerOAuth2Manager.loginUserByEmail(name,email,instituteId,sub,"apple")
+       └─ existing user → mint tokens │ new user → auto-signup per institute policy
+                        ▼
+   { accessToken, refreshToken }  ──(JSON body)──>  performFullAuthCycle()
+                        ▼
+   1 institute → /dashboard   │   2+ institutes → /institute-selection
+```
+
+Contrast with Google/GitHub on iOS, which open the system browser, complete a Spring OAuth2 redirect, and return tokens via an **Apple Universal Link** (`appUrlOpen` in `src/routes/__root.tsx`). The Apple native path needs **none** of that round-trip.
+
+> **Audience note (the #1 Apple-Sign-In bug):** the id_token `aud` equals the **iOS bundle id** for the native flow (vs the **Services ID** for the future web flow). The verifier accepts a list of bundle ids.
+
+---
+
+## 3. Backend (`auth_service`)
+
+### Endpoint
+
+```
+POST /auth-service/learner/v1/oauth/apple/native        (permit-all; under /learner/v1/**)
+Body: { identityToken, authorizationCode?, user?, email?, givenName?, familyName?,
+        fullName?, nonce?, instituteId (required), platform? }
+200 : JwtResponseDto { accessToken, refreshToken }   — or { session_limit_exceeded, active_sessions }
+4xx : ErrorInfo { ex: "<message>", ... }   (400 bad request / 401 auth failure)
+```
+
+### Files
+
+| File | Role |
+|---|---|
+| `feature/auth/controller/AppleNativeAuthController.java` | Endpoint. Verifies token, resolves email/name, upserts the `apple` vendor mapping, reuses `LearnerOAuth2Manager.loginUserByEmail`. |
+| `feature/auth/service/AppleIdentityTokenVerifier.java` | Verifies the Apple id_token. |
+| `feature/auth/dto/AppleNativeLoginRequestDto.java` | Request body. |
+| `resources/application-{stage,dev,k8s-local}.properties` | `apple.native.audiences` default. |
+
+### Token verification (`AppleIdentityTokenVerifier`)
+
+- **`NimbusJwtDecoder.withJwkSetUri("https://appleid.apple.com/auth/keys")`** — keys fetched & cached, key chosen by the token's `kid`.
+- **Algorithm: RS256.** Apple signs id_tokens with RS256 (RSA). *(ES256 is only relevant to the P1 web client-secret — not here.)* `alg=none` / HS256-confusion are not possible.
+- **Validators:** `JwtValidators.createDefaultWithIssuer("https://appleid.apple.com")` (signature + `iss` + `exp`/`nbf` timestamps) **plus** a custom audience validator.
+- **Audience is fail-closed:** the token's `aud` must be in `apple.native.audiences`. If that list is empty (misconfig), **every** token is rejected — a `@PostConstruct` logs a loud warning.
+
+### Account matching, linking & creation
+
+User accounts are **email-keyed** (there is no `users.vendor_id` column), but the
+controller resolves the email through the **stable Apple `sub`** first, so identity
+is anchored to the Apple user, not a possibly-changing email string. Logic:
+
+1. Take the email from the verified id_token (`email` claim), or the first-sign-in
+   body field as a fallback.
+2. **Recover by sub:** `getEmailByProviderIdAndSubject("apple", sub, email)` returns
+   any email previously recorded for this Apple `sub` (and upserts the mapping). The
+   recovered email wins when present.
+3. `loginUserByEmail(name, recoveredOrCurrentEmail, instituteId, sub, "apple")`:
+   - existing learner → deletes old refresh tokens, applies session-limit, mints tokens.
+   - no learner → auto-signup per the institute's signup policy (unless `passwordStrategy=manual` or no policy → `null` → 401).
+
+**Resulting linking policy:**
+
+| Scenario | Outcome |
+|---|---|
+| Returning Apple user (real **or** relay email) | Recovered by `sub` → **same account** every time |
+| First Apple sign-in, **real (shared)** email matching an existing account | Links to that account (**cross-provider** with a prior Google/email signup) |
+| First Apple sign-in, **Hide-My-Email** relay address | No prior match → **new account**, bound to the `sub` for next time |
+
+This mirrors the GitHub private-email handling in `CustomOAuth2SuccessHandler`. The
+`(provider_id="apple", subject=sub, email)` row lives in `oauth2_vendor_to_user_detail`
+(no DB migration — `provider_id` is a varchar). `is_private_email` is logged for support.
+
+### Audiences config
+
+Bundle ids are **public + static**, so they ship as the in-line **default** of the property — no k8s Secret, no CI change:
+
+```properties
+apple.native.audiences=${APPLE_NATIVE_AUDIENCES:io.vacademy.student.app,com.sevencs.learner,\
+  io.ssdc.student.app,io.fivesep.student.app,io.shikshanation.app,io.enarkuplift.app,\
+  io.chanakayaiasacademy.app,io.edzumo.app,io.sadbhavana.com}
+```
+
+To override at runtime (e.g. add a tenant without a rebuild), set `APPLE_NATIVE_AUDIENCES` — for prod that's a literal line in the `kubectl set env deployment/auth-service` step of `.github/workflows/maven-publish-auth-service.yml` (prod env is set imperatively there; there is no static k8s Secret YAML for that path).
+
+> **Adding a new white-label iOS target** ⇒ add its bundle id to this property (and the Apple Developer App ID — see §6).
+
+---
+
+## 4. Frontend (`frontend-learner-dashboard-app`)
+
+### Files
+
+| File | Role |
+|---|---|
+| `src/lib/auth/appleNativeAuth.ts` | The whole native flow: plugin → POST → store tokens → `performFullAuthCycle` → navigate. Exports `isAppleNativeAvailable()`, `loginWithAppleNative()`, `AppleSessionLimitError`, `AppleSignInCancelledError`. |
+| `src/components/common/auth/AppleSignInButton.tsx` | HIG-styled black button (phosphor `AppleLogo`). |
+| `src/constants/urls.ts` | `LOGIN_URL_APPLE_NATIVE`. |
+| `…/auth/login/forms/page/login-form.tsx` | Handler branch + Apple button + gate-lift. |
+| `…/auth/login/components/modular/ModularDynamicLoginContainer.tsx` | Same. |
+| `…/auth/signup/components/ModularDynamicSignupContainer.tsx` | Same (Apple is login-or-signup). |
+
+### The three surfaces & the 4.8 gating rule
+
+There are exactly **three** live OAuth UI surfaces (the `GoogleSignupProvider`/`GithubSignupProvider` files are dead mocks — not rendered). In each:
+
+- Google / GitHub buttons render with **no `!isIOSNative()` guard** (gated only by their provider flag).
+- The Apple button renders when **`isIOSNative() && (providers.google || providers.github)`** — i.e. **whenever a third-party social button appears on iOS, Apple appears too.** This is the 4.8 contract; there is no iOS state where Google/GitHub show without Apple.
+
+### Behavior notes
+
+- **Single vs multi institute:** the helper routes a learner with 2+ institutes to `/institute-selection` (mirrors the normal login flow); a single-institute learner goes straight to `/dashboard`.
+- **User cancel:** dismissing the Apple sheet throws `AppleSignInCancelledError`, which all three handlers swallow silently (no scary toast).
+- **instituteId:** taken from domain routing / URL / prop, with a fallback to the stored `Preferences["InstituteId"]`; the backend requires it.
+- **Error messages:** the helper reads the backend's message from `body.ex` (the `ErrorInfo` field), so real reasons surface to the user.
+
+---
+
+## 5. iOS native config
+
+All 8 iOS targets **share one entitlements file**, so one edit covers them:
+
+- `ios/App/App/App.entitlements` →
+  ```xml
+  <key>com.apple.developer.applesignin</key>
+  <array><string>Default</string></array>
+  ```
+- `ios/App/Podfile` → `pod 'CapacitorCommunityAppleSignIn', :path => '…/@capacitor-community/apple-sign-in'` inside the shared `capacitor_pods` def.
+- **No Info.plist URL scheme** is needed for the native sheet (unlike Google). Deployment target 15.0 is fine (SIWA native since iOS 13).
+
+> After pulling these changes, run **`npx cap sync ios && pod install`** on a Mac. `cap sync` will reconcile the Podfile line.
+
+### Bundle ids (8 iOS targets)
+
+`io.vacademy.student.app` · `com.sevencs.learner` · `io.ssdc.student.app` · `io.fivesep.student.app` · `io.shikshanation.app` · `io.enarkuplift.app` · `io.chanakayaiasacademy.app` · `io.edzumo.app`
+(STEMx `io.stemx.app` is Android-only — no iOS target. `io.sadbhavana.com` is in the audiences list per ops.)
+
+---
+
+## 6. Apple Developer setup
+
+**Required (done):** for **each** of the 8 App IDs, enable the **"Sign in with Apple"** capability (Identifiers → edit App ID), each as its **own primary** App ID (keep tenants ungrouped so every white-label has its own `sub` namespace). Signing fails for any target whose App ID lacks the capability, even though they share one entitlements file. On-device sign-in returns error 1000 if an App ID is not enabled.
+
+**Not needed for native (P0):** no Services ID, no `.p8` key, no client-secret JWT. Those are only for the P1 web/Android redirect path.
+
+---
+
+## 7. Security model
+
+**Verified server-side, per request:** RS256 signature against Apple's JWKS · `iss == https://appleid.apple.com` · `aud ∈ allowed bundle ids` (fail-closed) · `exp`/`nbf`. Email is taken from the **verified token**, never overridden by the request body.
+
+**Nonce:** Apple echoes `request.nonce` **verbatim** into the id_token; the plugin forwards our raw nonce, so token-nonce == body-nonce. Because the nonce is **client-generated on both sides**, it adds **no real replay protection** — so the server **logs but does not reject** on mismatch (avoids ever falsely blocking a valid login). The real controls are signature + aud + exp. True single-use replay protection would need a **server-issued nonce** (tracked for P1).
+
+---
+
+## 8. Known limitations / deferred
+
+- **P1 — Android & web Apple login** (redirect flow): a Spring `apple` `ClientRegistration` with a `.p8`-signed ES256 client-secret JWT (≤6-month rotation), `response_mode=form_post`, and `case "apple"` in `CustomOAuth2SuccessHandler`. Plus a Services ID + Key in the Apple portal. Not built.
+- **Account-linking (implemented — see §3):** identity is anchored on the Apple `sub`, so returning users (incl. relay) are stable, real shared emails link cross-provider, and relay emails get their own account. The only deferred piece is an **in-app "merge accounts" UI** for a user who has both a relay-based Apple account and a separate Google/email account — there is currently no self-serve merge.
+- **Apple Email Relay:** to email `@privaterelay.appleid.com` users, register sending domains in the Apple console. Skipped until needed.
+- **Name returned once:** Apple sends `givenName`/`familyName`/`email` only on the **first** authorization; null thereafter. Persisted on first sign-in. To re-test, revoke under iOS Settings → Apple ID → Sign in with Apple.
+- **HIG button glyph:** uses the phosphor `AppleLogo` (the repo design system mandates `@phosphor-icons/react`), not Apple's official asset — a minor review-cosmetics tradeoff.
+
+---
+
+## 9. Testing
+
+- **Real device only.** Sign in with Apple is unreliable on the simulator — test on a physical device signed into a real Apple ID with 2FA.
+- **First run vs subsequent:** name/email appear only on the first authorization. To repeat a first-run, revoke the app under iOS Settings → Apple ID → Sign in with Apple.
+- **Backend smoke:** with a valid id_token for a configured bundle id, `POST /auth-service/learner/v1/oauth/apple/native` returns `{ accessToken, refreshToken }`; an id_token with a wrong `aud` returns 401.
+- **4.8 visual check:** on iOS, the login & signup screens show Google, GitHub, **and** Apple together; tapping Apple opens the native sheet; cancelling shows no error.
+
+---
+
+## 10. Deep-review summary (2026-06-21)
+
+A multi-agent adversarial review (backend security · frontend correctness · iOS/4.8 compliance) ran against P0. Outcome — all fixed:
+
+| Sev | Finding | Resolution |
+|---|---|---|
+| ~~Critical~~ | "Nonce always mismatches (Apple hashes it)" | **False positive** — Apple echoes the nonce verbatim; raw==raw matches. The nonce check was made non-fatal anyway (see §7). |
+| High | `application-stage.properties` had a broken line-continuation that corrupted the first audience (prod fail-closed). | Fixed — single valid line. |
+| Medium | FE read `body.message`; backend returns `body.ex` → generic errors only. | FE now reads `body.ex`. |
+| Medium | User-cancel showed a cryptic native error toast. | `AppleSignInCancelledError` swallowed in all 3 handlers. |
+| Medium | Multi-institute learner dropped into one institute. | Routes to `/institute-selection`. |
+| Low | Auth failures returned HTTP 510. | Use `VacademyException(BAD_REQUEST/UNAUTHORIZED, …)`. |
+| Low | `instituteId` could be null before domain routing resolves. | Falls back to stored `Preferences["InstituteId"]`. |
+| Low | No pending state on the modular Apple buttons. | `isAppleLoading` + `disabled`. |
+
+**Verified correct by the review:** RS256 JWKS verification (no alg-confusion), `iss`/`exp` validation, fail-closed audience check, email-from-verified-token, the 4.8 gate-lift parity across all three surfaces (no other live social-render site), and the entitlement/per-target wiring.
+
+---
+
+## 11. File reference
+
+**Backend:** `auth_service/.../feature/auth/{controller/AppleNativeAuthController,service/AppleIdentityTokenVerifier,dto/AppleNativeLoginRequestDto}.java`, `auth_service/src/main/resources/application-{stage,dev,k8s-local}.properties`
+**Reused:** `auth_service/.../feature/auth/manager/LearnerOAuth2Manager.java`, `common_service/.../auth/service/OAuth2VendorToUserDetailService.java`, `auth_service/.../core/config/ApplicationSecurityConfig.java`
+**Frontend:** `src/lib/auth/appleNativeAuth.ts`, `src/components/common/auth/AppleSignInButton.tsx`, `src/constants/urls.ts`, `src/components/common/auth/login/forms/page/login-form.tsx`, `…/login/components/modular/ModularDynamicLoginContainer.tsx`, `…/signup/components/ModularDynamicSignupContainer.tsx`
+**iOS:** `ios/App/App/App.entitlements`, `ios/App/Podfile`

--- a/frontend-learner-dashboard-app/ios/App/App/App.entitlements
+++ b/frontend-learner-dashboard-app/ios/App/App/App.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:ssdc.vacademy.io</string>

--- a/frontend-learner-dashboard-app/ios/App/App/Info.plist
+++ b/frontend-learner-dashboard-app/ios/App/App/Info.plist
@@ -60,30 +60,32 @@
 			LSRequiresIPhoneOS
 		</key>
 		<true />
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false />
 		<!-- Camera Permissions -->
 		<key>
 			NSCameraUsageDescription
 		</key>
 		<string>
-			We need access to your camera to capture photos and record videos for property reviews and inspections.
+			We need access to your camera so you can upload a profile photo, share images or videos in course discussions and assignments, and complete proctored assessments and live classes.
 		</string>
 		<key>
 			NSPhotoLibraryAddUsageDescription
 		</key>
 		<string>
-			We need access to add photos to your library.
+			We need access to save course content and assignment materials to your photo library.
 		</string>
 		<key>
 			NSPhotoLibraryUsageDescription
 		</key>
 		<string>
-			We need access to your photos to allow selecting images for upload.
+			We need access to your photos so you can select and upload images for your profile and course assignments.
 		</string>
 		<key>
 			NSMicrophoneUsageDescription
 		</key>
 		<string>
-			We need access to your microphone to record audio and videos for property reviews and inspections.
+			We need access to your microphone so you can record audio and video submissions for assignments and participate in live class sessions.
 		</string>
 		<key>
 			UILaunchStoryboardName

--- a/frontend-learner-dashboard-app/ios/App/App/PrivacyInfo.xcprivacy
+++ b/frontend-learner-dashboard-app/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  App-target Apple privacy manifest (Apple Guideline 5.1.1 / required-reason APIs).
+  Declares the "required reason" APIs the first-party app + the Capgo OTA updater
+  use (UserDefaults, file modification timestamps). Firebase / GoogleUtilities /
+  Alamofire ship their own manifests inside Pods, so they are NOT redeclared here.
+
+  NOTE: this file must be added to the "Copy Bundle Resources" build phase of EVERY
+  shipping target (App + each per-institute brand target) in App.xcodeproj for it to
+  take effect — see VACADEMY_IOS_COMPLIANCE_CHECKLIST.md.
+
+  NSPrivacyTracking is false: analytics (Amplitude) is disabled on native iOS, so the
+  app performs no tracking. Keep this consistent with the App Store Connect privacy labels.
+-->
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/frontend-learner-dashboard-app/ios/App/Podfile
+++ b/frontend-learner-dashboard-app/ios/App/Podfile
@@ -21,6 +21,7 @@ def capacitor_pods
   pod 'CapacitorStorage', :path => '../../node_modules/.pnpm/@capacitor+storage@1.2.5_@capacitor+core@7.4.2/node_modules/@capacitor/storage'
   pod 'CapawesomeCapacitorAppUpdate', :path => '../../node_modules/.pnpm/@capawesome+capacitor-app-update@7.0.1_@capacitor+core@7.4.2/node_modules/@capawesome/capacitor-app-update'
   pod 'CapgoCapacitorUpdater', :path => '../../node_modules/.pnpm/@capgo+capacitor-updater@8.45.1_@capacitor+core@7.4.2/node_modules/@capgo/capacitor-updater'
+  pod 'CapacitorCommunityAppleSignIn', :path => '../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@7.4.2/node_modules/@capacitor-community/apple-sign-in'
 end
 
 target 'App' do

--- a/frontend-learner-dashboard-app/ios/App/STEMx-Info.plist
+++ b/frontend-learner-dashboard-app/ios/App/STEMx-Info.plist
@@ -24,13 +24,13 @@
 		<true />
 		<!-- Camera Permissions -->
 		<key>NSCameraUsageDescription</key>
-		<string>We need access to your camera to capture photos and record videos for property reviews and inspections.</string>
+		<string>We need access to your camera so you can upload a profile photo and share images or videos in course discussions and assignments.</string>
 		<key>NSPhotoLibraryAddUsageDescription</key>
 		<string>We need access to add photos to your library.</string>
 		<key>NSPhotoLibraryUsageDescription</key>
 		<string>We need access to your photos to allow selecting images for upload.</string>
 		<key>NSMicrophoneUsageDescription</key>
-		<string>We need access to your microphone to record audio and videos for property reviews and inspections.</string>
+		<string>We need access to your microphone so you can record audio and video submissions for assignments and participate in live class sessions.</string>
 		<key>UILaunchStoryboardName</key>
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>

--- a/frontend-learner-dashboard-app/ios/App/ithinkersByFiveSep-Info.plist
+++ b/frontend-learner-dashboard-app/ios/App/ithinkersByFiveSep-Info.plist
@@ -23,9 +23,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>We need access to your camera to capture photos and record videos for property reviews and inspections.</string>
+	<string>We need access to your camera so you can upload a profile photo and share images or videos in course discussions and assignments.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>We need access to your microphone to record audio and videos for property reviews and inspections.</string>
+	<string>We need access to your microphone so you can record audio and video submissions for assignments and participate in live class sessions.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>We need access to add photos to your library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/frontend-learner-dashboard-app/package.json
+++ b/frontend-learner-dashboard-app/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.19.0",
+    "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/electron": "^5.0.1",
     "@capacitor-community/privacy-screen": "^6.0.0",
     "@capacitor-firebase/messaging": "^7.3.0",

--- a/frontend-learner-dashboard-app/pnpm-lock.yaml
+++ b/frontend-learner-dashboard-app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@amplitude/analytics-browser':
         specifier: ^2.19.0
         version: 2.19.0
+      '@capacitor-community/apple-sign-in':
+        specifier: ^7.1.0
+        version: 7.1.0(@capacitor/core@7.4.2)
       '@capacitor-community/electron':
         specifier: ^5.0.1
         version: 5.0.1
@@ -786,6 +789,11 @@ packages:
 
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
+
+  '@capacitor-community/apple-sign-in@7.1.0':
+    resolution: {integrity: sha512-df7cA7vfvvvilTtpJKeVvxO31W+py5t3HK9233GBD5MvgAgtGvCqeQ3pI0noNkVsKPF9B1g/po8Mph6s4bVSmw==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
 
   '@capacitor-community/electron@5.0.1':
     resolution: {integrity: sha512-4/x12ycTq0Kq8JIn/BmIBdFVP5Cqw8iA6SU6YfFjmONfjW3OELwsB3zwLxOwAjLxnjyCMOBHl4ci9E5jLgZgAQ==}
@@ -3652,6 +3660,9 @@ packages:
 
   '@types/react@18.3.23':
     resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+
+  '@types/scriptjs@0.0.2':
+    resolution: {integrity: sha512-GFrUgzGYfNX3VWZwMyzr0JrBwzLv5Kes4BQBvo6hXdRy14/GBbpCiVwwB7v1o2xIEvFf+9GyznmYhuesQQjSag==}
 
   '@types/slice-ansi@4.0.0':
     resolution: {integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==}
@@ -7405,6 +7416,9 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
+  scriptjs@2.5.9:
+    resolution: {integrity: sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -8627,6 +8641,12 @@ snapshots:
   '@braintree/sanitize-url@6.0.2': {}
 
   '@braintree/sanitize-url@7.1.1': {}
+
+  '@capacitor-community/apple-sign-in@7.1.0(@capacitor/core@7.4.2)':
+    dependencies:
+      '@capacitor/core': 7.4.2
+      '@types/scriptjs': 0.0.2
+      scriptjs: 2.5.9
 
   '@capacitor-community/electron@5.0.1':
     dependencies:
@@ -11852,6 +11872,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/scriptjs@0.0.2': {}
 
   '@types/slice-ansi@4.0.0': {}
 
@@ -16296,6 +16318,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
+
+  scriptjs@2.5.9: {}
 
   semver@5.7.2: {}
 

--- a/frontend-learner-dashboard-app/src/components/common/auth/AppleSignInButton.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/AppleSignInButton.tsx
@@ -1,0 +1,37 @@
+import { AppleLogo } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+/**
+ * "Sign in with Apple" button.
+ *
+ * Apple Human Interface Guidelines require the Apple logo, an approved title
+ * ("Sign in with Apple" / "Continue with Apple"), and a black / white / white-
+ * outline style presented as a peer to other sign-in options. We use the solid
+ * black style here.
+ */
+export function AppleSignInButton({
+  onClick,
+  disabled,
+  className,
+  label = "Continue with Apple",
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "flex h-11 w-full items-center justify-center gap-2 rounded-md bg-black font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+    >
+      <AppleLogo weight="fill" className="h-5 w-5" />
+      <span className="text-sm">{label}</span>
+    </button>
+  );
+}

--- a/frontend-learner-dashboard-app/src/components/common/auth/login/components/modular/ModularDynamicLoginContainer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/components/modular/ModularDynamicLoginContainer.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import { FcGoogle } from "react-icons/fc"; // design-lint-ignore: Google brand logo
 import { ArrowRight } from "@phosphor-icons/react";
+import { isIOSNative } from "@/utils/ios-iap-compliance";
 import { LOGIN_URL_GOOGLE_GITHUB } from "@/constants/urls";
 import { toast } from "sonner";
 import { useEffect, useRef, useState } from "react";
@@ -688,8 +689,10 @@ export function ModularDynamicLoginContainer({
         </div>
       </motion.div>
 
-      {/* OAuth Providers */}
-      {(effectiveSettings.providers.google || effectiveSettings.providers.github) && (
+      {/* OAuth Providers — hidden on native iOS (Apple 4.8: third-party social
+          login needs Sign in with Apple parity, not yet implemented). web /
+          Android / Electron unaffected. */}
+      {!isIOSNative() && (effectiveSettings.providers.google || effectiveSettings.providers.github) && (
         <motion.div
           initial={{ y: 10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}

--- a/frontend-learner-dashboard-app/src/components/common/auth/login/components/modular/ModularDynamicLoginContainer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/components/modular/ModularDynamicLoginContainer.tsx
@@ -3,6 +3,12 @@ import { FcGoogle } from "react-icons/fc"; // design-lint-ignore: Google brand l
 import { ArrowRight } from "@phosphor-icons/react";
 import { isIOSNative } from "@/utils/ios-iap-compliance";
 import { LOGIN_URL_GOOGLE_GITHUB } from "@/constants/urls";
+import {
+  loginWithAppleNative,
+  AppleSessionLimitError,
+  AppleSignInCancelledError,
+} from "@/lib/auth/appleNativeAuth";
+import { AppleSignInButton } from "@/components/common/auth/AppleSignInButton";
 import { toast } from "sonner";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
@@ -99,6 +105,7 @@ export function ModularDynamicLoginContainer({
 
   // State to track OAuth processing (after popup closes, before redirect)
   const [isOAuthProcessing, setIsOAuthProcessing] = useState(false);
+  const [isAppleLoading, setIsAppleLoading] = useState(false);
   // When we open OAuth popup, set this so we only accept results written after open (avoids stale data)
   const oauthPopupOpenedAtRef = useRef<number>(0);
 
@@ -434,7 +441,36 @@ export function ModularDynamicLoginContainer({
     };
   }, [onLoginSuccess]);
 
-  const handleOAuthLogin = async (provider: "google" | "github") => {
+  const handleOAuthLogin = async (provider: "google" | "github" | "apple") => {
+    // Native iOS "Sign in with Apple" uses the native sheet (no popup / redirect)
+    // and completes the auth cycle itself.
+    if (provider === "apple" && isIOSNative()) {
+      try {
+        setIsAppleLoading(true);
+        const urlInstituteId =
+          new URLSearchParams(window.location.search).get("instituteId") ||
+          instituteId;
+        await loginWithAppleNative({ instituteId: urlInstituteId });
+      } catch (e) {
+        setIsAppleLoading(false);
+        if (e instanceof AppleSignInCancelledError) {
+          return; // user dismissed the sheet — no error UI
+        }
+        if (e instanceof AppleSessionLimitError) {
+          toast.error(
+            "You've reached the active session limit. Please log out from another device and try again.",
+          );
+        } else {
+          toast.error(
+            e instanceof Error
+              ? e.message
+              : "Failed to sign in with Apple. Please try again.",
+          );
+        }
+      }
+      return;
+    }
+
     try {
       // Get current page information for redirection after login
       const currentPath = window.location.pathname;
@@ -689,10 +725,10 @@ export function ModularDynamicLoginContainer({
         </div>
       </motion.div>
 
-      {/* OAuth Providers — hidden on native iOS (Apple 4.8: third-party social
-          login needs Sign in with Apple parity, not yet implemented). web /
-          Android / Electron unaffected. */}
-      {!isIOSNative() && (effectiveSettings.providers.google || effectiveSettings.providers.github) && (
+      {/* OAuth Providers. On native iOS, Sign in with Apple (below) provides the
+          Guideline 4.8 parity that previously required hiding Google/GitHub.
+          web / Android / Electron unaffected. */}
+      {(effectiveSettings.providers.google || effectiveSettings.providers.github) && (
         <motion.div
           initial={{ y: 10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
@@ -730,8 +766,19 @@ export function ModularDynamicLoginContainer({
               <ArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
             </motion.button>
           )}
+
+          {/* Sign in with Apple — native iOS only (no Android plugin support).
+              Shown whenever a third-party provider is offered, per Apple 4.8. */}
+          {isIOSNative() &&
+            (effectiveSettings.providers.google ||
+              effectiveSettings.providers.github) && (
+              <AppleSignInButton
+                onClick={() => handleOAuthLogin("apple")}
+                disabled={isAppleLoading}
+              />
+            )}
         </motion.div>
-      )} 
+      )}
 
       {/* Spacing between OAuth and forms */}
       {(effectiveSettings.providers.emailOtp || effectiveSettings.providers.usernamePassword) && (

--- a/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Capacitor } from "@capacitor/core";
+import { isIOSNative } from "@/utils/ios-iap-compliance";
 import { TokenKey } from "@/constants/auth/tokens";
 import { useNavigate } from "@tanstack/react-router";
 import { isNullOrEmptyOrUndefined } from "@/lib/utils";
@@ -978,7 +979,12 @@ export function LoginForm({
                   transition={{ delay: 0.7 }}
                   className="grid grid-cols-1 gap-3"
                 >
-                  {authProviders?.google && (
+                  {/* Apple Guideline 4.8: an iOS app that offers third-party
+                      social login (Google/GitHub) must also offer Sign in with
+                      Apple. Until that's implemented, hide social login on
+                      native iOS (email-OTP / username-password / phone remain).
+                      web / Android / Electron are unaffected. */}
+                  {!isIOSNative() && authProviders?.google && (
                     <Button
                       variant="outline"
                       className="w-full relative h-11"
@@ -989,7 +995,7 @@ export function LoginForm({
                       Continue with Google
                     </Button>
                   )}
-                  {authProviders?.github && (
+                  {!isIOSNative() && authProviders?.github && (
                     <Button
                       variant="outline"
                       className="w-full relative h-11"
@@ -1003,7 +1009,7 @@ export function LoginForm({
                 </motion.div>
 
                 {/* Divider */}
-                {(authProviders?.google || authProviders?.github) && (
+                {!isIOSNative() && (authProviders?.google || authProviders?.github) && (
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t" />

--- a/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/login-form.tsx
@@ -47,6 +47,12 @@ import {
   openOAuthInSystemBrowser,
 } from "@/lib/auth/nativeOAuth";
 import {
+  loginWithAppleNative,
+  AppleSessionLimitError,
+  AppleSignInCancelledError,
+} from "@/lib/auth/appleNativeAuth";
+import { AppleSignInButton } from "@/components/common/auth/AppleSignInButton";
+import {
   getTerminology,
   getTerminologyPlural,
 } from "@/components/common/layout-container/sidebar/utils";
@@ -807,7 +813,34 @@ export function LoginForm({
     }
   };
 
-  const handleOAuthLogin = async (provider: "google" | "github") => {
+  const handleOAuthLogin = async (provider: "google" | "github" | "apple") => {
+    // Native iOS: "Sign in with Apple" uses the native ASAuthorization sheet
+    // (no browser redirect / Universal Link). The helper completes the auth
+    // cycle and navigates on success.
+    if (provider === "apple" && isIOSNative()) {
+      try {
+        setIsSSOLoading(true);
+        await loginWithAppleNative({ instituteId: domainRouting?.instituteId });
+      } catch (e) {
+        setIsSSOLoading(false);
+        if (e instanceof AppleSignInCancelledError) {
+          return; // user dismissed the sheet — no error UI
+        }
+        if (e instanceof AppleSessionLimitError) {
+          toast.error(
+            "You've reached the active session limit. Please log out from another device and try again.",
+          );
+        } else {
+          toast.error(
+            e instanceof Error
+              ? e.message
+              : "Failed to sign in with Apple. Please try again.",
+          );
+        }
+      }
+      return;
+    }
+
     try {
       // Resolve the public-facing origin for OAuth redirect
       const redirectOrigin = await getOAuthRedirectOrigin();
@@ -979,12 +1012,12 @@ export function LoginForm({
                   transition={{ delay: 0.7 }}
                   className="grid grid-cols-1 gap-3"
                 >
-                  {/* Apple Guideline 4.8: an iOS app that offers third-party
-                      social login (Google/GitHub) must also offer Sign in with
-                      Apple. Until that's implemented, hide social login on
-                      native iOS (email-OTP / username-password / phone remain).
-                      web / Android / Electron are unaffected. */}
-                  {!isIOSNative() && authProviders?.google && (
+                  {/* Apple Guideline 4.8: on native iOS, an app offering
+                      third-party social login (Google/GitHub) MUST also offer
+                      Sign in with Apple as a peer. The Apple button below
+                      satisfies that, so Google/GitHub are no longer hidden on
+                      iOS. web / Android / Electron are unaffected. */}
+                  {authProviders?.google && (
                     <Button
                       variant="outline"
                       className="w-full relative h-11"
@@ -995,7 +1028,7 @@ export function LoginForm({
                       Continue with Google
                     </Button>
                   )}
-                  {!isIOSNative() && authProviders?.github && (
+                  {authProviders?.github && (
                     <Button
                       variant="outline"
                       className="w-full relative h-11"
@@ -1006,10 +1039,19 @@ export function LoginForm({
                       Continue with GitHub
                     </Button>
                   )}
+                  {/* Sign in with Apple — native iOS only (the plugin has no
+                      Android support; web/Android Apple login is a later phase).
+                      Shown whenever a third-party provider is offered, per 4.8. */}
+                  {isIOSNative() &&
+                    (authProviders?.google || authProviders?.github) && (
+                      <AppleSignInButton
+                        onClick={() => handleOAuthLogin("apple")}
+                      />
+                    )}
                 </motion.div>
 
                 {/* Divider */}
-                {!isIOSNative() && (authProviders?.google || authProviders?.github) && (
+                {(authProviders?.google || authProviders?.github) && (
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t" />

--- a/frontend-learner-dashboard-app/src/components/common/auth/signup/components/ModularDynamicSignupContainer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/signup/components/ModularDynamicSignupContainer.tsx
@@ -15,6 +15,12 @@ import { FcGoogle } from "react-icons/fc"; // design-lint-ignore: brand logo, no
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import { ArrowRight } from "@phosphor-icons/react";
 import {
+  loginWithAppleNative,
+  AppleSessionLimitError,
+  AppleSignInCancelledError,
+} from "@/lib/auth/appleNativeAuth";
+import { AppleSignInButton } from "@/components/common/auth/AppleSignInButton";
+import {
   LOGIN_URL_GOOGLE_GITHUB,
   LIVE_SESSION_REQUEST_OTP,
 } from "@/constants/urls";
@@ -67,6 +73,7 @@ export function ModularDynamicSignupContainer({
   const { setPrimaryColor } = useTheme();
   const { registerUser: registerUserUnified } = useUnifiedRegistration();
   const [currentStep, setCurrentStep] = useState<SignupStep>("providers");
+  const [isAppleLoading, setIsAppleLoading] = useState(false);
   const [emailInput, setEmailInput] = useState(initialEmail); // Pre-fill if provided
   const [isSendingOtp, setIsSendingOtp] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
@@ -591,9 +598,39 @@ export function ModularDynamicSignupContainer({
     }
   };
 
+  const handleAppleNativeSignup = async () => {
+    // Native iOS Apple sign-in is login-or-signup: the backend auto-creates the
+    // learner per the institute signup policy, then returns tokens.
+    try {
+      setIsAppleLoading(true);
+      await loginWithAppleNative({ instituteId });
+    } catch (e) {
+      setIsAppleLoading(false);
+      if (e instanceof AppleSignInCancelledError) {
+        return; // user dismissed the sheet — no error UI
+      }
+      if (e instanceof AppleSessionLimitError) {
+        toast.error(
+          "You've reached the active session limit. Please log out from another device and try again.",
+        );
+      } else {
+        toast.error(
+          e instanceof Error
+            ? e.message
+            : "Failed to sign in with Apple. Please try again.",
+        );
+      }
+    }
+  };
+
   const handleProviderSelect = (provider: string) => {
     if (provider === "google" || provider === "github") {
       handleOAuthSignUp(provider as "google" | "github");
+      return;
+    }
+
+    if (provider === "apple") {
+      handleAppleNativeSignup();
       return;
     }
 
@@ -916,9 +953,10 @@ export function ModularDynamicSignupContainer({
         </div>
       </SignupStep>
 
-      {/* OAuth Providers — hidden on native iOS (Apple 4.8: social login needs
-          Sign in with Apple parity, not yet implemented). web/Android unaffected. */}
-      {!isIOSNative() && (
+      {/* OAuth Providers. On native iOS, Sign in with Apple (below) provides the
+          Guideline 4.8 parity that previously required hiding Google/GitHub.
+          web/Android unaffected. */}
+      {(effectiveSettings.providers.google || effectiveSettings.providers.github) && (
       <SignupStep delay={0.2}>
         <div className="space-y-2 mb-6">
           {effectiveSettings.providers.google && (
@@ -948,6 +986,17 @@ export function ModularDynamicSignupContainer({
               <ArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
             </motion.button>
           )}
+
+          {/* Sign in with Apple — native iOS only (no Android plugin support).
+              Shown whenever a third-party provider is offered, per Apple 4.8. */}
+          {isIOSNative() &&
+            (effectiveSettings.providers.google ||
+              effectiveSettings.providers.github) && (
+              <AppleSignInButton
+                onClick={() => handleProviderSelect("apple")}
+                disabled={isAppleLoading}
+              />
+            )}
         </div>
       </SignupStep>
       )}

--- a/frontend-learner-dashboard-app/src/components/common/auth/signup/components/ModularDynamicSignupContainer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/signup/components/ModularDynamicSignupContainer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { isIOSNative } from "@/utils/ios-iap-compliance";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -915,7 +916,9 @@ export function ModularDynamicSignupContainer({
         </div>
       </SignupStep>
 
-      {/* OAuth Providers */}
+      {/* OAuth Providers — hidden on native iOS (Apple 4.8: social login needs
+          Sign in with Apple parity, not yet implemented). web/Android unaffected. */}
+      {!isIOSNative() && (
       <SignupStep delay={0.2}>
         <div className="space-y-2 mb-6">
           {effectiveSettings.providers.google && (
@@ -947,6 +950,7 @@ export function ModularDynamicSignupContainer({
           )}
         </div>
       </SignupStep>
+      )}
 
       {/* Divider */}
       {effectiveSettings.providers.emailOtp && (

--- a/frontend-learner-dashboard-app/src/components/common/donation/DonationDialog.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/donation/DonationDialog.tsx
@@ -12,6 +12,7 @@ import { fetchAndStoreInstituteDetails, type InstituteDetails } from "@/services
 import { getUserId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
 import { getTerminology } from "@/components/common/layout-container/sidebar/utils";
 import { ContentTerms, SystemTerms } from "@/types/naming-settings";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 export interface DonationDialogProps {
   open: boolean;
@@ -155,6 +156,12 @@ export const DonationDialog: React.FC<DonationDialogProps> = ({
 
     fetchInstituteBranding();
   }, [open, instituteId, enrollmentData, instituteBranding]);
+
+  // Reader mode (iOS / reader-mode institutes): donations via external gateways
+  // are forbidden in-app (Apple 3.1.1) — never render the donation dialog.
+  if (shouldHidePaidPurchaseUI()) {
+    return null;
+  }
 
   // Show loading state
   if (loading) {

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/enrollment-policy-dialog.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/enrollment-policy-dialog.tsx
@@ -18,6 +18,7 @@ import {
     X
 } from "@phosphor-icons/react";
 import { useState } from "react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 // Types for the enrollment policy response
 export interface EnrollmentPolicyFrontendAction {
@@ -107,7 +108,9 @@ const EnrollmentPolicyDialog = ({
     const reenrollmentPolicy = policyResponse?.reenrollmentPolicy;
     const onEnrollment = policyResponse?.onEnrollment;
 
-    // Handle action button click
+    // Handle action button click. These are post-enrollment activation steps
+    // (e.g. WhatsApp verification), NOT purchases, so they stay functional on
+    // iOS — only the paid-upgrade CTAs below are reader-mode gated.
     const handleActionClick = (action: EnrollmentPolicyFrontendAction) => {
         if (action.actionUrl) {
             setIsRedirecting(true);
@@ -118,6 +121,7 @@ const EnrollmentPolicyDialog = ({
 
     // Handle upgrade button click
     const handleUpgradeClick = (url: string) => {
+        if (shouldHidePaidPurchaseUI()) return;
         if (url) {
             setIsRedirecting(true);
             if (onUpgrade) {
@@ -233,7 +237,7 @@ const EnrollmentPolicyDialog = ({
                 </div> */}
 
                 {/* Upgrade option if available */}
-                {reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
+                {!shouldHidePaidPurchaseUI() && reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
                     <div className="rounded-xl bg-gradient-to-br from-primary-50 to-blue-50 border border-primary-200 p-5">
                         <div className="flex flex-col items-center text-center space-y-3">
                             <Sparkle className="w-6 h-6 text-primary-600" />
@@ -304,7 +308,7 @@ const EnrollmentPolicyDialog = ({
                 </div>
             </DialogHeader>
 
-            {reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
+            {!shouldHidePaidPurchaseUI() && reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
                 <div className="py-4">
                     <div className="rounded-xl bg-gradient-to-br from-primary-50 to-blue-50 border border-primary-200 p-5">
                         <div className="flex flex-col items-center text-center space-y-3">
@@ -350,7 +354,7 @@ const EnrollmentPolicyDialog = ({
                 </div>
             </DialogHeader>
 
-            {reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
+            {!shouldHidePaidPurchaseUI() && reenrollmentPolicy?.upgradeOptions?.paid_upgrade && (
                 <div className="py-4">
                     <div className="rounded-xl bg-gradient-to-br from-primary-50 to-blue-50 border border-primary-200 p-5">
                         <div className="flex flex-col items-center text-center space-y-3">

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/payment-pending-step.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/payment-pending-step.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "./payment-selection-step";
 import { getPaymentCompletionStatus } from "../-services/enroll-invite-services";
 import { useEffect } from "react";
 import { SelectedPayment } from "./types";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 export interface User {
   id: string;
@@ -60,6 +61,9 @@ const PaymentPendingStep = ({
   setCurrentStep,
 }: PaymentPendingStepProps) => {
   const handleCompletePayment = (paymentUrl: string) => {
+    // Reader mode (iOS / reader-mode institutes): never redirect to an external
+    // payment gateway (Apple 3.1.1).
+    if (shouldHidePaidPurchaseUI()) return;
     if (!paymentUrl) {
       return;
     }
@@ -157,22 +161,25 @@ const PaymentPendingStep = ({
 
       {/* Action Buttons */}
       <div className="flex flex-col gap-4 sm:items-center">
-        <MyButton
-          type="button"
-          buttonType="primary"
-          scale="large"
-          layoutVariant="default"
-          onClick={() =>
-            handleCompletePayment(
-              paymentCompletionResponse?.payment_response?.response_data
-                ?.paymentUrl
-            )
-          }
-          className="w-full sm:w-auto bg-primary-500 text-white font-semibold rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl"
-        >
-          Complete Payment
-          <ArrowRight className="w-5 h-5 ml-2" />
-        </MyButton>
+        {/* Complete Payment (external gateway) hidden in reader mode (Apple 3.1.1). */}
+        {!shouldHidePaidPurchaseUI() && (
+          <MyButton
+            type="button"
+            buttonType="primary"
+            scale="large"
+            layoutVariant="default"
+            onClick={() =>
+              handleCompletePayment(
+                paymentCompletionResponse?.payment_response?.response_data
+                  ?.paymentUrl
+              )
+            }
+            className="w-full sm:w-auto bg-primary-500 text-white font-semibold rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl"
+          >
+            Complete Payment
+            <ArrowRight className="w-5 h-5 ml-2" />
+          </MyButton>
+        )}
         <MyButton
           type="button"
           buttonType="secondary"
@@ -191,13 +198,15 @@ const PaymentPendingStep = ({
         </MyButton>
       </div>
 
-      {/* Redirect Notice */}
-      <div className="text-center space-y-2">
-        <p className="text-gray-600 text-sm">
-          You will be redirected to Stripe's secure payment page
-        </p>
-        <p className="text-gray-500 text-xs">Powered by Stripe</p>
-      </div>
+      {/* Redirect Notice — hidden in reader mode (no external payment). */}
+      {!shouldHidePaidPurchaseUI() && (
+        <div className="text-center space-y-2">
+          <p className="text-gray-600 text-sm">
+            You will be redirected to Stripe's secure payment page
+          </p>
+          <p className="text-gray-500 text-xs">Powered by Stripe</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -1,5 +1,6 @@
 import { Route } from "@/routes/learner-invitation-response";
 import { Preferences } from "@capacitor/preferences";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 import { applyTabBranding } from "@/utils/branding";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
@@ -1027,6 +1028,10 @@ const EnrollByInvite = ({
   };
 
   const handleUpgrade = (url: string) => {
+    // Reader mode (iOS / reader-mode institutes): never redirect to an external
+    // paid-upgrade URL (Apple 3.1.1). Defense-in-depth — the route is already
+    // blocked in reader mode.
+    if (shouldHidePaidPurchaseUI()) return;
     // Save form data to LocalStorage for prefilling the next form
     const formData = form.getValues();
     const prefillData: Record<string, string> = {};

--- a/frontend-learner-dashboard-app/src/components/common/price-with-mrp.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/price-with-mrp.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency, getCurrencySymbol } from "@/utils/currency";
 import { cn } from "@/lib/utils";
 import { Sparkle } from "@phosphor-icons/react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 export interface PriceWithMrpProps {
   actual?: number | null;
@@ -75,6 +76,12 @@ export const PriceWithMrp = ({
   freeForZero = true,
   className,
 }: PriceWithMrpProps) => {
+  // Reader mode (iOS / reader-mode institutes): hide all pricing. This is the
+  // global choke point for every price / MRP / "% off" in the app.
+  if (shouldHidePaidPurchaseUI()) {
+    return null;
+  }
+
   if (actual == null) {
     return <span className={className}>—</span>;
   }
@@ -145,6 +152,10 @@ export interface OfferBadgeProps {
 }
 
 export const OfferBadge = ({ actual, elevated, className }: OfferBadgeProps) => {
+  // Reader mode: hide all offer/discount/FREE ribbons alongside pricing.
+  if (shouldHidePaidPurchaseUI()) {
+    return null;
+  }
   // Free course → show a "FREE" ribbon instead of a discount percentage.
   // (A 0-priced course would otherwise read as "100% OFF", or show nothing
   //  when there's no elevated price.) Green to match the "Free" price text.

--- a/frontend-learner-dashboard-app/src/components/common/user-profile/user-page.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/user-profile/user-page.tsx
@@ -23,6 +23,7 @@ import { formatDate } from "@/lib/format-date";
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
 import { FileText } from "@phosphor-icons/react";
 import { playIllustrations } from "@/assets/play-illustrations";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 // import { SessionExpiry } from "./sessionExpiery";
 interface CourseDetails {
   packageName: string;
@@ -469,13 +470,17 @@ export default function ProfilePage() {
                 </div>
               </div>
 
-              {/* Session Expiry */}
-              <div className="bg-card rounded-xl border shadow p-6">
-                <h3 className="text-sm font-semibold text-foreground mb-4">
-                  Membership Status
-                </h3>
-                {studentData && SessionExpiry({ studentData })}
-              </div>
+              {/* Session Expiry / Membership Status — hidden in reader mode
+                  (iOS / reader-mode institutes): "Access Days" + expiry reads
+                  as a paid subscription to App Review (Apple 3.1.1). */}
+              {!shouldHidePaidPurchaseUI() && (
+                <div className="bg-card rounded-xl border shadow p-6">
+                  <h3 className="text-sm font-semibold text-foreground mb-4">
+                    Membership Status
+                  </h3>
+                  {studentData && SessionExpiry({ studentData })}
+                </div>
+              )}
               {studentData && <ProgressStats userId={studentData.user_id} />}
             </div>
 

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -30,6 +30,9 @@ export const HOLISTIC_INSTITUTE_ID =
 export const LOGIN_URL = `${BASE_URL}/auth-service/learner/v1/login`;
 
 export const LOGIN_URL_GOOGLE_GITHUB = `${BASE_URL}/auth-service/oauth2/authorization`;
+// Native iOS "Sign in with Apple" — the app POSTs the Apple identityToken here
+// (the native sheet returns it directly, so there is no browser-redirect round-trip).
+export const LOGIN_URL_APPLE_NATIVE = `${BASE_URL}/auth-service/learner/v1/oauth/apple/native`;
 export const LOGIN_USING_USERNAME = `${BASE_URL}/auth-service/open/user-details/by-username`;
 export const LOGIN_USING_OTP = `${BASE_URL}/auth-service/learner/v1/login-otp-ten-days`;
 

--- a/frontend-learner-dashboard-app/src/hooks/use-student-permissions.ts
+++ b/frontend-learner-dashboard-app/src/hooks/use-student-permissions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getStudentDisplaySettings } from "@/services/student-display-settings";
 import { StudentPermissions } from "@/types/student-display-settings";
+import { isIOSNative } from "@/utils/ios-iap-compliance";
 
 export function useStudentPermissions() {
   const {
@@ -13,13 +14,22 @@ export function useStudentPermissions() {
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
-  const permissions: StudentPermissions = settings?.permissions || {
+  const basePermissions: StudentPermissions = settings?.permissions || {
     canViewProfile: true,
     canEditProfile: false,
     canDeleteProfile: false,
     canViewFiles: false,
     canViewReports: false,
   };
+
+  // Apple Guideline 5.1.1(v): an app that allows account creation MUST let
+  // users delete their account from within the app. Signup is available on
+  // native iOS, so the in-app delete-account flow must always be reachable
+  // there — force the permission on regardless of the institute's display
+  // setting (which defaults to false). Other platforms are unaffected.
+  const permissions: StudentPermissions = isIOSNative()
+    ? { ...basePermissions, canDeleteProfile: true }
+    : basePermissions;
 
   return {
     permissions,

--- a/frontend-learner-dashboard-app/src/lib/analytics.ts
+++ b/frontend-learner-dashboard-app/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import * as amplitude from '@amplitude/analytics-browser';
+import { Capacitor } from '@capacitor/core';
 
 // Local readiness flag to ensure analytics failures never impact the app
 let analyticsReady = false;
@@ -11,6 +12,13 @@ const AMPLITUDE_API_KEY = import.meta.env.VITE_AMPLITUDE_API_KEY;
  * Initialize Amplitude analytics
  */
 export const initializeAnalytics = () => {
+  // Apple Guideline 5.1.2 (App Tracking Transparency): Amplitude's autocapture
+  // ties cross-session events to a persistent user id, which Apple treats as
+  // "tracking". The app shows no ATT prompt, so analytics must NOT run on
+  // native iOS. web / Android / Electron are unaffected.
+  if (Capacitor.getPlatform() === 'ios') {
+    return;
+  }
   try {
     amplitude.init(AMPLITUDE_API_KEY, {
       autocapture: true,

--- a/frontend-learner-dashboard-app/src/lib/auth/appleNativeAuth.ts
+++ b/frontend-learner-dashboard-app/src/lib/auth/appleNativeAuth.ts
@@ -1,0 +1,198 @@
+import { Capacitor } from "@capacitor/core";
+import { Preferences } from "@capacitor/preferences";
+import { getPlatformFlavorInfo } from "@/utils/platform-flavor";
+import { getOAuthRedirectOrigin } from "@/lib/auth/nativeOAuth";
+import {
+  getTokenDecodedData,
+  setTokenInStorage,
+  setAuthorizationCookie,
+} from "@/lib/auth/sessionUtility";
+import { TokenKey } from "@/constants/auth/tokens";
+import { LOGIN_URL_APPLE_NATIVE } from "@/constants/urls";
+
+/**
+ * Native "Sign in with Apple" for iOS (Capacitor).
+ *
+ * Unlike the Google/GitHub flow (a Spring OAuth2 server-side redirect captured
+ * by a Universal Link), iOS uses the native ASAuthorization sheet via
+ * `@capacitor-community/apple-sign-in`. The sheet returns an identityToken
+ * directly to JS, which we POST to the backend; the backend verifies it against
+ * Apple's JWKS and returns our own access/refresh tokens. No browser, no
+ * deep-link round-trip — so this completes the auth cycle itself, mirroring the
+ * `appUrlOpen` handler in `__root.tsx`.
+ *
+ * The plugin only supports iOS (and a web shim). On Android the Apple option
+ * must use the web-redirect flow (P1, backend pending).
+ */
+
+/** True only where the native Apple sheet is usable (iOS native). */
+export function isAppleNativeAvailable(): boolean {
+  return Capacitor.getPlatform() === "ios";
+}
+
+/** Thrown when the institute's session limit blocks a new login. */
+export class AppleSessionLimitError extends Error {
+  constructor(public activeSessions: unknown[]) {
+    super("session_limit_exceeded");
+    this.name = "AppleSessionLimitError";
+  }
+}
+
+/** Thrown when the user dismisses the Apple sheet — callers should swallow it. */
+export class AppleSignInCancelledError extends Error {
+  constructor() {
+    super("apple_sign_in_cancelled");
+    this.name = "AppleSignInCancelledError";
+  }
+}
+
+interface AppleAuthorizeResponse {
+  response: {
+    user?: string;
+    email?: string;
+    givenName?: string;
+    familyName?: string;
+    identityToken?: string;
+    authorizationCode?: string;
+  };
+}
+
+function randomNonce(): string {
+  try {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+      return crypto.randomUUID().replace(/-/g, "");
+    }
+  } catch {
+    /* fall through */
+  }
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+}
+
+/** ASAuthorizationError.canceled (1001) — a normal, intentional dismissal. */
+function isUserCancellation(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err || "")).toLowerCase();
+  return msg.includes("1001") || msg.includes("cancel");
+}
+
+/** Resolve the institute to sign into: caller-provided, else the stored one. */
+async function resolveInstituteId(provided?: string): Promise<string | undefined> {
+  if (provided) return provided;
+  try {
+    return (await Preferences.get({ key: "InstituteId" })).value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Runs the full native Apple sign-in and, on success, completes the auth cycle
+ * and navigates (dashboard for a single institute, institute-selection for
+ * several) — the same end states as the normal login flow.
+ *
+ * @throws AppleSignInCancelledError when the user dismisses the sheet (swallow it).
+ * @throws AppleSessionLimitError when the institute session limit is hit.
+ * @throws Error with a user-facing message on any other failure.
+ */
+export async function loginWithAppleNative(opts: {
+  instituteId?: string;
+}): Promise<void> {
+  const { SignInWithApple } = await import(
+    "@capacitor-community/apple-sign-in"
+  );
+
+  const instituteId = await resolveInstituteId(opts.instituteId);
+  const flavor = await getPlatformFlavorInfo();
+  const clientId = flavor.appId || "io.vacademy.student.app";
+  const redirectURI = `${await getOAuthRedirectOrigin()}/login/oauth/learner`;
+  const nonce = randomNonce();
+
+  let result: AppleAuthorizeResponse;
+  try {
+    result = (await SignInWithApple.authorize({
+      clientId,
+      redirectURI,
+      scopes: "email name",
+      nonce,
+    })) as AppleAuthorizeResponse;
+  } catch (err) {
+    if (isUserCancellation(err)) {
+      throw new AppleSignInCancelledError();
+    }
+    throw err instanceof Error ? err : new Error("Apple sign-in failed");
+  }
+
+  const r = result?.response;
+  if (!r?.identityToken) {
+    throw new Error("Apple sign-in did not return an identity token");
+  }
+
+  const res = await fetch(LOGIN_URL_APPLE_NATIVE, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      identityToken: r.identityToken,
+      authorizationCode: r.authorizationCode,
+      user: r.user,
+      email: r.email,
+      givenName: r.givenName,
+      familyName: r.familyName,
+      nonce,
+      instituteId,
+      platform: "ios",
+    }),
+  });
+
+  if (!res.ok) {
+    let message = "Apple sign-in failed. Please try again.";
+    try {
+      const body = await res.json();
+      // The backend's GlobalExceptionHandler serialises the message under `ex`.
+      if (body?.ex || body?.message) message = body.ex || body.message;
+    } catch {
+      /* keep default message */
+    }
+    throw new Error(message);
+  }
+
+  const data = await res.json();
+
+  if (data?.session_limit_exceeded) {
+    throw new AppleSessionLimitError(data.active_sessions || []);
+  }
+
+  const accessToken: string | undefined = data?.accessToken;
+  const refreshToken: string | undefined = data?.refreshToken;
+  if (!accessToken || !refreshToken) {
+    throw new Error("Apple sign-in returned no tokens. Please try again.");
+  }
+
+  // Persist tokens up front — both the dashboard and institute-selection need them.
+  await setTokenInStorage(TokenKey.accessToken, accessToken);
+  await setTokenInStorage(TokenKey.refreshToken, refreshToken);
+  setAuthorizationCookie(TokenKey.accessToken, accessToken);
+  setAuthorizationCookie(TokenKey.refreshToken, refreshToken);
+
+  const authorities = getTokenDecodedData(accessToken)?.authorities || {};
+  const instituteKeys = Object.keys(authorities);
+
+  // Multiple institutes → let the learner choose (mirrors the normal login flow,
+  // login-form.tsx / ModularDynamicLoginContainer.tsx).
+  if (instituteKeys.length > 1) {
+    window.location.replace(
+      `${window.location.origin}/institute-selection?redirect=/dashboard/`,
+    );
+    return;
+  }
+
+  // Single institute → complete the full auth cycle and go to the dashboard
+  // (same as the native deep-link handler in __root.tsx).
+  const targetInstitute =
+    instituteId && instituteKeys.includes(instituteId)
+      ? instituteId
+      : instituteKeys[0] || "";
+  const { performFullAuthCycle } = await import(
+    "@/services/auth-cycle-service"
+  );
+  await performFullAuthCycle({ accessToken, refreshToken }, targetInstitute);
+  window.location.replace(`${window.location.origin}/dashboard`);
+}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/index.tsx
@@ -1,12 +1,20 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { CourseDetailsPage } from "./-components/CourseDetailsPage";
 import { CourseSubPage } from "../-components/CourseSubPage";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import RootNotFoundComponent from "@/components/core/default-not-found";
 import { useEffect, useState } from "react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 export const Route = createFileRoute("/$tagName/$courseId/")({
+  // Reader mode (iOS always / reader-mode institutes): the public course
+  // details / enroll page is a marketplace surface — block it (Apple 3.1.1).
+  beforeLoad: () => {
+    if (shouldHidePaidPurchaseUI()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: RouteComponent,
   validateSearch: (search: Record<string, unknown>) => ({
     enrollInviteId: (search.enrollInviteId as string) || undefined,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/index.tsx
@@ -1,8 +1,9 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import RootNotFoundComponent from "@/components/core/default-not-found";
 import { useEffect, useState, lazy, Suspense } from "react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 // Code-split the catalogue render tree (JsonRenderer + all section components +
 // lead/intro modals) so it loads only when a catalogue route is visited.
@@ -13,6 +14,13 @@ const CourseCataloguePage = lazy(() =>
 );
 
 export const Route = createFileRoute("/$tagName/")({
+  // Reader mode (iOS always / reader-mode institutes): the public course
+  // catalogue is a marketplace surface — block it (Apple 3.1.1).
+  beforeLoad: () => {
+    if (shouldHidePaidPurchaseUI()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: RouteComponent,
 });
 

--- a/frontend-learner-dashboard-app/src/routes/__root.tsx
+++ b/frontend-learner-dashboard-app/src/routes/__root.tsx
@@ -37,6 +37,7 @@ import {
   resolveDomainRouting,
   getCurrentDomainInfo,
 } from "@/services/domain-routing";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 import { ChatbotPanel } from "@/components/chatbot/ChatbotPanel";
 import { ChatbotProvider } from "@/components/chatbot/ChatbotContext";
 import { getChatbotSettings } from "@/services/chatbot-settings";
@@ -73,6 +74,26 @@ const PUBLIC_ROUTES = [
   "/admission/payment", // Public admission payment links shared by institutes
   "/pay/invoice", // Shareable invoice payment links
 ];
+
+// Marketplace / external-payment route prefixes that are hidden when the app
+// is in App-Store "reader mode" (native iOS always, or a reader-mode
+// institute). Apple Guideline 3.1.1 — no external-gateway purchases in-app.
+// These overlap with PUBLIC_ROUTES, so the reader-mode guard in beforeLoad
+// must run BEFORE the public-route bypass. The dynamic catalogue routes
+// (/{tagName}, /{tagName}/{courseId}) are guarded at the component level
+// instead to avoid path-matching false positives.
+const READER_BLOCKED_PATH_PREFIXES = [
+  "/courses",
+  "/product-pages",
+  "/admission/payment",
+  "/pay",
+  "/payment-result",
+];
+
+const isReaderBlockedPath = (pathname: string): boolean =>
+  READER_BLOCKED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
 
 const isAuthenticated = async () => {
   const token = await getTokenFromStorage(TokenKey.accessToken);
@@ -723,6 +744,21 @@ export const Route = createRootRouteWithContext<{
         if (error instanceof Response) throw error;
         console.error("[__root] Auto-login via URL failed:", error);
       }
+    }
+
+    // Reader-mode guard: on native iOS (always) or a reader-mode institute,
+    // marketplace + external-payment routes must never render (Apple 3.1.1).
+    // Runs before the public-route bypass because those routes are "public".
+    if (
+      isReaderBlockedPath(location.pathname) &&
+      shouldHidePaidPurchaseUI()
+    ) {
+      console.log(
+        "[__root] Reader mode active — blocking marketplace/payment route:",
+        location.pathname,
+      );
+      const authed = await isAuthenticated();
+      throw redirect({ to: authed ? "/dashboard" : "/login" });
     }
 
     // Skip all logic for public routes - they should work without any redirects

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyBooksWidget.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyBooksWidget.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { BookOpen, CaretLeft, CaretRight } from "@phosphor-icons/react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 interface MyBooksWidgetProps {
     className?: string;
@@ -127,6 +128,13 @@ export const MyBooksWidget: React.FC<MyBooksWidgetProps> = ({ className }) => {
         };
         init();
     }, [fetchBooks]);
+
+    // Reader mode: the Purchased/Rented framing (time-limited paid access)
+    // reads as in-app commerce (Apple 3.1.1). The book content itself stays
+    // reachable via the study library, so hide this dashboard summary.
+    if (shouldHidePaidPurchaseUI()) {
+        return null;
+    }
 
     if (initialLoading) {
         return (

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyMembershipWidget.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyMembershipWidget.tsx
@@ -6,6 +6,7 @@ import { GET_BATCH_LIST, urlPublicCourseDetails, urlInstituteDetails } from "@/c
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
 import { cn } from "@/lib/utils";
 import { Crown, BookOpen } from "@phosphor-icons/react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 interface MyMembershipWidgetProps {
     className?: string;
@@ -155,6 +156,12 @@ export const MyMembershipWidget: React.FC<MyMembershipWidgetProps> = ({ classNam
 
         fetchData();
     }, []);
+
+    // Reader mode: "My Membership" + "Plan Active" + "Days Remaining" reads as a
+    // paid subscription status to App Review (Apple 3.1.1) — hide it entirely.
+    if (shouldHidePaidPurchaseUI()) {
+        return null;
+    }
 
     if (loading) {
         return (

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyOrdersWidget.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/MyOrdersWidget.tsx
@@ -9,6 +9,7 @@ import { PAYMENT_LOGS_URL } from "@/constants/urls";
 import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
 import { cn } from "@/lib/utils";
 import { ShoppingBag, CaretLeft, CaretRight, Package } from "@phosphor-icons/react";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 interface MyOrdersWidgetProps {
     className?: string;
@@ -336,6 +337,12 @@ export const MyOrdersWidget: React.FC<MyOrdersWidgetProps> = ({ className }) => 
     useEffect(() => {
         fetchOrders(page);
     }, [page]);
+
+    // Reader mode: "My Orders" shows paid amounts + payment/transaction history,
+    // i.e. an in-app purchase record — hide it entirely (Apple 3.1.1).
+    if (shouldHidePaidPurchaseUI()) {
+        return null;
+    }
 
     const getBookName = (entry: PaymentLogEntry): string => {
         return entry.user_plan?.enroll_invite?.name || "Unknown";

--- a/frontend-learner-dashboard-app/src/routes/dashboard/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/index.tsx
@@ -74,6 +74,7 @@ import { getChatbotSettings } from "@/services/chatbot-settings";
 import { MyMembershipWidget } from "./-components/MyMembershipWidget";
 import { MyBooksWidget } from "./-components/MyBooksWidget";
 import { MyOrdersWidget } from "./-components/MyOrdersWidget";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 import { UpcomingLiveClassesWidget } from "./-components/UpcomingLiveClassesWidget";
 import { Preferences } from "@capacitor/preferences";
 import { AttendanceWidget } from "./-components/AttendanceWidget";
@@ -886,8 +887,10 @@ export function DashboardComponent() {
               </Card>
             )}
 
-            {/* Explore Buttons Section — commerce, hidden for the play (K-12) audience */}
-            {!isPlayTheme && (
+            {/* Explore Buttons Section — commerce, hidden for the play (K-12)
+                audience and in reader mode (iOS / reader-mode institutes,
+                Apple 3.1.1). */}
+            {!isPlayTheme && !shouldHidePaidPurchaseUI() && (
               <div className="flex flex-wrap items-center justify-center gap-3 mt-4 pb-12 px-4">
                 {isWidgetVisible("myMembership") && (
                   <Button

--- a/frontend-learner-dashboard-app/src/routes/learner-invitation-response/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/learner-invitation-response/index.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { createFileRoute, useRouter, redirect } from "@tanstack/react-router";
 import { z } from "zod";
 import EnrollByInvite from "@/components/common/enroll-by-invite/enroll-form";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { handleGetEnrollInviteData } from "@/components/common/enroll-by-invite/-services/enroll-invite-services";
 import { PaymentGatewayWrapper } from "@/components/common/enroll-by-invite/-components/payment-gateway-wrapper";
@@ -151,6 +152,15 @@ function InviteErrorComponent({ error }: { error: unknown }) {
 
 export const Route = createFileRoute("/learner-invitation-response/")({
   validateSearch: inviteParamsSchema,
+  // Reader mode (iOS always / reader-mode institutes): the enroll-by-invite
+  // flow contains paid plan selection + external payment gateways + "Upgrade
+  // Now" redirects across many sub-steps. Block the whole route so none of it
+  // can render (Apple 3.1.1). Mirrors the $tagName marketplace guards.
+  beforeLoad: () => {
+    if (shouldHidePaidPurchaseUI()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: RouteComponent,
   errorComponent: ({ error }) => <InviteErrorComponent error={error} />,
 });

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/-component/CourseCatalougePage.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/-component/CourseCatalougePage.tsx
@@ -24,6 +24,7 @@ import type { StudentAllCoursesTabId } from "@/types/student-display-settings";
 import { useDripConditionStore } from "@/stores/study-library/drip-conditions-store";
 import { parseDripConditions } from "@/services/getIsDrippingEnable";
 import { getChatbotSettings } from "@/services/chatbot-settings.ts";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 /** Merge unique instructors from course list into existing list (by id). Ensures instructors attached to courses appear in the filter. */
 function mergeInstructorsFromCourses(
@@ -67,14 +68,21 @@ const CourseCatalougePage: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState("PROGRESS");
   const [visibleTabs, setVisibleTabs] = useState<
     { value: "ALL" | "PROGRESS" | "COMPLETED"; label?: string }[]
-  >([
-    { value: "PROGRESS", label: "In Progress" },
-    { value: "COMPLETED", label: "Completed" },
-    {
-      value: "ALL",
-      label: `All ${getTerminology(ContentTerms.Course, SystemTerms.Course)}s`,
-    },
-  ]);
+  >(() => {
+    const base: { value: "ALL" | "PROGRESS" | "COMPLETED"; label?: string }[] = [
+      { value: "PROGRESS", label: "In Progress" },
+      { value: "COMPLETED", label: "Completed" },
+      {
+        value: "ALL",
+        label: `All ${getTerminology(ContentTerms.Course, SystemTerms.Course)}s`,
+      },
+    ];
+    // Reader mode: drop the "All Courses" (browse/marketplace) tab — only the
+    // learner's own In-Progress / Completed courses remain (Apple 3.1.1).
+    return shouldHidePaidPurchaseUI()
+      ? base.filter((t) => t.value !== "ALL")
+      : base;
+  });
   const [allCourses, setAllCourses] = useState<CoursePackageResponse>({
     content: [],
     empty: false,
@@ -441,16 +449,22 @@ const CourseCatalougePage: React.FC = () => {
 
     getStudentDisplaySettings(false).then((settings) => {
       const tabs = settings?.allCourses?.tabs || [];
-      const ordered = tabs
+      const orderedRaw = tabs
         .filter((t) => t.visible !== false)
         .sort((a, b) => (a.order || 0) - (b.order || 0))
         .map((t) => ({
           value: mapSettingIdToValue(t.id),
           label: t.label,
         }));
+      // Reader mode: never surface the "All Courses" (browse) tab, regardless
+      // of admin display settings (Apple 3.1.1).
+      const ordered = shouldHidePaidPurchaseUI()
+        ? orderedRaw.filter((t) => t.value !== "ALL")
+        : orderedRaw;
       if (ordered.length) setVisibleTabs(ordered);
 
-      // Determine default tab from settings; ensure it's visible
+      // Determine default tab from settings; ensure it's visible (and never ALL
+      // in reader mode, which is excluded from `ordered` above).
       const defaultVal = mapSettingIdToValue(
         settings?.allCourses?.defaultTab || "InProgress"
       );

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-enrollment.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-enrollment.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getTerminology } from "@/components/common/layout-container/sidebar/utils";
 import { ContentTerms, RoleTerms, SystemTerms } from "@/types/naming-settings";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 // Static label for a session/level field — dropdowns are deprecated in favour of
 // navigating to the course from the catalog with a specific packageSessionId in the URL.
@@ -164,7 +165,9 @@ export const CourseEnrollment = ({
     selectedTab === "ALL" &&
     !!selectedSession &&
     !!selectedLevel &&
-    !isAlreadyEnrolledInCurrent;
+    !isAlreadyEnrolledInCurrent &&
+    // Reader mode: never surface an enroll/pay CTA (Apple 3.1.1).
+    !shouldHidePaidPurchaseUI();
   const hasAnythingToShow =
     showSessionField ||
     showLevelField ||
@@ -318,6 +321,7 @@ export const CourseEnrollment = ({
         {/* Inline Enroll card when sidebar is hidden */}
         {!hasRightSidebar &&
           selectedTab === "ALL" &&
+          !shouldHidePaidPurchaseUI() &&
           (() => {
             if (!selectedSession || !selectedLevel) return null;
             if (isAlreadyEnrolledInCurrent) return null;

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-sidebar.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   getTerminologyPlural,
 } from "@/components/common/layout-container/sidebar/utils";
 import { ContentTerms, RoleTerms, SystemTerms } from "@/types/naming-settings";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 import { CourseDetailsRatingsComponent } from "./course-details-ratings-page";
 import {
   formatTotalCourseDuration,
@@ -354,12 +355,15 @@ export const CourseSidebar = ({
             </div>
           )}
 
-          {/* Action Button — hidden entirely for learners already enrolled in this course */}
+          {/* Action Button — hidden entirely for learners already enrolled in
+              this course, and in reader mode (iOS / reader-mode institutes,
+              Apple 3.1.1). */}
           {selectedTab === "ALL" &&
             selectedSession &&
             selectedLevel &&
             !isEnrolledInCourse &&
-            !isAlreadyEnrolled && (
+            !isAlreadyEnrolled &&
+            !shouldHidePaidPurchaseUI() && (
               <div className="pt-2">
                 <Button
                   className={cn(

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/payment-dialogs/EnrollmentPaymentDialog.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/payment-dialogs/EnrollmentPaymentDialog.tsx
@@ -12,6 +12,7 @@ import { FreeEnrollmentConfirmationDialog } from "./FreeEnrollmentConfirmationDi
 import { EnhancedEnrollmentDialog } from "./EnhancedEnrollmentDialog";
 import { getTerminology } from "@/components/common/layout-container/sidebar/utils";
 import { ContentTerms, SystemTerms } from "@/types/naming-settings";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
 
 interface EnrollmentPaymentRouterProps {
   open: boolean;
@@ -104,6 +105,16 @@ export const EnrollmentPaymentDialog: React.FC<EnrollmentPaymentRouterProps> = (
   // Function to render the appropriate dialog based on payment type
   const renderPaymentDialog = () => {
     if (!paymentType) return null;
+
+    // Reader mode (iOS / reader-mode institutes): only the FREE path may
+    // render; every paid branch (donation / subscription / one-time) is hidden
+    // (Apple 3.1.1). Defense-in-depth — the enroll CTAs are already gated.
+    const normalizedType = paymentType.toLowerCase();
+    const isFreePlan =
+      normalizedType === "free" || normalizedType === "free_plan";
+    if (!isFreePlan && shouldHidePaidPurchaseUI()) {
+      return null;
+    }
 
     const commonProps = {
       packageSessionId,

--- a/frontend-learner-dashboard-app/src/utils/ios-iap-compliance.ts
+++ b/frontend-learner-dashboard-app/src/utils/ios-iap-compliance.ts
@@ -1,0 +1,30 @@
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * App-Store reader-app compliance gate (Apple Guideline 3.1.1 + 4.8).
+ *
+ * The native iOS app may not sell digital content through external payment
+ * gateways (3.1.1), nor offer third-party social login without Sign in with
+ * Apple (4.8). We comply by running iOS as a "reader app": every paid /
+ * commerce / membership surface and the Google/GitHub login options are hidden
+ * ON NATIVE iOS ONLY. Purchases happen on the web; the iOS app just unlocks
+ * already-owned content.
+ *
+ * This is a pure runtime check of the current platform — no institute setting,
+ * no remote flag, nothing to toggle later (a remotely re-enabled commerce/login
+ * surface after review is exactly what gets an app pulled under Guideline
+ * 2.3.1). Web, Android and desktop (Electron) are completely unaffected:
+ * pricing, checkout and social login all work there.
+ */
+
+/** True only on a native iOS device / simulator. */
+export const isIOSNative = (): boolean => Capacitor.getPlatform() === "ios";
+
+/**
+ * THE kill-switch. `true` ⇒ hide every paid / commerce / membership /
+ * access-period surface. Native iOS only; every other platform shows commerce.
+ */
+export const shouldHidePaidPurchaseUI = (): boolean => isIOSNative();
+
+/** Hook form of {@link shouldHidePaidPurchaseUI} for use inside components. */
+export const useHidePaidPurchaseUI = (): boolean => shouldHidePaidPurchaseUI();


### PR DESCRIPTION
… 5.1.2)

Hide all paid/commerce UI and Google/GitHub login on native iOS via a pure runtime isIOSNative() gate (no settings/toggle). Force in-app account deletion

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
