### PR TITLE
fix(assessment): register assessment to target batch on slide copy/mo…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/chapter/service/ChapterManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/chapter/service/ChapterManager.java
@@ -8,6 +8,7 @@ import vacademy.io.admin_core_service.features.chapter.repository.ChapterPackage
 import vacademy.io.admin_core_service.features.chapter.repository.ChapterRepository;
 import vacademy.io.admin_core_service.features.module.entity.ModuleChapterMapping;
 import vacademy.io.admin_core_service.features.module.repository.ModuleChapterMappingRepository;
+import vacademy.io.admin_core_service.features.slide.service.AssessmentSlideBatchRegistrationService;
 import vacademy.io.admin_core_service.features.slide.service.SlideService;
 import vacademy.io.common.institute.entity.module.Module;
 import vacademy.io.common.institute.entity.session.PackageSession;
@@ -24,6 +25,7 @@ public class ChapterManager {
     private final ChapterPackageSessionMappingRepository chapterPackageSessionMappingRepository;
     private final SlideService slideService;
     private final ChapterRepository chapterRepository;
+    private final AssessmentSlideBatchRegistrationService assessmentSlideBatchRegistrationService;
 
     public void copyChaptersOfModule(Module oldModule, Module newModule, PackageSession oldPackageSession, PackageSession newPackageSession) {
         List<Chapter> chapters = moduleChapterMappingRepository.findChaptersByModuleIdAndStatusNotDeleted(oldModule.getId(), oldPackageSession.getId());
@@ -55,7 +57,15 @@ public class ChapterManager {
         moduleChapterMappingRepository.saveAll(newModuleChapterMappings);
         chapterPackageSessionMappingRepository.saveAll(newChapterPackageSessionMappings);
         for (List<Chapter> newAndOldChapter : newChapterAndOldChapterMap) {
-            slideService.copySlidesOfChapter(newAndOldChapter.get(1), newAndOldChapter.get(0));
+            Chapter newChapter = newAndOldChapter.get(0);
+            slideService.copySlidesOfChapter(newAndOldChapter.get(1), newChapter);
+            // The deep copy reuses each assessment slide's assessmentId but lands it
+            // in a brand-new package_session (e.g. duplicating a session/batch). The
+            // assessment must be registered to that batch, otherwise learners there
+            // see the slide while the assessment never shows in their list / the
+            // course's assessment list. Best-effort — the service swallows failures.
+            assessmentSlideBatchRegistrationService
+                    .registerChapterAssessmentsToBatches(newChapter.getId(), List.of(newPackageSession.getId()));
         }
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -52,6 +52,7 @@ public class SlideService {
     private final SlideNotificationService slideNotificationService;
     private final ObjectMapper objectMapper;
     private final LearnerTrackingAsyncService learnerTrackingAsyncService;
+    private final AssessmentSlideBatchRegistrationService assessmentSlideBatchRegistrationService;
 
     @Transactional
     public String addOrUpdateDocumentSlide(AddDocumentSlideDTO addDocumentSlideDTO,
@@ -337,6 +338,15 @@ public class SlideService {
 
         chapterToSlidesRepository.save(new ChapterToSlides(chapter, newSlide, null, SlideStatus.DRAFT.name()));
 
+        // A copied ASSESSMENT slide keeps the same assessmentId but lands in a new
+        // batch. Register that assessment to the target batch so it shows up for
+        // those learners / in that course's assessment list — not just the slide.
+        // Best-effort: the registration service swallows its own failures.
+        if (SlideTypeEnum.ASSESSMENT.name().equalsIgnoreCase(slide.getSourceType())) {
+            assessmentSlideBatchRegistrationService
+                    .registerChapterAssessmentsToBatches(newChapterId, List.of(newPackageSessionId));
+        }
+
         // Update learner tracking for all slide types
         updateLearnerTrackingForSlide(slide, oldChapterId, oldModuleId, oldSubjectId, oldPackageSessionId,
                 newChapterId, newModuleId, newSubjectId, newPackageSessionId);
@@ -469,6 +479,18 @@ public class SlideService {
         chapterToSlidesRepository.save(newMapping);
 
         deleteMapping(slideId, oldChapterId);
+
+        // A moved ASSESSMENT slide now lives in a new batch. Register its assessment
+        // to the target batch so it appears for those learners / in that course's
+        // assessment list. Best-effort (the registration service swallows failures).
+        // We intentionally do not de-register the old batch here: the same
+        // assessment may still be reachable there via another slide, and dropping a
+        // live registration risks hiding an in-flight assessment.
+        if (existingMapping.getSlide() != null
+                && SlideTypeEnum.ASSESSMENT.name().equalsIgnoreCase(existingMapping.getSlide().getSourceType())) {
+            assessmentSlideBatchRegistrationService
+                    .registerChapterAssessmentsToBatches(newChapterId, List.of(newPackageSessionId));
+        }
 
         // Update learner tracking for all slide types
         updateLearnerTrackingForSlide(existingMapping.getSlide(), oldChapterId, oldModuleId, oldSubjectId,


### PR DESCRIPTION
…ve and session duplicate

The Jun-30 fix (5a9599317) registered assessments to new batches for the shared/reference chapter-copy, chapter-edit and course copy-content paths, but three deep-copy paths still landed an assessment slide in a new batch without registering the assessment there. The slide reuses the same assessmentId (no data loss), but the assessment never appeared in the target batch's learner / admin assessment list.

Covered now:
- SlideService.copySlide  (POST /slide/v1/copy, slide "Copy to")
- SlideService.moveSlide  (POST /slide/v1/move, slide "Move to")
- ChapterManager.copyChaptersOfModule (duplicate a session/batch via SessionService -> copySubjectsFromExistingPackageSessionMapping)

Each now calls AssessmentSlideBatchRegistrationService.registerChapterAssessmentsToBatches for the target package_session (gated on ASSESSMENT type for the slide-level paths). Best-effort and idempotent, so it can never break the copy/move; move intentionally does not de-register the old batch. admin_core_service only.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
