### PR TITLE
flyway: add audience_status column in audience_response table

### DIFF
--- a/admin_core_service/src/main/resources/db/migration/V359__Add_audience_status_to_audience_response.sql
+++ b/admin_core_service/src/main/resources/db/migration/V359__Add_audience_status_to_audience_response.sql
@@ -1,0 +1,16 @@
+-- Add audience_status column to audience_response for soft-deleting leads.
+-- ACTIVE  = normal, visible, eligible for promotional/automated sends
+-- INACTIVE = admin soft-deleted; hidden from lead views and send recipient lists
+-- Kept separate from overall_status (opt-out/engagement) and conversion_status.
+
+ALTER TABLE audience_response
+ADD COLUMN audience_status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE';
+
+-- Existing rows are active leads (DEFAULT already backfills; explicit for clarity).
+UPDATE audience_response
+SET audience_status = 'ACTIVE'
+WHERE audience_status IS NULL;
+
+-- Most lead reads filter by status; index it.
+CREATE INDEX idx_audience_response_audience_status
+ON audience_response(audience_status);


### PR DESCRIPTION
## Summary of Changes

Adds an `audience_status` column (`ACTIVE` / `INACTIVE`) to `audience_response`,
the soft-delete switch for leads. Shipped **ahead of the feature code** so the
schema is live in prod before the lead soft-delete / edit endpoints land — lets
us test the full feature against prod data next.

Additive and backward-compatible: `NOT NULL DEFAULT 'ACTIVE'` (metadata-only add
on PG16), existing rows backfill to `ACTIVE`, plus an index for the status filter.
Kept distinct from `overall_status` (opt-out) and `conversion_status`.

**Backend:**
- New Flyway migration `V359__Add_audience_status_to_audience_response.sql`

**Frontend:**
- None

## Related Issue

<leave blank>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Applied on a local prod-dump `admin_core_service` DB: V359 runs cleanly after V358.
- Verified the column exists, defaults to `ACTIVE`, and existing rows backfill to `ACTIVE`.
- Confirmed no clash with the existing V351–V358 (telephony/IVR/AI/sub-org) migrations.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
