### PR TITLE
fix(slide): copied slide inherits source status (PUBLISHED copies stay published)

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -336,7 +336,10 @@ public class SlideService {
 
         Slide newSlide = copySlideByType(slide);
 
-        chapterToSlidesRepository.save(new ChapterToSlides(chapter, newSlide, null, SlideStatus.DRAFT.name()));
+        // Keep the chapter_to_slides link status in sync with the (now
+        // source-preserving) slide status so a copied PUBLISHED slide is actually
+        // published end-to-end, not stuck in DRAFT and hidden from learners.
+        chapterToSlidesRepository.save(new ChapterToSlides(chapter, newSlide, null, newSlide.getStatus()));
 
         // A copied ASSESSMENT slide keeps the same assessmentId but lands in a new
         // batch. Register that assessment to the target batch so it shows up for
@@ -510,7 +513,18 @@ public class SlideService {
     private Slide createNewSlide(Slide slide, String newSourceId) {
         Slide newSlide = new Slide();
         newSlide.setId(UUID.randomUUID().toString());
-        newSlide.setStatus(SlideStatus.DRAFT.name());
+        // Preserve the source slide's status so a copy of PUBLISHED content is
+        // itself PUBLISHED — DRAFT slides are hidden from the learner list
+        // (LearnerSlideService only serves PUBLISHED/UNSYNC), so the previous
+        // hardcoded DRAFT meant copied slides silently never reached learners.
+        // Falls back to DRAFT only when the source has no status.
+        String status = (slide.getStatus() == null || slide.getStatus().isBlank())
+                ? SlideStatus.DRAFT.name()
+                : slide.getStatus();
+        newSlide.setStatus(status);
+        if (SlideStatus.PUBLISHED.name().equalsIgnoreCase(status)) {
+            newSlide.setLastSyncDate(new Timestamp(System.currentTimeMillis()));
+        }
         newSlide.setTitle(slide.getTitle());
         newSlide.setDescription(slide.getDescription());
         newSlide.setSourceType(slide.getSourceType());


### PR DESCRIPTION
## Problem
Copying a slide via **slide \"Copy to\"** (`POST /slide/v1/copy`) created the new slide row **and** its `chapter_to_slides` link hardcoded to `DRAFT`. Learners only ever see `PUBLISHED`/`UNSYNC` slides (`LearnerSlideService`), so a copy of a PUBLISHED slide was silently invisible to learners and left as DRAFT in the admin outline. Reported: "assessment is created properly but the slide is not published — it stays in DRAFT."

## Fix
`createNewSlide` (used only by the copy path) now **preserves the source slide's status**:
- PUBLISHED source → PUBLISHED copy (visible to learners), and `last_sync_date` is set per the entity convention.
- DRAFT source → DRAFT copy (no forced publishing of incomplete content).

The `chapter_to_slides` link is created with the same status so the slide is published end-to-end. This mirrors the already-correct `copySlidesOfChapter` and `CourseContentCopyService` paths.

## Scope / safety
- One file, `admin_core_service` only. `createNewSlide` has a single caller (`copySlide`), so no other flow is affected.
- Builds clean (0 compilation errors).
- Follows PR #2102 (assessment→batch registration on copy/move/session-duplicate).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>