### PR TITLE
fix(leads): enable bulk select in every view so assign/remove counsel…

### DIFF
--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
@@ -445,14 +445,15 @@ const CampaignUsersContent = ({
     const handleStatusUpdated = () =>
         queryClient.invalidateQueries({ queryKey: ['campaignUsers', campaignId] });
 
-    // ── Bulk assign counsellor (multi-select on the Unassigned view) ──
-    const isUnassignedView = counsellorFilter === UNASSIGNED_COUNSELLOR_VALUE;
+    // ── Bulk assign / remove counsellor (multi-select, every view) ──
     const [selectedLeads, setSelectedLeads] = useState<Map<string, { userId: string; name: string }>>(
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
 
-    // Selection only applies to the Unassigned view; drop it on filter change.
+    // Selection works in every view (previously Unassigned-only, which made
+    // reassign/remove unreachable); drop it on filter change so stale ids
+    // can't leak into an assign.
     useEffect(() => {
         setSelectedLeads(new Map());
     }, [counsellorFilter]);
@@ -989,8 +990,8 @@ const CampaignUsersContent = ({
                 onOpenChange={setIsSidebarOpen}
             >
                 <div className="min-w-0 flex-1">
-                    {/* Bulk-assign toolbar — only on the Unassigned view with a selection. */}
-                    {isUnassignedView && selectedLeads.size > 0 && (
+                    {/* Bulk-action toolbar — any view with a selection (assign / remove counsellor). */}
+                    {selectedLeads.size > 0 && (
                         <div className="mb-2 flex items-center justify-between rounded-lg border border-primary-200 bg-primary-50 px-3 py-2">
                             <span className="text-body font-medium text-primary-700">
                                 {selectedLeads.size} selected
@@ -1043,7 +1044,7 @@ const CampaignUsersContent = ({
                             actions={actions}
                             onStatusUpdated={handleStatusUpdated}
                             hiddenColumns={hiddenColumns}
-                            selectable={isUnassignedView}
+                            selectable
                             selectedIds={new Set(selectedLeads.keys())}
                             onToggleRow={toggleLeadRow}
                             onToggleAll={toggleAllLeads}

--- a/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
@@ -512,15 +512,16 @@ const RecentLeadsContent = () => {
         queryClient.invalidateQueries({ queryKey: ['lead-profiles-batch'] });
     };
 
-    // ── Bulk assign counsellor (multi-select on the Unassigned view) ──
-    const isUnassignedView = counsellorFilter === UNASSIGNED_COUNSELLOR_VALUE;
+    // ── Bulk assign / remove counsellor (multi-select, every view) ──
     const [selectedLeads, setSelectedLeads] = useState<Map<string, { userId: string; name: string }>>(
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
 
-    // Selection is only meaningful on the Unassigned view; drop it when the
-    // counsellor filter changes so stale ids can't leak into an assign.
+    // Selection works in EVERY view (assign, reassign AND bulk-remove need
+    // assigned leads too — it was previously Unassigned-only, which made the
+    // dialog's Remove mode unreachable). Drop it when the counsellor filter
+    // changes so stale ids can't leak into an assign.
     useEffect(() => {
         setSelectedLeads(new Map());
     }, [counsellorFilter]);
@@ -1137,8 +1138,8 @@ const RecentLeadsContent = () => {
                 onOpenChange={setIsSidebarOpen}
             >
                 <div className="min-w-0 flex-1">
-                    {/* Bulk-assign toolbar — only on the Unassigned view with a selection. */}
-                    {isUnassignedView && selectedLeads.size > 0 && (
+                    {/* Bulk-action toolbar — any view with a selection (assign / remove counsellor). */}
+                    {selectedLeads.size > 0 && (
                         <div className="mb-2 flex items-center justify-between rounded-lg border border-primary-200 bg-primary-50 px-3 py-2">
                             <span className="text-body font-medium text-primary-700">
                                 {selectedLeads.size} selected
@@ -1191,7 +1192,7 @@ const RecentLeadsContent = () => {
                             actions={actions}
                             onStatusUpdated={handleStatusUpdated}
                             hiddenColumns={hiddenColumns}
-                            selectable={isUnassignedView}
+                            selectable
                             selectedIds={new Set(selectedLeads.keys())}
                             onToggleRow={toggleLeadRow}
                             onToggleAll={toggleAllLeads}


### PR DESCRIPTION
…lor is reachable

Row checkboxes and the bulk toolbar were gated to the Unassigned counsellor filter on both lead tables, which made bulk reassign and the new bulk Remove-counsellor mode unreachable for assigned leads. Selection now works in every view; the selection still clears on counsellor-filter change and "Select all N" keeps honouring the active filters.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
