### PR TITLE
fix(ai-call): V344 workflow_execution_state.id UUID->VARCHAR + fronte…

### DIFF
--- a/admin_core_service/src/main/resources/db/migration/V344__Fix_workflow_execution_state_id_type.sql
+++ b/admin_core_service/src/main/resources/db/migration/V344__Fix_workflow_execution_state_id_type.sql
@@ -1,0 +1,10 @@
+-- workflow_execution_state.id was created as UUID (V180) but the JPA entity maps it
+-- as a String (@UuidGenerator on a String field). Hibernate therefore binds a String
+-- UUID, and Postgres rejects it:
+--   ERROR: column "id" is of type uuid but expression is of type character varying
+-- This failed EVERY pausable-workflow insert (DELAY/APPROVAL, and now the CALL_AI
+-- retry loop), which rolled back the entire workflow execution — so no execution row,
+-- no pause, no AI call. Align the column to VARCHAR(255) to match the entity and the
+-- rest of the workflow schema (workflow_execution.id and execution_id are VARCHAR(255)).
+ALTER TABLE workflow_execution_state ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE workflow_execution_state ALTER COLUMN id TYPE VARCHAR(255) USING id::text;

--- a/frontend-admin-dashboard/src/components/shared/leads/use-ai-calling-settings.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/use-ai-calling-settings.ts
@@ -22,7 +22,8 @@ export function useAiCallButtonEnabled(): boolean {
                 url: GET_URL,
                 params: { instituteId, settingKey: SETTING_KEY },
             });
-            return Boolean(res.data?.data?.[SETTING_KEY]?.data?.showInLeadList);
+            // `/get` returns a SettingDto shape: { key, name, data }.
+            return Boolean(res.data?.data?.showInLeadList);
         },
         staleTime: 5 * 60 * 1000,
     });

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiCallingSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiCallingSettings.tsx
@@ -163,7 +163,9 @@ const fetchAiCallingSettings = async (): Promise<AiCallingSettingsData> => {
         url: GET_URL,
         params: { instituteId, settingKey: SETTING_KEY },
     });
-    const saved = response.data?.data?.[SETTING_KEY]?.data as
+    // `/get` returns a SettingDto shape: { key, name, data } — the saved settings
+    // live at response.data.data, NOT nested again under the settingKey.
+    const saved = response.data?.data as
         | (Partial<AiCallingSettingsData> & { windowStart?: string; windowEnd?: string })
         | undefined;
     if (!saved) return DEFAULT_AI_CALLING_SETTINGS;


### PR DESCRIPTION
…nd settings read

V344 (THE blocker): workflow_execution_state.id was created UUID (V180) but the JPA entity maps it as a String (@UuidGenerator on a String field). Every CALL_AI pause insert died with "column id is of type uuid but expression is of type character varying", rolling back the whole workflow execution -> no execution row, no AI call. Align the column to VARCHAR(255) like the rest of the workflow schema (workflow_execution.id and execution_id are already VARCHAR).

frontend: AI Calling settings + lead-list button read response.data.data (the /get SettingDto shape is { key, name, data }), not response.data.data[KEY].data. The two-levels-too-deep read always returned undefined, so the UI always showed defaults (disabled, blank campaign) regardless of the saved DB value -- and re-saving from that state could write the defaults back.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
