### PR TITLE
fix(ai-call): break CALL_AI <-> AiCallOutcomeProcessor bean cycle wit…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/CallAiNodeHandler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/CallAiNodeHandler.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import vacademy.io.admin_core_service.features.telephony.core.AiCallNodeDispatcher;
 import vacademy.io.admin_core_service.features.telephony.core.AiCallOutcomeProcessor;
@@ -46,10 +48,19 @@ public class CallAiNodeHandler implements NodeHandler {
 
     private final AiCallNodeDispatcher aiCallDispatcher;
     private final AiCallRetryPlanner retryPlanner;
-    private final AiCallOutcomeProcessor aiCallOutcomeProcessor;
     private final WorkflowExecutionStateRepository executionStateRepository;
     private final WorkflowExecutionRepository executionRepository;
     private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Field-injected with {@code @Lazy} to break an init-time bean cycle:
+     * CALL_AI → AiCallOutcomeProcessor → LeadStatusService → WorkflowTriggerService →
+     * WorkflowEngineService → NodeHandlerRegistry → CALL_AI. It's only used at runtime
+     * on the exhausted-retry handoff, so a lazily-resolved proxy is correct.
+     */
+    @Autowired
+    @Lazy
+    private AiCallOutcomeProcessor aiCallOutcomeProcessor;
 
     @Override
     public boolean supports(String nodeType) {


### PR DESCRIPTION
…h @Lazy

The #2 exhausted-retry handoff injected AiCallOutcomeProcessor into CallAiNodeHandler, creating an init-time cycle (CallAiNodeHandler is part of the engine graph via NodeHandlerRegistry, and AiCallOutcomeProcessor pulls the engine back in via LeadStatusService -> WorkflowTriggerService -> WorkflowEngineService). Context failed to start. Field-inject that one edge with @Lazy so it's resolved at runtime (only used on give-up), breaking the eager cycle. No behavior change.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
