### PR TITLE
Fix/docx import empty links

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/EditorErrorBoundary.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/EditorErrorBoundary.tsx
@@ -1,0 +1,74 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import * as Sentry from '@sentry/react';
+import { MyButton } from '@/components/design-system/button';
+
+interface EditorErrorBoundaryProps {
+    children: ReactNode;
+    // Change this (e.g. the active slide id) to clear a caught error when the
+    // user navigates to a different slide, so one bad slide doesn't leave every
+    // subsequent slide showing the fallback.
+    resetKey?: unknown;
+}
+
+interface EditorErrorBoundaryState {
+    hasError: boolean;
+}
+
+/**
+ * Scoped error boundary around the study-library document (Yoopta/Slate) editor.
+ * If a slide's content throws during render — e.g. a future corrupted node we
+ * haven't sanitized yet — this degrades to a graceful message + a Sentry report
+ * instead of letting the whole app hit the global "Something went wrong" page.
+ *
+ * Defense-in-depth ONLY. The real fixes live at the three content layers:
+ * import (stripEmptyAnchors), save (stripEmptyAnchors) and load
+ * (repairSlateChildren). This boundary is the safety net for the unknown.
+ */
+export class EditorErrorBoundary extends Component<
+    EditorErrorBoundaryProps,
+    EditorErrorBoundaryState
+> {
+    state: EditorErrorBoundaryState = { hasError: false };
+
+    static getDerivedStateFromError(): EditorErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo): void {
+        console.error('[SlideEditor] render crash caught by boundary:', error, info);
+        Sentry.captureException(error, {
+            tags: { boundary: 'SlideEditorErrorBoundary' },
+            extra: { componentStack: info.componentStack },
+        });
+    }
+
+    componentDidUpdate(prevProps: EditorErrorBoundaryProps): void {
+        if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+            this.setState({ hasError: false });
+        }
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div className="flex w-full flex-col items-center justify-center gap-3 p-12 text-center">
+                    <p className="text-base font-semibold text-neutral-700">
+                        This slide couldn&apos;t be displayed
+                    </p>
+                    <p className="max-w-md text-sm text-neutral-500">
+                        Something in this slide&apos;s content couldn&apos;t be loaded. Please reload
+                        the page. If it keeps happening, let support know which slide it was.
+                    </p>
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={() => window.location.reload()}
+                    >
+                        Reload page
+                    </MyButton>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -18,6 +18,7 @@ import { EmptySlideMaterial } from '@/assets/svgs';
 import { useState } from 'react';
 import { html } from '@yoopta/exports';
 import { SlidesMenuOption } from './slides-menu-options/slides-menu-option';
+import { EditorErrorBoundary } from './EditorErrorBoundary';
 import { plugins, TOOLS, MARKS } from '@/constants/study-library/yoopta-editor-plugins-tools';
 import { useRouter } from '@tanstack/react-router';
 import { getPublicUrl } from '@/services/upload_file';
@@ -568,6 +569,7 @@ export const SlideMaterial = ({
                         </div>
                     }
                 >
+                    <EditorErrorBoundary resetKey={activeItem?.id}>
                     <YooptaEditorWrapper
                         editor={editor}
                         plugins={plugins}
@@ -599,6 +601,7 @@ export const SlideMaterial = ({
                         className="size-full"
                         style={{ width: '100%', height: '100%', minHeight: '200px' }}
                     />
+                    </EditorErrorBoundary>
                 </Suspense>
             </div>
         );

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/formatHtmlString.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/formatHtmlString.tsx
@@ -169,6 +169,21 @@ export const normalizeTableColumns = (htmlString: string): string => {
     });
 };
 
+/**
+ * Remove content-less anchor tags: Word/mammoth heading "bookmark" anchors
+ * (`<a id="_Toc…"></a>`) and empty Yoopta links (`<a href="" …></a>`). They have
+ * no text and no child elements, so they render nothing — but on deserialize
+ * they become invalid inline `link` nodes that crash the Slate slide editor when
+ * one sits at the start of a heading ("Cannot resolve a DOM node from Slate
+ * node" / "no start text node" white-screen). Anchors with text or child
+ * elements (e.g. image links) are preserved. Shared by the docx importer (A) and
+ * this save-path formatter (B); the load path uses repairSlateChildren (C).
+ */
+export const stripEmptyAnchors = (htmlString: string): string => {
+    if (!htmlString) return htmlString;
+    return htmlString.replace(/<a\b[^>]*>(?:\s|&nbsp;|&#160;|&#xA0;)*<\/a>/gi, '');
+};
+
 export const formatHTMLString = (htmlString: string) => {
     // Strip any existing html/head/body wrappers first to make this idempotent.
     // This prevents double-wrapping on repeated save cycles.
@@ -195,6 +210,10 @@ export const formatHTMLString = (htmlString: string) => {
         /<img[^>]*\ssrc="(?:null|undefined|)"[^>]*\/?>(?!\s*<\/div>)/gi,
         ''
     );
+
+    // Remove content-less anchors (Word bookmark anchors / empty links) so a
+    // save can never persist the artifact that crashes the editor on next open.
+    cleanedHtml = stripEmptyAnchors(cleanedHtml);
 
     // Strip expired query params from public S3 URLs
     cleanedHtml = stripAwsQueryParamsFromUrls(cleanedHtml);

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/utils/doc-to-html.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/utils/doc-to-html.ts
@@ -1,4 +1,5 @@
 import mammoth from 'mammoth';
+import { stripEmptyAnchors } from '../../slide-operations/formatHtmlString';
 
 const INLINE_TAGS = 'strong|em|b|i|u|code|span|mark|sub|sup|small';
 const BLOCK_CONTAINERS = new Set([
@@ -420,10 +421,16 @@ export const convertDocToHtml = async (file: File): Promise<string> => {
                 const imagesHoisted = hoistImagesFromBlocks(whitespaceFixed);
                 const listsFixed = splitListItemsOnDoubleBreaks(imagesHoisted);
                 const olsFlattened = flattenOrderedListsToParagraphs(listsFixed);
+                // Word inserts hidden "bookmark" anchors (<a id="_Toc…"></a>) at
+                // each heading when the doc has a Table of Contents / cross-refs;
+                // mammoth emits them as empty <a>. Strip them at import so they
+                // never reach the DB or the editor (root-cause fix — pairs with
+                // stripEmptyAnchors on save and repairSlateChildren on load).
+                const linksStripped = stripEmptyAnchors(olsFlattened);
 
                 const processedHTML = `
                     <div>
-                        ${olsFlattened}
+                        ${linksStripped}
                     </div>
                 `;
 


### PR DESCRIPTION
## Summary of Changes

Root-cause follow-up to the earlier slide-editor crash fix (the merged `repairSlateChildren` load-time repair, "C"). That fix *contained* the crash; this PR closes the **source** of the corruption and adds a safety net, so empty links stop being created and can never crash the editor again.

Background: Word `.docx` files with a Table of Contents / cross-references contain hidden heading bookmarks. On import, `mammoth` converts each to an empty `<a id="_Toc…"></a>`. These were saved raw, then round-tripped by the `@yoopta/link` (de)serializer into `<a href="" …></a>` — which becomes an invalid inline link node that crashes the Slate editor when it sits at the start of a heading. One real slide carried **44** of these.

Deliberately **not** included: a bulk DB migration ("D"). Existing affected slides already self-heal — on load via C, and on their next save via B — so no destructive backfill is needed.

**Backend:**
- None — frontend only.

**Frontend:**
- **A — fix at import:** `convertDocToHtml` now runs `stripEmptyAnchors` on the mammoth output, so Word bookmark anchors are removed before the HTML is ever saved (`doc-to-html.ts`).
- **B — fix on save:** `formatHTMLString` (the choke point every serialize/save flows through) now strips content-less anchors, so a corrupt link can never be persisted — this also closes the **paste** vector, which bypasses the load-time repair (`formatHtmlString.tsx`).
- **Shared helper:** added `stripEmptyAnchors` (one source of truth for A and B); the load path continues to use `repairSlateChildren` (C).
- **E — safety net:** added `EditorErrorBoundary` around the document editor. If any *future* unsanitized corruption throws during render, it degrades to a graceful in-place message + a Sentry report instead of the whole app hitting the global "Something went wrong" page. It resets on slide-switch so one bad slide doesn't blank out the rest.

## Related Issue

<link or leave blank>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran `stripEmptyAnchors` against the **real production payload** of the crashing slide (70 KB, 44 empty links): empty anchors 44 → 0, both genuine links preserved unchanged, all heading text intact ("From Script to Screen", "High Angle").
- Verified the mammoth bookmark case (`<h1><a id="_Toc…"></a>Heading</h1>` → `<h1>Heading</h1>`) and that a real `<a href="…">text</a>` is left byte-identical.
- `tsc --noEmit` (typecheck) passes clean.
- `EditorErrorBoundary` mirrors the existing, in-use `YooptaEditorWrapperSafe` pattern (class boundary + `Sentry.captureException`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
