### PR TITLE
fix(reports): send snake_case body for custom report run

### DIFF
--- a/frontend-admin-dashboard/src/routes/audience-manager/reports/-services/get-custom-report.ts
+++ b/frontend-admin-dashboard/src/routes/audience-manager/reports/-services/get-custom-report.ts
@@ -90,7 +90,23 @@ export interface CustomReportResult {
 }
 
 export async function runCustomReport(req: CustomReportRunRequest): Promise<CustomReportResult> {
-    const { data } = await authenticatedAxiosInstance.post(RUN_URL, req);
+    // The backend DTO (CustomReportRequest) is @JsonNaming(SnakeCaseStrategy), so the
+    // body MUST be snake_case — posting camelCase leaves institute_id null and the
+    // server rejects with "instituteId is required". (filters' field/values and sort's
+    // field/dir are single words, already snake-compatible.)
+    const body = {
+        institute_id: req.instituteId,
+        from_date: req.fromDate,
+        to_date: req.toDate,
+        team_id: req.teamId,
+        counsellor_user_id: req.counsellorUserId,
+        dimensions: req.dimensions,
+        measures: req.measures,
+        filters: req.filters,
+        sort: req.sort,
+        limit: req.limit,
+    };
+    const { data } = await authenticatedAxiosInstance.post(RUN_URL, body);
     return {
         columns: Array.isArray(data?.columns) ? data.columns : [],
         rows: Array.isArray(data?.rows) ? data.rows : [],


### PR DESCRIPTION
The /reports/custom/run DTO is @JsonNaming(SnakeCaseStrategy), so posting the raw camelCase spec left institute_id null and the server rejected the run with "instituteId is required". Map the body to snake_case (institute_id, from_date, to_date, team_id, counsellor_user_id) before POSTing.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
