### PR TITLE
fix(slides): prevent DOC slide content loss on reopen/save/publish

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/DocumentSlideDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/dto/DocumentSlideDTO.java
@@ -21,4 +21,11 @@ public class DocumentSlideDTO {
      * replace a large published document with a much smaller one (confirmed in the UI).
      */
     private boolean forcePublish;
+
+    /**
+     * When true, bypasses the draft/unsync structural-block loss guard so an author can
+     * intentionally remove a table/image/video/custom block (confirmed in the UI). The
+     * draft-save equivalent of {@link #forcePublish}.
+     */
+    private boolean forceOverwrite;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -28,6 +28,8 @@ import vacademy.io.common.exceptions.VacademyException;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import vacademy.io.admin_core_service.features.slide.repository.HtmlVideoSlideRepository;
@@ -568,8 +570,13 @@ public class SlideService {
             newPublishedData = documentSlide.getData();
             newPublishedTotalPages = documentSlide.getTotalPages();
         }
-        guardAgainstPublishedContentWipe(documentSlide.getPublishedData(), newPublishedData,
-                documentSlideDTO != null && documentSlideDTO.isForcePublish());
+        boolean force = documentSlideDTO != null && documentSlideDTO.isForcePublish();
+        // Two guards on the LIVE (published) content: the coarse byte-ratio wipe guard
+        // (catches a catastrophic text collapse) AND the precise structural-block guard
+        // (catches a dropped table/image/video/custom block even when byte size barely
+        // moves). Either one blocks with a 409 unless the author force-publishes.
+        guardAgainstPublishedContentWipe(documentSlide.getPublishedData(), newPublishedData, force);
+        guardAgainstStructuralBlockLoss(documentSlide.getPublishedData(), newPublishedData, force);
         documentSlide.setPublishedData(newPublishedData);
         documentSlide.setPublishedDocumentTotalPages(newPublishedTotalPages);
         // Keep the draft copy in sync with what we just published instead of nulling it.
@@ -588,15 +595,82 @@ public class SlideService {
         if (currentLen >= PUBLISHED_SHRINK_GUARD_MIN_CHARS
                 && incomingLen < currentLen * PUBLISHED_SHRINK_GUARD_RATIO) {
             throw new VacademyException(HttpStatus.CONFLICT,
-                    "Refusing to publish: this would replace the live content (" + currentLen
-                            + " chars) with a much smaller fragment (" + incomingLen
-                            + " chars), which looks like accidental data loss. "
-                            + "Re-publish with force enabled to override.");
+                    "This will replace the current slide content with a much shorter version.");
+        }
+    }
+
+    // --- Structural-block integrity guard (client-agnostic content-loss backstop) ---
+    // A save is rejected (409) when the incoming HTML drops a STRUCTURAL block — a custom
+    // Yoopta block (data-yoopta-type), table, image, or video/embed — that the stored HTML
+    // contained. These never disappear on a normal edit; their loss is the signature of an
+    // editor round-trip bug or a truncated client payload (see
+    // docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md). Plain text/paragraph shrink is NOT guarded
+    // here — authors delete text freely. The author overrides with force (confirmed in UI).
+    private static final Pattern YOOPTA_BLOCK_MARKER = Pattern.compile("data-yoopta-type=\"([a-zA-Z]+)\"");
+
+    private static int countOccurrences(String s, String sub) {
+        int n = 0, i = 0;
+        while ((i = s.indexOf(sub, i)) >= 0) {
+            n++;
+            i += sub.length();
+        }
+        return n;
+    }
+
+    private static Map<String, Integer> structuralMarkerCounts(String html) {
+        Map<String, Integer> counts = new HashMap<>();
+        if (html == null) {
+            return counts;
+        }
+        Matcher m = YOOPTA_BLOCK_MARKER.matcher(html);
+        while (m.find()) {
+            counts.merge(m.group(1), 1, Integer::sum);
+        }
+        int tables = countOccurrences(html, "<table");
+        if (tables > 0) counts.put("table", tables);
+        int imgs = countOccurrences(html, "<img");
+        if (imgs > 0) counts.put("image", imgs);
+        int media = countOccurrences(html, "<video") + countOccurrences(html, "<iframe");
+        if (media > 0) counts.put("video/embed", media);
+        return counts;
+    }
+
+    /** Human description of structural blocks the new HTML dropped vs old, or "" if none. */
+    static String describeStructuralLoss(String oldHtml, String newHtml) {
+        Map<String, Integer> before = structuralMarkerCounts(oldHtml);
+        Map<String, Integer> after = structuralMarkerCounts(newHtml);
+        List<String> lost = new ArrayList<>();
+        for (Map.Entry<String, Integer> e : before.entrySet()) {
+            int drop = e.getValue() - after.getOrDefault(e.getKey(), 0);
+            if (drop > 0) {
+                lost.add(drop + " " + e.getKey() + (drop > 1 ? "s" : ""));
+            }
+        }
+        return String.join(", ", lost);
+    }
+
+    private void guardAgainstStructuralBlockLoss(String oldHtml, String newHtml, boolean force) {
+        if (force) {
+            return;
+        }
+        // An empty/blank incoming payload is handled by the caller's own empty-guard; do
+        // not 409 here (that path is a distinct "editor returned nothing" case).
+        if (newHtml == null || newHtml.trim().isEmpty()) {
+            return;
+        }
+        String dropped = describeStructuralLoss(oldHtml, newHtml);
+        if (!dropped.isEmpty()) {
+            throw new VacademyException(HttpStatus.CONFLICT,
+                    "This will remove " + dropped + " from the slide.");
         }
     }
 
     public void handleDraftDocumentSlide(DocumentSlide documentSlide, DocumentSlideDTO documentSlideDTO) {
         if (documentSlideDTO.getData() != null && !documentSlideDTO.getData().isEmpty()) {
+            // Server-side backstop (client-agnostic): reject a draft save that would drop a
+            // structural block (table/image/video/custom block) present in the stored draft.
+            guardAgainstStructuralBlockLoss(documentSlide.getData(), documentSlideDTO.getData(),
+                    documentSlideDTO.isForceOverwrite());
             documentSlide.setData(documentSlideDTO.getData());
         }
 
@@ -610,6 +684,8 @@ public class SlideService {
         // touched here; published_data is written exclusively by the publish path, so a
         // draft save can never mutate what learners currently see.
         if (documentSlideDTO.getData() != null && !documentSlideDTO.getData().isEmpty()) {
+            guardAgainstStructuralBlockLoss(documentSlide.getData(), documentSlideDTO.getData(),
+                    documentSlideDTO.isForceOverwrite());
             documentSlide.setData(documentSlideDTO.getData());
         }
         if (documentSlideDTO.getTotalPages() != null) {

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/slide/service/SlideStructuralLossTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/slide/service/SlideStructuralLossTest.java
@@ -1,0 +1,65 @@
+package vacademy.io.admin_core_service.features.slide.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the server-side structural-block loss detector that backs the
+ * draft/unsync/publish content-integrity guard. See
+ * docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md.
+ */
+class SlideStructuralLossTest {
+
+    @Test
+    void noLossWhenIdentical() {
+        String h = "<p>hi</p><table><tbody><tr><td>c</td></tr></tbody></table>";
+        assertEquals("", SlideService.describeStructuralLoss(h, h));
+    }
+
+    @Test
+    void detectsDroppedTable() {
+        String oldH = "<p>x</p><table><tbody><tr><td>c</td></tr></tbody></table>";
+        String newH = "<p>x</p>";
+        assertTrue(SlideService.describeStructuralLoss(oldH, newH).contains("table"));
+    }
+
+    @Test
+    void detectsDroppedCustomBlock() {
+        String oldH = "<div data-yoopta-type=\"flashcard\" data-front=\"a\"></div>";
+        String newH = "<p>x</p>";
+        assertTrue(SlideService.describeStructuralLoss(oldH, newH).contains("flashcard"));
+    }
+
+    @Test
+    void detectsDroppedImageAndVideo() {
+        assertTrue(SlideService.describeStructuralLoss("<img src=\"a\"><img src=\"b\">", "<img src=\"a\">")
+                .contains("image"));
+        assertTrue(SlideService.describeStructuralLoss("<video src=\"a\"></video>", "<p>gone</p>")
+                .contains("video/embed"));
+    }
+
+    @Test
+    void allowsPlainTextShrink() {
+        // A user deleting text/paragraphs (but keeping the table) is NOT flagged.
+        String oldH = "<p>lots of text here and even more here</p><table><tbody><tr><td>c</td></tr></tbody></table>";
+        String newH = "<p>short</p><table><tbody><tr><td>c</td></tr></tbody></table>";
+        assertEquals("", SlideService.describeStructuralLoss(oldH, newH));
+    }
+
+    @Test
+    void noFalsePositiveWhenContentGrows() {
+        assertEquals(
+                "",
+                SlideService.describeStructuralLoss(
+                        "<img src=\"a\">",
+                        "<img src=\"a\"><img src=\"b\"><table></table>"));
+    }
+
+    @Test
+    void handlesNullOldContent() {
+        // First-ever publish (no prior content) must never report loss.
+        assertEquals("", SlideService.describeStructuralLoss(null, "<table></table>"));
+    }
+}

--- a/docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md
+++ b/docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md
@@ -1,0 +1,261 @@
+# DOC Slide Content-Loss Investigation ("history drops callouts / images / text / tables / headings")
+
+> **Status:** FIXED & verified (2026-07-08) on branch `fix/slide-content-loss`. Layers 4, 2, and 3B
+> implemented; Layer 1 skipped (made moot by Layer 4). Verified by unit tests (21 vitest + 7 backend),
+> 3 curl guard tests, and a live 4-round browser torture test (reopen/switch/reload, publish cycle,
+> 11 MB image race, guard popup) — **zero data loss** across ~25 operations. See [Fix Plan](#fix-plan)
+> for the design and §11 for the shipped files.
+> **Audience:** any future session picking up the slide save/history reliability work.
+
+This document records, in detail, the reproduction steps, symptoms, tools, evidence, and root-cause
+analysis behind the reported bug: *"the callouts and images are not being saved as part of history,
+sometimes the text is not even being saved."* It is intentionally exhaustive so a future session does
+not have to re-derive any of it.
+
+---
+
+## 1. TL;DR
+
+- The **`slide_content_history` audit table is NOT the bug.** It faithfully records whatever the save
+  wrote. The loss is **upstream**, at the editor serialize/deserialize level.
+- The reported symptom is really **three distinct defects**, all rooted in the fact that
+  **`html.deserialize` ⇄ `html.serialize` (Yoopta `@yoopta/exports`) is not a lossless round-trip**:
+  1. **Content LOSS (proven):** `html.deserialize` silently drops block elements (headings, paragraphs)
+     that are nested inside HTML5 **semantic wrappers** (`<section>`, `<header>`, nested `<div>`).
+  2. **Content BLOAT:** the round-trip can multiply empty `<p>` blocks (one slide reached **605** empty
+     paragraphs, now baked into its stored data).
+  3. **Stale-editor-state reset:** a Save Draft on a PUBLISHED/UNSYNC slide flips status → `loadContent`
+     re-runs → `applyDocContentToEditor()` re-deserializes → editor loses blocks → the next save
+     persists the reduced content.
+- **Amplifiers (no backstop):** the backend `handleDraftDocumentSlide` / `handleUnsyncDocumentSlide`
+  write `data` with **no shrink guard** (only PUBLISHED is guarded, and only on `published_data`, with a
+  ratio that would miss single-block losses); the frontend continuous stash uses `guardShrink=false`.
+- **Byte-size is the WRONG signal.** Real losses were 23%–70% (a single heading/table among many). Only
+  **block-count / block-identity** catches them.
+- **Fix for defect #1 is in our control** (our preprocessing, not a Yoopta patch): flatten semantic
+  wrappers before `html.deserialize`. Confirmed experimentally to restore all content.
+
+---
+
+## 2. Symptoms & original report
+
+- Founder report: history is "not saving callouts / images / text; sometimes text not saved."
+- User requirement: *"it should save every part of the document in whole — should not drop a callout or
+  flash card or image or video or anything, not a single thing."*
+- Actual observed behaviour: the editor **intermittently serializes and saves a shorter/incomplete
+  version** of the content (dropping blocks), and history faithfully records that shorter content. The
+  live `document_slide.data` ends up missing blocks that were previously present.
+
+### Concrete production evidence (original incident, slide `19fa0535-…`)
+`slide_content_history` timeline (draft size / has-image):
+`16:45 → 73606 B (img✓)`, … `17:13–17:21 → 42425 B (img✓, 4× "Executive Summary")`,
+`17:21:59 → 6739 B (img✗, 1 copy)` — **a single save collapsed 42 KB (with image) → 6.7 KB (no image).**
+The corrupted content was a **valid, complete HTML document** that was a clean **prefix** of the good one,
+truncated exactly at the image block — i.e. the editor genuinely serialized fewer blocks.
+
+---
+
+## 3. What was ruled OUT (do not re-litigate)
+
+1. **History table / trigger** — `slide_content_history` (migration `V364__Add_slide_content_history.sql`,
+   was `V363` locally) has a `BEFORE UPDATE` trigger on `document_slide`/`video`/`audio_slide` that
+   snapshots `OLD.data`/`OLD.published_data` when they change. It records exactly what the save wrote.
+2. **S3 URL sanitizer** — `stripAwsQueryParamsFromUrls` in `formatHtmlString.tsx` is bounded per-attribute
+   and cannot over-truncate.
+3. **Per-block "degraded" serialize fallback** — `getCurrentEditorHTMLContent` has a fallback that drops a
+   block whose serializer *throws* and sets `lastSerializeDegradedRef`. In the reproduced cases the
+   serialize did **not** throw (`degraded: false`); the blocks were genuinely absent from `editor.children`.
+
+---
+
+## 4. Environment & tools used
+
+- **Local backend** `admin_core_service` on `:8072` (VS Code "Local (Docker DB)" profile / `run-local.sh
+  admin_core`), talking to a **local Docker Postgres** `vacademy-localdb` (prod/dev dump).
+- **Frontend** on `localhost:5173`. For the test, the slide load/save/history/status URL constants in
+  `frontend-admin-dashboard/src/constants/urls.ts` were flipped to `LOCAL_ADMIN_CORE_BASE`
+  (`http://localhost:8072`) — tagged `// LOCALTEST`, **must be reverted before commit**.
+- **Backend logs** tee to `.samar/logs/backend.log` (via `run-local.sh`). Temporary `[SLIDE-DBG]` log lines
+  were added in `SlideService.java` (`updateDocument` / `handleDraft` / `handleUnsync` / `handlePublished`
+  / `guardAgainstPublishedContentWipe`) printing incoming vs stored `data` length, `<img>` count, head.
+- **Browser console** `[SLIDE-DBG]` logs in `slide-material.tsx` at the serialize sites (`onChange`,
+  `getCurrentEditorHTMLContent`) and the deserialize site (`applyDocContentToEditor`), printing
+  `blockCount` / `htmlLen` / `hasImg` / a source-vs-deserialized fingerprint.
+- **DB access:** `docker exec vacademy-localdb psql -U postgres -d admin_core_service -c "<sql>"`.
+  Note: `slide_content_history.changed_at` is stored in **UTC** (IST − 5:30).
+- **Headless round-trip harness:** `…/slides/-components/slide-operations/doc-slide-integrity/test.tsx`
+  (vitest + jsdom) drives the real pipeline `serialize → appReloadPreprocess → html.deserialize →
+  serialize` with the real plugin set. This is the single most valuable tool — it reproduces the loss
+  **deterministically, without a browser.** (vitest `include` is `**/test.{ts,tsx}` — a research file must
+  be named `test.tsx` inside its own folder to be picked up.)
+
+Useful SQL:
+```sql
+-- history sizes/images for a slide (source_id = document_slide.id)
+SELECT to_char(changed_at,'HH24:MI:SS') at, length(draft_value) d_len,
+       (draft_value ILIKE '%<img%') img, (draft_value ILIKE '%<table%') tbl
+FROM slide_content_history WHERE source_id='<document_slide.id>' ORDER BY changed_at DESC LIMIT 15;
+-- live content
+SELECT length(data), (data ILIKE '%<img%'), (data ILIKE '%<table%') FROM document_slide WHERE id='<id>';
+```
+
+---
+
+## 5. Tests performed & results (chronological)
+
+All on a fresh local DOC slide (`slide.id 1e3b2326…` / `document_slide.id dd79bd50…`) unless noted.
+
+| # | Test | Result |
+|---|------|--------|
+| 1 | Add **text → image → video**, Save Draft each time | ✅ All saved. Monotonic growth 97→132→559→912 B. Image (S3) + video (`<video>` YouTube) intact. |
+| 2 | **Reopen / switch away & back**, then save | ✅ No loss. Re-serialize was lossless for these (image/video are built-in Yoopta plugins). |
+| 3 | Add **callout + flashcard + accordion**, Save + Publish | ✅ All survived forward-save. Serialized forms: callout=`<dl data-theme="error">`, flashcard=`<div data-yoopta-type="flashcard" data-flashcard="<base64>" …>`, accordion=`<div data-yoopta-type="accordion"><details>…`. |
+| 4 | **Image/video race** — add a table + content, Save Draft while an upload was settling | ❌ **REPRODUCED.** 3746 B → 2899 B: the **table + trailing paragraph dropped**. Backend `handleUnsync … NO GUARD` wrote it. Live never recovered (`table=false`). |
+| 5 | Console capture of the bad save | `getCurrentEditorHTMLContent` went **blockCount 11 → 9**, `degraded: false`. Stack: post-save status flip → `setEditorContent()` (slide-material.tsx:2404) → `applyDocContentToEditor()` re-deserialize → 9 blocks → next save persisted 9. |
+| 6 | **Cold reopen** of slides with tables (`5a448b42`, `02a8a7e0`) — DESERIALIZE fingerprint | `LOSS_table:false` (table block type survives) **but** `02a8a7e0`: 10 `<h2>`/8 `<h3>` → `HeadingTwo:8`/`HeadingThree:4` (**6 headings lost**), 22540 B → 6482 B. `5a448b42`: 10944 B → **636 blocks incl. 605 empty paragraphs** (bloat). |
+| 7 | **Headless harness** on real `02a8a7e0` published_data, stage by stage | See table below — pinned the loss to Yoopta's `html.deserialize`. |
+| 8 | **Flatten experiment** in the harness | ✅ Flattening semantic wrappers before deserialize restores **all** headings/paragraphs. |
+
+### Stage-by-stage heading counts (headless harness, real `02a8a7e0` published_data)
+| Stage | len | h1 | h2 | h3 | p | li |
+|---|---|---|---|---|---|---|
+| 1. RAW stored HTML | 22540 | 1 | **10** | **8** | 41 | 50 |
+| 2. after `appReloadPreprocess` | 15259 | 1 | **10** | **8** | 41 | 50 | ← our preprocessing preserves everything |
+| 3. after `html.deserialize` | — | 1 | **8** | **4** | 13 | (12 lists) | ← **Yoopta drops 2 h2 + 4 h3** |
+| 4. after re-serialize | 7556 | 1 | 8 | 4 | 13 | 12 |
+| 5. after experimental **flatten** | 13683 | 1 | **10** | **8** | 41 | 50 |
+| 6. deserialize after flatten | — | 1 | **10** | **8** | 41 | (50 lists) | ← **all content preserved** |
+
+### Why Yoopta drops them — nesting analysis
+The `02a8a7e0` HTML is AI-generated rich markup using `<header>`, `<section>`, and nested `<div>`. The
+dropped headings are the ones buried at `divDepth ≥ 2` inside `<section>`/`<div>`. Yoopta's
+`html.deserialize` does not reliably recurse through semantic/`<div>` wrappers, so block elements inside
+them are lost. `appReloadPreprocess` only unwraps *single-child* top-level divs and specific
+media/accordion wrappers — it never flattens `<section>`/`<header>`/multi-child `<div>`.
+
+---
+
+## 6. Root causes
+
+### Defect A — lossy deserialize through semantic wrappers (PROVEN, primary)
+`html.deserialize` drops block elements (headings, paragraphs) nested in `<section>`/`<header>`/nested
+`<div>`. Reproduced deterministically in the headless harness (§5, stage 3). **Fix is in our
+preprocessing.**
+
+### Defect B — paragraph bloat
+The round-trip can produce large numbers of empty `<p>` blocks (slide `5a448b42`: 605, now stored). Likely
+compounds over repeated round-trips. Separate from A; needs its own repro but shares the "round-trip not
+faithful" family.
+
+### Defect C — stale-editor-state reset (the reproduced table drop)
+Save Draft on PUBLISHED/UNSYNC flips status → `loadContent` re-runs. The guard meant to skip
+re-deserialization on a same-slide re-run — `isSameSlideRerun` (slide-material.tsx:1738 / :2390) — was
+**false** when it should have been true, so `setEditorContent()` → `applyDocContentToEditor()`
+re-deserialized live content and (via Defect A / a transient state) dropped blocks (11 → 9). The next save
+persisted the reduced content.
+
+### Amplifiers (no backstop)
+- **Backend:** `handleDraftDocumentSlide` / `handleUnsyncDocumentSlide` (`SlideService.java`) write `data`
+  unconditionally — **no shrink guard**. Only `handlePublishedDocumentSlide` guards, via
+  `guardAgainstPublishedContentWipe` (`MIN_CHARS=2000`, `RATIO=0.25`) — which would **miss** a 3746→2899
+  (23%) single-block loss.
+- **Frontend:** the continuous `onChange` stash calls `stashDocDraftLocally(…, guardShrink=false)`, so a
+  transient short serialize overwrites the good local draft, which then wins on reopen
+  (`getRestorableLocalDraftHtml` in `applyDocContentToEditor`).
+- **`degraded` flag** does not catch it (serialize doesn't throw when blocks are simply absent).
+
+---
+
+## 7. Contexts where this bug can appear
+
+Every path that **deserializes stored HTML into the editor and later re-serializes + saves**:
+1. Save Draft on a PUBLISHED/UNSYNC slide (status flip → reload) — *reproduced*.
+2. Slide reopen / switch back.
+3. Page reload.
+4. Publish.
+5. Version-history restore (`SlideContentHistoryService.restore` writes `data` → reload deserializes).
+6. Copy / Move slide.
+7. AI-copilot course-generation viewer — `SortableViewerSlideItem.tsx` (5 `html.deserialize` sites);
+   AI content is exactly the semantic-wrapper-heavy HTML that triggers Defect A.
+8. Cold-path manual plugin init (`usedManualPluginInitRef`, slide-material.tsx ~764).
+
+Per block type: `table`/`image`/`video` block **types** survive; **headings / paragraph structure** do
+not when wrapped in semantic containers.
+
+---
+
+## 8. Fix Plan
+
+Layered defense; the user's requirement is a **robust, long-term** solution, so Layer 4 (cure) + Layer 2
+(net) are mandatory — the byte-size backstop alone is insufficient.
+
+- **Layer 4 — make the round-trip lossless (the cure).** Extend `appReloadPreprocess`
+  (`doc-slide-integrity/reload.ts` and the mirror in `slide-material.tsx applyDocContentToEditor`) to
+  **recursively flatten non-block wrapper elements** (`section`/`header`/`article`/`main`/`aside`/`figure`
+  and plain wrapper `div`s), promoting children to the root — while **protecting** block containers
+  (`[data-yoopta-type]`, `table`/`thead`/`tbody`/`tr`/`td`/`th`, `ul`/`ol`/`li`, `dl`, `details`,
+  `.mermaid`). Confirmed in the harness to restore all headings/paragraphs. Lock it in with the
+  `doc-slide-integrity/test.tsx` suite, asserting **block-count/type parity** for each plugin AND for a
+  semantic-wrapper fixture. Investigate Defect B (paragraph bloat) separately.
+- **Layer 2 — load-time integrity gate (the net).** After `applyDocContentToEditor` deserializes,
+  fingerprint the source HTML (block-by-type counts incl. headings + media src set) vs the re-serialized
+  editor. If the editor is missing content, **do not make it authoritative**: keep the stored HTML, warn,
+  and block save. Block-agnostic; protects against unknown/future block types.
+- **Layer 1 — minimize re-deserialize.** Make `isSameSlideRerun` robust so a post-save status flip never
+  re-deserializes a slide the editor already holds.
+- **Layer 3 — backend backstop (coarse).** Add a shrink guard to `handleDraft`/`handleUnsync` mirroring
+  `guardAgainstPublishedContentWipe`, with a `force` override, for catastrophic collapses only.
+
+---
+
+## 9. How to reproduce (headless, no browser)
+
+The fastest loop is the vitest harness:
+1. Dump a real semantic-wrapper slide's HTML to a file (e.g. `psql -tAc "SELECT published_data FROM
+   document_slide WHERE id='02a8a7e0-…'" > fixture.html`).
+2. In `doc-slide-integrity/…/test.tsx`, deserialize `appReloadPreprocess(fixture)` with the real plugin
+   set (`makeEditor()` in `test.tsx`) and compare block-type counts to the source `<h2>`/`<h3>`/`<p>` counts.
+3. `npx vitest run <path/to/test.tsx>`.
+
+A semantic-wrapper document (`<section><h2>…</h2><p>…</p></section>`, headings at `divDepth ≥ 2`)
+reproduces the heading loss; a flat document does not.
+
+---
+
+## 10. Debug scaffolding (used during the investigation — REMOVED before commit)
+
+The investigation was instrumented with temporary scaffolding, all of which has since been reverted so
+the branch is clean. Recorded here only so a future session knows how it was captured and can re-add it
+if needed:
+
+- `frontend-admin-dashboard/src/constants/urls.ts` — 9 slide endpoints were temporarily flipped to
+  `LOCAL_ADMIN_CORE_BASE` (`http://localhost:8072`) to point the app at the local backend/DB.
+- `SlideService.java` + `slide-material.tsx` — `[SLIDE-DBG]` log lines tracing incoming-vs-stored payloads
+  and each serialize/deserialize block census.
+- A Vite dev middleware (`/__slidedbg` in `vite.config.ts`) + `slide-dbg-sink.ts` teed console `[SLIDE-DBG]`
+  output to `.samar/logs/frontend-dbg.log` for untruncated, reload-surviving capture.
+- `doc-slide-integrity/_hdbg_research/` — a temporary headless research test that fed real slide HTML
+  through the pipeline stage-by-stage to pinpoint the heading loss.
+
+The permanent, committed verification lives in `doc-slide-integrity/test.tsx` (semantic-wrapper +
+integrity-detector regression tests) and `SlideStructuralLossTest.java` (backend guard tests).
+
+---
+
+## 11. Key file references
+
+- Frontend: `…/slides/-components/slide-material.tsx` — `applyDocContentToEditor` (deserialize @ ~1045),
+  `getCurrentEditorHTMLContent` (serialize), `EditorWithPlaceholder.onChange` stash,
+  `stashDocDraftLocally` / `getRestorableLocalDraftHtml`, `isSameSlideRerun` (1738/2390),
+  `setEditorContent` (2404), `captureInitialDocSnapshot`.
+- Preprocessing: `…/slides/-components/slide-operations/doc-slide-integrity/reload.ts` (`appReloadPreprocess`).
+- Round-trip suite: `…/doc-slide-integrity/test.tsx`.
+- Backend: `admin_core_service/.../slide/service/SlideService.java` — `updateDocument`,
+  `handleDraftDocumentSlide`, `handleUnsyncDocumentSlide`, `handlePublishedDocumentSlide`,
+  `guardAgainstPublishedContentWipe`.
+- History: `SlideContentHistoryService.java`, `SlideContentHistoryController.java`,
+  migration `V364__Add_slide_content_history.sql`, UI `slide-history-dialog.tsx`.
+
+---
+
+*Related: `docs/CODING_SLIDE_FEATURE.md`, `frontend-admin-dashboard/docs/adding-new-slide-type.md`.*

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -47,6 +47,7 @@ import { handlePublishSlide } from './slide-operations/handlePublishSlide';
 import { handleUnpublishSlide } from './slide-operations/handleUnpublishSlide';
 import { updateHeading } from './slide-operations/updateSlideHeading';
 import { formatHTMLString, stripAwsQueryParamsFromUrls } from './slide-operations/formatHtmlString';
+import { flattenSemanticWrappers, detectDeserializeLoss } from './slide-operations/doc-slide-integrity/reload';
 import { handleConvertAndUpload } from './slide-operations/handleConvertUpload';
 const SlideEditor = React.lazy(() =>
     import('./SlideEditor').then((module) => ({ default: module.default }))
@@ -413,6 +414,16 @@ export const SlideMaterial = ({
     // auto-save reads this to refuse a destructive overwrite. Reset on every
     // serialize; only the LAST serialize before a save matters.
     const lastSerializeDegradedRef = useRef(false);
+    // Layer-2 load integrity: set when the last DOC deserialize dropped blocks vs the
+    // stored HTML (a lossy round-trip for some block type). Tagged with the slide it
+    // was computed for. While set for the active slide, the DOC save path REFUSES to
+    // overwrite `data` — otherwise the reduced editor state would be persisted and the
+    // dropped content lost permanently. Recomputed on every content-apply.
+    const docLoadIntegrityRef = useRef<{ slideId: string | null; lossy: boolean; lost: string[] }>({
+        slideId: null,
+        lossy: false,
+        lost: [],
+    });
     // Dedup guard to prevent double-save on add + switch happening together
     const lastHandledPrevSlideIdRef = useRef<string | null>(null);
     // activeItem.id from the previous loadContent() run. Lets the DOC branch tell
@@ -1032,7 +1043,38 @@ export const SlideMaterial = ({
             console.error('Error parsing HTML for Yoopta:', e);
         }
 
+        // Flatten semantic wrappers (<section>/<header>/nested <div>) LAST, so blocks
+        // (headings/paragraphs) nested inside them survive html.deserialize instead of
+        // being silently dropped. See docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md.
+        contentForDeserialization = flattenSemanticWrappers(contentForDeserialization || '');
         const rawEditorContent = html.deserialize(editor, contentForDeserialization || '');
+
+        // Layer-2 load-integrity check: did html.deserialize drop any block (table,
+        // image, heading, custom block) that the stored HTML contained? If so, this
+        // editor state is a lossy view of the slide — record it so the save path can
+        // refuse to overwrite the DB with the reduced content. Compares load INPUT vs
+        // load OUTPUT, so it never fires on a genuine user edit.
+        try {
+            const loss = detectDeserializeLoss(
+                contentForDeserialization || '',
+                rawEditorContent as Record<string, unknown>
+            );
+            docLoadIntegrityRef.current = {
+                slideId: activeItem?.id ?? null,
+                lossy: loss.lossy,
+                lost: loss.lost,
+            };
+            if (loss.lossy) {
+                console.error(
+                    '[slide] deserialize dropped content on load — save disabled to protect it:',
+                    loss.lost.join(', '),
+                    'slide',
+                    activeItem?.id
+                );
+            }
+        } catch {
+            docLoadIntegrityRef.current = { slideId: activeItem?.id ?? null, lossy: false, lost: [] };
+        }
 
         const processNode = (node: any): any => {
             const newNode = { ...node };
@@ -2923,6 +2965,21 @@ export const SlideMaterial = ({
             }
 
             // Handle regular documents
+            // Layer-2 guard: if this slide's content was dropped by the deserializer on
+            // load (a lossy round-trip), the editor holds LESS than the DB. Persisting
+            // it would make the loss permanent, so refuse the save and keep the DB safe.
+            if (
+                docLoadIntegrityRef.current.lossy &&
+                docLoadIntegrityRef.current.slideId === slide?.id
+            ) {
+                toast.error(
+                    'This slide did not load completely (' +
+                        docLoadIntegrityRef.current.lost.join(', ') +
+                        ' missing). To protect your content it was NOT saved. Please reload the page and try again.'
+                );
+                return;
+            }
+
             const currentHtml = getCurrentEditorHTMLContent();
 
             // Explicit Save proceeds on user intent, but if a block's serializer
@@ -2972,8 +3029,11 @@ export const SlideMaterial = ({
                 return;
             }
 
-            try {
-                await addUpdateDocumentSlide({
+            // force=false first; the backend rejects (409) a save that would drop a
+            // structural block (table/image/video/custom block). On that 409 we ask the
+            // author to confirm and retry with force_overwrite — mirrors handlePublishSlide.
+            const saveDocDraft = (force: boolean) =>
+                addUpdateDocumentSlide({
                     id: slide?.id || '',
                     title: slide?.title || '',
                     image_file_id: '',
@@ -2993,16 +3053,39 @@ export const SlideMaterial = ({
                         published_data: slide?.document_slide?.published_data || null,
                         published_document_total_pages:
                             slide?.document_slide?.published_document_total_pages || 1,
+                        force_overwrite: force,
                     },
                     status: status,
                     new_slide: false,
                     notify: false,
                 });
+
+            try {
+                await saveDocDraft(false);
                 if (!containsBase64Images(currentHtml) || uploadedImagesCount === 0) {
                     toast.success(`slide saved in draft successfully!`);
                 }
-            } catch {
-                toast.error(`Error in saving the slide`);
+            } catch (error) {
+                const response = (
+                    error as {
+                        response?: { status?: number; data?: { ex?: string; message?: string } };
+                    }
+                )?.response;
+                const serverMessage = response?.data?.ex || response?.data?.message;
+                if (response?.status === 409 && serverMessage) {
+                    const confirmed = window.confirm(
+                        `To prevent accidental data loss, please confirm.\n\n${serverMessage}\n\nAre you sure you want to continue and save?`
+                    );
+                    if (!confirmed) return;
+                    try {
+                        await saveDocDraft(true);
+                        toast.success('Slide saved (forced override).');
+                    } catch {
+                        toast.error('Error in saving the slide');
+                    }
+                    return;
+                }
+                toast.error(serverMessage || `Error in saving the slide`);
             }
         } finally {
             setIsSaving(false);
@@ -3588,6 +3671,23 @@ export const SlideMaterial = ({
                                                     activeItem?.source_type === 'DOCUMENT' &&
                                                     activeItem?.document_slide?.type === 'DOC'
                                                 ) {
+                                                    // Layer-2 guard: never publish a lossy-loaded
+                                                    // slide (editor holds less than the DB).
+                                                    if (
+                                                        docLoadIntegrityRef.current.lossy &&
+                                                        docLoadIntegrityRef.current.slideId ===
+                                                            activeItem?.id
+                                                    ) {
+                                                        toast.error(
+                                                            'This slide did not load completely (' +
+                                                                docLoadIntegrityRef.current.lost.join(
+                                                                    ', '
+                                                                ) +
+                                                                ' missing). Publish blocked to protect your content. Please reload the page.'
+                                                        );
+                                                        setIsPublishDialogOpen(false);
+                                                        return;
+                                                    }
                                                     let currentHtml = getCurrentEditorHTMLContent();
                                                     if (containsBase64Images(currentHtml)) {
                                                         const { processedHtml } =

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
@@ -6,6 +6,126 @@
  */
 import { stripAwsQueryParamsFromUrls } from '../formatHtmlString';
 
+// Wrapper elements to flatten (they carry no block meaning to Yoopta). AI-generated
+// and pasted HTML nests content in these; Yoopta's html.deserialize does NOT reliably
+// recurse into them, so any block (heading, paragraph, list, …) buried inside is
+// silently dropped on reload. See docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md.
+const FLATTEN_TAGS = 'section, header, footer, article, main, aside, figure, figcaption, div';
+// Elements that ARE (or whose descendants are) real blocks / block internals — never
+// flatten these or anything inside them. Every custom Yoopta block serializes its root
+// with data-yoopta-type, so that one selector covers all of them; the rest guards the
+// built-in structural blocks (table, lists, callout <dl>, code, mermaid, accordion).
+const PROTECTED_SELECTOR =
+    '[data-yoopta-type],[data-tabs],[data-columns],[data-quiz],[data-steps],[data-front],[data-back],[data-flashcard],[data-tab-index],table,thead,tbody,tfoot,tr,td,th,caption,colgroup,ul,ol,li,dl,dt,dd,details,summary,pre,code,.mermaid';
+
+/**
+ * Recursively unwrap non-block wrapper elements (section/header/article/div/…),
+ * promoting their children to the parent, so every block-level element becomes a
+ * direct sibling that Yoopta's deserializer recognises. Elements that are (or live
+ * inside) a real block — tables, lists, callouts, code, or any data-yoopta-type
+ * custom block — are left completely untouched.
+ *
+ * This is the fix for the "reload drops headings/paragraphs nested in <section>/<div>"
+ * data-loss (proven in doc-slide-integrity/test.tsx). Idempotent and order-preserving.
+ */
+export function flattenSemanticWrappers(innerHtml: string): string {
+    if (!innerHtml || !innerHtml.includes('<')) return innerHtml;
+    try {
+        const doc = new DOMParser().parseFromString(innerHtml, 'text/html');
+        let changed = true;
+        let guard = 0;
+        while (changed && guard++ < 200) {
+            changed = false;
+            const candidates = Array.from(doc.body.querySelectorAll(FLATTEN_TAGS));
+            for (const el of candidates) {
+                // Skip if this element IS, or is nested INSIDE, a protected block —
+                // we must never disturb the internals of a table/list/custom block.
+                if (el.closest(PROTECTED_SELECTOR)) continue;
+                const parent = el.parentNode;
+                if (!parent) continue;
+                while (el.firstChild) parent.insertBefore(el.firstChild, el);
+                parent.removeChild(el);
+                changed = true;
+            }
+        }
+        return doc.body.innerHTML.trim();
+    } catch {
+        // On any DOM failure, fall back to the unflattened HTML — never lose content.
+        return innerHtml;
+    }
+}
+
+export interface DeserializeLossReport {
+    /** True when html.deserialize produced fewer real blocks than the source HTML had. */
+    lossy: boolean;
+    /** Human-readable list of what was dropped, e.g. ["1 table", "2 heading(s)"]. */
+    lost: string[];
+}
+
+/**
+ * Layer-2 safety net: after html.deserialize, compare the structural blocks the source
+ * HTML contained against the blocks Yoopta actually produced. A DECREASE in any custom
+ * block (data-yoopta-type), table, image, video/embed, or heading means the deserialize
+ * silently dropped content — the slide must NOT be re-saved from this editor state, or
+ * the loss becomes permanent. This catches block types the flatten fix doesn't cover
+ * (unknown / future blocks) without ever firing on a legitimate user edit (it compares
+ * load input vs load output, not old vs new content).
+ *
+ * Reliability: custom-block subtrees are removed before counting tables/images/headings,
+ * so media/headings nested INSIDE a quiz/columns/flashcard block don't cause a false
+ * "loss" (those are part of the custom block, not standalone Yoopta blocks).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function detectDeserializeLoss(
+    sourceHtml: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    deserializedValue: Record<string, any>
+): DeserializeLossReport {
+    const lost: string[] = [];
+    try {
+        const doc = new DOMParser().parseFromString(sourceHtml || '', 'text/html');
+
+        // Source custom blocks (by data-yoopta-type), counted BEFORE stripping.
+        const srcCustom: Record<string, number> = {};
+        doc.body.querySelectorAll('[data-yoopta-type]').forEach((el) => {
+            const t = el.getAttribute('data-yoopta-type') || 'unknown';
+            srcCustom[t] = (srcCustom[t] || 0) + 1;
+        });
+        // Remove custom-block subtrees so their inner media/headings aren't counted.
+        doc.body.querySelectorAll('[data-yoopta-type]').forEach((el) => el.remove());
+        const srcTable = doc.body.querySelectorAll('table').length;
+        const srcImg = doc.body.querySelectorAll('img').length;
+        const srcVideo =
+            doc.body.querySelectorAll('video').length + doc.body.querySelectorAll('iframe').length;
+        const srcHeading = doc.body.querySelectorAll('h1, h2, h3').length;
+
+        // Editor block-type counts.
+        const tc: Record<string, number> = {};
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Object.values(deserializedValue || {}).forEach((b: any) => {
+            const t = b?.type ?? 'UNKNOWN';
+            tc[t] = (tc[t] || 0) + 1;
+        });
+        const edTable = tc['Table'] || 0;
+        const edImg = tc['Image'] || 0;
+        const edVideo = (tc['Video'] || 0) + (tc['Embed'] || 0);
+        const edHeading = (tc['HeadingOne'] || 0) + (tc['HeadingTwo'] || 0) + (tc['HeadingThree'] || 0);
+
+        Object.keys(srcCustom).forEach((t) => {
+            const drop = (srcCustom[t] || 0) - (tc[t] || 0);
+            if (drop > 0) lost.push(`${drop} ${t}`);
+        });
+        if (srcTable > edTable) lost.push(`${srcTable - edTable} table(s)`);
+        if (srcImg > edImg) lost.push(`${srcImg - edImg} image(s)`);
+        if (srcVideo > edVideo) lost.push(`${srcVideo - edVideo} video/embed(s)`);
+        if (srcHeading > edHeading) lost.push(`${srcHeading - edHeading} heading(s)`);
+    } catch {
+        // Detection must never throw or block a load — treat as non-lossy on failure.
+        return { lossy: false, lost: [] };
+    }
+    return { lossy: lost.length > 0, lost };
+}
+
 export function appReloadPreprocess(storedHtml: string): string {
     let sanitized = stripAwsQueryParamsFromUrls(storedHtml || '');
     let contentForDeserialization = sanitized || '';
@@ -117,5 +237,8 @@ export function appReloadPreprocess(storedHtml: string): string {
     } catch (e) {
         // ignore
     }
+    // Flatten semantic wrappers LAST, so headings/paragraphs nested in <section>/<div>
+    // survive html.deserialize (the reload data-loss fix).
+    contentForDeserialization = flattenSemanticWrappers(contentForDeserialization);
     return contentForDeserialization || '';
 }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
@@ -18,7 +18,7 @@ import { createYooptaEditor } from '@yoopta/editor';
 import { html } from '@yoopta/exports';
 import { plugins } from '@/constants/study-library/yoopta-editor-plugins-tools';
 import { formatHTMLString, stripAwsQueryParamsFromUrls } from '../formatHtmlString';
-import { appReloadPreprocess } from './reload';
+import { appReloadPreprocess, detectDeserializeLoss } from './reload';
 
 // Register the app's real plugins onto a bare editor, mirroring
 // slide-material.tsx applyDocContentToEditor() so serialize/deserialize
@@ -469,5 +469,107 @@ describe('DOC slide: signed S3 images survive and get de-signed (truncation regr
             expect(searchable, `combined slide lost image "${img}"`).toContain(img);
         }
         expect(searchable, 'every image de-signed').not.toContain('X-Amz-Signature');
+    });
+});
+
+describe('DOC slide: content nested in semantic wrappers survives reload (heading-loss regression)', () => {
+    // Yoopta's html.deserialize does NOT recurse into <section>/<header>/nested <div>,
+    // so blocks buried inside them were silently dropped on reload. appReloadPreprocess
+    // now flattens those wrappers first. See docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md.
+    const typeCounts = (value: Record<string, any>) => {
+        const counts: Record<string, number> = {};
+        Object.values(value || {}).forEach((b: any) => {
+            counts[b?.type ?? 'UNKNOWN'] = (counts[b?.type ?? 'UNKNOWN'] || 0) + 1;
+        });
+        return counts;
+    };
+
+    it('keeps every heading/paragraph nested in <section>/<header>/<div>', () => {
+        const stored = `<html><head></head><body>
+            <header><div><h1>SIG_H1</h1></div></header>
+            <section>
+                <h2>SIG_H2_A</h2>
+                <p>SIG_P_A</p>
+                <div><h3>SIG_H3_A</h3><p>SIG_P_NESTED</p></div>
+            </section>
+            <section>
+                <div><div><h2>SIG_H2_DEEP</h2></div></div>
+                <h3>SIG_H3_B</h3>
+            </section>
+        </body></html>`;
+
+        const reloaded = makeEditor();
+        const value = html.deserialize(reloaded, appReloadPreprocess(stored));
+        const counts = typeCounts(value as any);
+
+        // Source has 1 h1, 2 h2, 2 h3 — all must survive (pre-fix: several dropped).
+        expect(counts.HeadingOne ?? 0, 'lost the <h1>').toBe(1);
+        expect(counts.HeadingTwo ?? 0, 'lost an <h2> nested in a wrapper').toBe(2);
+        expect(counts.HeadingThree ?? 0, 'lost an <h3> nested in a wrapper').toBe(2);
+
+        reloaded.setEditorValue(value);
+        const out = formatHTMLString(html.serialize(reloaded, reloaded.getEditorValue()));
+        for (const sig of ['SIG_H1', 'SIG_H2_A', 'SIG_P_A', 'SIG_H3_A', 'SIG_P_NESTED', 'SIG_H2_DEEP', 'SIG_H3_B']) {
+            expect(out, `content "${sig}" lost through the semantic-wrapper round-trip`).toContain(sig);
+        }
+    });
+
+    it('does NOT flatten the internals of protected blocks (table/list/custom) inside a section', () => {
+        const stored = `<html><head></head><body>
+            <section>
+                <h2>SIG_BEFORE_TABLE</h2>
+                <table><thead><tr><th>SIG_TH</th></tr></thead><tbody><tr><td>SIG_TD</td></tr></tbody></table>
+                <ul><li>SIG_LI_ONE</li><li>SIG_LI_TWO</li></ul>
+            </section>
+        </body></html>`;
+
+        const reloaded = makeEditor();
+        const value = html.deserialize(reloaded, appReloadPreprocess(stored));
+        const counts = typeCounts(value as any);
+
+        expect(counts.Table ?? 0, 'table dropped or shredded when its section was flattened').toBe(1);
+        reloaded.setEditorValue(value);
+        const out = formatHTMLString(html.serialize(reloaded, reloaded.getEditorValue()));
+        for (const sig of ['SIG_BEFORE_TABLE', 'SIG_TH', 'SIG_TD', 'SIG_LI_ONE', 'SIG_LI_TWO']) {
+            expect(out, `protected-block content "${sig}" lost`).toContain(sig);
+        }
+    });
+});
+
+describe('DOC slide: load-integrity detector flags a lossy deserialize (Layer 2)', () => {
+    it('flags a dropped table', () => {
+        const src = '<h2>x</h2><table><tbody><tr><td>c</td></tr></tbody></table>';
+        const value = { a: blk(0, 'HeadingTwo', 'heading-two', 'x') }; // Table missing
+        const r = detectDeserializeLoss(src, value as any);
+        expect(r.lossy).toBe(true);
+        expect(r.lost.join(' ')).toMatch(/table/);
+    });
+
+    it('flags a dropped heading', () => {
+        const src = '<h2>a</h2><h2>b</h2>';
+        const value = { a: blk(0, 'HeadingTwo', 'heading-two', 'a') }; // one h2 missing
+        expect(detectDeserializeLoss(src, value as any).lossy).toBe(true);
+    });
+
+    it('does NOT flag a clean round-trip', () => {
+        const src = '<h2>x</h2>';
+        const value = { a: blk(0, 'HeadingTwo', 'heading-two', 'x') };
+        expect(detectDeserializeLoss(src, value as any).lossy).toBe(false);
+    });
+
+    it('does NOT false-positive on media/headings nested inside a custom block', () => {
+        // A quiz block whose serialized markup contains an inner <img> and <h3>.
+        const src = '<div data-yoopta-type="quizBlock"><h3>inner</h3><img src="x"/></div>';
+        const value = { q: custom(0, 'quizBlock', { quizData: {} }) };
+        // The quiz block survived; its inner img/heading are part of it, not lost blocks.
+        expect(detectDeserializeLoss(src, value as any).lossy).toBe(false);
+    });
+
+    it('flags a dropped custom block', () => {
+        const src = '<div data-yoopta-type="flashcard" data-front="a" data-back="b"></div>';
+        const value = { p: blk(0, 'Paragraph', 'paragraph', 'nothing') }; // flashcard gone
+        const r = detectDeserializeLoss(src, value as any);
+        expect(r.lossy).toBe(true);
+        expect(r.lost.join(' ')).toMatch(/flashcard/);
     });
 });

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
@@ -143,7 +143,7 @@ export const handlePublishSlide = async (
             const serverMessage = response?.data?.ex || response?.data?.message;
             if (response?.status === 409 && serverMessage) {
                 const confirmed = window.confirm(
-                    `${serverMessage}\n\nDo you want to publish anyway and replace the live version?`
+                    `To prevent accidental data loss, please confirm.\n\n${serverMessage}\n\nAre you sure you want to publish this version?`
                 );
                 if (!confirmed) return;
                 try {

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides.tsx
@@ -250,6 +250,8 @@ export interface DocumentSlidePayload {
         published_document_total_pages: number;
         /** When true, bypass the backend publish-time shrink guard (author confirmed). */
         force_publish?: boolean;
+        /** When true, bypass the backend draft/unsync structural-block loss guard (author confirmed). */
+        force_overwrite?: boolean;
     };
     status: string;
     new_slide: boolean;


### PR DESCRIPTION
## Summary of Changes

DOC slides intermittently lost content (headings, tables, images) on reopen/save/publish. Root cause: Yoopta's `html.deserialize` is not a lossless inverse of `html.serialize` — blocks nested in HTML5 semantic wrappers (`<section>`/`<header>`/`<div>`) were silently dropped on reload, and the reduced content was then persisted. This adds a layered defense (cure + net + server backstop).

**Backend:**
- Marker-based structural-loss guard on draft/unsync/publish saves: rejects (409) any write that would drop a table/image/video/custom block vs the stored content, unless the author force-overrides. Plain text/paragraph edits are not guarded.
- Added `forceOverwrite` to `DocumentSlideDTO` (draft equivalent of `forcePublish`).
- Softened guard/wipe messages to non-technical wording.
- Added `SlideStructuralLossTest` (7 unit tests).

**Frontend:**
- Cure: `flattenSemanticWrappers()` unwraps `<section>`/`<header>`/`<div>` before `html.deserialize` so nested blocks survive; wired into `applyDocContentToEditor` and the reload preprocessor.
- Net: `detectDeserializeLoss()` flags a lossy load and blocks Save/Publish so a reduced editor state can't overwrite the DB.
- Force-overwrite flow in Save Draft (409 → confirm → retry), mirroring publish; friendly confirm wording.
- Regression tests in `doc-slide-integrity/test.tsx` (semantic-wrapper + detector).

## Related Issue



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- 21 frontend vitest + 7 backend unit tests, all passing locally.
- 3 curl end-to-end guard tests against a local DB (409 block → force → restore).
- Live 4-round browser torture test (reopen/switch/reload ×many, publish cycle, 11 MB image race, guard popup) — zero data loss across ~25 operations, verified in the DB after each step.
- Headless harness reproduced the original heading loss on a real slide (10 h2/8 h3 → 8/4) and confirmed the fix preserves all of it.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
