### PR TITLE
fix(call-log): KPI strip survives a worklist-chip query failure

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallSearchService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallSearchService.java
@@ -203,22 +203,31 @@ public class CallSearchService {
         return m;
     }
 
-    /** COUNT(*) for one worklist chip over scope + date window only (ignores the table's other filters). */
+    /**
+     * COUNT(*) for one worklist chip over scope + date window only (ignores the table's other filters).
+     * Best-effort: a chip-query failure must never blank the whole KPI strip — the headline counts are
+     * the primary value, the chip badges are secondary. Returns 0 on error (logged).
+     */
     private long chipCount(CallSearchFilterDTO src, ZoneId tz, LeadReportSettingService.ReportSettings settings,
                            String scopeCsv, boolean missed, boolean callbacks) {
-        CallSearchFilterDTO chip = new CallSearchFilterDTO();
-        chip.setInstituteId(src.getInstituteId());
-        chip.setFromDate(src.getFromDate());
-        chip.setToDate(src.getToDate());
-        chip.setMissedInbound(missed);
-        chip.setCallbacksDue(callbacks);
-        MapSqlParameterSource p = new MapSqlParameterSource();
-        String where = buildWhere(chip, tz, settings, scopeCsv, p, true);
-        Long c = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM telephony_call_log tcl " + AI_LATERAL +
-                        " LEFT JOIN audience_response ar ON ar.id = tcl.response_id " + where,
-                p, Long.class);
-        return c == null ? 0 : c;
+        try {
+            CallSearchFilterDTO chip = new CallSearchFilterDTO();
+            chip.setInstituteId(src.getInstituteId());
+            chip.setFromDate(src.getFromDate());
+            chip.setToDate(src.getToDate());
+            chip.setMissedInbound(missed);
+            chip.setCallbacksDue(callbacks);
+            MapSqlParameterSource p = new MapSqlParameterSource();
+            String where = buildWhere(chip, tz, settings, scopeCsv, p, true);
+            Long c = jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM telephony_call_log tcl " + AI_LATERAL +
+                            " LEFT JOIN audience_response ar ON ar.id = tcl.response_id " + where,
+                    p, Long.class);
+            return c == null ? 0 : c;
+        } catch (Exception e) {
+            log.warn("[CallSearch] chip count failed (missed={}, callbacks={}): {}", missed, callbacks, e.getMessage());
+            return 0;
+        }
     }
 
     private static final String ROW_SELECT = """


### PR DESCRIPTION
Wrap each missed-inbound / callbacks-due chip count in try/catch (log + return 0) so a chip-query error no longer 500s the whole /metrics call and blanks every KPI card. Headline counts (total/connected/talk-time/unique-leads/AI-vs-human) are the primary value and now render even if a chip badge can't be computed.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
