### PR TITLE
fixed(phonepay) : payment gateway

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/PhonePePaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/PhonePePaymentManager.java
@@ -7,7 +7,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.exceptions.VacademyException;
@@ -18,9 +21,11 @@ import vacademy.io.common.payment.enums.PaymentStatusEnum;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class PhonePePaymentManager implements PaymentServiceStrategy {
@@ -28,6 +33,22 @@ public class PhonePePaymentManager implements PaymentServiceStrategy {
     private static final Logger logger = LoggerFactory.getLogger(PhonePePaymentManager.class);
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
+
+    /**
+     * V2 OAuth access tokens are reusable until they expire, so cache them per
+     * client id to avoid a token round-trip on every payment/status call.
+     */
+    private final Map<String, CachedToken> tokenCache = new ConcurrentHashMap<>();
+
+    private static final class CachedToken {
+        final String token;
+        final long expiresAtEpochSec;
+
+        CachedToken(String token, long expiresAtEpochSec) {
+            this.token = token;
+            this.expiresAtEpochSec = expiresAtEpochSec;
+        }
+    }
 
     public PhonePePaymentManager(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.build();
@@ -40,6 +61,14 @@ public class PhonePePaymentManager implements PaymentServiceStrategy {
         logger.info("Initiating PhonePe Standard Checkout payment for order: {}", request.getOrderId());
 
         try {
+            // Route to the OAuth-based V2 flow when the institute is onboarded on V2
+            // (client_id + client_secret + client_version). A configured
+            // "clientVersion" is the discriminator; without it we fall back to the
+            // legacy V1 salt-key / X-VERIFY flow below for older merchants.
+            if (StringUtils.hasText((String) paymentGatewaySpecificData.get("clientVersion"))) {
+                return initiatePaymentV2(user, request, paymentGatewaySpecificData);
+            }
+
             // Extract Credentials
             String merchantId = (String) paymentGatewaySpecificData.get("clientId");
             String saltKey = (String) paymentGatewaySpecificData.get("clientSecret");
@@ -122,6 +151,13 @@ public class PhonePePaymentManager implements PaymentServiceStrategy {
         PhonePeRequestDTO phonePeRequest = request.getPhonePeRequest();
         String redirectUrl = phonePeRequest != null ? phonePeRequest.getRedirectUrl() : "";
 
+        // PhonePe sends the learner back to this redirectUrl after the hosted
+        // checkout. The frontend result page needs the order id (= merchant
+        // transaction id = payment log id) and the institute id to poll status
+        // and complete the enrollment, so stamp them onto the URL here — the
+        // frontend can't know the server-generated order id at request time.
+        redirectUrl = appendReturnParams(redirectUrl, request.getOrderId(), request.getInstituteId());
+
         // CRITICAL FIX: callbackUrl must be the BACKEND webhook endpoint, not frontend
         // URL
         // PhonePe will POST to this URL when payment completes/fails
@@ -145,6 +181,228 @@ public class PhonePePaymentManager implements PaymentServiceStrategy {
                         .type("PAY_PAGE")
                         .build())
                 .build();
+    }
+
+    /**
+     * Appends {@code orderId} and {@code instituteId} to the frontend redirect
+     * URL so the payment-result page can resolve and poll the right order after
+     * PhonePe redirects the learner back. Preserves any existing query string
+     * and skips params that are already present or missing.
+     */
+    private String appendReturnParams(String redirectUrl, String orderId, String instituteId) {
+        if (!StringUtils.hasText(redirectUrl)) {
+            return redirectUrl;
+        }
+        StringBuilder url = new StringBuilder(redirectUrl);
+        if (StringUtils.hasText(orderId) && !redirectUrl.contains("orderId=")) {
+            url.append(redirectUrl.contains("?") ? '&' : '?').append("orderId=").append(orderId);
+        }
+        if (StringUtils.hasText(instituteId) && !redirectUrl.contains("instituteId=")) {
+            url.append(url.indexOf("?") >= 0 ? '&' : '?').append("instituteId=").append(instituteId);
+        }
+        return url.toString();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // V2 (OAuth-based Standard Checkout)
+    // Docs: https://developer.phonepe.com/payment-gateway/website-integration/standard-checkout
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * V2 payment initiation. Fetches an OAuth token, calls
+     * {@code POST {payBase}/checkout/v2/pay} with an {@code O-Bearer} header and
+     * returns the hosted {@code redirectUrl}. The learner is redirected there;
+     * the payment-result page + the dashboard-configured webhook drive
+     * completion (identical to the V1 flow from the caller's perspective).
+     */
+    private PaymentResponseDTO initiatePaymentV2(UserDTO user, PaymentInitiationRequestDTO request,
+            Map<String, Object> data) {
+        String payBaseUrl = resolvePayBaseUrl(data);
+        if (!StringUtils.hasText(payBaseUrl)) {
+            throw new VacademyException("PhonePe API Base URL is missing.");
+        }
+
+        String token = getAccessToken(data);
+        long amountInPaise = CurrencyRegistry.toMinorUnits(request.getAmount(), request.getCurrency());
+
+        PhonePeRequestDTO phonePeRequest = request.getPhonePeRequest();
+        String redirectUrl = phonePeRequest != null ? phonePeRequest.getRedirectUrl() : "";
+        redirectUrl = appendReturnParams(redirectUrl, request.getOrderId(), request.getInstituteId());
+
+        Map<String, Object> merchantUrls = new HashMap<>();
+        merchantUrls.put("redirectUrl", redirectUrl);
+
+        Map<String, Object> paymentFlow = new HashMap<>();
+        paymentFlow.put("type", "PG_CHECKOUT");
+        paymentFlow.put("merchantUrls", merchantUrls);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("merchantOrderId", request.getOrderId());
+        body.put("amount", amountInPaise);
+        body.put("expireAfter", 1200);
+        body.put("paymentFlow", paymentFlow);
+        // V2 webhooks carry no query string, so stash the instituteId in metaInfo
+        // (udf1) — PhonePeWebHookService resolves it from there.
+        if (StringUtils.hasText(request.getInstituteId())) {
+            Map<String, Object> metaInfo = new HashMap<>();
+            metaInfo.put("udf1", request.getInstituteId());
+            body.put("metaInfo", metaInfo);
+        }
+
+        String url = payBaseUrl + "/checkout/v2/pay";
+        logger.info("Calling PhonePe V2 pay API: {}", url);
+
+        Map<String, Object> response = webClient.post()
+                .uri(url)
+                .header("Authorization", "O-Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+
+        Object hostedUrl = response != null ? response.get("redirectUrl") : null;
+        if (hostedUrl == null) {
+            String state = response != null ? String.valueOf(response.get("state")) : "no response";
+            logger.error("PhonePe V2 payment initiation returned no redirectUrl (state={})", state);
+            throw new VacademyException("PhonePe payment initiation failed: no redirect URL returned.");
+        }
+
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("phonePeOrderId", response.get("orderId"));
+        responseData.put("redirectUrl", hostedUrl);
+        responseData.put("status", response.get("state"));
+
+        PaymentResponseDTO dto = new PaymentResponseDTO();
+        dto.setOrderId(request.getOrderId());
+        dto.setResponseData(responseData);
+        dto.setMessage("Payment Initiated");
+        return dto;
+    }
+
+    /**
+     * V2 status check: {@code GET {payBase}/checkout/v2/order/{merchantOrderId}/status}
+     * with an {@code O-Bearer} header. Returns the PhonePe order state
+     * (COMPLETED / FAILED / PENDING). Never throws — returns a FAILED-state DTO on
+     * error so the caller (PaymentService) can proceed without NPEs.
+     */
+    private PhonePeStatusResponseDTO checkPaymentStatusV2(String merchantOrderId, Map<String, Object> data) {
+        try {
+            String payBaseUrl = resolvePayBaseUrl(data);
+            if (!StringUtils.hasText(payBaseUrl)) {
+                throw new VacademyException("PhonePe API Base URL is missing.");
+            }
+            String token = getAccessToken(data);
+            String url = payBaseUrl + "/checkout/v2/order/" + merchantOrderId + "/status";
+            logger.info("Calling PhonePe V2 status API: {}", url);
+
+            PhonePeStatusResponseDTO status = webClient.get()
+                    .uri(url)
+                    .header("Authorization", "O-Bearer " + token)
+                    .retrieve()
+                    .bodyToMono(PhonePeStatusResponseDTO.class)
+                    .block();
+
+            if (status != null && StringUtils.hasText(status.getState())) {
+                if (!StringUtils.hasText(status.getMerchantOrderId())) {
+                    status.setMerchantOrderId(merchantOrderId);
+                }
+                return status;
+            }
+            logger.error("PhonePe V2 status check returned empty state for order {}", merchantOrderId);
+            return PhonePeStatusResponseDTO.builder().state("FAILED").merchantOrderId(merchantOrderId).build();
+        } catch (Exception e) {
+            logger.error("Error checking PhonePe V2 payment status for order {}", merchantOrderId, e);
+            return PhonePeStatusResponseDTO.builder().state("FAILED").merchantOrderId(merchantOrderId).build();
+        }
+    }
+
+    /**
+     * Returns a valid V2 OAuth access token, fetching and caching a new one when
+     * the cached token is absent or within 60s of expiry.
+     */
+    private String getAccessToken(Map<String, Object> data) {
+        String clientId = trimToNull((String) data.get("clientId"));
+        String clientSecret = trimToNull((String) data.get("clientSecret"));
+        String clientVersion = trimToNull((String) data.get("clientVersion"));
+
+        if (clientId == null || clientSecret == null || clientVersion == null) {
+            throw new VacademyException("PhonePe V2 requires Client ID, Client Secret and Client Version.");
+        }
+
+        long now = Instant.now().getEpochSecond();
+        CachedToken cached = tokenCache.get(clientId);
+        if (cached != null && cached.expiresAtEpochSec - 60 > now) {
+            return cached.token;
+        }
+
+        String oauthUrl = resolveOAuthUrl(data);
+        if (!StringUtils.hasText(oauthUrl)) {
+            throw new VacademyException("PhonePe OAuth token URL could not be resolved. Set the API Base URL.");
+        }
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("client_id", clientId);
+        form.add("client_version", clientVersion);
+        form.add("client_secret", clientSecret);
+        form.add("grant_type", "client_credentials");
+
+        Map<String, Object> tokenResponse = webClient.post()
+                .uri(oauthUrl)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(form))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+
+        Object accessToken = tokenResponse != null ? tokenResponse.get("access_token") : null;
+        if (accessToken == null) {
+            throw new VacademyException("Failed to obtain PhonePe access token.");
+        }
+
+        Object expiresAt = tokenResponse.get("expires_at");
+        long expiresAtEpochSec = (expiresAt instanceof Number) ? ((Number) expiresAt).longValue() : now + 1200;
+        tokenCache.put(clientId, new CachedToken(String.valueOf(accessToken), expiresAtEpochSec));
+        return String.valueOf(accessToken);
+    }
+
+    /** Base URL for the V2 pay/status APIs (falls back to legacy config keys). */
+    private String resolvePayBaseUrl(Map<String, Object> data) {
+        String baseUrl = (String) data.get("baseUrl");
+        if (!StringUtils.hasText(baseUrl)) {
+            baseUrl = (String) data.getOrDefault("payBaseUrl", data.get("authBaseUrl"));
+        }
+        return baseUrl != null ? baseUrl.trim().replaceAll("/+$", "") : null;
+    }
+
+    /**
+     * Resolves the OAuth token endpoint. Honours an explicit {@code oauthUrl}
+     * override, otherwise derives it: sandbox tokens live under the same
+     * pg-sandbox base, production tokens under the identity-manager host.
+     */
+    private String resolveOAuthUrl(Map<String, Object> data) {
+        String explicit = trimToNull((String) data.get("oauthUrl"));
+        if (explicit != null) {
+            return explicit;
+        }
+        String payBaseUrl = resolvePayBaseUrl(data);
+        if (payBaseUrl == null) {
+            return null;
+        }
+        if (payBaseUrl.contains("preprod") || payBaseUrl.contains("sandbox")) {
+            return payBaseUrl + "/v1/oauth/token";
+        }
+        return "https://api.phonepe.com/apis/identity-manager/v1/oauth/token";
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     /**
@@ -249,6 +507,11 @@ public class PhonePePaymentManager implements PaymentServiceStrategy {
     public PhonePeStatusResponseDTO checkPaymentStatus(String merchantTransactionId,
             Map<String, Object> paymentGatewaySpecificData) {
         logger.info("Checking PhonePe payment status for transaction: {}", merchantTransactionId);
+
+        // V2 (OAuth) institutes use the /checkout/v2/order/{id}/status endpoint.
+        if (StringUtils.hasText((String) paymentGatewaySpecificData.get("clientVersion"))) {
+            return checkPaymentStatusV2(merchantTransactionId, paymentGatewaySpecificData);
+        }
 
         try {
             String merchantId = (String) paymentGatewaySpecificData.get("clientId");

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/PhonePeWebHookService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/PhonePeWebHookService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.institute.service.InstitutePaymentGatewayMappingService;
 import vacademy.io.admin_core_service.features.payments.enums.WebHookStatus;
 import vacademy.io.admin_core_service.features.payments.util.WebHookErrorUtils;
@@ -42,12 +43,9 @@ public class PhonePeWebHookService {
             // descriptive message)
             webhookId = webHookService.saveWebhook(PaymentGateway.PHONEPE.name(), payload, null);
 
-            // Step 4: Verify Authorization (skip for now as PhonePe doesn't send auth
-            // header in standard flow). For production, implement proper signature check.
-            log.debug(
-                    "Skipping auth verification for PhonePe webhook (implement signature verification for production)");
-
-            return processVerifiedPayload(webhookId, payload, instituteIdParam);
+            // Step 4: Signature verification happens inside processVerifiedPayload,
+            // once the instituteId (and thus the webhook credentials) is resolved.
+            return processVerifiedPayload(webhookId, payload, authHeader, instituteIdParam, true);
 
         } catch (Exception e) {
             String detailedMessage = WebHookErrorUtils.describeException(e);
@@ -88,8 +86,9 @@ public class PhonePeWebHookService {
         webHookService.resetForReprocess(webhookId);
 
         try {
-            // instituteIdParam is null on reprocess — service will fall back to metaInfo.udf1
-            return processVerifiedPayload(webhookId, payload, null);
+            // instituteIdParam is null on reprocess — service will fall back to metaInfo.udf1.
+            // Signature was already verified on first delivery, so skip it on reprocess.
+            return processVerifiedPayload(webhookId, payload, null, null, false);
         } catch (Exception e) {
             String detailedMessage = WebHookErrorUtils.describeException(e);
             log.error("Manual reprocess failed for PhonePe webhookId={}: {}", webhookId, detailedMessage, e);
@@ -99,11 +98,13 @@ public class PhonePeWebHookService {
     }
 
     /**
-     * Steps 1, 3, 5, 6 of the pipeline — payload parse, instituteId resolution,
-     * event handling, and webhook-row finalization. Shared between live webhook
-     * delivery (after no-op auth check) and manual reprocess.
+     * Steps 1, 3, 4, 5, 6 of the pipeline — payload parse, instituteId resolution,
+     * signature verification, event handling, and webhook-row finalization. Shared
+     * between live webhook delivery ({@code verifySignature=true}) and manual
+     * reprocess ({@code verifySignature=false}).
      */
-    private ResponseEntity<String> processVerifiedPayload(String webhookId, String payload, String instituteIdParam)
+    private ResponseEntity<String> processVerifiedPayload(String webhookId, String payload, String authHeader,
+            String instituteIdParam, boolean verifySignature)
             throws Exception {
         // Step 1: Parse payload
         PhonePeWebHookDTO webhookDTO = objectMapper.readValue(payload, PhonePeWebHookDTO.class);
@@ -124,6 +125,15 @@ public class PhonePeWebHookService {
             log.error("Webhook missing instituteId. Cannot process payment update.");
             webHookService.updateWebHookStatus(webhookId, WebHookStatus.FAILED, "Missing instituteId");
             return ResponseEntity.status(400).body("Missing instituteId");
+        }
+
+        // Step 4: Verify the SHA256(username:password) signature PhonePe sends in
+        // the Authorization header — but only when webhook credentials have been
+        // configured for this institute (opt-in). If none are set we skip, so
+        // existing setups without credentials keep working unchanged.
+        if (verifySignature && !isSignatureAcceptable(authHeader, instituteId)) {
+            webHookService.updateWebHookStatus(webhookId, WebHookStatus.FAILED, "Signature verification failed");
+            return ResponseEntity.status(401).body("Invalid webhook signature");
         }
 
         log.info("Processing PhonePe webhook for instituteId: {}, orderId: {} (webhookId={})", instituteId,
@@ -160,35 +170,49 @@ public class PhonePeWebHookService {
         }
     }
 
-    private boolean verifyAuth(String authHeader, String instituteId) {
-        if (authHeader == null || instituteId == null)
-            return false;
-
+    /**
+     * Validates the PhonePe webhook Authorization header, which is
+     * {@code SHA256(username:password)} (hex) of the credentials configured on
+     * both the PhonePe dashboard and our gateway mapping.
+     *
+     * <p>Opt-in: if no webhook credentials are configured for the institute we
+     * return {@code true} (skip), preserving behaviour for setups that haven't
+     * set them yet. When credentials ARE configured, a missing or mismatched
+     * header is rejected.
+     */
+    private boolean isSignatureAcceptable(String authHeader, String instituteId) {
         try {
-            // Get credentials for this institute
             Map<String, Object> gatewayData = institutePaymentGatewayMappingService
                     .findInstitutePaymentGatewaySpecifData(PaymentGateway.PHONEPE.name(), instituteId);
-            String username = (String) gatewayData.get("webhookUsername");
-            String password = (String) gatewayData.get("webhookPassword");
+            String username = gatewayData != null ? (String) gatewayData.get("webhookUsername") : null;
+            String password = gatewayData != null ? (String) gatewayData.get("webhookPassword") : null;
 
-            if (username == null || password == null) {
-                log.error("PhonePe webhook credentials missing for institute: {}", instituteId);
+            if (!StringUtils.hasText(username) || !StringUtils.hasText(password)) {
+                log.warn("No PhonePe webhook credentials configured for institute {} — skipping signature verification",
+                        instituteId);
+                return true;
+            }
+
+            if (!StringUtils.hasText(authHeader)) {
+                log.error("PhonePe webhook missing Authorization header but credentials are configured for institute {}",
+                        instituteId);
                 return false;
             }
 
             String input = username + ":" + password;
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] encodedhash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-
             String expectedAuth = bytesToHex(encodedhash);
 
-            // Per doc: Authorization: SHA256(username:password)
-            // Note: The doc says SHA256, but doesn't specify if it's hex or base64.
-            // Usually it's hex for SHA256 headers like this.
-            return authHeader.equalsIgnoreCase(expectedAuth);
+            // Per docs: Authorization: SHA256(username:password), hex-encoded.
+            boolean matches = authHeader.trim().equalsIgnoreCase(expectedAuth);
+            if (!matches) {
+                log.error("PhonePe webhook signature mismatch for institute {}", instituteId);
+            }
+            return matches;
 
         } catch (Exception e) {
-            log.error("Error verifying PhonePe webhook auth", e);
+            log.error("Error verifying PhonePe webhook signature for institute {}", instituteId, e);
             return false;
         }
     }

--- a/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
@@ -75,6 +75,11 @@ interface VendorSchema {
     label: string;
     description: string;
     docsUrl?: string;
+    /**
+     * Optional ordered "where to find your keys" walkthrough shown above the
+     * fields. Use for gateways whose credentials are buried in a dashboard.
+     */
+    setupSteps?: string[];
     fields: VendorFieldSchema[];
     /**
      * Returns the webhook URL the admin must paste into the vendor's dashboard.
@@ -154,31 +159,56 @@ const VENDOR_SCHEMAS: VendorSchema[] = [
     {
         vendor: 'PHONEPE',
         label: 'PhonePe',
-        description: 'PhonePe PG for Indian merchants.',
+        description: 'PhonePe PG for Indian merchants (UPI, cards, wallets). V2 (OAuth) Standard Checkout. Settles in INR only.',
+        docsUrl: 'https://business.phonepe.com/',
+        setupSteps: [
+            'Sign in to the PhonePe Business dashboard (business.phonepe.com) with your PhonePe for Business merchant login.',
+            'Go to Developer Settings → API Keys. New (V2) merchants see a Client ID, Client Secret and Client Version — copy all three into the fields below.',
+            'Legacy merchants only: if you were instead given a Salt Key + Salt Index, put your Merchant ID in “Client ID”, your Salt Key (as KEY###INDEX) in “Client Secret”, and LEAVE “Client Version” blank.',
+            'Set “API Base URL”: V2 LIVE = https://api.phonepe.com/apis/pg, V2 UAT/Sandbox = https://api-preprod.phonepe.com/apis/pg-sandbox (legacy V1 = https://api.phonepe.com/apis/hermes).',
+            'Under Developer Settings → Webhooks, add the Webhook URL shown below and set a username + password. Enter the same username/password below to secure incoming callbacks.',
+        ],
         fields: [
             {
                 key: 'clientId',
-                label: 'Merchant ID',
-                placeholder: 'PGTEST… or your live merchant id',
+                label: 'Client ID',
+                placeholder: 'V2 Client ID (or legacy Merchant ID)',
                 required: true,
+                helper: 'V2: Client ID from Developer Settings → API Keys. Legacy V1 merchants: your Merchant ID (MID).',
             },
             {
                 key: 'clientSecret',
-                label: 'Salt Key',
-                placeholder: 'Your salt key',
+                label: 'Client Secret',
+                placeholder: 'V2 Client Secret (or legacy Salt Key###index)',
                 secret: true,
                 required: true,
+                helper: 'V2: your Client Secret. Legacy V1 merchants: your Salt Key, pasted as KEY###INDEX (index usually 1). Kept secret.',
+            },
+            {
+                key: 'clientVersion',
+                label: 'Client Version',
+                placeholder: 'e.g. 1',
+                helper: 'V2 only — the Client Version from the dashboard (usually 1). LEAVE BLANK if you are a legacy merchant using a Salt Key.',
             },
             {
                 key: 'baseUrl',
                 label: 'API Base URL',
-                placeholder: 'https://api.phonepe.com/apis/hermes',
+                placeholder: 'https://api.phonepe.com/apis/pg',
                 required: true,
+                helper: 'V2 LIVE: https://api.phonepe.com/apis/pg • V2 UAT: https://api-preprod.phonepe.com/apis/pg-sandbox • Legacy V1: https://api.phonepe.com/apis/hermes',
             },
             {
-                key: 'payBaseUrl',
-                label: 'Pay Base URL',
-                placeholder: 'https://api.phonepe.com/apis/pg-sandbox',
+                key: 'webhookUsername',
+                label: 'Webhook Username (optional)',
+                placeholder: 'Same username you set on PhonePe → Webhooks',
+                helper: 'Enables signature verification of incoming callbacks. Must match the username configured on the PhonePe dashboard.',
+            },
+            {
+                key: 'webhookPassword',
+                label: 'Webhook Password (optional)',
+                placeholder: 'Same password you set on PhonePe → Webhooks',
+                secret: true,
+                helper: 'Must match the password configured on the PhonePe dashboard. Leave both webhook fields blank to skip verification.',
             },
         ],
         webhookUrl: (instituteId) =>
@@ -420,7 +450,7 @@ const GatewayDialog = ({
 
     return (
         <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-            <DialogContent className="max-h-screen overflow-y-auto sm:max-w-2xl">
+            <DialogContent className="max-h-screen w-full overflow-y-auto sm:max-w-3xl">
                 <DialogHeader>
                     <DialogTitle>
                         {mode === 'create' ? 'Add payment gateway' : `Edit ${schema?.label ?? ''}`}
@@ -485,6 +515,22 @@ const GatewayDialog = ({
                                 .
                             </AlertDescription>
                         </Alert>
+                    )}
+
+                    {/* Where-to-find-your-keys walkthrough */}
+                    {schema?.setupSteps && schema.setupSteps.length > 0 && (
+                        <div className="space-y-2 rounded-md border border-slate-200 bg-slate-50 p-3">
+                            <Label className="text-caption font-medium text-slate-600">
+                                Where to find these values
+                            </Label>
+                            <ol className="ml-4 list-decimal space-y-1.5 text-caption leading-relaxed text-slate-600">
+                                {schema.setupSteps.map((step, i) => (
+                                    <li key={i} className="pl-1">
+                                        {step}
+                                    </li>
+                                ))}
+                            </ol>
+                        </div>
                     )}
 
                     {/* Webhook URL — paste into the vendor's webhooks page */}

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/payment-info-step.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/payment-info-step.tsx
@@ -303,10 +303,38 @@ const PaymentInfoStep = ({
         />
       )}
 
+      {vendor === "PHONEPE" && (
+        <div className="w-full max-w-md mx-auto">
+          <div className="bg-white rounded-md border border-gray-200 p-6 text-center">
+            <h2 className="text-xl font-bold text-gray-800 mb-2">
+              Pay with PhonePe
+            </h2>
+            <p className="text-gray-600 mb-4">
+              You'll be securely redirected to PhonePe to complete your payment
+              {typeof amount === "number" && amount > 0
+                ? ` of ${currency || "INR"} ${amount}`
+                : ""}
+              . After paying, you'll be brought back here automatically.
+            </p>
+            <p className="text-sm text-gray-500">
+              Click <span className="font-semibold">Confirm &amp; Pay</span>{" "}
+              below to continue.
+            </p>
+            {error && (
+              <div className="mt-5 p-4 bg-red-50 border border-red-200 rounded-lg text-left">
+                <strong className="text-red-800">Error</strong>
+                <p className="text-red-700 text-sm mt-1">{error}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {vendor !== "STRIPE" &&
         vendor !== "EWAY" &&
         vendor !== "RAZORPAY" &&
-        vendor !== "CASHFREE" && (
+        vendor !== "CASHFREE" &&
+        vendor !== "PHONEPE" && (
         <div className="w-full max-w-md mx-auto">
           <div className="bg-yellow-50 border border-yellow-200 rounded-md p-6 text-center">
             <h2 className="text-xl font-bold text-yellow-800 mb-2">

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-services/enroll-invite-services.ts
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-services/enroll-invite-services.ts
@@ -138,8 +138,11 @@ interface EnrollLearnerForPaymentProps {
     razorpay_order_id: string;
     razorpay_signature: string;
   };
-  // Payment vendor (STRIPE, EWAY, RAZORPAY, or CASHFREE)
-  paymentVendor?: "STRIPE" | "EWAY" | "RAZORPAY" | "CASHFREE";
+  // Payment vendor (STRIPE, EWAY, RAZORPAY, CASHFREE, or PHONEPE)
+  paymentVendor?: "STRIPE" | "EWAY" | "RAZORPAY" | "CASHFREE" | "PHONEPE";
+  // PhonePe redirect (return) URL — where PhonePe sends the learner back after
+  // the hosted checkout. The backend stamps orderId + instituteId onto it.
+  phonePeRedirectUrl?: string;
   // Flag to indicate if using institute custom fields (don't exclude from custom_field_values)
   isUsingInstituteCustomFields?: boolean;
   // Optional User ID from form-submit step
@@ -408,6 +411,7 @@ export const handleEnrollLearnerForPayment = async ({
   ewayPaymentData,
   razorpayPaymentData,
   paymentVendor = "STRIPE",
+  phonePeRedirectUrl,
   isUsingInstituteCustomFields = false,
   userId,
   couponCode,
@@ -477,6 +481,17 @@ export const handleEnrollLearnerForPayment = async ({
       }
       : {};
 
+  // For PhonePe: redirect (Standard Checkout) flow. redirect_url is where PhonePe
+  // sends the learner back; the backend stamps orderId + instituteId onto it.
+  const phonepe_request =
+    paymentVendor === "PHONEPE"
+      ? {
+        contact: phoneNumber,
+        email: email,
+        redirect_url: phonePeRedirectUrl || "",
+      }
+      : {};
+
   const convertedData = {
     user: {
       email: email,
@@ -532,6 +547,7 @@ export const handleEnrollLearnerForPayment = async ({
         stripe_request,
         razorpay_request,
         cashfree_request,
+        phonepe_request,
         pay_pal_request: {},
         eway_request,
         include_pending_items: true,

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/payment-vendor-helper.ts
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/payment-vendor-helper.ts
@@ -1,5 +1,12 @@
 // Payment vendor types
-export type PaymentVendor = "STRIPE" | "EWAY" | "RAZORPAY" | "PAYPAL" | "CASHFREE" | "FREE";
+export type PaymentVendor =
+  | "STRIPE"
+  | "EWAY"
+  | "RAZORPAY"
+  | "PAYPAL"
+  | "CASHFREE"
+  | "PHONEPE"
+  | "FREE";
 
 interface InviteDataWithPayment {
   vendor: PaymentVendor | null;

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -43,6 +43,7 @@ import {
   getCashfreeReturnUrl,
 } from "@/services/cashfree-payment";
 import { load as loadCashfree } from "@cashfreepayments/cashfree-js";
+import { getPhonePeReturnUrl } from "@/services/phonepe-payment";
 import { getTokenFromStorage } from "@/lib/auth/sessionUtility";
 import { TokenKey } from "@/constants/auth/tokens";
 
@@ -1573,6 +1574,120 @@ const EnrollByInvite = ({
         }
         console.error(err);
       } finally {
+        setLoading(false);
+      }
+      return;
+    }
+
+    // For PHONEPE payments — Standard Checkout full-page redirect flow.
+    // Enrollment (user + user plan, payment pending) is created, then the learner
+    // is sent to PhonePe's hosted page; the payment-result page polls status and
+    // logs them in once PhonePe confirms the payment.
+    if (vendor === "PHONEPE") {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const phonePeRedirectUrl = getPhonePeReturnUrl(instituteId);
+        const paymentResponse = await handleEnrollLearnerForPayment({
+          registrationData: form.getValues(),
+          enrollmentData: enrollmentData,
+          instituteId,
+          enrollInviteId: inviteData?.id,
+          payment_option_id:
+            inviteData?.package_session_to_payment_options[0].payment_option.id,
+          package_session_ids:
+            inviteData?.package_session_to_payment_options.map(
+              (ps: { package_session_id: string }) => ps?.package_session_id,
+            ) || [""],
+          allowLearnersToCreateCourses: getAllowLearnersToCreateCourses(),
+          referRequest: referRequest,
+          couponCode: appliedCouponCode,
+          couponDiscount,
+          paymentVendor: "PHONEPE",
+          phonePeRedirectUrl,
+          isUsingInstituteCustomFields: isUsingInstituteCustomFields,
+          billingContact: collectBillingContact ? billingContact : undefined,
+        });
+
+        const ordId =
+          paymentResponse?.payment_response?.order_id ||
+          paymentResponse?.order_id ||
+          "";
+        const redirectUrl =
+          paymentResponse?.payment_response?.response_data?.redirectUrl ||
+          paymentResponse?.payment_response?.response_data?.redirect_url;
+
+        if (!redirectUrl) {
+          throw new Error(
+            "Could not start PhonePe checkout. Please try again or contact support.",
+          );
+        }
+
+        setOrderId(ordId);
+        setPaymentCompletionResponse(paymentResponse);
+
+        // Persist credentials + order id so the payment-result page can auto-login
+        // the learner and resolve the order after PhonePe redirects back.
+        const username =
+          paymentResponse?.user?.username ??
+          paymentResponse?.user?.email ??
+          getUserDetails().email;
+        const userPassword =
+          paymentResponse?.user?.password ?? getPasswordField(form.getValues());
+        if (ordId && username && userPassword) {
+          try {
+            sessionStorage.setItem(
+              `enroll_payment_creds_${ordId}`,
+              JSON.stringify({ username, password: userPassword }),
+            );
+          } catch {
+            /* ignore */
+          }
+        }
+        if (ordId) {
+          try {
+            localStorage.setItem(
+              "phonepe_pending_order",
+              JSON.stringify({ orderId: ordId, instituteId }),
+            );
+          } catch {
+            /* ignore */
+          }
+        }
+
+        // Hand off to PhonePe's hosted checkout page (full-page redirect).
+        window.location.href = redirectUrl;
+        return;
+      } catch (err) {
+        const errorData = (
+          err as {
+            response?: { data?: { ex?: string; responseCode?: string } };
+          }
+        )?.response?.data;
+        if (errorData?.responseCode?.includes("510")) {
+          const dialogOpened = await fetchAndHandleEnrollmentPolicy(
+            "error_already_enrolled",
+            errorData?.ex,
+          );
+          if (!dialogOpened) {
+            toast.error(errorData?.ex || "Payment failed");
+          }
+        }
+        const phonePeErrorMsg =
+          errorData?.ex ||
+          (err instanceof Error ? err.message : null) ||
+          "Failed to initiate PhonePe payment";
+        setError(phonePeErrorMsg);
+        if (inviteData?.gtm_container_id) {
+          pushPaymentFailed({
+            courseName: courseData.course || "",
+            vendor: "PHONEPE",
+            errorMessage: phonePeErrorMsg,
+            utmParams,
+          });
+        }
+        console.error("PhonePe enrollment error:", err);
         setLoading(false);
       }
       return;

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -227,6 +227,10 @@ export const USER_PLAN_PAYMENT_URL = `${BASE_URL}/admin-core-service/payments/us
 // Cashfree payment status (no auth required) – uses same base as enroll API (localhost:8072)
 export const CASHFREE_PAYMENT_STATUS_URL = `${ENROLL_API_BASE}/admin-core-service/payments/user-plan/CASHFREE/status`;
 
+// PhonePe payment status (no auth required) – actively queries PhonePe and updates the payment log.
+// Path: /admin-core-service/open/payments/PHONEPE/status/{orderId}?instituteId={instituteId}
+export const PHONEPE_PAYMENT_STATUS_URL = `${BASE_URL}/admin-core-service/open/payments/PHONEPE/status`;
+
 // Server time
 export const GET_SERVER_TIME = `${BASE_URL}/auth-service/v1/server-time/utc`;
 

--- a/frontend-learner-dashboard-app/src/routes/payment-result/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/payment-result/index.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getPaymentCompletionStatus } from "@/components/common/enroll-by-invite/-services/enroll-invite-services";
 import { getCashfreePaymentStatus } from "@/services/cashfree-payment";
+import { getPhonePePaymentStatus } from "@/services/phonepe-payment";
 import { performFullAuthCycle } from "@/services/auth-cycle-service";
 import { loginEnrolledUser } from "@/services/signup-api";
 import { CheckCircle, XCircle, SpinnerGap } from "@phosphor-icons/react";
@@ -16,6 +17,7 @@ const paymentResultSearchSchema = z.object({
   institute_id: z.string().optional(), // snake_case fallback
   status: z.enum(["success", "failed", "cancelled"]).optional(),
   source: z.string().optional(), // "invoice" skips gateway-specific status polling
+  vendor: z.string().optional(), // "PHONEPE" routes to the PhonePe status endpoint
 });
 
 export const Route = createFileRoute("/payment-result/")({
@@ -36,14 +38,36 @@ function PaymentResultPage() {
     institute_id: instituteIdSnake,
     status: queryStatus,
     source,
+    vendor: vendorParam,
   } = search;
+
+  const isPhonePeFlow = (vendorParam ?? "").toUpperCase() === "PHONEPE";
+
+  // PhonePe redirects can land here without the query params (some return modes
+  // drop them). Recover the order id + institute id we stashed before handing off
+  // to PhonePe's hosted page.
+  const phonePePending = useMemo(() => {
+    if (!isPhonePeFlow || typeof window === "undefined") return null;
+    try {
+      const raw = localStorage.getItem("phonepe_pending_order");
+      return raw
+        ? (JSON.parse(raw) as { orderId?: string; instituteId?: string })
+        : null;
+    } catch {
+      return null;
+    }
+  }, [isPhonePeFlow]);
+
   // Prefer orderId (payment log ID) from our return URL; order_id may be Cashfree's ID
-  const orderId = orderIdParam ?? orderIdSnake ?? "";
-  const instituteId = instituteIdParam ?? instituteIdSnake;
+  const orderId =
+    orderIdParam ?? orderIdSnake ?? phonePePending?.orderId ?? "";
+  const instituteId =
+    instituteIdParam ?? instituteIdSnake ?? phonePePending?.instituteId;
   const validInstituteId = isValidInstituteId(instituteId) ? instituteId : undefined;
   // Invoice payments must not use the Cashfree user-plan status endpoint
   const isInvoicePayment = source === "invoice";
-  const isCashfreeFlow = !!orderId && !!validInstituteId && !isInvoicePayment;
+  const isCashfreeFlow =
+    !isPhonePeFlow && !!orderId && !!validInstituteId && !isInvoicePayment;
   const hasRedirectedRef = useRef(false);
 
   // Extract status from various backend response shapes (payment_status, status, paymentStatus, nested)
@@ -66,19 +90,24 @@ function PaymentResultPage() {
   };
 
   const { data: paymentStatus, isLoading } = useQuery({
-    queryKey: isCashfreeFlow
-      ? ["CASHFREE_PAYMENT_STATUS", orderId, validInstituteId]
-      : ["GET_PAYMENT_COMPLETION_STATUS", orderId],
+    queryKey: isPhonePeFlow
+      ? ["PHONEPE_PAYMENT_STATUS", orderId, validInstituteId]
+      : isCashfreeFlow
+        ? ["CASHFREE_PAYMENT_STATUS", orderId, validInstituteId]
+        : ["GET_PAYMENT_COMPLETION_STATUS", orderId],
     queryFn: () =>
-      isCashfreeFlow && orderId && validInstituteId
-        ? getCashfreePaymentStatus(orderId, validInstituteId)
-        : getPaymentCompletionStatus({ paymentLogId: orderId || "" }),
+      isPhonePeFlow && orderId && validInstituteId
+        ? getPhonePePaymentStatus(orderId, validInstituteId)
+        : isCashfreeFlow && orderId && validInstituteId
+          ? getCashfreePaymentStatus(orderId, validInstituteId)
+          : getPaymentCompletionStatus({ paymentLogId: orderId || "" }),
     enabled: !!orderId,
     refetchInterval: (query) => {
       const ps = getStatusFromResponse(query.state.data);
       if (
         ps === "PAID" ||
         ps === "SUCCESS" ||
+        ps === "COMPLETED" ||
         ps === "FLAGGED" ||
         ps === "FAILED"
       )
@@ -92,6 +121,7 @@ function PaymentResultPage() {
   const isPaid =
     paymentStatusValue === "PAID" ||
     paymentStatusValue === "SUCCESS" ||
+    paymentStatusValue === "COMPLETED" ||
     paymentStatusValue === "FLAGGED";
   const isFailed =
     paymentStatusValue === "FAILED" ||
@@ -104,6 +134,16 @@ function PaymentResultPage() {
   // When payment is successful: auto-login via tokens from status API, or fallback to stored creds + login API
   useEffect(() => {
     if (!isPaid || hasRedirectedRef.current) return;
+
+    // PhonePe order is settled — drop the pending marker so a later visit doesn't
+    // resurrect a stale order id.
+    if (isPhonePeFlow && typeof window !== "undefined") {
+      try {
+        localStorage.removeItem("phonepe_pending_order");
+      } catch {
+        /* ignore */
+      }
+    }
 
     const doRedirect = (path = "/study-library/courses") => {
       if (hasRedirectedRef.current) return;
@@ -203,7 +243,7 @@ function PaymentResultPage() {
     };
 
     runLoginAndRedirect();
-  }, [isPaid, paymentStatus, orderId, validInstituteId]);
+  }, [isPaid, paymentStatus, orderId, validInstituteId, isPhonePeFlow]);
 
   const useFullScreenLayout = isPending || isPaid;
 

--- a/frontend-learner-dashboard-app/src/services/phonepe-payment.ts
+++ b/frontend-learner-dashboard-app/src/services/phonepe-payment.ts
@@ -1,0 +1,55 @@
+import axios from "axios";
+import {
+  PHONEPE_PAYMENT_STATUS_URL,
+  BASE_URL_LEARNER_DASHBOARD,
+} from "@/constants/urls";
+
+/**
+ * PhonePe Standard Checkout is a full-page redirect flow (no inline SDK):
+ *  1. Backend creates the enrollment + payment log and calls PhonePe `/pg/v1/pay`,
+ *     returning a hosted `redirectUrl`.
+ *  2. The learner is sent to PhonePe to pay.
+ *  3. PhonePe redirects back to the URL we configured (the payment-result page,
+ *     stamped server-side with `orderId` + `instituteId`) and also POSTs to the
+ *     backend webhook.
+ *  4. The result page polls {@link getPhonePePaymentStatus} until the order is
+ *     COMPLETED / FAILED.
+ */
+
+/** Return URL PhonePe redirects the learner back to after checkout. */
+export const getPhonePeReturnUrl = (instituteId: string): string => {
+  const base =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : BASE_URL_LEARNER_DASHBOARD;
+  const params = new URLSearchParams({ vendor: "PHONEPE" });
+  if (instituteId && instituteId !== "null" && instituteId.trim() !== "") {
+    params.set("instituteId", instituteId);
+  }
+  return `${base}/payment-result?${params.toString()}`;
+};
+
+/** Active status-check response. `status` is PhonePe's state (COMPLETED/FAILED/PENDING). */
+export interface PhonePePaymentStatusResponse {
+  status?: string;
+  details?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Actively queries PhonePe for the order's state and updates the payment log
+ * server-side. No auth required. Only sends instituteId when valid — omitting or
+ * sending "null" triggers extra DB lookups on the backend.
+ */
+export const getPhonePePaymentStatus = async (
+  orderId: string,
+  instituteId: string,
+): Promise<PhonePePaymentStatusResponse> => {
+  const isValidInstitute =
+    !!instituteId && instituteId !== "null" && instituteId.trim() !== "";
+  const params = isValidInstitute ? { instituteId } : {};
+  const response = await axios.get(`${PHONEPE_PAYMENT_STATUS_URL}/${orderId}`, {
+    params,
+  });
+  return response.data;
+};


### PR DESCRIPTION
Make PhonePe payments actually work

**### What was the problem?**
PhonePe looked like a supported payment option, but it never actually worked. If a school chose PhonePe, learners couldn't pay with it — the checkout quietly tried to use Stripe instead, never sent the learner to PhonePe's payment page, and in one place just pretended the payment succeeded without checking. On top of that, the code used PhonePe's old system that PhonePe has now shut down, so any newly-registered PhonePe merchant couldn't use it at all.

**What does this PR fix?**
Learners can now pay with PhonePe. The checkout sends them to PhonePe's page, they pay, come back, and get enrolled automatically — with a proper receipt, just like Stripe/Razorpay/Cashfree.
Upgraded to PhonePe's current system (V2). New PhonePe merchants now work. Older merchants still work too (the code automatically uses whichever type of keys they have).
Payment confirmations are now verified. PhonePe's callback is security-checked before we trust it (turns on automatically once the school adds the webhook username/password).
Cleaner admin setup. The PhonePe settings screen now shows the right fields with step-by-step help on where to find each value, and the setup popup is wider so it's easier to read."

**### How it works now**
Learner clicks pay → we create their enrollment (marked "pending") and send them to PhonePe → they pay → PhonePe sends them back → we confirm the payment → their enrollment goes live and they're logged in.

Good to know
The backend needs to be deployed, not just merged.
PhonePe works on the main enroll/invite checkout. It's not yet added to installment plans or the catalogue "cart" — a follow-up.
The learner-facing app didn't need any changes for the V2 upgrade.
Testing
Set up PhonePe in Settings → pay through an enrol link using PhonePe's test mode → the learner ends up enrolled and the payment shows as PAID. A failed payment correctly shows "Payment Failed" and does not enrol them. All builds/type-checks pass.