### PR TITLE
fix(reports): show every active counsellor in performance + dispositi…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadReportService.java
@@ -43,6 +43,7 @@ public class LeadReportService {
     private final LeadSlaConfigService leadSlaConfigService;
     private final AuthService authService;
     private final ReportScopeResolver reportScopeResolver;
+    private final vacademy.io.admin_core_service.features.counsellor_workbench.service.CounsellorScopeService counsellorScopeService;
 
     private static final int DEFAULT_RANGE_DAYS = 30;
 
@@ -176,9 +177,18 @@ public class LeadReportService {
                 .findReportCounselorPerformance(instituteId, range.from, range.to, tatHoursParam,
                         scopeCsv, trimToNull(audienceId), trimToNull(sourceType));
 
-        // Batch-resolve counsellor names (one call to auth-service for all ids in the result).
+        // Every ACTIVE counsellor in the caller's scope must get a row — the
+        // SQL groups the lead DATA, so a counsellor with zero leads in the
+        // window produced no row at all and read as "missing" in the report.
+        // Zero rows are appended after the data-driven ones (below).
+        List<String> scopedCounsellors = scopedActiveCounsellors(instituteId, scopeCsv);
+
+        // Batch-resolve counsellor names (one call to auth-service for all ids
+        // in the result AND the zero-padded roster).
         Map<String, String> nameById = Collections.emptyMap();
-        List<String> ids = raw.stream().map(LeadReportProjections.CounselorRowProjection::getCounselorId)
+        List<String> ids = java.util.stream.Stream.concat(
+                        raw.stream().map(LeadReportProjections.CounselorRowProjection::getCounselorId),
+                        scopedCounsellors.stream())
                 .filter(s -> s != null && !s.isBlank()).distinct().collect(Collectors.toList());
         if (!ids.isEmpty()) {
             try {
@@ -215,6 +225,32 @@ public class LeadReportService {
                     .build();
         }).collect(Collectors.toList());
 
+        // Zero rows for scoped active counsellors with no lead data in the
+        // window, name-sorted after the data-driven rows.
+        Set<String> presentIds = rows.stream()
+                .map(CounselorPerformanceDTO.Row::getCounselorId)
+                .collect(Collectors.toSet());
+        scopedCounsellors.stream()
+                .filter(id -> !presentIds.contains(id))
+                .map(id -> CounselorPerformanceDTO.Row.builder()
+                        .counselorId(id)
+                        .counselorName(Optional.ofNullable(nameByIdFinal.get(id))
+                                .filter(s -> !s.isBlank())
+                                .orElse(id))
+                        .leadsAssigned(0)
+                        .leadsResponded(0)
+                        .conversions(0)
+                        .conversionRate(null)
+                        .avgResponseMinutes(null)
+                        .tatMetCount(tatHours == null ? null : 0L)
+                        .tatMetRate(null)
+                        .openLeads(0)
+                        .overdueLeads(0)
+                        .build())
+                .sorted(Comparator.comparing(CounselorPerformanceDTO.Row::getCounselorName,
+                        String.CASE_INSENSITIVE_ORDER))
+                .forEach(rows::add);
+
         // Summary: weighted averages so a few heavy counsellors don't get equal weight to outliers.
         long totalAssigned = rows.stream().mapToLong(CounselorPerformanceDTO.Row::getLeadsAssigned).sum();
         long totalConversions = rows.stream().mapToLong(CounselorPerformanceDTO.Row::getConversions).sum();
@@ -245,6 +281,24 @@ public class LeadReportService {
 
     private static String trimToNull(String s) {
         return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+    /**
+     * The ACTIVE counsellor-role users inside the resolved report scope — the
+     * roster that per-counsellor reports must render even with zero activity.
+     * The scope CSV may also carry non-counsellor ids (explicit teamId filters
+     * list whole teams), so it's intersected with the role roster. Empty when
+     * the scope is unfiltered (setup mode — nothing sensible to pad with).
+     */
+    private List<String> scopedActiveCounsellors(String instituteId, String scopeCsv) {
+        if (scopeCsv == null || scopeCsv.isBlank()) return List.of();
+        Set<String> counsellors = new java.util.HashSet<>(
+                counsellorScopeService.allCounsellorUserIds(instituteId));
+        return java.util.Arrays.stream(scopeCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty() && counsellors.contains(s))
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     /** Read tat_hours when TAT is enabled; null otherwise (drives "is TAT shown?" downstream). */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
@@ -57,6 +57,7 @@ public class PipelineReportService {
     private final ReportScopeResolver scopeResolver;
     private final LeadReportSettingService settingService;
     private final AuthService authService;
+    private final vacademy.io.admin_core_service.features.counsellor_workbench.service.CounsellorScopeService counsellorScopeService;
 
     private static final int DEFAULT_RANGE_DAYS = 30;
     private static final String SYSTEM_ACTOR_ID = "SYSTEM";
@@ -300,6 +301,15 @@ public class PipelineReportService {
                     .merge(rs.getString("status"), rs.getLong("n"), Long::sum);
         };
         jdbc.query(CALL_OUTCOMES_SQL, p, outcomesCollector);
+
+        // Every ACTIVE counsellor in scope gets a row in BOTH matrices — the
+        // SQL groups the DATA, so a counsellor with no status changes / calls
+        // in the window used to vanish from the report entirely. Zero-filled
+        // rows sort to the bottom via the existing total-desc ordering.
+        for (String id : scopedActiveCounsellors(instituteId, scopeCsv)) {
+            changesByActor.computeIfAbsent(id, k -> new LinkedHashMap<>());
+            outcomesByActor.computeIfAbsent(id, k -> new LinkedHashMap<>());
+        }
 
         // One auth-service batch for the union of human actor ids across both groupings.
         Set<String> ids = new LinkedHashSet<>();
@@ -567,6 +577,24 @@ public class PipelineReportService {
 
     private static String trimToNull(String s) {
         return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+    /**
+     * The ACTIVE counsellor-role users inside the resolved report scope — the
+     * roster per-counsellor report rows must render even with zero activity.
+     * Intersected with the role roster because a teamId-filtered scope CSV can
+     * carry non-counsellor team members. Empty when the scope is unfiltered
+     * (setup mode — nothing sensible to pad with).
+     */
+    private java.util.List<String> scopedActiveCounsellors(String instituteId, String scopeCsv) {
+        if (scopeCsv == null || scopeCsv.isBlank()) return java.util.List.of();
+        Set<String> counsellors = new java.util.HashSet<>(
+                counsellorScopeService.allCounsellorUserIds(instituteId));
+        return java.util.Arrays.stream(scopeCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty() && counsellors.contains(s))
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     /** numerator/denominator * 100, one decimal; null when denominator is 0. */


### PR DESCRIPTION
…ons, zero rows included

Both reports built their per-counsellor rows purely from data grouping, so an ACTIVE counsellor with no leads / status changes / calls in the window produced no row at all and read as missing. The scoped active-counsellor roster (scope CSV intersected with the COUNSELLOR-role list) is now padded in: counsellor-performance appends zero rows (name-sorted after the data-driven ones, names batch-resolved together), and the dispositions report zero-fills both the status-change and call-outcome matrices. Team rollups inherit the padding via getCounselorPerformance.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
