### PR TITLE
flyway: add engaged_ms column to activity_log

### DIFF
--- a/admin_core_service/src/main/resources/db/migration/V360__Add_engaged_ms_to_activity_log.sql
+++ b/admin_core_service/src/main/resources/db/migration/V360__Add_engaged_ms_to_activity_log.sql
@@ -1,0 +1,6 @@
+-- Bug 1 fix: authoritative "engaged time" per activity (milliseconds).
+-- Populated at ingestion from the merged/union of breadcrumb intervals (passive media)
+-- or the clamped wall-clock window (interactive / no-breadcrumb rows).
+-- All time-reporting queries read SUM(engaged_ms) instead of (end_time - start_time),
+-- which counted wall-clock tab-open time and inflated the leaderboard.
+ALTER TABLE activity_log ADD COLUMN IF NOT EXISTS engaged_ms BIGINT;


### PR DESCRIPTION
## Summary of Changes

Adds a nullable `engaged_ms` (BIGINT) column to `activity_log`. Schema-only foundation for the
learning-time leaderboard fix (follow-up PR): the column holds each activity's real engaged time in
milliseconds, so time-reporting queries can sum a trustworthy value instead of `end_time - start_time`
(wall-clock "slide was open" time, which inflated the leaderboard). Shipped separately and first so the
column exists before the code that reads it.

**Backend:**
- New Flyway migration `V360__Add_engaged_ms_to_activity_log.sql`: `ALTER TABLE activity_log ADD COLUMN IF NOT EXISTS engaged_ms BIGINT` — nullable, no backfill, no locking work.

**Frontend:**
- None.

## Related Issue



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Confirmed prod is at Flyway version 359, so 360 is the correct next number.
- Applied on a local Postgres 16 clone of prod data: column added cleanly, nullable, existing rows and existing (old) code unaffected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
