### PR TITLE
Fix/yoopta slide editor crashes

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -158,6 +158,63 @@ function estimatePageCount(htmlString: string): number {
         return 1;
     }
 }
+
+/**
+ * Repair a Slate element's `children` so it satisfies Slate's structural
+ * invariants. This heals the production white-screen where a heading/paragraph
+ * began with an EMPTY inline <link> (url:"" , text:"") — such a node makes
+ * toDOMNode / Editor.start / focus throw ("Cannot resolve a DOM node from Slate
+ * node" / "...has no start text node"), crashing the whole slide on open. 250+
+ * stored slides carry this artifact, so we heal it on load instead of chasing
+ * async suppressors that can't catch the setTimeout-scheduled focus throw.
+ *
+ * Rules: drop empty broken links (type 'link', no url AND no text); guarantee a
+ * text node immediately before and after every inline element; never leave an
+ * element with empty children. Valid links (real url or text) pass untouched.
+ */
+const isInlineSlateElement = (n: any): boolean =>
+    !!n &&
+    typeof n === 'object' &&
+    Array.isArray(n.children) &&
+    (n?.props?.nodeType === 'inline' || n?.type === 'link' || n?.type === 'Link');
+const isSlateTextNode = (n: any): boolean =>
+    !!n && typeof n === 'object' && typeof n.text === 'string';
+const collectSlateText = (n: any): string => {
+    if (!n) return '';
+    if (typeof n.text === 'string') return n.text;
+    if (Array.isArray(n.children)) return n.children.map(collectSlateText).join('');
+    return '';
+};
+function repairSlateChildren(children: any): any {
+    if (!Array.isArray(children)) return children;
+    const out: any[] = [];
+    for (const child of children) {
+        if (!child) continue;
+        if (isInlineSlateElement(child)) {
+            const inner = repairSlateChildren(child.children);
+            const text = inner.map(collectSlateText).join('');
+            const url = child?.props?.url;
+            // Drop empty broken links — the artifact that crashes Slate.
+            if ((child.type === 'link' || child.type === 'Link') && !text.trim() && !url) {
+                continue;
+            }
+            // Slate invariant: a text node must precede an inline.
+            if (out.length === 0 || !isSlateTextNode(out[out.length - 1])) {
+                out.push({ text: '' });
+            }
+            out.push({ ...child, children: inner.length ? inner : [{ text: '' }] });
+        } else if (Array.isArray(child.children) && typeof child.type === 'string') {
+            out.push({ ...child, children: repairSlateChildren(child.children) });
+        } else {
+            out.push(child);
+        }
+    }
+    // Slate invariant: a text node must follow a trailing inline.
+    if (out.length && isInlineSlateElement(out[out.length - 1])) {
+        out.push({ text: '' });
+    }
+    return out.length ? out : [{ text: '' }];
+}
 import ScormSlidePreview from './scorm-slide-preview';
 import AssessmentSlidePreview from './assessment-slide-preview';
 import AssessmentCreateForm from './assessment-create-form';
@@ -921,7 +978,10 @@ export const SlideMaterial = ({
                         ) {
                             return { ...slateEl, children: [{ text: '' }] };
                         }
-                        return slateEl;
+                        // Heal Slate inline invariants — e.g. an empty inline
+                        // <link> at the start of a heading/paragraph, which
+                        // otherwise crashes the whole slide on open.
+                        return { ...slateEl, children: repairSlateChildren(slateEl.children) };
                     });
                 }
             }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/yoopta-editor-customizations/jupyter-notebook.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/yoopta-editor-customizations/jupyter-notebook.tsx
@@ -96,6 +96,21 @@ export function JupyterNotebook({
                 backgroundColor: '#fafafa',
             }}
         >
+            {/*
+              Non-editable island. This block renders native <input>/<select>
+              controls and static labels *inside* Slate's contentEditable region.
+              Without contentEditable={false}, two things break:
+                1. Typing in a field fires a native `beforeinput` that bubbles to
+                   Slate's editable handler, which calls toSlatePoint on the
+                   input's DOM node (not in Slate's model) and throws
+                   "Cannot resolve a Slate point from DOM point" on every keystroke.
+                2. Slate treats the labels as editable document text, so clicking a
+                   label and typing corrupts it (e.g. "notebook" -> "noteboasdfok").
+              Marking this subtree non-editable makes Slate's hasEditableTarget
+              check bail out, fixing both. The `{children}` text anchor Slate
+              requires is kept OUTSIDE this wrapper so Slate still manages it.
+            */}
+            <div contentEditable={false} suppressContentEditableWarning>
             <div style={{ marginBottom: '16px' }}>
                 <div
                     style={{
@@ -401,8 +416,19 @@ export function JupyterNotebook({
                     )}
                 </div>
             )}
+            </div>
+            {/* end non-editable island */}
 
-            {children}
+            {/* Slate requires {children} in the DOM for the block to stay valid,
+                but Yoopta paints its default "Type / for commands" placeholder
+                over it. Keep it mounted but visually hidden — same pattern as
+                tabs-editor / mermaid-editor / table-of-contents. */}
+            <div
+                aria-hidden
+                className="pointer-events-none absolute size-0 overflow-hidden opacity-0"
+            >
+                {children}
+            </div>
 
             <style>{`
         @keyframes spin {


### PR DESCRIPTION
## Summary of Changes

Fixes three crashes/regressions in the study-library **document slide editor** (Yoopta + Slate), all triggered by malformed inline content reaching Slate.

The headline fix stops a **full-page crash** ("Something went wrong") that fired whenever a document slide was opened whose content began with an empty inline link (`<a href=""></a>`) — a leftover artifact from deleted/pasted links. Slate's `Editor.start` / `toDOMNode` / focus throw on such a node, React's error boundary catches it, and the whole slide white-screens on every open. A replica scan found this artifact in **250+ stored slides**, so it's healed generically at load time rather than per-slide.

**Backend:**
- None — frontend only.

**Frontend:**
- **Empty-link crash (primary):** added a `repairSlateChildren` sanitizer in `slide-material.tsx`, invoked in `processNode` on the slide-load path (before `setEditorValue`). It recursively drops empty broken links (no `url` and no text) and enforces Slate's invariant that inline nodes are surrounded by text nodes. Valid links pass through untouched. Heals all affected stored slides on open.
- **Jupyter block ↔ Slate isolation:** wrapped the Jupyter Notebook block's native `<input>`/`<select>` UI in a `contentEditable={false}` island. Stops the per-keystroke `Cannot resolve a Slate point from DOM point` error flood and prevents typing from corrupting the block's static labels.
- **Jupyter placeholder overlay:** hid the block's required-but-empty Slate `{children}` node so Yoopta's default "Type / for commands" placeholder no longer overlays the block UI (same pattern already used by the tabs/mermaid/table-of-contents blocks).

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Reproduced the full-page crash by opening the affected production slide (empty inline link at the start of a heading) and confirmed the "Something went wrong" boundary.
- Ran the `repairSlateChildren` logic against the real crashing node plus edge cases (valid mid-text link, leading link, plain paragraph, back-to-back empty links) — 5/5 produce Slate-valid output; the empty link is removed and real content/links are preserved.
- `tsc --noEmit` (typecheck) passes clean.
- Reproduced the Jupyter block error flood (typing in Content URL) and the "Type / for commands" overlay; verified the `contentEditable` island + hidden-children wrapper resolve both.
- Replica scan confirmed prevalence (254 slides with `href=""`, 367 with empty `<a></a>`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
