### PR TITLE
feat(leads): split bulk toolbar into an explicit Bulk actions menu

### DIFF
--- a/frontend-admin-dashboard/src/components/shared/leads/bulk-assign-counsellor-dialog.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/bulk-assign-counsellor-dialog.tsx
@@ -16,7 +16,8 @@ import { cn } from '@/lib/utils';
 import type { CounsellorOption } from '@/hooks/use-lead-counsellor-options';
 import { assignLeads } from '@/routes/counsellors/-services/counsellor-workbench-services';
 
-type Mode = 'ROUND_ROBIN' | 'SINGLE' | 'MANUAL' | 'REMOVE';
+export type BulkAssignMode = 'ROUND_ROBIN' | 'SINGLE' | 'MANUAL' | 'REMOVE';
+type Mode = BulkAssignMode;
 
 export interface BulkAssignLead {
     userId: string;
@@ -31,6 +32,9 @@ interface BulkAssignCounsellorDialogProps {
     leads: BulkAssignLead[];
     /** Scoped counsellor list (id + name) — the assignable targets. */
     counsellorOptions: CounsellorOption[];
+    /** Mode pre-selected when the dialog opens — the "Bulk actions" menu
+     *  opens straight into Assign (ROUND_ROBIN) or Unassign (REMOVE). */
+    initialMode?: BulkAssignMode;
     /** Fired after a successful commit (refetch + clear selection). */
     onSuccess?: () => void;
 }
@@ -74,9 +78,10 @@ export function BulkAssignCounsellorDialog({
     instituteId,
     leads,
     counsellorOptions,
+    initialMode = 'ROUND_ROBIN',
     onSuccess,
 }: BulkAssignCounsellorDialogProps) {
-    const [mode, setMode] = useState<Mode>('ROUND_ROBIN');
+    const [mode, setMode] = useState<Mode>(initialMode);
     const [singleTarget, setSingleTarget] = useState<string>('');
     // Round-robin participants — all counsellors pre-checked; admin can deselect.
     const [rrChecked, setRrChecked] = useState<Set<string>>(new Set());
@@ -86,12 +91,12 @@ export function BulkAssignCounsellorDialog({
     // (Re)initialise when the dialog opens or the counsellor list loads.
     useEffect(() => {
         if (open) {
-            setMode('ROUND_ROBIN');
+            setMode(initialMode);
             setSingleTarget('');
             setRrChecked(new Set(counsellorOptions.map((c) => c.id)));
             setOverrides({});
         }
-    }, [open, counsellorOptions]);
+    }, [open, counsellorOptions, initialMode]);
 
     const activeCandidates = useMemo(
         () => counsellorOptions.filter((c) => rrChecked.has(c.id)),
@@ -213,7 +218,7 @@ export function BulkAssignCounsellorDialog({
 
     return (
         <MyDialog
-            heading="Assign counsellor"
+            heading={mode === 'REMOVE' ? 'Unassign leads' : 'Assign counsellor'}
             open={open}
             onOpenChange={onOpenChange}
             dialogWidth="w-full max-w-2xl"

--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
@@ -12,11 +12,13 @@ import {
     Flame,
     CheckCircle,
     UserPlus,
+    UserMinus,
     UploadSimple,
     DownloadSimple,
     PaperPlaneTilt,
     X,
     Clock,
+    CaretDown,
 } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -55,7 +57,11 @@ import { SendMessageDialog } from './SendMessageDialog';
 import { CommunicationHistory } from './CommunicationHistory';
 import { parseCustomFieldsFromJson } from '../../-utils/lead-bulk-import-utils';
 import { AddLeadNoteDialog } from '@/components/shared/add-lead-note-dialog';
-import { BulkAssignCounsellorDialog } from '@/components/shared/leads/bulk-assign-counsellor-dialog';
+import {
+    BulkAssignCounsellorDialog,
+    type BulkAssignMode,
+} from '@/components/shared/leads/bulk-assign-counsellor-dialog';
+import { MyDropdown } from '@/components/design-system/dropdown';
 import type { LeadCardVM } from '@/components/shared/leads/lead-view-model';
 import { MyButton } from '@/components/design-system/button';
 import { AssignCounselorToLeadDialog } from '@/components/shared/assign-counselor-to-lead-dialog';
@@ -450,6 +456,9 @@ const CampaignUsersContent = ({
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+    // Which flow the "Bulk actions" menu opened: assign (round-robin default)
+    // or unassign (REMOVE).
+    const [bulkActionMode, setBulkActionMode] = useState<BulkAssignMode>('ROUND_ROBIN');
 
     // Selection works in every view (previously Unassigned-only, which made
     // reassign/remove unreachable); drop it on filter change so stale ids
@@ -1016,14 +1025,31 @@ const CampaignUsersContent = ({
                                 >
                                     Clear
                                 </MyButton>
-                                <MyButton
-                                    buttonType="primary"
-                                    scale="small"
-                                    onClick={() => setBulkAssignOpen(true)}
+                                <MyDropdown
+                                    dropdownList={[
+                                        {
+                                            label: 'Assign leads',
+                                            value: 'assign',
+                                            icon: <UserPlus className="size-4" />,
+                                        },
+                                        {
+                                            label: 'Unassign leads',
+                                            value: 'unassign',
+                                            icon: <UserMinus className="size-4" />,
+                                        },
+                                    ]}
+                                    onSelect={(value) => {
+                                        setBulkActionMode(
+                                            value === 'unassign' ? 'REMOVE' : 'ROUND_ROBIN'
+                                        );
+                                        setBulkAssignOpen(true);
+                                    }}
                                 >
-                                    <UserPlus className="size-3.5" />
-                                    Assign counsellor
-                                </MyButton>
+                                    <MyButton buttonType="primary" scale="small">
+                                        Bulk actions
+                                        <CaretDown className="size-3.5" />
+                                    </MyButton>
+                                </MyDropdown>
                             </div>
                         </div>
                     )}
@@ -1079,6 +1105,7 @@ const CampaignUsersContent = ({
                     instituteId={instituteId ?? ''}
                     leads={Array.from(selectedLeads.values())}
                     counsellorOptions={assignableCounsellorOptions}
+                    initialMode={bulkActionMode}
                     onSuccess={handleBulkAssignSuccess}
                 />
 

--- a/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
@@ -51,10 +51,14 @@ import { CustomFieldMultiSelectFilter } from '@/components/shared/leads/custom-f
 import { useLeadFilterCustomFields } from '@/components/shared/leads/use-lead-filter-custom-fields';
 import { AddLeadNoteDialog } from '@/components/shared/add-lead-note-dialog';
 import { AssignCounselorToLeadDialog } from '@/components/shared/assign-counselor-to-lead-dialog';
-import { BulkAssignCounsellorDialog } from '@/components/shared/leads/bulk-assign-counsellor-dialog';
+import {
+    BulkAssignCounsellorDialog,
+    type BulkAssignMode,
+} from '@/components/shared/leads/bulk-assign-counsellor-dialog';
+import { MyDropdown } from '@/components/design-system/dropdown';
 import type { LeadCardVM } from '@/components/shared/leads/lead-view-model';
 import { MyButton } from '@/components/design-system/button';
-import { UserPlus } from '@phosphor-icons/react';
+import { CaretDown, UserMinus, UserPlus } from '@phosphor-icons/react';
 import {
     LeadEmptyState,
     LeadTable,
@@ -517,6 +521,9 @@ const RecentLeadsContent = () => {
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+    // Which flow the "Bulk actions" menu opened: assign (round-robin default)
+    // or unassign (REMOVE).
+    const [bulkActionMode, setBulkActionMode] = useState<BulkAssignMode>('ROUND_ROBIN');
 
     // Selection works in EVERY view (assign, reassign AND bulk-remove need
     // assigned leads too — it was previously Unassigned-only, which made the
@@ -1164,14 +1171,31 @@ const RecentLeadsContent = () => {
                                 >
                                     Clear
                                 </MyButton>
-                                <MyButton
-                                    buttonType="primary"
-                                    scale="small"
-                                    onClick={() => setBulkAssignOpen(true)}
+                                <MyDropdown
+                                    dropdownList={[
+                                        {
+                                            label: 'Assign leads',
+                                            value: 'assign',
+                                            icon: <UserPlus className="size-4" />,
+                                        },
+                                        {
+                                            label: 'Unassign leads',
+                                            value: 'unassign',
+                                            icon: <UserMinus className="size-4" />,
+                                        },
+                                    ]}
+                                    onSelect={(value) => {
+                                        setBulkActionMode(
+                                            value === 'unassign' ? 'REMOVE' : 'ROUND_ROBIN'
+                                        );
+                                        setBulkAssignOpen(true);
+                                    }}
                                 >
-                                    <UserPlus className="size-3.5" />
-                                    Assign counsellor
-                                </MyButton>
+                                    <MyButton buttonType="primary" scale="small">
+                                        Bulk actions
+                                        <CaretDown className="size-3.5" />
+                                    </MyButton>
+                                </MyDropdown>
                             </div>
                         </div>
                     )}
@@ -1217,6 +1241,7 @@ const RecentLeadsContent = () => {
                     instituteId={instituteId ?? ''}
                     leads={Array.from(selectedLeads.values())}
                     counsellorOptions={assignableCounsellorOptions}
+                    initialMode={bulkActionMode}
                     onSuccess={handleBulkAssignSuccess}
                 />
 


### PR DESCRIPTION
The single "Assign counsellor" button hid the unassign flow inside the dialog's mode tiles, which wasn't discoverable. The toolbar now shows a "Bulk actions" dropdown with two explicit entries — "Assign leads" and "Unassign leads" — and the dialog opens pre-set to the chosen flow (initialMode), with its heading matching ("Assign counsellor" / "Unassign leads"). Applied to both the Recent Leads page and the per-campaign leads table.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
