### PR TITLE
fix(reports): fix disposition CSV totals and add Lead Status column t…

### DIFF
--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
@@ -685,6 +685,7 @@ const CampaignUsersContent = ({
             });
             const tailHeaders = showOps
                 ? [
+                      'Lead Status',
                       'Counsellor',
                       'Activity & Notes',
                       'Notes Count',
@@ -735,6 +736,7 @@ const CampaignUsersContent = ({
                         })
                         .join('\n\n');
                     row.push(
+                        csvSafe(lead.lead_status ?? ''),
                         csvSafe(counsellor),
                         csvSafe(notesBlock),
                         csvSafe(summary?.count ?? 0),

--- a/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
@@ -692,7 +692,7 @@ const RecentLeadsContent = () => {
         const baseHeaders = ['Lead ID', 'Submitted At', 'Name', 'Email', 'Mobile', 'Audience'];
         const tail = showOps
             ? [
-                  'Status',
+                  'Lead Status',
                   'Counsellor',
                   'Activity & Notes',
                   'Notes Count',

--- a/frontend-admin-dashboard/src/routes/audience-manager/reports/-components/dispositions-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/reports/-components/dispositions-tab.tsx
@@ -87,27 +87,40 @@ export function DispositionsTab({
         return <ReportErrorState error={query.error} onRetry={() => query.refetch()} />;
     }
 
-    const exportStatusMatrix = () =>
+    const exportStatusMatrix = () => {
+        const dataRows = statusRows.map((r) => {
+            const cols = statuses.map((s) => r.changes[s.status_key] ?? 0);
+            const total = cols.reduce((sum, n) => sum + n, 0);
+            return [actorName(r), ...cols, total];
+        });
+        // Totals footer row: sum each status column across all actors.
+        const footerCols = statuses.map((_, si) =>
+            dataRows.reduce((sum, row) => sum + ((row[si + 1] as number) ?? 0), 0)
+        );
+        const footerTotal = footerCols.reduce((sum, n) => sum + n, 0);
         exportCsv(
             `dispositions-status-changes_${fromDate}_${toDate}.csv`,
             ['Counsellor', ...statuses.map((s) => s.label || s.status_key), 'Total'],
-            statusRows.map((r) => [
-                actorName(r),
-                ...statuses.map((s) => r.changes[s.status_key] ?? 0),
-                r.total_changes,
-            ])
+            [...dataRows, ['TOTAL', ...footerCols, footerTotal]]
         );
+    };
 
-    const exportOutcomeMatrix = () =>
+    const exportOutcomeMatrix = () => {
+        const dataRows = outcomeRows.map((r) => [
+            actorName(r),
+            ...outcomeKeys.map((k) => r.outcomes[k] ?? 0),
+            outcomeTotal(r),
+        ]);
+        const footerCols = outcomeKeys.map((_, ki) =>
+            dataRows.reduce((sum, row) => sum + ((row[ki + 1] as number) ?? 0), 0)
+        );
+        const footerTotal = footerCols.reduce((sum, n) => sum + n, 0);
         exportCsv(
             `dispositions-call-outcomes_${fromDate}_${toDate}.csv`,
             ['Counsellor', ...outcomeKeys.map(outcomeLabel), 'Total'],
-            outcomeRows.map((r) => [
-                actorName(r),
-                ...outcomeKeys.map((k) => r.outcomes[k] ?? 0),
-                outcomeTotal(r),
-            ])
+            [...dataRows, ['TOTAL', ...footerCols, footerTotal]]
         );
+    };
 
     return (
         <div className="flex flex-col gap-6">


### PR DESCRIPTION
…o lead exports

- Disposition status-changes CSV: Total column now sums only visible (active) status columns so each row is self-consistent; added TOTAL footer row for column-level sums across all counsellors. Same fix for call-outcomes CSV.
- Lead list CSV (campaign-users-table): added Lead Status column (current status) before Counsellor — it was entirely missing from the export.
- Recent leads CSV: renamed 'Status' header to 'Lead Status' for consistency.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
