### PR TITLE
Fix/slide save lifecycle

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/controller/SlideContentHistoryController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/controller/SlideContentHistoryController.java
@@ -1,0 +1,55 @@
+package vacademy.io.admin_core_service.features.slide.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import vacademy.io.admin_core_service.features.slide.dto.SlideContentHistoryDTO;
+import vacademy.io.admin_core_service.features.slide.dto.SlideContentRestoreResponseDTO;
+import vacademy.io.admin_core_service.features.slide.service.SlideContentHistoryService;
+import vacademy.io.common.auth.model.CustomUserDetails;
+
+import java.util.List;
+
+/**
+ * Version history for slide content (document / video / audio), backed by the
+ * trigger-written slide_content_history audit table. List shows metadata only;
+ * detail returns the snapshot bodies for preview; restore copies a snapshot
+ * back into the slide's draft columns.
+ */
+@RestController
+@RequestMapping("/admin-core-service/slide/v1/content-history")
+@AllArgsConstructor
+public class SlideContentHistoryController {
+
+    private final SlideContentHistoryService slideContentHistoryService;
+
+    @GetMapping
+    public ResponseEntity<List<SlideContentHistoryDTO>> getHistory(@RequestParam String slideId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "30") int size,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity.ok(slideContentHistoryService.getHistoryForSlide(slideId, page, size));
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<SlideContentHistoryDTO> getHistoryDetail(@RequestParam String slideId,
+            @RequestParam Long historyId,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity.ok(slideContentHistoryService.getHistoryDetail(slideId, historyId));
+    }
+
+    @PostMapping("/restore")
+    public ResponseEntity<SlideContentRestoreResponseDTO> restore(@RequestParam String slideId,
+            @RequestParam Long historyId,
+            @RequestParam(defaultValue = "DRAFT") String source,
+            @RequestParam(required = false) String chapterId,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity
+                .ok(slideContentHistoryService.restore(slideId, historyId, source, chapterId, user));
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/DocumentSlideDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/DocumentSlideDTO.java
@@ -15,4 +15,10 @@ public class DocumentSlideDTO {
     private Integer totalPages;
     private String publishedData;
     private Integer publishedDocumentTotalPages;
+
+    /**
+     * When true, bypasses the publish-time shrink guard so an author can intentionally
+     * replace a large published document with a much smaller one (confirmed in the UI).
+     */
+    private boolean forcePublish;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/SlideContentHistoryDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/SlideContentHistoryDTO.java
@@ -1,0 +1,27 @@
+package vacademy.io.admin_core_service.features.slide.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+/**
+ * One snapshot from slide_content_history. The list endpoint ships only
+ * metadata (lengths, not the bodies — a DOC slide body can be megabytes);
+ * the detail endpoint fills in draftValue / publishedValue for preview.
+ */
+@Data
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SlideContentHistoryDTO {
+    private Long id;
+    private String sourceTable;
+    private Timestamp changedAt;
+    private String changedBy;
+    private Integer draftLength;
+    private Integer publishedLength;
+    private String draftValue;
+    private String publishedValue;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/SlideContentRestoreResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/SlideContentRestoreResponseDTO.java
@@ -1,0 +1,19 @@
+package vacademy.io.admin_core_service.features.slide.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Result of restoring a history snapshot into a slide's draft columns. The
+ * restored value is echoed back so the editor can reload the content without
+ * refetching the whole chapter's slides.
+ */
+@Data
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SlideContentRestoreResponseDTO {
+    private String restoredValue;
+    private String slideStatus;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/SlideContentHistory.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/SlideContentHistory.java
@@ -1,0 +1,48 @@
+package vacademy.io.admin_core_service.features.slide.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+/**
+ * Read-only view over the append-only audit trail written by the V363
+ * before-update triggers on document_slide / video / audio_slide. Rows are
+ * ONLY inserted by those DB triggers — the application never writes here, it
+ * reads (history listing) and copies values back into the source rows (restore).
+ */
+@Entity
+@Table(name = "slide_content_history")
+@Getter
+@Setter
+public class SlideContentHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "source_table")
+    private String sourceTable;
+
+    @Column(name = "source_id")
+    private String sourceId;
+
+    @Column(name = "draft_value")
+    private String draftValue;
+
+    @Column(name = "published_value")
+    private String publishedValue;
+
+    @Column(name = "changed_by")
+    private String changedBy;
+
+    @Column(name = "changed_at", insertable = false, updatable = false)
+    private Timestamp changedAt;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/repository/SlideContentHistoryRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/repository/SlideContentHistoryRepository.java
@@ -1,0 +1,13 @@
+package vacademy.io.admin_core_service.features.slide.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import vacademy.io.admin_core_service.features.slide.entity.SlideContentHistory;
+
+public interface SlideContentHistoryRepository extends JpaRepository<SlideContentHistory, Long> {
+
+    Page<SlideContentHistory> findBySourceTableAndSourceIdOrderByChangedAtDesc(String sourceTable,
+            String sourceId,
+            Pageable pageable);
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideContentHistoryService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideContentHistoryService.java
@@ -1,0 +1,185 @@
+package vacademy.io.admin_core_service.features.slide.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.chapter.repository.ChapterToSlidesRepository;
+import vacademy.io.admin_core_service.features.slide.dto.SlideContentHistoryDTO;
+import vacademy.io.admin_core_service.features.slide.dto.SlideContentRestoreResponseDTO;
+import vacademy.io.admin_core_service.features.slide.entity.AudioSlide;
+import vacademy.io.admin_core_service.features.slide.entity.DocumentSlide;
+import vacademy.io.admin_core_service.features.slide.entity.Slide;
+import vacademy.io.admin_core_service.features.slide.entity.SlideContentHistory;
+import vacademy.io.admin_core_service.features.slide.entity.VideoSlide;
+import vacademy.io.admin_core_service.features.slide.enums.SlideStatus;
+import vacademy.io.admin_core_service.features.slide.enums.SlideTypeEnum;
+import vacademy.io.admin_core_service.features.slide.repository.AudioSlideRepository;
+import vacademy.io.admin_core_service.features.slide.repository.DocumentSlideRepository;
+import vacademy.io.admin_core_service.features.slide.repository.SlideContentHistoryRepository;
+import vacademy.io.admin_core_service.features.slide.repository.SlideRepository;
+import vacademy.io.admin_core_service.features.slide.repository.VideoSlideRepository;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.util.List;
+
+/**
+ * Read + restore API over the slide_content_history audit trail (V363).
+ * History rows are written exclusively by DB triggers; this service lists
+ * them per slide and can copy a snapshot back into the slide's DRAFT columns.
+ * Restore never touches published content — the author reviews the restored
+ * draft in the editor and re-publishes explicitly.
+ */
+@Service
+@RequiredArgsConstructor
+public class SlideContentHistoryService {
+
+    private final SlideContentHistoryRepository slideContentHistoryRepository;
+    private final SlideRepository slideRepository;
+    private final DocumentSlideRepository documentSlideRepository;
+    private final VideoSlideRepository videoSlideRepository;
+    private final AudioSlideRepository audioSlideRepository;
+    private final ChapterToSlidesRepository chapterToSlidesRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public List<SlideContentHistoryDTO> getHistoryForSlide(String slideId, int page, int size) {
+        Slide slide = getSlide(slideId);
+        String sourceTable = resolveSourceTable(slide);
+        return slideContentHistoryRepository
+                .findBySourceTableAndSourceIdOrderByChangedAtDesc(sourceTable, slide.getSourceId(),
+                        PageRequest.of(page, Math.min(Math.max(size, 1), 100)))
+                .map(h -> toDTO(h, false))
+                .getContent();
+    }
+
+    public SlideContentHistoryDTO getHistoryDetail(String slideId, Long historyId) {
+        Slide slide = getSlide(slideId);
+        return toDTO(getEntryForSlide(slide, historyId), true);
+    }
+
+    /**
+     * Copy one snapshot column (the draft or the published value as it existed
+     * at that point in time) back into the slide's DRAFT column. The V363
+     * trigger snapshots the pre-restore state first, so a restore is itself
+     * undoable. A PUBLISHED slide flips to UNSYNC — live content is untouched
+     * until the author explicitly re-publishes.
+     */
+    @Transactional
+    public SlideContentRestoreResponseDTO restore(String slideId, Long historyId, String source,
+            String chapterId, CustomUserDetails user) {
+        Slide slide = getSlide(slideId);
+        SlideContentHistory entry = getEntryForSlide(slide, historyId);
+
+        boolean fromPublished = "PUBLISHED".equalsIgnoreCase(source);
+        String value = fromPublished ? entry.getPublishedValue() : entry.getDraftValue();
+        if (!StringUtils.hasText(value)) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST,
+                    "This version has no " + (fromPublished ? "published" : "draft")
+                            + " content to restore.");
+        }
+
+        // Attribute the trigger-written snapshot of the pre-restore state to the
+        // restoring user (set_config with is_local=true scopes it to this tx).
+        if (user != null && StringUtils.hasText(user.getUserId())) {
+            entityManager.createNativeQuery("SELECT set_config('app.user_id', :uid, true)")
+                    .setParameter("uid", user.getUserId())
+                    .getSingleResult();
+        }
+
+        writeDraftValue(slide, value);
+
+        if (SlideStatus.PUBLISHED.name().equalsIgnoreCase(slide.getStatus())) {
+            slide.setStatus(SlideStatus.UNSYNC.name());
+            slideRepository.save(slide);
+            if (StringUtils.hasText(chapterId)) {
+                chapterToSlidesRepository.findByChapterIdAndSlideId(chapterId, slideId)
+                        .ifPresent(cts -> {
+                            cts.setStatus(SlideStatus.UNSYNC.name());
+                            chapterToSlidesRepository.save(cts);
+                        });
+            }
+        }
+
+        return SlideContentRestoreResponseDTO.builder()
+                .restoredValue(value)
+                .slideStatus(slide.getStatus())
+                .build();
+    }
+
+    private void writeDraftValue(Slide slide, String value) {
+        String sourceType = slide.getSourceType();
+        if (SlideTypeEnum.DOCUMENT.name().equalsIgnoreCase(sourceType)) {
+            DocumentSlide documentSlide = documentSlideRepository.findById(slide.getSourceId())
+                    .orElseThrow(() -> new VacademyException("Document slide not found"));
+            documentSlide.setData(value);
+            documentSlideRepository.save(documentSlide);
+        } else if (SlideTypeEnum.VIDEO.name().equalsIgnoreCase(sourceType)) {
+            VideoSlide videoSlide = videoSlideRepository.findById(slide.getSourceId())
+                    .orElseThrow(() -> new VacademyException("Video slide not found"));
+            videoSlide.setUrl(value);
+            videoSlideRepository.save(videoSlide);
+        } else if (SlideTypeEnum.AUDIO.name().equalsIgnoreCase(sourceType)) {
+            AudioSlide audioSlide = audioSlideRepository.findById(slide.getSourceId())
+                    .orElseThrow(() -> new VacademyException("Audio slide not found"));
+            audioSlide.setAudioFileId(value);
+            audioSlideRepository.save(audioSlide);
+        } else {
+            throw new VacademyException(HttpStatus.BAD_REQUEST,
+                    "Content history is not tracked for slide type: " + sourceType);
+        }
+    }
+
+    private Slide getSlide(String slideId) {
+        return slideRepository.findById(slideId)
+                .orElseThrow(() -> new VacademyException("Slide not found"));
+    }
+
+    /** History rows must belong to this slide's source row — no cross-slide reads. */
+    private SlideContentHistory getEntryForSlide(Slide slide, Long historyId) {
+        SlideContentHistory entry = slideContentHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new VacademyException("History entry not found"));
+        String sourceTable = resolveSourceTable(slide);
+        if (!entry.getSourceTable().equals(sourceTable)
+                || !entry.getSourceId().equals(slide.getSourceId())) {
+            throw new VacademyException(HttpStatus.FORBIDDEN,
+                    "History entry does not belong to this slide");
+        }
+        return entry;
+    }
+
+    private String resolveSourceTable(Slide slide) {
+        String sourceType = slide.getSourceType();
+        if (SlideTypeEnum.DOCUMENT.name().equalsIgnoreCase(sourceType)) {
+            return "document_slide";
+        }
+        if (SlideTypeEnum.VIDEO.name().equalsIgnoreCase(sourceType)) {
+            return "video";
+        }
+        if (SlideTypeEnum.AUDIO.name().equalsIgnoreCase(sourceType)) {
+            return "audio_slide";
+        }
+        throw new VacademyException(HttpStatus.BAD_REQUEST,
+                "Content history is not tracked for slide type: " + sourceType);
+    }
+
+    private SlideContentHistoryDTO toDTO(SlideContentHistory entry, boolean includeValues) {
+        return SlideContentHistoryDTO.builder()
+                .id(entry.getId())
+                .sourceTable(entry.getSourceTable())
+                .changedAt(entry.getChangedAt())
+                .changedBy(entry.getChangedBy())
+                .draftLength(entry.getDraftValue() == null ? 0 : entry.getDraftValue().length())
+                .publishedLength(
+                        entry.getPublishedValue() == null ? 0 : entry.getPublishedValue().length())
+                .draftValue(includeValues ? entry.getDraftValue() : null)
+                .publishedValue(includeValues ? entry.getPublishedValue() : null)
+                .build();
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -6,6 +6,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.chapter.entity.Chapter;
 import vacademy.io.admin_core_service.features.chapter.entity.ChapterToSlides;
@@ -257,9 +258,8 @@ public class SlideService {
         if (StringUtils.hasText(videoSlideDTO.getUrl())) {
             videoSlide.setUrl(videoSlideDTO.getUrl());
         }
-        if (StringUtils.hasText(videoSlideDTO.getPublishedUrl())) {
-            videoSlide.setPublishedUrl(videoSlideDTO.getPublishedUrl());
-        }
+        // published_url is written only by the publish path (handlePublishedVideoSlide),
+        // never on a draft/unsync save, so a draft edit can't change what learners see.
         if (StringUtils.hasText(videoSlideDTO.getSourceType())) {
             videoSlide.setSourceType(videoSlideDTO.getSourceType());
         }
@@ -550,17 +550,49 @@ public class SlideService {
                 .orElseThrow(() -> new VacademyException("Chapter to slide not found"));
     }
 
+    // Publishing a substantial live document down to a near-empty fragment is almost
+    // always an accidental editor wipe, not a real edit. Block it unless the caller
+    // explicitly forces it (author confirmed the deletion in the UI). This is the
+    // server-side backstop that would have prevented the silent slide-wipe incidents.
+    private static final int PUBLISHED_SHRINK_GUARD_MIN_CHARS = 2000;
+    private static final double PUBLISHED_SHRINK_GUARD_RATIO = 0.25;
+
     public void handlePublishedDocumentSlide(DocumentSlide documentSlide, DocumentSlideDTO documentSlideDTO) {
+        String newPublishedData;
+        Integer newPublishedTotalPages;
         if (documentSlideDTO != null && documentSlideDTO.getPublishedData() != null
                 && documentSlideDTO.getPublishedData().trim().length() > 0) {
-            documentSlide.setPublishedData(documentSlideDTO.getPublishedData());
-            documentSlide.setPublishedDocumentTotalPages(documentSlideDTO.getPublishedDocumentTotalPages());
+            newPublishedData = documentSlideDTO.getPublishedData();
+            newPublishedTotalPages = documentSlideDTO.getPublishedDocumentTotalPages();
         } else {
-            documentSlide.setPublishedData(documentSlide.getData());
-            documentSlide.setPublishedDocumentTotalPages(documentSlide.getTotalPages());
+            newPublishedData = documentSlide.getData();
+            newPublishedTotalPages = documentSlide.getTotalPages();
         }
-        documentSlide.setData(null);
-        documentSlide.setTotalPages(null);
+        guardAgainstPublishedContentWipe(documentSlide.getPublishedData(), newPublishedData,
+                documentSlideDTO != null && documentSlideDTO.isForcePublish());
+        documentSlide.setPublishedData(newPublishedData);
+        documentSlide.setPublishedDocumentTotalPages(newPublishedTotalPages);
+        // Keep the draft copy in sync with what we just published instead of nulling it.
+        // A published slide must reopen in the editor with its real content, so an author
+        // can never re-save over an empty editor and wipe published_data.
+        documentSlide.setData(newPublishedData);
+        documentSlide.setTotalPages(newPublishedTotalPages);
+    }
+
+    private void guardAgainstPublishedContentWipe(String currentPublished, String incomingPublished, boolean force) {
+        if (force) {
+            return;
+        }
+        int currentLen = currentPublished == null ? 0 : currentPublished.trim().length();
+        int incomingLen = incomingPublished == null ? 0 : incomingPublished.trim().length();
+        if (currentLen >= PUBLISHED_SHRINK_GUARD_MIN_CHARS
+                && incomingLen < currentLen * PUBLISHED_SHRINK_GUARD_RATIO) {
+            throw new VacademyException(HttpStatus.CONFLICT,
+                    "Refusing to publish: this would replace the live content (" + currentLen
+                            + " chars) with a much smaller fragment (" + incomingLen
+                            + " chars), which looks like accidental data loss. "
+                            + "Re-publish with force enabled to override.");
+        }
     }
 
     public void handleDraftDocumentSlide(DocumentSlide documentSlide, DocumentSlideDTO documentSlideDTO) {
@@ -574,32 +606,35 @@ public class SlideService {
     }
 
     public void handleUnsyncDocumentSlide(DocumentSlide documentSlide, DocumentSlideDTO documentSlideDTO) {
+        // UNSYNC = a published slide with pending draft edits. Only the draft columns are
+        // touched here; published_data is written exclusively by the publish path, so a
+        // draft save can never mutate what learners currently see.
         if (documentSlideDTO.getData() != null && !documentSlideDTO.getData().isEmpty()) {
             documentSlide.setData(documentSlideDTO.getData());
         }
-
         if (documentSlideDTO.getTotalPages() != null) {
             documentSlide.setTotalPages(documentSlideDTO.getTotalPages());
-        }
-        if (documentSlideDTO.getPublishedData() != null && !documentSlideDTO.getPublishedData().isEmpty()) {
-            documentSlide.setPublishedData(documentSlideDTO.getPublishedData());
-        }
-        if (documentSlideDTO.getPublishedDocumentTotalPages() != null) {
-            documentSlide.setPublishedDocumentTotalPages(documentSlideDTO.getPublishedDocumentTotalPages());
         }
     }
 
     public void handlePublishedVideoSlide(VideoSlide videoSlide, VideoSlideDTO videoSlideDTO) {
+        String newPublishedUrl;
+        Long newPublishedLength;
         if (videoSlide != null && videoSlideDTO.getPublishedUrl() != null
                 && videoSlideDTO.getPublishedUrl().trim().length() > 0) {
-            videoSlide.setPublishedUrl(videoSlideDTO.getPublishedUrl());
-            videoSlide.setPublishedVideoLengthInMillis(videoSlide.getPublishedVideoLengthInMillis());
+            newPublishedUrl = videoSlideDTO.getPublishedUrl();
+            newPublishedLength = videoSlide.getPublishedVideoLengthInMillis();
         } else {
-            videoSlide.setPublishedUrl(videoSlide.getUrl());
-            videoSlide.setPublishedVideoLengthInMillis(videoSlideDTO.getVideoLengthInMillis());
+            newPublishedUrl = videoSlide.getUrl();
+            newPublishedLength = videoSlideDTO.getVideoLengthInMillis();
         }
-        videoSlide.setUrl(null);
-        videoSlide.setVideoLengthInMillis(null);
+        videoSlide.setPublishedUrl(newPublishedUrl);
+        videoSlide.setPublishedVideoLengthInMillis(newPublishedLength);
+        // Keep the draft url/length in sync with the just-published content instead of
+        // nulling them, so a published video always reopens in the editor with its real
+        // URL and a re-save over an empty editor can never wipe published_url.
+        videoSlide.setUrl(newPublishedUrl);
+        videoSlide.setVideoLengthInMillis(newPublishedLength);
     }
 
     public void handleDraftVideoSlide(VideoSlide videoSlide, VideoSlideDTO videoSlideDTO) {

--- a/admin_core_service/src/main/resources/db/migration/V363__Add_slide_content_history.sql
+++ b/admin_core_service/src/main/resources/db/migration/V363__Add_slide_content_history.sql
@@ -1,0 +1,71 @@
+-- Append-only audit trail for slide body content (document_slide / video / audio_slide).
+-- Captures the BEFORE image of the draft + published columns on every content-changing
+-- UPDATE, so a bad/accidental overwrite (from any writer, including out-of-service raw
+-- SQL) becomes recoverable with a single query instead of forensic archaeology.
+--
+-- There was no history/audit table for slide content before this; slide bodies were
+-- overwritten in place with no way to recover.
+
+CREATE TABLE IF NOT EXISTS slide_content_history (
+    id              BIGSERIAL PRIMARY KEY,
+    source_table    TEXT         NOT NULL,      -- 'document_slide' | 'video' | 'audio_slide'
+    source_id       VARCHAR(255) NOT NULL,      -- id of the changed content row
+    draft_value     TEXT,                       -- previous draft column (data / url / audio_file_id)
+    published_value TEXT,                       -- previous published column (published_data / published_url / published_audio_file_id)
+    changed_by      VARCHAR(255),               -- app user id if set via app.user_id GUC, else null
+    changed_at      TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_slide_content_history_source
+    ON slide_content_history (source_table, source_id, changed_at DESC);
+
+-- document_slide: snapshot old (data, published_data) when either changes
+CREATE OR REPLACE FUNCTION fn_document_slide_content_history() RETURNS trigger AS $$
+BEGIN
+    IF (OLD.data IS DISTINCT FROM NEW.data)
+       OR (OLD.published_data IS DISTINCT FROM NEW.published_data) THEN
+        INSERT INTO slide_content_history (source_table, source_id, draft_value, published_value, changed_by)
+        VALUES ('document_slide', OLD.id, OLD.data, OLD.published_data, current_setting('app.user_id', true));
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_document_slide_content_history ON document_slide;
+CREATE TRIGGER trg_document_slide_content_history
+    BEFORE UPDATE ON document_slide
+    FOR EACH ROW EXECUTE FUNCTION fn_document_slide_content_history();
+
+-- video: snapshot old (url, published_url) when either changes
+CREATE OR REPLACE FUNCTION fn_video_slide_content_history() RETURNS trigger AS $$
+BEGIN
+    IF (OLD.url IS DISTINCT FROM NEW.url)
+       OR (OLD.published_url IS DISTINCT FROM NEW.published_url) THEN
+        INSERT INTO slide_content_history (source_table, source_id, draft_value, published_value, changed_by)
+        VALUES ('video', OLD.id, OLD.url, OLD.published_url, current_setting('app.user_id', true));
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_video_slide_content_history ON video;
+CREATE TRIGGER trg_video_slide_content_history
+    BEFORE UPDATE ON video
+    FOR EACH ROW EXECUTE FUNCTION fn_video_slide_content_history();
+
+-- audio_slide: snapshot old (audio_file_id, published_audio_file_id) when either changes
+CREATE OR REPLACE FUNCTION fn_audio_slide_content_history() RETURNS trigger AS $$
+BEGIN
+    IF (OLD.audio_file_id IS DISTINCT FROM NEW.audio_file_id)
+       OR (OLD.published_audio_file_id IS DISTINCT FROM NEW.published_audio_file_id) THEN
+        INSERT INTO slide_content_history (source_table, source_id, draft_value, published_value, changed_by)
+        VALUES ('audio_slide', OLD.id, OLD.audio_file_id, OLD.published_audio_file_id, current_setting('app.user_id', true));
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_audio_slide_content_history ON audio_slide;
+CREATE TRIGGER trg_audio_slide_content_history
+    BEFORE UPDATE ON audio_slide
+    FOR EACH ROW EXECUTE FUNCTION fn_audio_slide_content_history();

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -543,6 +543,10 @@ export const GET_CHAPTERS_WITH_SLIDES = `${BASE_URL}/admin-core-service/v1/study
 export const ADD_UPDATE_SPLIT_SCREEN_SLIDE = `${BASE_URL}/admin-core-service/slide/v1/add-update-video-slide`;
 export const GET_ALL_SLIDES = `${BASE_URL}/admin-core-service/v1/study-library/chapters-with-slides`;
 export const ADD_UPDATE_DOCUMENT_SLIDE = `${BASE_URL}/admin-core-service/slide/v1/add-update-document-slide`;
+// Version history of slide content (trigger-written audit trail) + restore.
+export const GET_SLIDE_CONTENT_HISTORY = `${BASE_URL}/admin-core-service/slide/v1/content-history`;
+export const GET_SLIDE_CONTENT_HISTORY_DETAIL = `${BASE_URL}/admin-core-service/slide/v1/content-history/detail`;
+export const RESTORE_SLIDE_CONTENT_HISTORY = `${BASE_URL}/admin-core-service/slide/v1/content-history/restore`;
 export const UPDATE_SLIDE_STATUS = `${BASE_URL}/admin-core-service/slide/v1/update-status`;
 export const UPDATE_SLIDE_ORDER = `${BASE_URL}/admin-core-service/slide/v1/update-slide-order`;
 export const UPDATE_QUESTION_ORDER = `${BASE_URL}/admin-core-service/slide/question-slide/add-or-update`;

--- a/frontend-admin-dashboard/src/index.css
+++ b/frontend-admin-dashboard/src/index.css
@@ -1056,3 +1056,20 @@ body .yoopta-accordion-list-item-content [data-slate-placeholder='true'] {
     font-size: 16px; /* matches .yoopta-numbered-list font-size */
 }
 
+/* Uploaded images are stored with their natural pixel size (`sizes` on upload),
+   so Yoopta renders the image block at that raw width. A large photo (e.g.
+   ~2000px) then overflows the editor column: the block's options (⋯) button and
+   resize handles — pinned to the image's right edge — land off-frame, and a
+   horizontal scrollbar appears that swallows the click. Cap the image block to
+   the column width so it always fits and its controls stay reachable. A user's
+   deliberate down-size (width < column) is below the cap, so this doesn't touch
+   intentionally-smaller images. */
+.yoopta-editor .yoopta-image,
+.yoopta-editor .yoopta-image-inner {
+    max-width: 100% !important;
+}
+.yoopta-editor .yoopta-image-inner img {
+    max-width: 100% !important;
+    height: auto !important;
+}
+

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/publish-slide-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/publish-slide-dialog.tsx
@@ -1,8 +1,7 @@
 // publish-dialog.tsx
 import { MyButton } from '@/components/design-system/button';
-import { MyDialog } from '@/components/design-system/dialog';
-import { useContentStore } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-stores/chapter-sidebar-store';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { Dispatch, ReactNode, SetStateAction, useState } from 'react';
 
 interface PublishDialogProps {
     isOpen: boolean;
@@ -11,103 +10,100 @@ interface PublishDialogProps {
         setIsOpen: Dispatch<SetStateAction<boolean>>,
         notify: boolean
     ) => void;
+    /** The button the confirm popover anchors to (rendered by the caller so it
+        keeps its exact styling / responsive labels). */
+    trigger?: ReactNode;
 }
-interface NotifyDialogProps {
-    openNotifyDialog: boolean;
-    setOpenNotifyDialog: Dispatch<SetStateAction<boolean>>;
-    handleNotify: (notify: boolean) => void;
-}
-
-const NotifyDialog = ({
-    openNotifyDialog,
-    setOpenNotifyDialog,
-    handleNotify,
-}: NotifyDialogProps) => {
-    return (
-        <MyDialog
-            heading="Notify"
-            dialogWidth="w-[400px]"
-            open={openNotifyDialog}
-            onOpenChange={setOpenNotifyDialog}
-        >
-            <div className="flex w-full flex-col gap-6">
-                <p>Do you want to send the notification to students about this slide?</p>
-                <div className="flex justify-end gap-4">
-                    <MyButton
-                        buttonType="secondary"
-                        onClick={() => {
-                            handleNotify(false);
-                        }}
-                    >
-                        No
-                    </MyButton>
-                    <MyButton
-                        buttonType="primary"
-                        onClick={() => {
-                            handleNotify(true);
-                        }}
-                    >
-                        Yes
-                    </MyButton>
-                </div>
-            </div>
-        </MyDialog>
-    );
-};
 
 export const PublishDialog = ({
     isOpen,
     setIsOpen,
     handlePublishUnpublishSlide,
+    trigger,
 }: PublishDialogProps) => {
-    const { activeItem } = useContentStore();
+    // Two-step compact confirm: publish? → notify? — same call flow as before,
+    // just rendered inline in a single anchored popover instead of two modals.
     const [notify, setNotify] = useState(false);
-    const [openNotifyDialog, setOpenNotifyDialog] = useState(false);
-
-    const publishTrigger = (
-        <MyButton
-            buttonType="primary"
-            scale="medium"
-            layoutVariant="default"
-            disable={activeItem?.status == 'PUBLISHED'}
-        >
-            Publish
-        </MyButton>
-    );
+    const [step, setStep] = useState<'confirm' | 'notify'>('confirm');
 
     const handleNotify = (notify: boolean) => {
         setNotify(notify);
-        setOpenNotifyDialog(false);
+        setStep('confirm');
         setIsOpen(false);
         handlePublishUnpublishSlide(setIsOpen, notify);
     };
 
     return (
-        <MyDialog
-            heading={`Publish Slide`}
-            dialogWidth="w-[400px]"
+        <Popover
             open={isOpen}
-            onOpenChange={setIsOpen}
-            trigger={publishTrigger}
+            onOpenChange={(open) => {
+                setIsOpen(open);
+                // Reset to the first step whenever the popover closes.
+                if (!open) setStep('confirm');
+            }}
         >
-            <div className="flex w-full flex-col gap-6">
-                <p>Are you sure you want to publish this slide?</p>
-                <div className="flex justify-end gap-4">
-                    <MyButton buttonType="secondary" onClick={() => setIsOpen(false)}>
-                        Cancel
-                    </MyButton>
-
-                    <MyButton buttonType="primary" onClick={() => setOpenNotifyDialog(true)}>
-                        Yes, I&apos;m sure
-                    </MyButton>
-
-                    <NotifyDialog
-                        openNotifyDialog={openNotifyDialog}
-                        setOpenNotifyDialog={setOpenNotifyDialog}
-                        handleNotify={() => handleNotify(notify)}
-                    />
-                </div>
-            </div>
-        </MyDialog>
+            {trigger && <PopoverAnchor asChild>{trigger}</PopoverAnchor>}
+            <PopoverContent align="end" sideOffset={8} className="w-72 p-4">
+                {step === 'confirm' ? (
+                    <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1">
+                            <p className="text-subtitle font-semibold text-neutral-700">
+                                Publish this slide?
+                            </p>
+                            <p className="text-caption text-neutral-500">
+                                Learners will be able to see it.
+                            </p>
+                        </div>
+                        <div className="flex justify-end gap-2">
+                            <MyButton
+                                buttonType="secondary"
+                                scale="medium"
+                                className="min-w-0 sm:min-w-0"
+                                onClick={() => setIsOpen(false)}
+                            >
+                                Cancel
+                            </MyButton>
+                            <MyButton
+                                buttonType="primary"
+                                scale="medium"
+                                className="min-w-0 sm:min-w-0"
+                                onClick={() => setStep('notify')}
+                            >
+                                Publish
+                            </MyButton>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1">
+                            <p className="text-subtitle font-semibold text-neutral-700">
+                                Notify students?
+                            </p>
+                            <p className="text-caption text-neutral-500">
+                                Send an update about this slide.
+                            </p>
+                        </div>
+                        <div className="flex justify-end gap-2">
+                            <MyButton
+                                buttonType="secondary"
+                                scale="medium"
+                                className="min-w-0 sm:min-w-0"
+                                onClick={() => handleNotify(false)}
+                            >
+                                Skip
+                            </MyButton>
+                            <MyButton
+                                buttonType="primary"
+                                scale="medium"
+                                className="min-w-0 sm:min-w-0"
+                                onClick={() => handleNotify(true)}
+                            >
+                                Notify
+                            </MyButton>
+                        </div>
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
     );
 };

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
@@ -1,0 +1,363 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+    CircleNotch,
+    ClockCounterClockwise,
+    FileText,
+    Globe,
+    Warning,
+} from '@phosphor-icons/react';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import {
+    GET_SLIDE_CONTENT_HISTORY,
+    GET_SLIDE_CONTENT_HISTORY_DETAIL,
+    RESTORE_SLIDE_CONTENT_HISTORY,
+} from '@/constants/urls';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyButton } from '@/components/design-system/button';
+import { cn } from '@/lib/utils';
+import { Slide } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides';
+
+/* API payloads use snake_case (backend convention). */
+interface SlideContentHistoryItem {
+    id: number;
+    source_table: string;
+    changed_at: string;
+    changed_by: string | null;
+    draft_length: number;
+    published_length: number;
+    draft_value?: string | null;
+    published_value?: string | null;
+}
+
+interface RestoreResponse {
+    restored_value: string;
+    slide_status: string;
+}
+
+type SnapshotSource = 'DRAFT' | 'PUBLISHED';
+
+const formatChangedAt = (iso: string): string => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+};
+
+const formatSize = (chars: number): string => {
+    if (!chars) return 'empty';
+    if (chars < 1000) return `${chars} chars`;
+    return `${(chars / 1000).toFixed(1)}k chars`;
+};
+
+/**
+ * Version history for a slide's content, read from the trigger-written
+ * slide_content_history audit table. Each entry is the BEFORE image of the
+ * slide's draft + published content at the moment it was overwritten.
+ * Restoring copies the selected snapshot into the slide's DRAFT — published
+ * content stays untouched until the author re-publishes explicitly.
+ */
+export const SlideHistoryDialog = ({
+    activeItem,
+    chapterId,
+    onRestored,
+}: {
+    activeItem: Slide;
+    chapterId: string;
+    onRestored: (restoredValue: string, slideStatus: string) => void;
+}) => {
+    const [open, setOpen] = useState(false);
+    const [selectedId, setSelectedId] = useState<number | null>(null);
+    const [previewSource, setPreviewSource] = useState<SnapshotSource>('DRAFT');
+    const [confirmingRestore, setConfirmingRestore] = useState(false);
+    const queryClient = useQueryClient();
+
+    const slideId = activeItem.id;
+    const isDocEditor = activeItem.document_slide?.type === 'DOC';
+
+    const historyQuery = useQuery({
+        queryKey: ['slide-content-history', slideId],
+        enabled: open,
+        queryFn: async () => {
+            const res = await authenticatedAxiosInstance.get<SlideContentHistoryItem[]>(
+                GET_SLIDE_CONTENT_HISTORY,
+                { params: { slideId, page: 0, size: 50 } }
+            );
+            return res.data;
+        },
+    });
+
+    const detailQuery = useQuery({
+        queryKey: ['slide-content-history-detail', slideId, selectedId],
+        enabled: open && selectedId != null,
+        queryFn: async () => {
+            const res = await authenticatedAxiosInstance.get<SlideContentHistoryItem>(
+                GET_SLIDE_CONTENT_HISTORY_DETAIL,
+                { params: { slideId, historyId: selectedId } }
+            );
+            return res.data;
+        },
+    });
+
+    const restoreMutation = useMutation({
+        mutationFn: async ({
+            historyId,
+            source,
+        }: {
+            historyId: number;
+            source: SnapshotSource;
+        }) => {
+            const res = await authenticatedAxiosInstance.post<RestoreResponse>(
+                RESTORE_SLIDE_CONTENT_HISTORY,
+                null,
+                { params: { slideId, historyId, source, chapterId } }
+            );
+            return res.data;
+        },
+        onSuccess: async (data) => {
+            toast.success('Version restored as the current draft. Review it, then publish.');
+            await queryClient.invalidateQueries({ queryKey: ['slides'] });
+            queryClient.invalidateQueries({ queryKey: ['slide-content-history', slideId] });
+            onRestored(data.restored_value, data.slide_status);
+            setOpen(false);
+        },
+        onError: (err: unknown) => {
+            const message =
+                (err as { response?: { data?: { ex?: string; message?: string } } })?.response?.data
+                    ?.ex ||
+                (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+                'Failed to restore this version';
+            toast.error(message);
+        },
+        onSettled: () => setConfirmingRestore(false),
+    });
+
+    const entries = historyQuery.data ?? [];
+    const selected = detailQuery.data;
+    const previewValue =
+        previewSource === 'DRAFT' ? selected?.draft_value : selected?.published_value;
+
+    const selectEntry = (entry: SlideContentHistoryItem) => {
+        setSelectedId(entry.id);
+        setConfirmingRestore(false);
+        // Default the preview to whichever snapshot column actually has content.
+        setPreviewSource(entry.draft_length > 0 ? 'DRAFT' : 'PUBLISHED');
+    };
+
+    return (
+        <>
+            <MyButton
+                buttonType="secondary"
+                scale="medium"
+                layoutVariant="default"
+                title="View and restore previous versions"
+                onClick={() => {
+                    setSelectedId(null);
+                    setConfirmingRestore(false);
+                    setOpen(true);
+                }}
+            >
+                <ClockCounterClockwise size={18} />
+                <span className="hidden md:inline">History</span>
+            </MyButton>
+            <MyDialog
+                heading="Version history"
+                open={open}
+                onOpenChange={(o) => {
+                    setOpen(o);
+                    if (!o) {
+                        setSelectedId(null);
+                        setConfirmingRestore(false);
+                    }
+                }}
+                dialogWidth="w-full max-w-4xl"
+            >
+                <div className="flex flex-col gap-3">
+                    <p className="text-caption text-neutral-500">
+                        Each version is a snapshot of this slide&apos;s content taken just before it
+                        was overwritten. Restoring copies a snapshot into the current draft —
+                        published content is not changed until you publish again.
+                    </p>
+                    <div className="flex min-h-80 flex-col gap-3 md:flex-row">
+                        {/* Version list */}
+                        <div className="flex max-h-96 shrink-0 flex-col gap-1 overflow-y-auto md:w-64">
+                            {historyQuery.isLoading && (
+                                <div className="flex flex-1 items-center justify-center p-6">
+                                    <CircleNotch className="size-6 animate-spin text-primary-500" />
+                                </div>
+                            )}
+                            {historyQuery.isError && (
+                                <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+                                    <Warning size={24} className="text-danger-500" />
+                                    <p className="text-caption text-neutral-500">
+                                        Could not load version history.
+                                    </p>
+                                    <MyButton
+                                        buttonType="secondary"
+                                        scale="small"
+                                        onClick={() => historyQuery.refetch()}
+                                    >
+                                        Retry
+                                    </MyButton>
+                                </div>
+                            )}
+                            {historyQuery.isSuccess && entries.length === 0 && (
+                                <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+                                    <ClockCounterClockwise size={24} className="text-neutral-300" />
+                                    <p className="text-caption text-neutral-500">
+                                        No previous versions yet. A version is recorded each time
+                                        this slide&apos;s content changes.
+                                    </p>
+                                </div>
+                            )}
+                            {entries.map((entry) => (
+                                <button
+                                    key={entry.id}
+                                    type="button"
+                                    onClick={() => selectEntry(entry)}
+                                    className={cn(
+                                        'flex flex-col gap-0.5 rounded-md border px-3 py-2 text-left transition-colors',
+                                        selectedId === entry.id
+                                            ? 'border-primary-300 bg-primary-50'
+                                            : 'border-neutral-200 bg-white hover:bg-neutral-50'
+                                    )}
+                                >
+                                    <span className="text-body font-medium text-neutral-700">
+                                        {formatChangedAt(entry.changed_at)}
+                                    </span>
+                                    <span className="text-caption text-neutral-500">
+                                        Draft: {formatSize(entry.draft_length)} · Published:{' '}
+                                        {formatSize(entry.published_length)}
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+
+                        {/* Preview + restore */}
+                        <div className="flex min-w-0 flex-1 flex-col gap-2">
+                            {selectedId == null ? (
+                                <div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-neutral-200 p-6">
+                                    <p className="text-caption text-neutral-400">
+                                        Select a version to preview it
+                                    </p>
+                                </div>
+                            ) : detailQuery.isLoading ? (
+                                <div className="flex flex-1 items-center justify-center p-6">
+                                    <CircleNotch className="size-6 animate-spin text-primary-500" />
+                                </div>
+                            ) : detailQuery.isError ? (
+                                <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+                                    <Warning size={24} className="text-danger-500" />
+                                    <p className="text-caption text-neutral-500">
+                                        Could not load this version.
+                                    </p>
+                                    <MyButton
+                                        buttonType="secondary"
+                                        scale="small"
+                                        onClick={() => detailQuery.refetch()}
+                                    >
+                                        Retry
+                                    </MyButton>
+                                </div>
+                            ) : (
+                                <>
+                                    <div className="flex flex-wrap items-center justify-between gap-2">
+                                        <div className="flex items-center gap-1">
+                                            <MyButton
+                                                buttonType={
+                                                    previewSource === 'DRAFT'
+                                                        ? 'primary'
+                                                        : 'secondary'
+                                                }
+                                                scale="small"
+                                                onClick={() => {
+                                                    setPreviewSource('DRAFT');
+                                                    setConfirmingRestore(false);
+                                                }}
+                                            >
+                                                <FileText size={14} />
+                                                Draft
+                                            </MyButton>
+                                            <MyButton
+                                                buttonType={
+                                                    previewSource === 'PUBLISHED'
+                                                        ? 'primary'
+                                                        : 'secondary'
+                                                }
+                                                scale="small"
+                                                onClick={() => {
+                                                    setPreviewSource('PUBLISHED');
+                                                    setConfirmingRestore(false);
+                                                }}
+                                            >
+                                                <Globe size={14} />
+                                                Published
+                                            </MyButton>
+                                        </div>
+                                        <MyButton
+                                            buttonType={confirmingRestore ? 'primary' : 'secondary'}
+                                            scale="small"
+                                            disabled={!previewValue || restoreMutation.isPending}
+                                            className={cn(
+                                                restoreMutation.isPending && 'pointer-events-none'
+                                            )}
+                                            onClick={() => {
+                                                if (!confirmingRestore) {
+                                                    setConfirmingRestore(true);
+                                                    return;
+                                                }
+                                                if (selectedId != null) {
+                                                    restoreMutation.mutate({
+                                                        historyId: selectedId,
+                                                        source: previewSource,
+                                                    });
+                                                }
+                                            }}
+                                        >
+                                            {restoreMutation.isPending ? (
+                                                <>
+                                                    <CircleNotch className="size-4 animate-spin" />
+                                                    Restoring…
+                                                </>
+                                            ) : confirmingRestore ? (
+                                                'Confirm restore to draft?'
+                                            ) : (
+                                                'Restore this version'
+                                            )}
+                                        </MyButton>
+                                    </div>
+                                    {!previewValue ? (
+                                        <div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-neutral-200 p-6">
+                                            <p className="text-caption text-neutral-400">
+                                                This snapshot has no{' '}
+                                                {previewSource === 'DRAFT' ? 'draft' : 'published'}{' '}
+                                                content
+                                            </p>
+                                        </div>
+                                    ) : isDocEditor ? (
+                                        <iframe
+                                            title="Version preview"
+                                            sandbox=""
+                                            srcDoc={previewValue}
+                                            className="h-80 w-full rounded-md border border-neutral-200 bg-white"
+                                        />
+                                    ) : (
+                                        <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all rounded-md border border-neutral-200 bg-neutral-50 p-3 text-caption text-neutral-600">
+                                            {previewValue}
+                                        </pre>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </MyDialog>
+        </>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import { html } from '@yoopta/exports';
 import { SlidesMenuOption } from './slides-menu-options/slides-menu-option';
 import { plugins, TOOLS, MARKS } from '@/constants/study-library/yoopta-editor-plugins-tools';
-import { useRouter } from '@tanstack/react-router';
+import { useRouter, useBlocker } from '@tanstack/react-router';
 import { getPublicUrl } from '@/services/upload_file';
 import DeckPlayer from './deck-player';
 import { PublishDialog } from './publish-slide-dialog';
@@ -29,7 +29,7 @@ import {
     useSlidesMutations,
 } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides';
 import { toast } from 'sonner';
-import { Check, DownloadSimple, PencilSimpleLine, Trash, FloppyDisk, LinkSimple } from '@phosphor-icons/react';
+import { Check, DownloadSimple, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning } from '@phosphor-icons/react';
 import { AlertCircle } from 'lucide-react';
 import {
     converDataToAssignmentFormat,
@@ -65,6 +65,13 @@ import { SplitScreenSlide } from './split-screen-slide';
 import { getTokenFromCookie, getTokenDecodedData, getUserRoles } from '@/lib/auth/sessionUtility';
 import { UploadFileInS3 } from '@/services/upload_file';
 import { TokenKey } from '@/constants/auth/tokens';
+import {
+    saveDraft as saveLocalDraft,
+    loadDraft as loadLocalDraft,
+    removeDraft as removeLocalDraft,
+    dirtySlideIds as getDirtySlideIds,
+    pruneOldDrafts,
+} from '../-utils/slide-draft-store';
 import QuizPreview from './QuizPreview';
 import { createQuizSlidePayload } from './quiz/utils/api-helpers';
 import { getDisplaySettings, getDisplaySettingsFromCache } from '@/services/display-settings';
@@ -427,6 +434,111 @@ export const SlideMaterial = ({
         searchParams;
 
     const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
+
+    // ---- Explicit-save lifecycle: local (unsaved) draft persistence ----
+    // Autosave to the DB is gone. Unsaved editor edits are stashed in localStorage
+    // (per user+slide) so they survive slide-switch / refresh, are restored when the
+    // slide reopens, and are cleared on an explicit Save draft / Publish or Discard.
+    const [currentUserId] = useState<string>(() => {
+        try {
+            const t = getTokenFromCookie(TokenKey.accessToken);
+            return (t ? getTokenDecodedData(t)?.sub : null) || 'anonymous';
+        } catch {
+            return 'anonymous';
+        }
+    });
+    const [dirtySlideIdSet, setDirtySlideIdSet] = useState<Set<string>>(() =>
+        getDirtySlideIds(currentUserId)
+    );
+    const refreshDirtySlides = useCallback(() => {
+        setDirtySlideIdSet((prev) => {
+            const next = getDirtySlideIds(currentUserId);
+            // Return the SAME reference when membership is unchanged so React skips a
+            // re-render — the continuous 500ms stash calls this on every edit tick.
+            if (prev.size === next.size && [...next].every((id) => prev.has(id))) {
+                return prev;
+            }
+            return next;
+        });
+    }, [currentUserId]);
+    useEffect(() => {
+        pruneOldDrafts(currentUserId);
+        refreshDirtySlides();
+    }, [currentUserId, refreshDirtySlides]);
+    const stashDocDraftLocally = useCallback(
+        (slideId: string, htmlString: string, guardShrink = true) => {
+            if (!slideId) return;
+            // Anti-clobber (switch-time only): a truncated/degraded switch-time
+            // serialization must not overwrite a larger draft already saved by the
+            // continuous onChange stash. The continuous stash passes guardShrink=false
+            // because it reflects the user's real current edits (incl. intentional
+            // deletions), which must always win.
+            if (guardShrink) {
+                const existing = loadLocalDraft<string>(currentUserId, slideId);
+                if (
+                    existing &&
+                    typeof existing.content === 'string' &&
+                    htmlString.trim().length < existing.content.trim().length * 0.6
+                ) {
+                    return;
+                }
+            }
+            saveLocalDraft(currentUserId, slideId, htmlString);
+            refreshDirtySlides();
+        },
+        [currentUserId, refreshDirtySlides]
+    );
+    const clearLocalDraft = useCallback(
+        (slideId?: string | null) => {
+            if (!slideId) return;
+            removeLocalDraft(currentUserId, slideId);
+            refreshDirtySlides();
+        },
+        [currentUserId, refreshDirtySlides]
+    );
+    const clearAllLocalDrafts = useCallback(() => {
+        dirtySlideIdSet.forEach((id) => removeLocalDraft(currentUserId, id));
+        refreshDirtySlides();
+    }, [dirtySlideIdSet, currentUserId, refreshDirtySlides]);
+    const getRestorableLocalDraftHtml = useCallback(
+        (slide?: Slide | null): string | null => {
+            if (!slide?.id) return null;
+            const d = loadLocalDraft<string>(currentUserId, slide.id);
+            if (
+                d &&
+                typeof d.content === 'string' &&
+                d.content.trim().length > 0 &&
+                !checkIsHtmlEmpty(d.content)
+            ) {
+                return d.content;
+            }
+            return null;
+        },
+        [currentUserId]
+    );
+    // Warn only on a real browser close/refresh while a slide has unsaved local edits.
+    // We intentionally do NOT block in-app slide-switching or navigation: edits are
+    // stashed to localStorage and restored on return, so switching is always safe
+    // (blocking it prompted even on unchanged slides — bug).
+    useEffect(() => {
+        if (dirtySlideIdSet.size === 0) return;
+        const handler = (e: BeforeUnloadEvent) => {
+            e.preventDefault();
+            e.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [dirtySlideIdSet.size]);
+    // In-app navigation guard: when leaving the slides editor (a real pathname
+    // change — NOT a slide-switch, which only mutates the ?slideId search param)
+    // while any slide has an unsaved local draft, block and offer a styled dialog
+    // instead of losing the edits silently. Slide-switching stays intentionally
+    // unblocked (see the beforeunload note above).
+    const leaveBlocker = useBlocker({
+        withResolver: true,
+        disabled: dirtySlideIdSet.size === 0,
+        shouldBlockFn: ({ current, next }) => current.pathname !== next.pathname,
+    });
     const [isUnpublishDialogOpen, setIsUnpublishDialogOpen] = useState(false);
     const [isEditLinkDialogOpen, setIsEditLinkDialogOpen] = useState(false);
     const { getPackageSessionId } = useInstituteDetailsStore();
@@ -587,10 +699,35 @@ export const SlideMaterial = ({
                             debounceTimerRef.current = setTimeout(() => {
                                 try {
                                     const currentContent = html.serialize(editor, editor.children);
+                                    const serializedHtml = formatHTMLString(currentContent || '');
+                                    const targetSlideId =
+                                        prevDocSlideRef.current?.id ?? activeItem?.id ?? null;
                                     currentDocHtmlRef.current = {
-                                        slideId: prevDocSlideRef.current?.id ?? null,
-                                        html: formatHTMLString(currentContent || ''),
+                                        slideId: targetSlideId,
+                                        html: serializedHtml,
                                     };
+                                    // Continuously persist the unsaved edit to localStorage as the
+                                    // user types/pastes, so it survives a slide switch / refresh.
+                                    // Only stash a REAL edit: Yoopta's setEditorValue on load also
+                                    // fires onChange, so without the changed-vs-initial check merely
+                                    // opening a slide would mark it dirty.
+                                    const initialForThisSlide =
+                                        initialDocHtmlRef.current.slideId === targetSlideId
+                                            ? initialDocHtmlRef.current.html
+                                            : null;
+                                    const isRealEdit =
+                                        initialForThisSlide !== null &&
+                                        serializedHtml !== initialForThisSlide;
+                                    if (
+                                        targetSlideId &&
+                                        serializedHtml &&
+                                        !checkIsHtmlEmpty(serializedHtml) &&
+                                        isRealEdit
+                                    ) {
+                                        // guardShrink=false: continuous stash reflects the user's real
+                                        // current content and must always win over an older draft.
+                                        stashDocDraftLocally(targetSlideId, serializedHtml, false);
+                                    }
                                 } catch (error) {
                                     console.error('Error serializing content in onChange:', error);
                                 }
@@ -687,14 +824,18 @@ export const SlideMaterial = ({
         // the slide opens blank even though the content survives in
         // published_data. checkIsHtmlEmpty detects the blank wrapper.
         const draftDocData = activeItem?.document_slide?.data;
+        // Restore an unsaved LOCAL draft (stashed on a previous switch/refresh) over
+        // the server content so in-progress edits are never lost on reopen.
+        const restorableLocalDraft = getRestorableLocalDraftHtml(activeItem);
         const docData =
-            activeItem?.status == 'PUBLISHED'
+            restorableLocalDraft ??
+            (activeItem?.status == 'PUBLISHED'
                 ? activeItem.document_slide?.published_data || null
                 : (draftDocData && !checkIsHtmlEmpty(draftDocData)
                       ? draftDocData
                       : null) ||
                   activeItem?.document_slide?.published_data ||
-                  null;
+                  null);
 
         // Sanitize any public S3 URLs that may contain expired signatures
         let sanitizedDocData = stripAwsQueryParamsFromUrls(docData || '');
@@ -1544,52 +1685,11 @@ export const SlideMaterial = ({
                 }
             }
 
-            const totalPages = estimatePageCount(processedHtmlString);
-
-            // Determine status and published_data based on role
-            let newStatus = slide.status;
-            let publishedData = slide.document_slide?.published_data || '';
-
-            if (hidePublishButtons) {
-                // Non-admin (Teacher): Auto-publish
-                newStatus = 'PUBLISHED';
-                publishedData = processedHtmlString;
-            } else {
-                // Admin: Auto-save draft
-                // If currently published, it becomes UNSYNC because draft has changed
-                if (slide.status === 'PUBLISHED') {
-                    newStatus = 'UNSYNC';
-                } else {
-                    newStatus = slide.status || 'DRAFT';
-                }
-                // Do NOT update publishedData for admins — keep live version safe
-            }
-
-            await addUpdateDocumentSlide({
-                id: slide?.id || '',
-                title: slide?.title || '',
-                image_file_id: '',
-                description: slide?.description || '',
-                slide_order: null,
-                document_slide: {
-                    id: slide?.document_slide?.id || '',
-                    type: 'DOC',
-                    data: processedHtmlString,
-                    title: slide?.document_slide?.title || '',
-                    cover_file_id: '',
-                    total_pages: totalPages,
-                    published_data: publishedData,
-                    published_document_total_pages: 1,
-                },
-                status: newStatus,
-                new_slide: false,
-                notify: false,
-            });
-            if (!hidePublishButtons) {
-                toast.success('Draft auto-saved');
-            } else {
-                toast.success('Changes saved and published');
-            }
+            // Autosave is gone: do NOT write to the DB or publish here. Persist the
+            // edit to localStorage so it survives this slide switch / a refresh and is
+            // restored when the slide reopens. The author commits it explicitly via the
+            // Save draft / Publish buttons (which clear this local copy).
+            stashDocDraftLocally(slide.id, processedHtmlString);
         } catch (error) {
             console.error('Error auto-publishing DOC slide:', error);
             toast.error('Failed to auto-save changes');
@@ -3042,6 +3142,7 @@ export const SlideMaterial = ({
             if (customSaveFunction && activeItem) {
                 console.log('🔄 Using custom save function for non-admin');
                 await customSaveFunction(activeItem);
+                clearLocalDraft(activeItem?.id);
                 return; // Don't show additional toast as custom function handles it
             }
 
@@ -3051,6 +3152,7 @@ export const SlideMaterial = ({
             // success-after-error stack when the DOC branch guarded empty
             // editor content.
             await SaveDraft(activeItem);
+            clearLocalDraft(activeItem?.id);
         } catch {
             toast.error('error saving document');
         }
@@ -3188,8 +3290,73 @@ export const SlideMaterial = ({
             className="flex h-[calc(100vh-76px)] w-full flex-1 flex-col overflow-y-auto overflow-x-hidden transition-all duration-300 ease-in-out sm:h-[calc(100vh-84px)] md:h-[calc(100vh-108px)] lg:h-[calc(100vh-132px)]"
             ref={selectionRef}
         >
+            {/* Bug 2: styled leave-guard dialog (replaces the browser-default prompt)
+                when navigating away from the slides editor with unsaved local edits. */}
+            {leaveBlocker.status === 'blocked' && (
+                <MyDialog
+                    heading="Unsaved changes"
+                    open
+                    onOpenChange={(open) => {
+                        if (!open) leaveBlocker.reset?.();
+                    }}
+                    dialogWidth="w-full max-w-md"
+                    footer={
+                        <div className="flex w-full flex-col gap-3">
+                            <p className="text-caption text-neutral-500">
+                                Kept only on this device — logging out or clearing browser
+                                data will lose these changes.
+                            </p>
+                            <div className="flex flex-wrap items-center justify-end gap-2">
+                                <MyButton
+                                    buttonType="secondary"
+                                    scale="medium"
+                                    onClick={() => leaveBlocker.proceed?.()}
+                                >
+                                    Keep in browser
+                                </MyButton>
+                                <MyButton
+                                    buttonType="secondary"
+                                    scale="medium"
+                                    className="border-danger-400 text-danger-600 hover:bg-danger-50"
+                                    onClick={() => {
+                                        clearAllLocalDrafts();
+                                        leaveBlocker.proceed?.();
+                                    }}
+                                >
+                                    Discard changes
+                                </MyButton>
+                                <MyButton
+                                    buttonType="primary"
+                                    scale="medium"
+                                    disabled={isSaving}
+                                    className={cn(isSaving && 'pointer-events-none')}
+                                    onClick={async () => {
+                                        await handleSaveDraftClick();
+                                        leaveBlocker.proceed?.();
+                                    }}
+                                >
+                                    {isSaving ? 'Saving…' : 'Save draft'}
+                                </MyButton>
+                            </div>
+                        </div>
+                    }
+                >
+                    <div className="flex items-start gap-3">
+                        <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full bg-danger-50 text-danger-600">
+                            <Warning size={20} weight="fill" />
+                        </span>
+                        <p className="text-subtitle text-neutral-600">
+                            You have edits that haven&apos;t been saved to the database. Choose
+                            what to do before leaving this page.
+                        </p>
+                    </div>
+                </MyDialog>
+            )}
             {activeItem && (
-                <div className="sticky top-0 z-50 -mx-2 -mt-2 flex flex-wrap items-center justify-between gap-1 border-b border-neutral-200 bg-white/80 px-2 py-1 shadow-sm backdrop-blur-sm sm:-mx-3 sm:-mt-3 sm:px-3 sm:py-1.5 md:-mx-4 md:-mt-4 md:flex-nowrap md:gap-3 md:px-4 md:py-2.5 lg:-mx-7 lg:-mt-7 lg:gap-4 lg:px-7 lg:py-3">
+                <div className="sticky top-0 z-50 -mx-2 -mt-2 flex flex-col gap-2 border-b border-neutral-200 bg-white/80 px-2 py-1 shadow-sm backdrop-blur-sm sm:-mx-3 sm:-mt-3 sm:px-3 sm:py-1.5 md:-mx-4 md:-mt-4 md:px-4 md:py-2.5 lg:-mx-7 lg:-mt-7 lg:px-7 lg:py-3">
+                    {/* Row 1 — editable title + actions. Wraps so the title truncates
+                        and the actions drop to their own line before anything clips. */}
+                    <div className="flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2">
                     <div className="w-full min-w-0 md:w-auto md:flex-1">
                         {isEditing ? (
                             <div className="flex items-center justify-center gap-2 duration-200 animate-in fade-in">
@@ -3233,7 +3400,7 @@ export const SlideMaterial = ({
                     </div>
 
                     {!isLearnerView && (
-                        <div className="flex shrink-0 items-center gap-1 sm:gap-2 md:gap-3">
+                        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1 sm:gap-2 md:gap-3">
                             <div className="flex items-center gap-1 sm:gap-2 md:gap-3">
                                 {activeItem.source_type === 'DOCUMENT' &&
                                     activeItem?.document_slide?.type === 'DOC' && (
@@ -3318,35 +3485,24 @@ export const SlideMaterial = ({
                                     </MyButton>
                                 )}
 
-                                {/* Single Publish/Unpublish Button - Hidden for non-admin users */}
-                                {!hidePublishButtons &&
-                                    (activeItem.status === 'PUBLISHED' ? (
-                                        <MyButton
-                                            buttonType="secondary"
-                                            scale="medium"
-                                            layoutVariant="default"
-                                            onClick={() => setIsUnpublishDialogOpen(true)}
-                                        >
-                                            <span className="hidden sm:inline">Unpublish</span>
-                                            <span className="text-xs sm:hidden">Unpub</span>
-                                        </MyButton>
-                                    ) : (
-                                        <MyButton
-                                            buttonType="primary"
-                                            scale="medium"
-                                            layoutVariant="default"
-                                            onClick={() => setIsPublishDialogOpen(true)}
-                                        >
-                                            <span className="hidden sm:inline">Publish</span>
-                                            <span className="text-xs sm:hidden">Pub</span>
-                                        </MyButton>
-                                    ))}
-
-                                {/* Keep dialogs but make them conditional */}
-                                {isUnpublishDialogOpen && (
+                                {/* Publish/Unpublish — shown to ALL roles (no auto-publish anymore).
+                                    The confirm step is a compact popover anchored to this button
+                                    (no full-screen modal); the button below is its anchor. */}
+                                {activeItem.status === 'PUBLISHED' ? (
                                     <UnpublishDialog
                                         isOpen={isUnpublishDialogOpen}
                                         setIsOpen={setIsUnpublishDialogOpen}
+                                        trigger={
+                                            <MyButton
+                                                buttonType="secondary"
+                                                scale="medium"
+                                                layoutVariant="default"
+                                                onClick={() => setIsUnpublishDialogOpen(true)}
+                                            >
+                                                <span className="hidden sm:inline">Unpublish</span>
+                                                <span className="text-xs sm:hidden">Unpub</span>
+                                            </MyButton>
+                                        }
                                         handlePublishUnpublishSlide={() =>
                                             handleUnpublishSlide(
                                                 setIsUnpublishDialogOpen,
@@ -3365,17 +3521,27 @@ export const SlideMaterial = ({
                                             )
                                         }
                                     />
-                                )}
-
-                                {isPublishDialogOpen && (
+                                ) : (
                                     <PublishDialog
                                         isOpen={isPublishDialogOpen}
                                         setIsOpen={setIsPublishDialogOpen}
+                                        trigger={
+                                            <MyButton
+                                                buttonType="primary"
+                                                scale="medium"
+                                                layoutVariant="default"
+                                                onClick={() => setIsPublishDialogOpen(true)}
+                                            >
+                                                <span className="hidden sm:inline">Publish</span>
+                                                <span className="text-xs sm:hidden">Pub</span>
+                                            </MyButton>
+                                        }
                                         handlePublishUnpublishSlide={async () => {
                                             if (
                                                 activeItem?.document_slide?.type === 'PRESENTATION'
                                             ) {
                                                 publishExcalidrawPresentation();
+                                                clearLocalDraft(activeItem?.id);
                                                 setIsPublishDialogOpen(false);
                                             } else {
                                                 // For DOC slides, get fresh editor HTML so
@@ -3414,7 +3580,8 @@ export const SlideMaterial = ({
                                                     addUpdateScormSlide,
                                                     SaveDraft,
                                                     playerRef,
-                                                    addUpdateAssessmentSlide
+                                                    addUpdateAssessmentSlide,
+                                                    () => clearLocalDraft(activeItem?.id)
                                                 );
                                             }
                                         }}
@@ -3469,6 +3636,21 @@ export const SlideMaterial = ({
                             )}
                             {/* Slides Menu Option */}
                             <SlidesMenuOption />
+                        </div>
+                    )}
+                    </div>
+                    {/* Bug 4 — unsaved notice on its own row so it never crowds or
+                        overlaps the title / action buttons at any viewport width. */}
+                    {!isLearnerView && activeItem?.id && dirtySlideIdSet.has(activeItem.id) && (
+                        <div
+                            role="status"
+                            className="flex w-fit items-center gap-1.5 rounded-md bg-danger-50 px-2 py-1 text-caption font-semibold text-danger-600"
+                        >
+                            <Warning size={16} weight="fill" className="shrink-0" />
+                            <span>
+                                Unsaved — not saved to the database. Use Save Draft or Publish
+                                to persist.
+                            </span>
                         </div>
                     )}
                 </div>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -225,6 +225,7 @@ function repairSlateChildren(children: any): any {
 import ScormSlidePreview from './scorm-slide-preview';
 import AssessmentSlidePreview from './assessment-slide-preview';
 import AssessmentCreateForm from './assessment-create-form';
+import { SlideHistoryDialog } from './slide-history-dialog';
 
 export const SlideMaterial = ({
     setGetCurrentEditorHTMLContent,
@@ -434,6 +435,10 @@ export const SlideMaterial = ({
         searchParams;
 
     const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
+    // Bumped after a version-history restore to force loadContent to re-run (and
+    // re-deserialize) even when the slide's id/status didn't change — the effect's
+    // deps intentionally exclude document_slide.data for DOC slides.
+    const [historyRestoreNonce, setHistoryRestoreNonce] = useState(0);
 
     // ---- Explicit-save lifecycle: local (unsaved) draft persistence ----
     // Autosave to the DB is gone. Unsaved editor edits are stashed in localStorage
@@ -3260,7 +3265,27 @@ export const SlideMaterial = ({
         // Re-render the video preview when an external link is edited in place.
         activeItem?.video_slide?.url,
         activeItem?.video_slide?.published_url,
+        // Reload the editor with the restored content after a history restore.
+        historyRestoreNonce,
     ]);
+
+    // A version-history snapshot was copied into this slide's draft on the
+    // backend. Mirror it into the store and force a full editor reload: clear
+    // the local (unsaved) draft so it can't shadow the restored content, and
+    // reset the same-slide guard so the DOC branch re-deserializes.
+    const handleHistoryRestored = (restoredValue: string, slideStatus: string) => {
+        if (!activeItem) return;
+        clearLocalDraft(activeItem.id);
+        lastLoadContentSlideIdRef.current = null;
+        setActiveItem({
+            ...activeItem,
+            status: slideStatus || activeItem.status,
+            document_slide: activeItem.document_slide
+                ? { ...activeItem.document_slide, data: restoredValue }
+                : activeItem.document_slide,
+        } as Slide);
+        setHistoryRestoreNonce((n) => n + 1);
+    };
 
     // Update the refs whenever these functions change
     useEffect(() => {
@@ -3431,6 +3456,18 @@ export const SlideMaterial = ({
                                     )}
 
                                 <ActivityStatsSidebar />
+
+                                {/* Version history + restore — content snapshots are
+                                    trigger-written for document slides (V363). */}
+                                {activeItem.source_type === 'DOCUMENT' &&
+                                    activeItem?.document_slide?.type !== 'PRESENTATION' && (
+                                        <SlideHistoryDialog
+                                            key={activeItem.id}
+                                            activeItem={activeItem}
+                                            chapterId={chapterId || ''}
+                                            onRestored={handleHistoryRestored}
+                                        />
+                                    )}
 
                                 {isExternalVideoLink && (
                                     <MyButton

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
@@ -62,7 +62,9 @@ export const handlePublishSlide = async (
         Error,
         AssessmentSlidePayload,
         unknown
-    >
+    >,
+    /** Called only after the publish network call SUCCEEDS (e.g. to clear the local draft). */
+    onPublishSuccess?: () => void
 ) => {
     const status = 'PUBLISHED';
 
@@ -98,8 +100,8 @@ export const handlePublishSlide = async (
             return;
         }
 
-        try {
-            await addUpdateDocumentSlide({
+        const publishDocumentSlide = (force: boolean) =>
+            addUpdateDocumentSlide({
                 id: activeItem?.id || '',
                 title: activeItem.title || '',
                 image_file_id: activeItem?.image_file_id || '',
@@ -117,15 +119,44 @@ export const handlePublishSlide = async (
                     total_pages: activeItem?.document_slide?.total_pages || 0,
                     published_data: publishedData,
                     published_document_total_pages: activeItem?.document_slide?.total_pages || 0,
+                    force_publish: force,
                 },
                 status: status,
                 new_slide: false,
                 notify: notify,
             });
+
+        try {
+            await publishDocumentSlide(false);
             toast.success(`Slide published successfully!`);
             setIsOpen(false);
-        } catch {
-            toast.error(`Error in publishing the slide`);
+            onPublishSuccess?.();
+        } catch (error) {
+            // The backend blocks a publish that would shrink a large live slide down to
+            // a tiny fragment (409). Surface the real reason and let the author confirm
+            // an explicit force-override instead of a generic "error saving".
+            const response = (
+                error as {
+                    response?: { status?: number; data?: { ex?: string; message?: string } };
+                }
+            )?.response;
+            const serverMessage = response?.data?.ex || response?.data?.message;
+            if (response?.status === 409 && serverMessage) {
+                const confirmed = window.confirm(
+                    `${serverMessage}\n\nDo you want to publish anyway and replace the live version?`
+                );
+                if (!confirmed) return;
+                try {
+                    await publishDocumentSlide(true);
+                    toast.success('Slide published (forced override).');
+                    setIsOpen(false);
+                    onPublishSuccess?.();
+                } catch {
+                    toast.error('Error in publishing the slide');
+                }
+                return;
+            }
+            toast.error(serverMessage || `Error in publishing the slide`);
         }
     }
 

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/slides-sidebar-add-button.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/slides-sidebar-add-button.tsx
@@ -718,14 +718,14 @@ export const ChapterSidebarAddButton = () => {
     return (
         <div className="w-full px-1 duration-500 animate-in fade-in slide-in-from-top-2">
             <div className="flex w-full items-center gap-2">
-                <div className="flex-1">
+                <div className="min-w-0 flex-1">
                     <MyDropdown dropdownList={filteredDropdownList} onSelect={handleSelect}>
                         <MyButton
                             buttonType="primary"
                             scale="medium"
                             className={`
-                                group relative h-9 w-full
-                                overflow-hidden border-0 bg-gradient-to-r
+                                group relative h-9 w-full min-w-0
+                                overflow-hidden border-0 bg-gradient-to-r sm:min-w-0
                                 from-primary-400 to-primary-400
                                 shadow-md shadow-primary-500/20
                                 transition-all duration-300 ease-in-out
@@ -735,6 +735,7 @@ export const ChapterSidebarAddButton = () => {
                                 ${open ? 'px-3' : 'px-2.5'}
                             `}
                             id="add-slides"
+                            title="Add a single slide — pick a type (document, PDF, video, quiz, code…)"
                         >
                             <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-white/0 via-white/20 to-white/0 transition-transform duration-700 ease-out group-hover:translate-x-full" />
 
@@ -755,11 +756,12 @@ export const ChapterSidebarAddButton = () => {
                         </MyButton>
                     </MyDropdown>
                 </div>
-                <div>
+                <div className="shrink-0">
                     <MyButton
                         buttonType="primary"
                         scale="medium"
-                        className={`flex items-center justify-center gap-1.5 ${open ? 'px-3' : 'px-2.5'}`}
+                        className={`flex min-w-0 items-center justify-center gap-1.5 whitespace-nowrap sm:min-w-0 ${open ? 'px-3' : 'px-2.5'}`}
+                        title="Quick add — upload and publish several slides at once"
                         onClick={() => {
                             const s = route.state.location.search as Record<string, unknown>;
                             const search = {
@@ -785,7 +787,7 @@ export const ChapterSidebarAddButton = () => {
                         }}
                         id="quick-add-fast"
                     >
-                        <Lightning className="size-4" />
+                        <Lightning className="size-4 shrink-0" />
                         {open && <span className="text-sm font-medium">Quick Add</span>}
                     </MyButton>
                 </div>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unpublish-slide-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unpublish-slide-dialog.tsx
@@ -1,8 +1,7 @@
-// publish-dialog.tsx
+// unpublish-dialog.tsx
 import { MyButton } from '@/components/design-system/button';
-import { MyDialog } from '@/components/design-system/dialog';
-import { useContentStore } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-stores/chapter-sidebar-store';
-import { Dispatch, SetStateAction } from 'react';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 
 interface UnpublishDialogProps {
     isOpen: boolean;
@@ -11,48 +10,50 @@ interface UnpublishDialogProps {
         setIsOpen: Dispatch<SetStateAction<boolean>>,
         notify: boolean
     ) => void;
+    /** The button the confirm popover anchors to (rendered by the caller so it
+        keeps its exact styling / responsive labels). */
+    trigger?: ReactNode;
 }
 
 export const UnpublishDialog = ({
     isOpen,
     setIsOpen,
     handlePublishUnpublishSlide,
+    trigger,
 }: UnpublishDialogProps) => {
-    const { activeItem } = useContentStore();
-    const unpublishTrigger = (
-        <MyButton
-            buttonType="secondary"
-            scale="medium"
-            layoutVariant="default"
-            disable={activeItem?.status == 'DRAFT'}
-        >
-            Unpublish
-        </MyButton>
-    );
-
     return (
-        <MyDialog
-            heading={`Unpublish Slide`}
-            dialogWidth="w-[400px]"
-            open={isOpen}
-            onOpenChange={setIsOpen}
-            trigger={unpublishTrigger}
-        >
-            <div className="flex w-full flex-col gap-6">
-                <p>Are you sure you want to unpublish publish this slide? </p>
-                <div className="flex justify-end gap-4">
-                    <MyButton buttonType="secondary" onClick={() => setIsOpen(false)}>
-                        Cancel
-                    </MyButton>
-
-                    <MyButton
-                        buttonType="primary"
-                        onClick={() => handlePublishUnpublishSlide(setIsOpen, false)}
-                    >
-                        Yes, I&apos;m sure
-                    </MyButton>
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+            {trigger && <PopoverAnchor asChild>{trigger}</PopoverAnchor>}
+            <PopoverContent align="end" sideOffset={8} className="w-72 p-4">
+                <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                        <p className="text-subtitle font-semibold text-neutral-700">
+                            Unpublish this slide?
+                        </p>
+                        <p className="text-caption text-neutral-500">
+                            Learners will no longer be able to see it.
+                        </p>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            className="min-w-0 sm:min-w-0"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Cancel
+                        </MyButton>
+                        <MyButton
+                            buttonType="primary"
+                            scale="medium"
+                            className="min-w-0 sm:min-w-0"
+                            onClick={() => handlePublishUnpublishSlide(setIsOpen, false)}
+                        >
+                            Unpublish
+                        </MyButton>
+                    </div>
                 </div>
-            </div>
-        </MyDialog>
+            </PopoverContent>
+        </Popover>
     );
 };

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides.tsx
@@ -248,6 +248,8 @@ export interface DocumentSlidePayload {
         total_pages: number;
         published_data: string | null;
         published_document_total_pages: number;
+        /** When true, bypass the backend publish-time shrink guard (author confirmed). */
+        force_publish?: boolean;
     };
     status: string;
     new_slide: boolean;

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-utils/slide-draft-store.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-utils/slide-draft-store.ts
@@ -1,0 +1,160 @@
+/**
+ * Local (browser) persistence of UNSAVED slide edits.
+ *
+ * Autosave-to-the-DB is gone; edits live in React state and are explicitly
+ * committed via Save draft / Publish. To make sure nothing is silently lost when
+ * the author switches slides, refreshes, or the tab crashes, we mirror the
+ * in-progress edit into this store, keyed per user + slide. The entry is removed
+ * the moment the edit is Saved/Published to the DB or explicitly Discarded.
+ *
+ * Backed by localStorage today (slide bodies are ~10–60 KB of HTML — well under
+ * the ~5 MB budget for dozens of dirty slides). Everything goes through the tiny
+ * `backend` object below so we can swap to IndexedDB later without touching callers.
+ */
+
+export interface SlideDraft<T = unknown> {
+    slideId: string;
+    /** The editor payload — HTML string, Excalidraw JSON, code data, etc. */
+    content: T;
+    /** Cheap hash of `content`, used for dirty comparison without deep-equals. */
+    contentHash: string;
+    /**
+     * The server `updated_at` (or equivalent) the draft was derived from. On load
+     * we compare it against the current server value to detect that the slide was
+     * changed elsewhere (another tab / another user) while this draft sat unsaved.
+     */
+    baselineUpdatedAt?: string | null;
+    /** epoch ms when this draft was last written locally. */
+    savedAt: number;
+}
+
+const PREFIX = 'slideDraft';
+/** Drafts older than this are pruned on load — stale local work we never committed. */
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+function keyFor(userId: string, slideId: string): string {
+    return `${PREFIX}:${userId}:${slideId}`;
+}
+
+/** Stable, collision-cheap hash (djb2) as `${length}:${base36}` — enough for dirty checks. */
+export function hashContent(content: unknown): string {
+    const str = typeof content === 'string' ? content : JSON.stringify(content ?? '');
+    let h = 5381;
+    for (let i = 0; i < str.length; i++) {
+        h = ((h << 5) + h + str.charCodeAt(i)) | 0;
+    }
+    return `${str.length}:${(h >>> 0).toString(36)}`;
+}
+
+// Thin storage adapter. Swap the body for IndexedDB (idb/localForage) if drafts
+// ever outgrow localStorage; the exported API below stays identical.
+const backend = {
+    get(key: string): string | null {
+        try {
+            return window.localStorage.getItem(key);
+        } catch {
+            return null;
+        }
+    },
+    set(key: string, value: string): boolean {
+        try {
+            window.localStorage.setItem(key, value);
+            return true;
+        } catch {
+            // Quota exceeded / storage disabled — fail soft; the in-memory dirty
+            // state still protects against silent loss within the session.
+            return false;
+        }
+    },
+    remove(key: string): void {
+        try {
+            window.localStorage.removeItem(key);
+        } catch {
+            /* ignore */
+        }
+    },
+    keys(): string[] {
+        try {
+            return Object.keys(window.localStorage);
+        } catch {
+            return [];
+        }
+    },
+};
+
+export function saveDraft<T>(
+    userId: string,
+    slideId: string,
+    content: T,
+    baselineUpdatedAt?: string | null
+): SlideDraft<T> {
+    const draft: SlideDraft<T> = {
+        slideId,
+        content,
+        contentHash: hashContent(content),
+        baselineUpdatedAt: baselineUpdatedAt ?? null,
+        savedAt: Date.now(),
+    };
+    backend.set(keyFor(userId, slideId), JSON.stringify(draft));
+    return draft;
+}
+
+export function loadDraft<T = unknown>(userId: string, slideId: string): SlideDraft<T> | null {
+    const raw = backend.get(keyFor(userId, slideId));
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw) as SlideDraft<T>;
+    } catch {
+        backend.remove(keyFor(userId, slideId));
+        return null;
+    }
+}
+
+export function removeDraft(userId: string, slideId: string): void {
+    backend.remove(keyFor(userId, slideId));
+}
+
+export function hasDraft(userId: string, slideId: string): boolean {
+    return backend.get(keyFor(userId, slideId)) != null;
+}
+
+/** All drafts for a user (used to render dirty badges + a global "N unsaved" count). */
+export function listDrafts<T = unknown>(userId: string): SlideDraft<T>[] {
+    const wanted = `${PREFIX}:${userId}:`;
+    const out: SlideDraft<T>[] = [];
+    for (const key of backend.keys()) {
+        if (!key.startsWith(wanted)) continue;
+        const raw = backend.get(key);
+        if (!raw) continue;
+        try {
+            out.push(JSON.parse(raw) as SlideDraft<T>);
+        } catch {
+            backend.remove(key);
+        }
+    }
+    return out;
+}
+
+/** The set of slideIds that currently have a locally-persisted unsaved draft. */
+export function dirtySlideIds(userId: string): Set<string> {
+    return new Set(listDrafts(userId).map((d) => d.slideId));
+}
+
+/** Drop drafts older than MAX_AGE_MS. Call once on mount. */
+export function pruneOldDrafts(userId: string): void {
+    const wanted = `${PREFIX}:${userId}:`;
+    const cutoff = Date.now() - MAX_AGE_MS;
+    for (const key of backend.keys()) {
+        if (!key.startsWith(wanted)) continue;
+        const raw = backend.get(key);
+        if (!raw) continue;
+        try {
+            const draft = JSON.parse(raw) as SlideDraft;
+            if (typeof draft.savedAt !== 'number' || draft.savedAt < cutoff) {
+                backend.remove(key);
+            }
+        } catch {
+            backend.remove(key);
+        }
+    }
+}


### PR DESCRIPTION
## Why
Chapter-slide editing silently autosaved on every change/slide-switch, and publishing nulled the draft — so a published slide reopened empty, and a stray re-save (or a truncated serialize on fast switching) overwrote `published_data`, the copy learners see. With no history, losses were unrecoverable. This caused real production lesson loss.

## What changed

### Backend (`admin_core_service`)
- Publish no longer nulls the draft — keeps `data == published_data` (documents **and** video), so a published slide always reopens with its content and can't be re-saved-over-empty.
- **Shrink-guard:** a publish that would collapse a ≥2 KB live slide to <25% of its size returns **409** unless `force_publish` is set.
- Draft/UNSYNC saves no longer touch `published_data`/`published_url` — the publish path is the single writer of published content.
- **`slide_content_history`** table + `BEFORE UPDATE` triggers on `document_slide`/`video`/`audio_slide` capture the before-image of every content change → any future loss is one query to recover.

### Frontend (`frontend-admin-dashboard`)
- Removed DB autosave; explicit **Save draft** + **Publish** for all roles (no auto-publish).
- Unsaved edits persist to **localStorage** (survive slide-switch/refresh), restore on reopen, clear on successful save/publish only.
- Red "Unsaved — not saved to the database" banner + `beforeunload` warning.
- On a shrink-guard **409**, the real server reason is shown with a **force-override** confirm.
- Publish/unpublish confirmation reworked into an anchored popover + related style tweaks.

## Testing
- Backend compiles (`BUILD SUCCESS`); frontend `tsc --noEmit` = 0 errors.
- Verified against a local prod-snapshot DB: publish keeps `data == published_data`; history rows captured per edit; 409 fires on big shrink and force overrides; no network write on slide-switch; localStorage restore on reopen.
- Two adversarial code reviews run; all introduced content-loss/false-dirty paths fixed.

## Scope / follow-ups (next PR)
- Not converted (still autosave, protected by the backend net): Excalidraw + interactive (code/jupyter/scratch) slides.
- Next PR: "Restore published version" button, slide history viewer, cross-device stale-draft conflict detection, publish/leave dialog polish + header responsiveness, `changed_by` GUC + history retention.
