### PR TITLE
fix: invitation accept-link rendering as null in invite/resend/update emails

### DIFF
--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/InviteUserEmailBody.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/InviteUserEmailBody.java
@@ -1,13 +1,7 @@
 package vacademy.io.auth_service.feature.user.service;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
 
 public class InviteUserEmailBody {
-
-    @Value("${teacher.portal.client.url}:https://dash.vacademy.io")
-    private static String adminPortalClientUrl;
-
-    public static final String ADMIN_LOGIN_URL = adminPortalClientUrl + "/login";
 
     public static String createInviteUserEmail(
             String name,
@@ -97,7 +91,7 @@ public class InviteUserEmailBody {
             """.formatted(themeColor, name, username, password, rolesFormatted, adminLoginUrl,instituteName);
     }
 
-    public static String createReminderEmail(String name, String username, String password, List<String> roles) {
+    public static String createReminderEmail(String name, String username, String password, List<String> roles, String adminLoginUrl) {
         String rolesFormatted = String.join(", ", roles);
 
         return """
@@ -191,6 +185,6 @@ public class InviteUserEmailBody {
                     </div>
                 </body>
                 </html>
-                """.formatted(name, username, password, rolesFormatted, ADMIN_LOGIN_URL);
+                """.formatted(name, username, password, rolesFormatted, adminLoginUrl);
     }
 }

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/InviteUserService.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/InviteUserService.java
@@ -86,8 +86,8 @@ public class InviteUserService {
                 instituteName=instituteInfoDTO.getInstituteName();
             if(instituteInfoDTO.getInstituteThemeCode()!=null)
                 theme=instituteInfoDTO.getInstituteThemeCode();
-            if(instituteInfoDTO.getLearnerPortalUrl()!=null)
-                adminLoginUrl=instituteInfoDTO.getAdminPortalUrl();
+            if(StringUtils.hasText(instituteInfoDTO.getAdminPortalUrl()))
+                adminLoginUrl=normalizeUrl(instituteInfoDTO.getAdminPortalUrl());
         }
         GenericEmailRequest emailRequest = createEmailRequest(
                 userDTO.getEmail(), "Invitation Mail",
@@ -102,13 +102,24 @@ public class InviteUserService {
         if (user.getRoles() != null && !user.getRoles().isEmpty()) {
             instituteId = user.getRoles().iterator().next().getInstituteId();
         }
-        
+
+        String adminLoginUrl = "https://dash.vacademy.io";
+        if (StringUtils.hasText(instituteId)) {
+            InstituteInfoDTO instituteInfoDTO = instituteInternalService.getInstituteByInstituteId(instituteId);
+            if (instituteInfoDTO != null && StringUtils.hasText(instituteInfoDTO.getAdminPortalUrl()))
+                adminLoginUrl = normalizeUrl(instituteInfoDTO.getAdminPortalUrl());
+        }
+
         GenericEmailRequest emailRequest = createEmailRequest(
                 user.getEmail(), "Invitation Reminder Mail",
                 InviteUserEmailBody.createReminderEmail(
-                        user.getFullName(), user.getUsername(), user.getPassword(), getUserRoleNames(user))
+                        user.getFullName(), user.getUsername(), user.getPassword(), getUserRoleNames(user), adminLoginUrl)
         );
         notificationService.sendGenericHtmlMailViaUnified(emailRequest, instituteId);
+    }
+
+    private String normalizeUrl(String url) {
+        return url.startsWith("http") ? url : "https://" + url;
     }
 
     private ModifyUserRolesDTO createModifyRolesDTO(String userId, String instituteId, List<String> roles) {


### PR DESCRIPTION
## Summary of Changes

Fixes the "Accept Invitation" button in team/role invitation emails resolving to a broken `null` link (DNS NXDOMAIN). When a user is invited to a team with a role (e.g. COUNSELLOR), the email's login URL was computed incorrectly and rendered as the literal string `null`.

Root cause: in `InviteUserService.sendInvitationEmail`, the null-guard checked `learnerPortalUrl` but assigned `adminPortalUrl`. For institutes that have a learner portal URL set but a null admin portal URL (the common case — `admin_portal_base_url` is a nullable column and Hibernate bypasses its DB default), the guard passed and overwrote the safe default with `null`. That `null` was then formatted into the email's `href`.

A second, independent bug is also fixed: the resend/update invitation emails used a `static @Value` field (`ADMIN_LOGIN_URL`), which Spring cannot inject — so it was always `null`, producing a permanent `null/login` link for every resend/update.

**Backend:**
- `InviteUserService.sendInvitationEmail`: guard now checks `adminPortalUrl` (the field actually used) via `StringUtils.hasText`; falls back to `https://dash.vacademy.io` when unset.
- Added `normalizeUrl` helper that prepends `https://` to schemeless portal URLs (DB column default and some stored values have no scheme), preventing relative/broken links.
- `InviteUserService.sendReminderEmail`: now resolves the institute's admin portal URL (same logic + fallback) and passes it into the reminder template.
- `InviteUserEmailBody`: removed the broken `static @Value adminPortalClientUrl` and `ADMIN_LOGIN_URL` constant; `createReminderEmail` now accepts an `adminLoginUrl` parameter.

**Frontend:**
- None.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Invited a user to a team with the COUNSELLOR role against a local auth_service; confirmed the "Accept Invitation" email link now renders a valid URL (`https://dash.vacademy.io` for an institute with no admin portal URL) instead of `null`.
- Verified institutes with an explicit admin portal URL get that branded URL, scheme-normalized.
- Verified resend/update invitation emails now produce a valid login link instead of `null/login`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
