### PR TITLE
feat(leads): edit lead profile, soft-delete leads, per-channel unsubs…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
@@ -167,9 +167,24 @@ public class AudienceController {
     }
 
     @DeleteMapping("/lead/{responseId}")
-    public ResponseEntity<String> deleteLead(@PathVariable String responseId) {
-        audienceService.deleteLead(responseId);
+    public ResponseEntity<String> deleteLead(@PathVariable String responseId,
+                                             @RequestAttribute("user") CustomUserDetails user) {
+        audienceService.deleteLead(responseId, user);
         return ResponseEntity.ok("Lead deleted successfully");
+    }
+
+    /**
+     * Edit a lead's profile from the CRM. Authenticated counterpart to the
+     * student edit endpoint, but writes only where a lead is read from:
+     * the auth user, the audience_response guardian fields, and the lead's
+     * custom field values. Keyed by the audience_response id.
+     */
+    @PutMapping("/lead/{responseId}/profile")
+    public ResponseEntity<String> updateLeadProfile(@PathVariable String responseId,
+                                                    @RequestBody LeadProfileEditRequestDTO request,
+                                                    @RequestAttribute("user") CustomUserDetails user) {
+        audienceService.updateLeadProfile(responseId, request);
+        return ResponseEntity.ok("Lead profile updated");
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadProfileEditRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadProfileEditRequestDTO.java
@@ -1,0 +1,43 @@
+package vacademy.io.admin_core_service.features.audience.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import vacademy.io.admin_core_service.features.common.dto.request.CustomFieldValueDto;
+import vacademy.io.common.auth.dto.UserDTO;
+
+import java.util.List;
+
+/**
+ * Request body for editing a lead's profile from the CRM (admin dashboard).
+ *
+ * <p>Deliberately scoped to exactly what a lead reads/round-trips:
+ * <ul>
+ *   <li>{@code user_details} → the lead's own auth user (name / email / mobile,
+ *       plus any other {@link UserDTO} field if sent)</li>
+ *   <li>{@code parent_*} → the guardian fields on the {@code audience_response} row</li>
+ *   <li>{@code custom_field_values} → the lead's form answers (source AUDIENCE_RESPONSE)</li>
+ * </ul>
+ * It does NOT touch the {@code student} table — leads have no student row.</p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LeadProfileEditRequestDTO {
+
+    /** Identity fields written back to the lead's auth user. */
+    private UserDTO userDetails;
+
+    /** Guardian fields written back to audience_response. */
+    private String parentName;
+    private String parentEmail;
+    private String parentMobile;
+
+    /** Lead form answers; each entry should carry source_type=AUDIENCE_RESPONSE and source_id=responseId. */
+    private List<CustomFieldValueDto> customFieldValues;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/entity/AudienceResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/entity/AudienceResponse.java
@@ -81,6 +81,16 @@ public class AudienceResponse {
     @Column(name = "overall_status", length = 50)
     private String overallStatus;
 
+    /**
+     * Soft-delete lifecycle status — {@code ACTIVE} / {@code INACTIVE}
+     * (see {@link vacademy.io.admin_core_service.features.audience.enums.AudienceStatusEnum}).
+     * INACTIVE = admin-deleted lead; excluded from lead views and from
+     * promotional/automated send recipient queries.
+     */
+    @Column(name = "audience_status", length = 50)
+    @Builder.Default
+    private String audienceStatus = "ACTIVE";
+
     // ── Deduplication fields ──────────────────────────────────
 
     /** SHA-256 hash of normalized email+phone for dedup within campaign */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/enums/AudienceStatusEnum.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/enums/AudienceStatusEnum.java
@@ -1,0 +1,15 @@
+package vacademy.io.admin_core_service.features.audience.enums;
+
+/**
+ * Lifecycle status of an audience_response (lead) row.
+ *
+ * <p>This is the soft-delete switch, kept separate from {@code overall_status}
+ * (which carries opt-out/engagement meaning) and {@code conversion_status}.
+ * Operational lead views and — most importantly — promotional/automated
+ * email + WhatsApp recipient-selection queries must exclude {@link #INACTIVE}
+ * rows so a deleted lead stops receiving messages.</p>
+ */
+public enum AudienceStatusEnum {
+    ACTIVE,    // Visible everywhere; eligible for promotional sends
+    INACTIVE   // Soft-deleted by an admin; hidden from lead views + send recipient lists
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -24,9 +24,16 @@ import java.util.Optional;
 public interface AudienceResponseRepository extends JpaRepository<AudienceResponse, String> {
 
         /**
-         * Find all leads for a specific campaign
+         * Find all leads for a specific campaign. Soft-deleted (INACTIVE) leads are
+         * excluded so lead lists, bulk sends and AI call campaigns never act on them.
          */
-        List<AudienceResponse> findByAudienceId(String audienceId);
+        @Query(value = """
+                SELECT ar.*
+                FROM audience_response ar
+                WHERE ar.audience_id = :audienceId
+                  AND ar.audience_status = 'ACTIVE'
+                """, nativeQuery = true)
+        List<AudienceResponse> findByAudienceId(@Param("audienceId") String audienceId);
 
         /**
          * Lead lookup by phone number for telephony attribution: the most recent
@@ -41,6 +48,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                 FROM audience_response ar
                 JOIN audience a ON a.id = ar.audience_id
                 WHERE a.institute_id = :instituteId
+                  AND ar.audience_status = 'ACTIVE'
                   AND ar.parent_mobile IS NOT NULL
                   AND RIGHT(regexp_replace(ar.parent_mobile, '[^0-9]', '', 'g'), 10) = :last10
                 ORDER BY ar.created_at DESC
@@ -63,6 +71,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                 JOIN audience a ON a.id = ar.audience_id
                 WHERE a.institute_id = :instituteId
                   AND ar.user_id = :userId
+                  AND ar.audience_status = 'ACTIVE'
                 ORDER BY ar.created_at DESC
                 LIMIT 1
                 """, nativeQuery = true)
@@ -169,6 +178,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 (COALESCE(:overallStatusStr, '') = '' AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT'))
                                 OR (COALESCE(:overallStatusStr, '') != '' AND ar.overall_status = ANY(STRING_TO_ARRAY(:overallStatusStr, ',')))
                               )
+                              AND ar.audience_status = 'ACTIVE'
                               AND (
                                 COALESCE(:conversionStatusFilter, 'EXCLUDE_CONVERTED') = 'ALL'
                                 OR (
@@ -307,6 +317,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 (COALESCE(:overallStatusStr, '') = '' AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT'))
                                 OR (COALESCE(:overallStatusStr, '') != '' AND ar.overall_status = ANY(STRING_TO_ARRAY(:overallStatusStr, ',')))
                               )
+                              AND ar.audience_status = 'ACTIVE'
                               AND (
                                 COALESCE(:conversionStatusFilter, 'EXCLUDE_CONVERTED') = 'ALL'
                                 OR (
@@ -417,6 +428,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             JOIN Audience a ON a.id = ar.audienceId
                             WHERE a.instituteId = :instituteId
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                             ORDER BY ar.submittedAt DESC
                         """)
         Page<AudienceResponse> findAllLeadsForInstitute(
@@ -490,6 +502,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 )
                               )
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                              AND ar.audience_status = 'ACTIVE'
                               -- SLA-state filter. Aligned with the row-level badges + the new
                               -- column semantics:
                               --   * Reach-out buckets use submitted_at + tatHours AND a NOT EXISTS
@@ -615,6 +628,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 )
                               )
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                              AND ar.audience_status = 'ACTIVE'
                               -- SLA-state filter. Aligned with the row-level badges + the new
                               -- column semantics:
                               --   * Reach-out buckets use submitted_at + tatHours AND a NOT EXISTS
@@ -713,6 +727,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             JOIN audience a ON a.id = ar.audience_id
                             WHERE cfv.source_type = 'AUDIENCE_RESPONSE'
                               AND a.institute_id = :instituteId
+                              AND ar.audience_status = 'ACTIVE'
                               AND cfv.custom_field_id = :customFieldId
                               AND cfv.value IS NOT NULL
                               AND cfv.value <> ''
@@ -725,6 +740,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             JOIN audience a ON a.id = ar.audience_id
                             WHERE cfv.source_type = 'AUDIENCE_RESPONSE'
                               AND a.institute_id = :instituteId
+                              AND ar.audience_status = 'ACTIVE'
                               AND cfv.custom_field_id = :customFieldId
                               AND cfv.value IS NOT NULL
                               AND cfv.value <> ''
@@ -762,6 +778,9 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
          * Check if a user has already submitted a response for this audience
          */
         boolean existsByAudienceIdAndUserId(String audienceId, String userId);
+
+        /** Most-recent response for an audience+user — used to reactivate a soft-deleted lead on re-submission. */
+        Optional<AudienceResponse> findTopByAudienceIdAndUserIdOrderByCreatedAtDesc(String audienceId, String userId);
 
         /**
          * Check if a child (student) has already been submitted for this audience campaign.
@@ -834,6 +853,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.audienceId = :audienceId
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByAudienceAndDateRange(
                         @Param("instituteId") String instituteId,
@@ -855,6 +875,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND ar.conversionStatus = :conversionStatus
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByAudienceDateRangeAndConversionStatus(
                         @Param("instituteId") String instituteId,
@@ -874,6 +895,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.userId IS NOT NULL
                             AND ar.parentMobile IS NOT NULL
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findActiveLeadsByAudienceIds(
                         @Param("audienceIds") List<String> audienceIds);
@@ -889,6 +911,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             WHERE a.instituteId = :instituteId
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByInstituteAndDateRange(
                         @Param("instituteId") String instituteId,
@@ -984,6 +1007,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             FROM audience_response ar
                             JOIN audience a ON a.id = ar.audience_id
                             WHERE (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                              AND ar.audience_status = 'ACTIVE'
                         """, nativeQuery = true)
         List<String> findInstituteIdsWithActiveLeads();
 
@@ -1028,6 +1052,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 ON ulp.user_id = ar.user_id AND ulp.institute_id = a.institute_id
                             WHERE a.institute_id = :instituteId
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                              AND ar.audience_status = 'ACTIVE'
                               AND (ulp.conversion_status IS NULL OR ulp.conversion_status != 'CONVERTED')
                               AND COALESCE(lu.user_id, ulp.assigned_counselor_id) IS NOT NULL
                         """, nativeQuery = true)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -12,7 +12,9 @@ import vacademy.io.admin_core_service.features.audience.dto.*;
 import vacademy.io.admin_core_service.features.audience.dto.CounsellorAllocationSettingDTO;
 import vacademy.io.admin_core_service.features.audience.entity.Audience;
 import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
+import vacademy.io.admin_core_service.features.audience.enums.AudienceStatusEnum;
 import vacademy.io.admin_core_service.features.audience.enums.CampaignStatusEnum;
+import vacademy.io.admin_core_service.features.audience.enums.CustomFieldValueSourceType;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceRepository;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
 import vacademy.io.admin_core_service.features.audience.entity.LeadScore;
@@ -58,6 +60,10 @@ import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerS
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.notification.dto.GenericEmailRequest;
+import vacademy.io.common.exceptions.ConflictException;
+import vacademy.io.common.exceptions.ForbiddenException;
+import vacademy.io.common.exceptions.InvalidRequestException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -96,6 +102,9 @@ public class AudienceService {
 
     @Autowired
     private CustomFieldValuesRepository customFieldValuesRepository;
+
+    @Autowired
+    private vacademy.io.admin_core_service.features.common.service.CustomFieldValueService customFieldValueService;
 
     @Autowired
     private AuthService authService;
@@ -507,6 +516,8 @@ public class AudienceService {
         // 2. Dedup per person per campaign (same behaviour as submitLeadV2).
         if (StringUtils.hasText(userId)
                 && audienceResponseRepository.existsByAudienceIdAndUserId(audience.getId(), userId)) {
+            // Silently revive a previously soft-deleted lead on re-submission.
+            reactivateSoftDeletedLeadByUser(audience.getId(), userId);
             return "You have already submitted your response for this campaign";
         }
 
@@ -613,6 +624,8 @@ public class AudienceService {
                 // Duplicate submission guard: same audience + same user
                 if (StringUtils.hasText(userId) &&
                         audienceResponseRepository.existsByAudienceIdAndUserId(requestDTO.getAudienceId(), userId)) {
+                    // Silently revive a previously soft-deleted lead on re-submission.
+                    reactivateSoftDeletedLeadByUser(requestDTO.getAudienceId(), userId);
                     return "You have already submitted your response for this campaign";
                 }
 
@@ -1048,6 +1061,8 @@ public class AudienceService {
                 // Duplicate submission guard: same audience + same user
                 if (StringUtils.hasText(userId) &&
                         audienceResponseRepository.existsByAudienceIdAndUserId(requestDTO.getAudienceId(), userId)) {
+                    // Silently revive a previously soft-deleted lead on re-submission.
+                    reactivateSoftDeletedLeadByUser(requestDTO.getAudienceId(), userId);
                     return "You have already submitted your response for this campaign";
                 }
 
@@ -1561,9 +1576,11 @@ public class AudienceService {
             java.util.Optional<AudienceResponse> existingPrimary = leadDeduplicationService
                     .findDuplicate(requestDTO.getAudienceId(), dedupeKey);
             if (existingPrimary.isPresent()) {
-                leadDeduplicationService.markDuplicate(response, existingPrimary.get(), requestDTO.getSourceType());
+                AudienceResponse primary = existingPrimary.get();
+                reactivateIfSoftDeleted(primary);
+                leadDeduplicationService.markDuplicate(response, primary, requestDTO.getSourceType());
                 logger.info("Duplicate lead detected for campaign {}, primary={}",
-                        requestDTO.getAudienceId(), existingPrimary.get().getId());
+                        requestDTO.getAudienceId(), primary.getId());
             }
         }
 
@@ -2596,6 +2613,11 @@ public class AudienceService {
         AudienceResponse response = audienceResponseRepository.findById(responseId)
                 .orElseThrow(() -> new VacademyException("Lead not found"));
 
+        // Soft-deleted (INACTIVE) leads are treated as not found for the detail fetch.
+        if (AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(response.getAudienceStatus())) {
+            throw new ResourceNotFoundException("Lead not found");
+        }
+
         Audience audience = audienceRepository.findById(response.getAudienceId())
                 .orElseThrow(() -> new VacademyException("Audience not found"));
 
@@ -2614,14 +2636,155 @@ public class AudienceService {
     }
 
     /**
-     * Delete a single lead (audience response) by response ID.
+     * Soft-delete a single lead (audience response) by response ID.
+     *
+     * <p>Sets {@code audience_status = INACTIVE} so the lead disappears from lead
+     * views and — importantly — from promotional/automated send recipient
+     * queries, instead of physically removing the row. Restricted to ADMIN
+     * callers; a lead that has already converted to a student cannot be deleted.</p>
      */
     @Transactional
-    public void deleteLead(String responseId) {
+    public void deleteLead(String responseId, CustomUserDetails actor) {
+        if (!hasAdminRole(actor)) {
+            throw new ForbiddenException("Only an admin can delete a lead");
+        }
+
         AudienceResponse response = audienceResponseRepository.findById(responseId)
-                .orElseThrow(() -> new VacademyException("Lead not found"));
-        audienceResponseRepository.delete(response);
-        logger.info("Deleted lead: {}", responseId);
+                .orElseThrow(() -> new ResourceNotFoundException("Lead not found"));
+
+        // Block deleting a lead that has converted to a student.
+        String leadUserId = response.getUserId() != null ? response.getUserId() : response.getStudentUserId();
+        if (leadUserId != null) {
+            boolean converted = userLeadProfileRepository.findByUserId(leadUserId)
+                    .map(p -> "CONVERTED".equalsIgnoreCase(p.getConversionStatus()))
+                    .orElse(false);
+            if (converted) {
+                throw new ConflictException("This lead has converted to a student and cannot be deleted.");
+            }
+        }
+
+        response.setAudienceStatus(AudienceStatusEnum.INACTIVE.name());
+        audienceResponseRepository.save(response);
+        logger.info("Soft-deleted lead {} by user {}", responseId, actor.getUserId());
+    }
+
+    /** Flip a soft-deleted (INACTIVE) lead back to ACTIVE; no-op otherwise. */
+    private void reactivateIfSoftDeleted(AudienceResponse lead) {
+        if (lead != null && AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(lead.getAudienceStatus())) {
+            lead.setAudienceStatus(AudienceStatusEnum.ACTIVE.name());
+            audienceResponseRepository.save(lead);
+            logger.info("Reactivated soft-deleted lead {} on re-submission", lead.getId());
+        }
+    }
+
+    /**
+     * Silently reactivate a previously soft-deleted lead for this audience+user,
+     * so a re-submission revives the existing row instead of staying hidden.
+     */
+    private void reactivateSoftDeletedLeadByUser(String audienceId, String userId) {
+        if (!StringUtils.hasText(audienceId) || !StringUtils.hasText(userId)) {
+            return;
+        }
+        audienceResponseRepository
+                .findTopByAudienceIdAndUserIdOrderByCreatedAtDesc(audienceId, userId)
+                .ifPresent(this::reactivateIfSoftDeleted);
+    }
+
+    /** True when the caller carries the institute ADMIN role. */
+    private boolean hasAdminRole(CustomUserDetails user) {
+        if (user == null || user.getAuthorities() == null) {
+            return false;
+        }
+        return user.getAuthorities().stream()
+                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
+                .filter(java.util.Objects::nonNull)
+                .anyMatch("ADMIN"::equalsIgnoreCase);
+    }
+
+    /**
+     * Edit a lead's profile from the CRM. Writes ONLY to the places a lead is
+     * actually read from — the auth user (name/email/mobile, etc.), the
+     * audience_response guardian fields, and the lead's custom field values.
+     * Never touches the student table (leads have no student row).
+     *
+     * <p>If the edit changes email/phone to a combination that already belongs
+     * to a different lead in the same campaign, it is rejected so two leads can't
+     * collide on the same identity.</p>
+     */
+    @Transactional
+    public void updateLeadProfile(String responseId, LeadProfileEditRequestDTO request) {
+        if (request == null) {
+            throw new InvalidRequestException("Request body is required");
+        }
+
+        AudienceResponse response = audienceResponseRepository.findById(responseId)
+                .orElseThrow(() -> new ResourceNotFoundException("Lead not found"));
+
+        UserDTO updates = request.getUserDetails();
+
+        // 1) Update the lead's own auth user (merge over the existing record).
+        String leadUserId = response.getUserId() != null ? response.getUserId() : response.getStudentUserId();
+        if (updates != null && StringUtils.hasText(leadUserId)) {
+            // Collision guard: recompute the dedupe key from the (possibly) new
+            // email/phone and reject if a DIFFERENT lead in this campaign owns it.
+            String newEmail = updates.getEmail();
+            String newPhone = updates.getMobileNumber();
+            if (StringUtils.hasText(newEmail) || StringUtils.hasText(newPhone)) {
+                String newKey = leadDeduplicationService.generateDedupeKey(newEmail, newPhone);
+                if (newKey != null && response.getAudienceId() != null) {
+                    leadDeduplicationService.findDuplicate(response.getAudienceId(), newKey)
+                            .filter(existing -> !existing.getId().equals(responseId))
+                            .ifPresent(existing -> {
+                                throw new ConflictException(
+                                        "A lead already exists with this phone number or email.");
+                            });
+                    response.setDedupeKey(newKey);
+                }
+            }
+
+            List<UserDTO> existingUsers = authService.getUsersFromAuthServiceByUserIds(List.of(leadUserId));
+            UserDTO existing = (existingUsers != null && !existingUsers.isEmpty()) ? existingUsers.get(0) : null;
+            UserDTO merged = (existing != null) ? mergeUserDTO(existing, updates) : updates;
+            merged.setId(leadUserId);
+            authService.updateUser(merged, leadUserId);
+        }
+
+        // 2) Update guardian fields on the audience_response row.
+        boolean responseModified = false;
+        if (request.getParentName() != null) {
+            response.setParentName(request.getParentName());
+            responseModified = true;
+        }
+        if (request.getParentEmail() != null) {
+            response.setParentEmail(request.getParentEmail());
+            responseModified = true;
+        }
+        if (request.getParentMobile() != null) {
+            response.setParentMobile(request.getParentMobile());
+            responseModified = true;
+        }
+        // dedupe_key may also have been updated above.
+        audienceResponseRepository.save(response);
+        if (responseModified) {
+            logger.info("Updated guardian fields on lead {}", responseId);
+        }
+
+        // 3) Upsert the lead's custom field values (source AUDIENCE_RESPONSE).
+        if (!CollectionUtils.isEmpty(request.getCustomFieldValues())) {
+            request.getCustomFieldValues().forEach(cfv -> {
+                if (cfv != null) {
+                    if (!StringUtils.hasText(cfv.getSourceType())) {
+                        cfv.setSourceType(CustomFieldValueSourceType.AUDIENCE_RESPONSE.name());
+                    }
+                    if (!StringUtils.hasText(cfv.getSourceId())) {
+                        cfv.setSourceId(responseId);
+                    }
+                }
+            });
+            customFieldValueService.upsertCustomFieldValues(request.getCustomFieldValues());
+        }
+
+        logger.info("Lead profile updated for response {}", responseId);
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerService.java
@@ -13,6 +13,7 @@ import vacademy.io.admin_core_service.features.learner.dto.LearnerDetailsEditDTO
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.auth.dto.learner.LearnerExtraDetails;
 import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.UserNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class LearnerService {
             throw new VacademyException("Invalid request");
         }
         Student student = instituteStudentRepository.findTopByUserId(learnerDetailsEditDTO.getUserId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
         if (StringUtils.hasText(learnerDetailsEditDTO.getEmail()))
             student.setEmail(learnerDetailsEditDTO.getEmail());
         if (StringUtils.hasText(learnerDetailsEditDTO.getFullName()))
@@ -76,7 +77,7 @@ public class LearnerService {
     public String updateFaceFileId(String faceFileId, CustomUserDetails userDetails) {
         if (StringUtils.hasText(userDetails.getId()) && StringUtils.hasText(faceFileId)) {
             Student student = instituteStudentRepository.findTopByUserId(userDetails.getId())
-                    .orElseThrow(() -> new VacademyException("User not found"));
+                    .orElseThrow(() -> new UserNotFoundException("User not found"));
             student.setFaceFileId(faceFileId);
             instituteStudentRepository.save(student);
             return "success";
@@ -97,7 +98,7 @@ public class LearnerService {
 
     public String updateLearnerDetail(UserDTO userDTO, LearnerExtraDetails learnerExtraDetails) {
         Student student = instituteStudentRepository.findTopByUserId(userDTO.getId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         student.setUsername(userDTO.getUsername());
         student.setFullName(userDTO.getFullName());
@@ -123,7 +124,7 @@ public class LearnerService {
 
     public String updateLearnerDetail(UserDTO userDTO) {
         Student student = instituteStudentRepository.findTopByUserId(userDTO.getId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         if (StringUtils.hasText(userDTO.getUsername())) {
             student.setUsername(userDTO.getUsername());
@@ -168,7 +169,7 @@ public class LearnerService {
         }
 
         Student student = instituteStudentRepository.findTopByUserId(userId)
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         if (StringUtils.hasText(learnerExtraDetails.getFathersName())) {
             student.setFatherName(learnerExtraDetails.getFathersName());

--- a/common_service/src/main/java/vacademy/io/common/core/exception/GlobalExceptionHandler.java
+++ b/common_service/src/main/java/vacademy/io/common/core/exception/GlobalExceptionHandler.java
@@ -6,6 +6,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import vacademy.io.common.exceptions.ConflictException;
+import vacademy.io.common.exceptions.ForbiddenException;
+import vacademy.io.common.exceptions.InvalidRequestException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
+import vacademy.io.common.exceptions.UserNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.Date;
@@ -13,6 +18,36 @@ import java.util.Date;
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorInfo> handleUserNotFound(HttpServletRequest req, UserNotFoundException ex) {
+        log.error("User Not Found: {} Stack Trace: {}", ex, ex.getStackTrace());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.NOT_FOUND), new Date()));
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorInfo> handleResourceNotFound(HttpServletRequest req, ResourceNotFoundException ex) {
+        log.warn("Resource Not Found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.NOT_FOUND), new Date()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorInfo> handleForbidden(HttpServletRequest req, ForbiddenException ex) {
+        log.warn("Forbidden: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.FORBIDDEN), new Date()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorInfo> handleConflict(HttpServletRequest req, ConflictException ex) {
+        log.warn("Conflict: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.CONFLICT), new Date()));
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorInfo> handleInvalidRequest(HttpServletRequest req, InvalidRequestException ex) {
+        log.warn("Invalid Request: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.BAD_REQUEST), new Date()));
+    }
+
     @ExceptionHandler(VacademyException.class)
     public ResponseEntity<ErrorInfo> handleExceptionForOthers(HttpServletRequest req, VacademyException ex) {
         log.error("Vacademy Error: {} Stack Trace: {}", ex, ex.getStackTrace());

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ConflictException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ConflictException.java
@@ -1,0 +1,12 @@
+package vacademy.io.common.exceptions;
+
+/**
+ * Thrown when a request conflicts with the current state of a resource
+ * (e.g. a duplicate, or an action disallowed by the resource's status).
+ * Maps to HTTP 409.
+ */
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ForbiddenException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ForbiddenException.java
@@ -1,0 +1,8 @@
+package vacademy.io.common.exceptions;
+
+/** Thrown when the caller lacks permission for an action. Maps to HTTP 403. */
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ResourceNotFoundException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package vacademy.io.common.exceptions;
+
+/** Thrown when a requested resource does not exist. Maps to HTTP 404. */
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/frontend-admin-dashboard/src/components/shared/leads/lead-view-model.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/lead-view-model.ts
@@ -130,10 +130,12 @@ export const mapRecentLeadToStudent = (lead: RecentLeadDetail): StudentTable => 
         attendance_percent: 0,
         referral_count: 0,
         pin_code: '',
-        fathers_name: '',
+        // Guardian fields for a lead live on audience_response.parent_* — surface
+        // them so the sidebar shows them and EditLeadDetails can round-trip them.
+        fathers_name: lead.parent_name || '',
         mothers_name: '',
-        father_mobile_number: '',
-        father_email: '',
+        father_mobile_number: lead.parent_mobile || '',
+        father_email: lead.parent_email || '',
         mother_mobile_number: '',
         mother_email: '',
         linked_institute_name: null,

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -252,6 +252,8 @@ export const GET_LEAD_REPORT_SUMMARY = `${BASE_URL}/admin-core-service/v1/report
 export const GET_COUNSELOR_PERFORMANCE = `${BASE_URL}/admin-core-service/v1/reports/counselor-performance`;
 export const DELETE_AUDIENCE_LEAD = (responseId: string) =>
     `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}`;
+export const UPDATE_LEAD_PROFILE = (responseId: string) =>
+    `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}/profile`;
 export const GET_ENQUIRIES = `${BASE_URL}/admin-core-service/v1/audience/enquiries`;
 // Distinct values a custom field holds across the institute's leads — searchable
 // + paginated. Powers the multi-select custom-field dropdowns in the leads filter bar.
@@ -803,6 +805,11 @@ export const UPDATE_NAMING_SETTINGS = `${BASE_URL}/admin-core-service/institute/
 
 // Notification Service
 export const NOTIFICATION_SERVICE_BASE = `${BASE_URL}/notification-service/v1`;
+// User announcement (promotional) preferences — GET current + PUT to (un)subscribe per channel.
+export const USER_ANNOUNCEMENT_PREFERENCES = (username: string) =>
+    `${BASE_URL}/notification-service/public/v1/user-announcement-preferences/${encodeURIComponent(
+        username
+    )}`;
 
 // Chatbot Flow Builder
 export const CHATBOT_FLOW_BASE = `${NOTIFICATION_SERVICE_BASE}/chatbot-flow`;

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/UnsubscribeButtons.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/UnsubscribeButtons.tsx
@@ -1,0 +1,148 @@
+import { useMemo } from 'react';
+import { MyButton } from '@/components/design-system/button';
+import { EnvelopeSimple, WhatsappLogo } from '@phosphor-icons/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { USER_ANNOUNCEMENT_PREFERENCES } from '@/constants/urls';
+import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
+import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
+import { getTokenFromCookie, getUserRoles } from '@/lib/auth/sessionUtility';
+import { TokenKey } from '@/constants/auth/tokens';
+import { DashboardLoader } from '@/components/core/dashboard-loader';
+import { cn } from '@/lib/utils';
+
+// Two admin-only buttons to (un)subscribe this user from promotional Email /
+// WhatsApp. Reuses the notification-service preference API, which also cascades
+// to the audience opt-out. Each button: spinner while the call is in flight,
+// then a red "Unsubscribed" state once the server confirms (200).
+
+interface EmailSenderOption {
+    emailType: string;
+    fromAddress?: string;
+}
+interface PreferenceResponse {
+    settings?: {
+        email?: { globallyUnsubscribed?: boolean; senders?: { unsubscribed?: boolean }[] };
+        whatsapp?: { unsubscribed?: boolean };
+    };
+    availableSenders?: { emailSenders?: EmailSenderOption[] };
+}
+
+export const UnsubscribeButtons = () => {
+    const { selectedStudent } = useStudentSidebar();
+    const { instituteDetails } = useInstituteDetailsStore();
+    const queryClient = useQueryClient();
+
+    const instituteId = instituteDetails?.id ?? '';
+    // Leads have no username; key by email (the identifier they always carry).
+    const identifier = selectedStudent?.username || selectedStudent?.email || '';
+    const isAdmin = getUserRoles(getTokenFromCookie(TokenKey.accessToken)).includes('ADMIN');
+
+    const prefKey = ['announcement-preferences', identifier, instituteId];
+
+    const { data, isLoading } = useQuery({
+        queryKey: prefKey,
+        queryFn: async (): Promise<PreferenceResponse> => {
+            const res = await authenticatedAxiosInstance.get(
+                USER_ANNOUNCEMENT_PREFERENCES(identifier),
+                { params: { instituteId } }
+            );
+            return res.data;
+        },
+        enabled: isAdmin && !!identifier && !!instituteId,
+    });
+
+    const emailSenders = useMemo(
+        () => data?.availableSenders?.emailSenders ?? [],
+        [data]
+    );
+    const emailUnsubscribed =
+        !!data?.settings?.email?.globallyUnsubscribed ||
+        (!!data?.settings?.email?.senders?.length &&
+            data.settings.email.senders.every((s) => s.unsubscribed));
+    const whatsappUnsubscribed = !!data?.settings?.whatsapp?.unsubscribed;
+
+    const updatePref = useMutation({
+        mutationFn: (body: Record<string, unknown>) =>
+            authenticatedAxiosInstance.put(USER_ANNOUNCEMENT_PREFERENCES(identifier), body, {
+                params: { instituteId },
+            }),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: prefKey }),
+        onError: () => toast.error('Could not update preference'),
+    });
+
+    const toggleEmail = () =>
+        updatePref.mutate({
+            preferences: {
+                emailSenders: emailSenders.map((s) => ({
+                    emailType: s.emailType,
+                    unsubscribed: !emailUnsubscribed,
+                })),
+            },
+        });
+
+    const toggleWhatsapp = () =>
+        updatePref.mutate({ preferences: { whatsappUnsubscribed: !whatsappUnsubscribed } });
+
+    if (!selectedStudent || !isAdmin || !identifier) return null;
+
+    const pendingChannel = updatePref.isPending
+        ? ((updatePref.variables as { preferences?: { whatsappUnsubscribed?: unknown } })
+              ?.preferences?.whatsappUnsubscribed !== undefined
+              ? 'whatsapp'
+              : 'email')
+        : null;
+
+    return (
+        <div className="flex flex-col gap-2 rounded-lg border border-neutral-200 bg-white p-4">
+            <p className="text-sm font-semibold text-neutral-900">Promotional messages</p>
+            <p className="text-xs text-neutral-500">
+                Stop sending marketing Email / WhatsApp to this person.
+            </p>
+            {isLoading ? (
+                <div className="flex h-9 items-center">
+                    <DashboardLoader />
+                </div>
+            ) : (
+                <div className="mt-1 flex flex-wrap items-center gap-2">
+                    <MyButton
+                        type="button"
+                        buttonType="secondary"
+                        scale="small"
+                        disable={updatePref.isPending}
+                        onClick={toggleEmail}
+                        className={cn(
+                            emailUnsubscribed && '!border-danger-200 !text-danger-600 hover:!bg-danger-50'
+                        )}
+                    >
+                        {pendingChannel === 'email' ? (
+                            <DashboardLoader size={16} />
+                        ) : (
+                            <EnvelopeSimple className="size-3.5" />
+                        )}
+                        {emailUnsubscribed ? 'Email unsubscribed' : 'Unsubscribe from Email'}
+                    </MyButton>
+                    <MyButton
+                        type="button"
+                        buttonType="secondary"
+                        scale="small"
+                        disable={updatePref.isPending}
+                        onClick={toggleWhatsapp}
+                        className={cn(
+                            whatsappUnsubscribed &&
+                                '!border-danger-200 !text-danger-600 hover:!bg-danger-50'
+                        )}
+                    >
+                        {pendingChannel === 'whatsapp' ? (
+                            <DashboardLoader size={16} />
+                        ) : (
+                            <WhatsappLogo className="size-3.5" />
+                        )}
+                        {whatsappUnsubscribed ? 'WhatsApp unsubscribed' : 'Unsubscribe from WhatsApp'}
+                    </MyButton>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from '@/lib/utils';
 import { MyButton } from '@/components/design-system/button';
 import { IndividualSendDialog } from './individual-send-dialog';
+import { UnsubscribeButtons } from './UnsubscribeButtons';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import {
     ProfileSkeleton,
@@ -633,6 +634,9 @@ export const StudentCommunicationTimeline = () => {
                     </MyButton>
                 </div>
             </div>
+
+            {/* ── Promotional unsubscribe (admin-only) ─────────────────────── */}
+            <UnsubscribeButtons />
 
             {/* ── Channel filter chips ─────────────────────────────────────── */}
             <div className="flex flex-wrap items-center gap-2">

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/DeleteLeadButton.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/DeleteLeadButton.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { MyButton } from '@/components/design-system/button';
+import { MyDialog } from '@/components/design-system/dialog';
+import { Trash } from '@phosphor-icons/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AxiosError } from 'axios';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { DELETE_AUDIENCE_LEAD } from '@/constants/urls';
+import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
+import { getTokenFromCookie, getUserRoles } from '@/lib/auth/sessionUtility';
+import { TokenKey } from '@/constants/auth/tokens';
+
+// Soft-deletes a lead (sets audience_status=INACTIVE on the backend). Admin-only:
+// the button is hidden for counsellors/other roles, and the backend re-checks.
+export const DeleteLeadButton = () => {
+    const { selectedStudent, setSelectedStudent } = useStudentSidebar();
+    const queryClient = useQueryClient();
+    const [open, setOpen] = useState(false);
+
+    const responseId =
+        (selectedStudent as unknown as Record<string, unknown>)?._response_id as string | null;
+
+    const isAdmin = getUserRoles(getTokenFromCookie(TokenKey.accessToken)).includes('ADMIN');
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            authenticatedAxiosInstance.delete(DELETE_AUDIENCE_LEAD(responseId || '')),
+        onSuccess: () => {
+            toast.success('Lead deleted');
+            queryClient.invalidateQueries({ queryKey: ['recent-leads'] });
+            queryClient.invalidateQueries({ queryKey: ['leads'] });
+            setOpen(false);
+            setSelectedStudent(null); // close the sidebar — the lead is gone
+        },
+        onError: (err: AxiosError<{ ex?: string }>) => {
+            // Surfaces the backend's 403 (not admin) / 409 (converted) message.
+            toast.error(err.response?.data?.ex || 'Failed to delete lead');
+        },
+    });
+
+    if (!selectedStudent || !responseId || !isAdmin) return null;
+
+    const footer = (
+        <div className="flex w-full items-center justify-end gap-3">
+            <MyButton
+                type="button"
+                buttonType="secondary"
+                scale="medium"
+                onClick={() => setOpen(false)}
+            >
+                Cancel
+            </MyButton>
+            <MyButton
+                type="button"
+                buttonType="primary"
+                scale="medium"
+                disable={mutation.isPending}
+                className="!bg-danger-600 hover:!bg-danger-500"
+                onClick={() => mutation.mutate()}
+            >
+                {mutation.isPending ? 'Deleting…' : 'Delete Lead'}
+            </MyButton>
+        </div>
+    );
+
+    return (
+        <MyDialog
+            trigger={
+                <MyButton
+                    buttonType="secondary"
+                    scale="small"
+                    className="!border-danger-200 !text-danger-600 hover:!bg-danger-50"
+                >
+                    <Trash className="size-3.5" />
+                    Delete Lead
+                </MyButton>
+            }
+            heading="Delete this lead?"
+            footer={footer}
+            open={open}
+            onOpenChange={setOpen}
+            dialogWidth="max-w-md"
+        >
+            <p className="text-sm text-neutral-600">
+                This lead will be removed from your lead lists and will no longer receive
+                promotional emails or WhatsApp messages. This can be undone if they submit a form
+                again.
+            </p>
+        </MyDialog>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditLeadDetails.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditLeadDetails.tsx
@@ -1,0 +1,391 @@
+import { MyButton } from '@/components/design-system/button';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyInput } from '@/components/design-system/input';
+import PhoneInputField from '@/components/design-system/phone-input-field';
+import { FormControl, FormField, FormItem } from '@/components/ui/form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, FormProvider } from 'react-hook-form';
+import { z } from 'zod';
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { UPDATE_LEAD_PROFILE } from '@/constants/urls';
+import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
+import {
+    PencilSimple,
+    UserCircle,
+    Phone,
+    UsersThree,
+    SlidersHorizontal,
+    type Icon as PhosphorIcon,
+} from '@phosphor-icons/react';
+
+// A lead is read from auth-users (name/email/mobile) + audience_response.parent_*
+// (guardian) + custom field answers. This dialog edits exactly those — nothing the
+// lead doesn't have (no enrollment/student fields). Branch into it from the shared
+// sidebar when the selected row carries a `_response_id` (i.e. it's a lead).
+
+const EditLeadFormSchema = z.object({
+    full_name: z.string().min(1, 'This field is required'),
+    email: z.string().email('Invalid email address'),
+    contact_number: z.string().optional().or(z.literal('')),
+    guardian_name: z.string().optional(),
+    guardian_mobile: z.string().optional(),
+    guardian_email: z.string().email('Invalid email').optional().or(z.literal('')),
+    custom_fields: z.record(z.string()).optional(),
+});
+
+type EditLeadFormValues = z.infer<typeof EditLeadFormSchema>;
+
+interface LeadResponseField {
+    id: string;
+    name: string;
+    type: string;
+    rawValue: string | null;
+}
+
+const FormCard = ({
+    icon: Icon,
+    title,
+    helper,
+    children,
+}: {
+    icon: PhosphorIcon;
+    title: string;
+    helper?: string;
+    children: React.ReactNode;
+}) => (
+    <section className="rounded-lg border border-neutral-200 bg-white p-5">
+        <header className="mb-4 flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary-50 text-primary-600">
+                <Icon className="size-5" weight="duotone" />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col">
+                <h3 className="text-base font-semibold text-neutral-900">{title}</h3>
+                {helper && <p className="mt-0.5 text-xs text-neutral-500">{helper}</p>}
+            </div>
+        </header>
+        <div className="flex flex-col gap-4">{children}</div>
+    </section>
+);
+
+const PHONE_INPUT_OVERRIDE_CSS = `
+.elp-phone > div { display: flex; flex-direction: column; row-gap: 4px; }
+.elp-phone .react-tel-input { width: 100% !important; font-size: 14px !important; }
+.elp-phone .react-tel-input .form-control {
+  width: 100% !important;
+  height: 36px !important;
+  padding: 4px 12px 4px 52px !important;
+  font-size: 14px !important;
+  line-height: 1.2 !important;
+}
+.elp-phone .react-tel-input .flag-dropdown,
+.elp-phone .react-tel-input .selected-flag { height: 36px !important; }
+`;
+
+export const EditLeadDetails = () => {
+    const { selectedStudent, setSelectedStudent } = useStudentSidebar();
+    const queryClient = useQueryClient();
+    const [openDialog, setOpenDialog] = useState(false);
+
+    const responseId =
+        (selectedStudent as unknown as Record<string, unknown>)?._response_id as string | null;
+    const allResponseFields =
+        ((selectedStudent as unknown as Record<string, unknown>)?._response_fields as
+            | LeadResponseField[]
+            | undefined) ?? [];
+
+    // Lead forms usually capture Full Name / Email / Phone as custom-field answers
+    // too, so those show up in _response_fields AND as the system fields we already
+    // edit at the top. Drop the identity mirrors here so they aren't rendered (and
+    // editable) twice — match by field type/name, then by value as a fallback.
+    const digits = (s?: string | null) => (s ?? '').replace(/\D/g, '');
+    const norm = (s?: string | null) => (s ?? '').trim().toLowerCase();
+    const isIdentityMirror = (f: LeadResponseField): boolean => {
+        const t = (f.type ?? '').toLowerCase().trim();
+        const n = (f.name ?? '').toLowerCase();
+        const v = norm(f.rawValue);
+        // Email
+        if (t === 'email' || /e-?mail/.test(n)) return true;
+        if (v && v === norm(selectedStudent?.email)) return true;
+        // Phone / mobile
+        if (['phone', 'mobile', 'telephone'].includes(t) || /\bphone\b|\bmobile\b|\btelephone\b/.test(n))
+            return true;
+        if (digits(f.rawValue) && digits(f.rawValue) === digits(selectedStudent?.mobile_number))
+            return true;
+        // Full name
+        if (/\bfull\s*name\b|^name$/.test(n)) return true;
+        if (v && v === norm(selectedStudent?.full_name)) return true;
+        return false;
+    };
+    const responseFields = allResponseFields.filter((f) => !isIdentityMirror(f));
+
+    const form = useForm<EditLeadFormValues>({
+        resolver: zodResolver(EditLeadFormSchema),
+        defaultValues: {},
+    });
+
+    // Seed from the same values the sidebar reads, so the edit round-trips.
+    useEffect(() => {
+        if (!selectedStudent || !openDialog) return;
+        const customFields: Record<string, string> = {};
+        responseFields.forEach((f) => {
+            customFields[f.id] = f.rawValue ?? '';
+        });
+        form.reset({
+            full_name: selectedStudent.full_name || '',
+            email: selectedStudent.email || '',
+            contact_number: selectedStudent.mobile_number || '',
+            guardian_name: selectedStudent.fathers_name || '',
+            guardian_mobile: selectedStudent.father_mobile_number || '',
+            guardian_email: selectedStudent.father_email || '',
+            custom_fields: customFields,
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedStudent, openDialog]);
+
+    const mutation = useMutation({
+        mutationFn: (values: EditLeadFormValues) => {
+            const customFieldValues = Object.entries(values.custom_fields ?? {}).map(
+                ([custom_field_id, value]) => ({
+                    source_type: 'AUDIENCE_RESPONSE',
+                    source_id: responseId,
+                    custom_field_id,
+                    value: value || '',
+                })
+            );
+            const payload = {
+                user_details: {
+                    id: selectedStudent?.user_id,
+                    full_name: values.full_name,
+                    email: values.email,
+                    mobile_number: values.contact_number || '',
+                },
+                parent_name: values.guardian_name || '',
+                parent_email: values.guardian_email || '',
+                parent_mobile: values.guardian_mobile || '',
+                custom_field_values: customFieldValues,
+            };
+            return authenticatedAxiosInstance.put(UPDATE_LEAD_PROFILE(responseId || ''), payload);
+        },
+        onSuccess: (_data, values) => {
+            toast.success('Lead profile updated');
+            // Reflect the edit in the open sidebar immediately.
+            if (selectedStudent) {
+                setSelectedStudent(
+                    {
+                        ...selectedStudent,
+                        full_name: values.full_name,
+                        email: values.email,
+                        mobile_number: values.contact_number || '',
+                        fathers_name: values.guardian_name || '',
+                        father_mobile_number: values.guardian_mobile || '',
+                        father_email: values.guardian_email || '',
+                    },
+                    { openOverlay: false }
+                );
+            }
+            queryClient.invalidateQueries({ queryKey: ['recent-leads'] });
+            queryClient.invalidateQueries({ queryKey: ['leads'] });
+            setOpenDialog(false);
+        },
+        onError: () => {
+            toast.error('Failed to update lead profile');
+        },
+    });
+
+    const onSubmit = (values: EditLeadFormValues) => mutation.mutate(values);
+
+    if (!selectedStudent || !responseId) return null;
+
+    const footer = (
+        <div className="flex w-full items-center justify-end gap-3">
+            <MyButton
+                type="button"
+                buttonType="secondary"
+                scale="medium"
+                onClick={() => setOpenDialog(false)}
+            >
+                Cancel
+            </MyButton>
+            <MyButton
+                type="button"
+                buttonType="primary"
+                scale="medium"
+                disable={mutation.isPending}
+                onClick={() => form.handleSubmit(onSubmit)()}
+            >
+                {mutation.isPending ? 'Saving…' : 'Save Changes'}
+            </MyButton>
+        </div>
+    );
+
+    return (
+        <MyDialog
+            trigger={
+                <MyButton buttonType="secondary" scale="medium">
+                    <PencilSimple className="size-4" />
+                    Edit Details
+                </MyButton>
+            }
+            footer={footer}
+            heading="Edit Lead Profile"
+            open={openDialog}
+            onOpenChange={setOpenDialog}
+            dialogWidth="max-w-2xl"
+        >
+            <FormProvider {...form}>
+                <style dangerouslySetInnerHTML={{ __html: PHONE_INPUT_OVERRIDE_CSS }} />
+                <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-5">
+                    {/* IDENTITY */}
+                    <FormCard icon={UserCircle} title="Identity" helper="Their name and basic info.">
+                        <FormField
+                            control={form.control}
+                            name="full_name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Full Name"
+                                            required
+                                            inputType="text"
+                                            inputPlaceholder="Full name"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.full_name?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* CONTACT */}
+                    <FormCard icon={Phone} title="Contact" helper="Primary channels for reach-out.">
+                        <FormField
+                            control={form.control}
+                            name="email"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Email"
+                                            required
+                                            inputType="text"
+                                            inputPlaceholder="name@example.com"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.email?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name="contact_number"
+                            render={() => (
+                                <FormItem>
+                                    <FormControl>
+                                        <div className="elp-phone w-full">
+                                            <PhoneInputField
+                                                label="Mobile Number"
+                                                placeholder="123 456 7890"
+                                                name="contact_number"
+                                                control={form.control}
+                                                required={false}
+                                            />
+                                        </div>
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* GUARDIAN */}
+                    <FormCard
+                        icon={UsersThree}
+                        title="Guardian"
+                        helper="Parent / guardian contact (optional)."
+                    >
+                        <FormField
+                            control={form.control}
+                            name="guardian_name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Guardian Name"
+                                            inputType="text"
+                                            inputPlaceholder="Guardian name"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <div className="elp-phone w-full">
+                            <PhoneInputField
+                                label="Guardian Mobile"
+                                placeholder="123 456 7890"
+                                name="guardian_mobile"
+                                control={form.control}
+                                required={false}
+                            />
+                        </div>
+                        <FormField
+                            control={form.control}
+                            name="guardian_email"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Guardian Email"
+                                            inputType="text"
+                                            inputPlaceholder="guardian@example.com"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.guardian_email?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* CUSTOM FIELDS (the lead's form answers) */}
+                    {responseFields.length > 0 && (
+                        <FormCard
+                            icon={SlidersHorizontal}
+                            title="Additional Details"
+                            helper="Answers captured on the lead form."
+                        >
+                            {responseFields.map((f) => (
+                                <FormField
+                                    key={f.id}
+                                    control={form.control}
+                                    name={`custom_fields.${f.id}` as const}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormControl>
+                                                <MyInput
+                                                    label={f.name}
+                                                    inputType="text"
+                                                    inputPlaceholder={f.name}
+                                                    input={field.value ?? ''}
+                                                    onChangeFunction={(e) => field.onChange(e.target.value)}
+                                                />
+                                            </FormControl>
+                                        </FormItem>
+                                    )}
+                                />
+                            ))}
+                        </FormCard>
+                    )}
+                </form>
+            </FormProvider>
+        </MyDialog>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditStudentDetails.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditStudentDetails.tsx
@@ -48,7 +48,7 @@ const EditStudentDetailsFormSchema = z.object({
     username: z.string().optional(),
     email: z.string().email('Invalid email address'),
     full_name: z.string().min(1, 'This field is required'),
-    contact_number: z.string().min(1, 'This field is required'),
+    contact_number: z.string().optional().or(z.literal('')),
     gender: z.string().optional(),
     date_of_birth: z.string().optional(),
     address_line: z.string().optional(),
@@ -485,7 +485,7 @@ export const EditStudentDetails = () => {
                                 placeholder="123 456 7890"
                                 name="contact_number"
                                 control={form.control}
-                                required={true}
+                                required={false}
                             />
                             {form.formState.errors.contact_number?.message && (
                                 <p className="mt-1 text-caption text-danger-600">

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
@@ -25,6 +25,7 @@ import type { FieldGroup } from '@/services/custom-field-settings';
 import { getPublicUrl } from '@/services/upload_file';
 import { ProfileSectionCard, ProfileFieldRow, ProfileEmpty } from '../profile-ui';
 import { EditStudentDetails } from './EditStudentDetails';
+import { EditLeadDetails } from './EditLeadDetails';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
@@ -223,9 +224,15 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
 
     return (
         <div className="flex flex-col gap-3 text-card-foreground">
-            {/* Single primary action — edit the learner's profile. */}
+            {/* Single primary action — edit the profile. Leads (rows carrying a
+                `_response_id` marker) get the lead-shaped editor; contacts get the
+                student editor. */}
             <div className="flex justify-end">
-                <EditStudentDetails />
+                {(selectedStudent as unknown as Record<string, unknown>)?._response_id ? (
+                    <EditLeadDetails />
+                ) : (
+                    <EditStudentDetails />
+                )}
             </div>
 
             {/* Detail sections — clean label/value cards (General Details,

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
@@ -6,6 +6,7 @@ import { X, ArrowsOutSimple, CaretLeft, CaretRight } from '@phosphor-icons/react
 import { useState, useEffect, useRef, useCallback } from 'react';
 import DummyProfile from '@/assets/svgs/dummy_profile_photo.svg';
 import { StatusChips } from '@/components/design-system/chips';
+import { DeleteLeadButton } from './student-overview/DeleteLeadButton';
 import { StudentOverview } from './student-overview/student-overview';
 import { StudentCourses } from './student-courses/student-courses';
 import { StudentLearningProgress } from './student-learning-progress/student-learning-progress';
@@ -332,6 +333,9 @@ export const StudentSidebar = ({
                                 {selectedStudent?.status && (
                                     <StatusChips status={selectedStudent.status} />
                                 )}
+                                {/* Delete Lead — self-hides unless this is a lead and the
+                                    caller is an admin. Sits beside the status pill. */}
+                                <DeleteLeadButton />
                             </div>
 
                             {/* The full-screen profile overlay is mounted only by the


### PR DESCRIPTION
## Summary of Changes

Lead CRM management: leads can now be edited, soft-deleted, and unsubscribed from
promotional messages — using the `audience_status` column shipped separately (PR #2114).
Fixes the original bug where editing a lead 510'd because the CRM reused the
student-edit endpoint (leads have no `student` row).

**Backend:**
- New `PUT /v1/audience/lead/{responseId}/profile` — edits a lead where it's actually
  stored: auth user (name/email/mobile) + `audience_response.parent_*` + custom fields.
  Never touches the `student` table.
- `deleteLead` is now a **soft delete** (sets `audience_status=INACTIVE`), **ADMIN-only**,
  and blocks deleting a converted lead.
- Re-submitting a deleted lead silently **reactivates** it (via the existing `dedupe_key`);
  editing into a colliding email/phone returns 409.
- Excludes `INACTIVE` leads from lead lists, counts, detail fetch, and — key — the
  promotional/automated send recipient queries (scheduler + campaign). Reports/admission
  /payments untouched.
- Typed exceptions with correct HTTP status (`ResourceNotFoundException` 404,
  `ForbiddenException` 403, `ConflictException` 409, wired `InvalidRequestException` 400)
  + handlers, replacing default `VacademyException` (510).

**Frontend:**
- New `EditLeadDetails` dialog (name/email/mobile + guardian + custom fields only —
  no student-only fields; identity mirrors de-duplicated); shown for leads via the
  `_response_id` marker; contacts keep the student dialog.
- Admin-only **Delete Lead** button beside the status pill (confirm dialog, soft delete).
- Two per-channel **Unsubscribe** buttons (Email / WhatsApp) on the Notifications tab,
  spinner→confirmed-red on 200.
- Surfaced `parent_*` guardian fields in the lead view-model so edits round-trip.

## Related Issue

<leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Local admin_core (prod-dump DB) + local auth: lead profile edit persists (identity → auth
  user, guardian/custom fields → audience_response); duplicate email/phone → 409.
- Soft delete sets `audience_status=INACTIVE`; lead disappears from the list; button hidden
  for non-admins.
- Backend compiles clean after rebasing onto latest main; frontend design-lint + typecheck clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
