### PR TITLE
fix(learner): commit missing Capacitor plugin shims to unblock production build

### DIFF
--- a/frontend-learner-dashboard-app/src/utils/app-plugin.ts
+++ b/frontend-learner-dashboard-app/src/utils/app-plugin.ts
@@ -1,0 +1,73 @@
+import { Capacitor } from '@capacitor/core';
+import { App as CapacitorApp } from '@capacitor/app';
+import type { PluginListenerHandle } from '@capacitor/core';
+import type { AppInfo } from '@capacitor/app';
+
+// Crash-proof drop-in for the deprecated lazy-web-chunk behaviour of
+// `@capacitor/app` on web.
+//
+// On web the plugin resolves its implementation by lazily importing a separate
+// chunk (`web: () => import('./web').then(m => new m.AppWeb())`). After a deploy
+// the chunk hash changes; a stale, cached `index-*.js` then resolves that dynamic
+// import to a module without `AppWeb`, so `new e.AppWeb()` throws an *unhandled
+// promise rejection*:
+//   TypeError: undefined is not an object (evaluating 'new e.AppWeb')
+// This was observed crashing /assessment/examination on iPad (Sentry 7593599251) —
+// the same failure class the `storage-plugin.ts` shim already sidesteps for
+// `@capacitor/storage` (`StorageWeb`).
+//
+// On web there is no hardware back button, deep link or app-lifecycle to bridge,
+// so every method is an inert no-op that never touches the plugin (and so never
+// loads the chunk). On native we delegate to the real plugin.
+const isNative = (): boolean => {
+  const platform = Capacitor.getPlatform();
+  return platform === 'android' || platform === 'ios' || platform === 'electron';
+};
+
+type AppListenerEvent =
+  | 'backButton'
+  | 'appUrlOpen'
+  | 'appStateChange'
+  | 'pause'
+  | 'resume'
+  | 'appRestoredResult';
+
+export const App = {
+  async addListener(
+    eventName: AppListenerEvent,
+    listenerFunc: (event: any) => void,
+  ): Promise<PluginListenerHandle> {
+    if (isNative()) {
+      return (
+        CapacitorApp.addListener as (
+          e: string,
+          cb: (event: any) => void,
+        ) => Promise<PluginListenerHandle>
+      )(eventName, listenerFunc);
+    }
+    // No back button / deep links / app-state on web — return an inert handle so
+    // callers' `await` + `.remove()` keep working without loading the AppWeb chunk.
+    return { remove: async () => {} };
+  },
+
+  async getInfo(): Promise<AppInfo> {
+    if (isNative()) return CapacitorApp.getInfo();
+    // Matches the real plugin's web behaviour: getInfo is not available on web.
+    // Every caller already guards this in try/catch and falls back.
+    throw new Error('App.getInfo() is not available on web');
+  },
+
+  async minimizeApp(): Promise<void> {
+    if (isNative()) {
+      await CapacitorApp.minimizeApp();
+    }
+    // no-op on web
+  },
+
+  async exitApp(): Promise<void> {
+    if (isNative()) {
+      await CapacitorApp.exitApp();
+    }
+    // no-op on web
+  },
+};

--- a/frontend-learner-dashboard-app/src/utils/network-plugin.ts
+++ b/frontend-learner-dashboard-app/src/utils/network-plugin.ts
@@ -1,0 +1,56 @@
+import { Capacitor } from '@capacitor/core';
+import { Network as CapacitorNetwork } from '@capacitor/network';
+import type { PluginListenerHandle } from '@capacitor/core';
+import type { ConnectionStatus } from '@capacitor/network';
+
+// Crash-proof drop-in for the deprecated lazy-web-chunk behaviour of
+// `@capacitor/network` on web.
+//
+// On web the plugin resolves its implementation by lazily importing a separate
+// chunk (`web: () => import('./web').then(m => new m.NetworkWeb())`). After a
+// deploy the chunk hash changes; a stale, cached `index-*.js` then resolves that
+// dynamic import to a module without `NetworkWeb`, so `new e.NetworkWeb()` throws
+// an *unhandled promise rejection*:
+//   TypeError: undefined is not an object (evaluating 'new e.NetworkWeb')
+// This was observed crashing /assessment/examination on iPad (Sentry 7593599251) —
+// the same failure class the `storage-plugin.ts` shim already sidesteps for
+// `@capacitor/storage` (`StorageWeb`).
+//
+// On web we derive connectivity from the browser's own `navigator.onLine` and
+// `online`/`offline` events — never touching the plugin, so the chunk import can
+// never fire. On native we delegate to the real plugin.
+const isNative = (): boolean => {
+  const platform = Capacitor.getPlatform();
+  return platform === 'android' || platform === 'ios' || platform === 'electron';
+};
+
+const webStatus = (): ConnectionStatus => {
+  const connected =
+    typeof navigator !== 'undefined' ? navigator.onLine !== false : true;
+  return { connected, connectionType: connected ? 'unknown' : 'none' };
+};
+
+export const Network = {
+  async getStatus(): Promise<ConnectionStatus> {
+    if (isNative()) return CapacitorNetwork.getStatus();
+    return webStatus();
+  },
+
+  async addListener(
+    eventName: 'networkStatusChange',
+    listenerFunc: (status: ConnectionStatus) => void,
+  ): Promise<PluginListenerHandle> {
+    if (isNative()) {
+      return CapacitorNetwork.addListener(eventName, listenerFunc);
+    }
+    const handler = () => listenerFunc(webStatus());
+    window.addEventListener('online', handler);
+    window.addEventListener('offline', handler);
+    return {
+      remove: async () => {
+        window.removeEventListener('online', handler);
+        window.removeEventListener('offline', handler);
+      },
+    };
+  },
+};

--- a/frontend-learner-dashboard-app/src/utils/storage-plugin.ts
+++ b/frontend-learner-dashboard-app/src/utils/storage-plugin.ts
@@ -1,0 +1,49 @@
+import { Capacitor } from '@capacitor/core';
+import { Storage as CapacitorStorage } from '@capacitor/storage';
+
+// Crash-proof drop-in for the deprecated `@capacitor/storage` plugin on web.
+//
+// On web browsers the plugin resolves its implementation by lazily importing a
+// separate `StorageWeb` chunk (`web: () => import('./web').then(m => new m.StorageWeb())`).
+// After a deploy the chunk hash changes; a stale, cached `index-*.js` then resolves
+// that dynamic import to a module without `StorageWeb`, so `new e.StorageWeb()` throws
+// an *unhandled promise rejection*:
+//   TypeError: undefined is not an object (evaluating 'new e.StorageWeb')
+// This was observed crashing /assessment/examination on Safari (Sentry 7593586138).
+//
+// Same failure class the `preferences-storage.ts` shim already sidesteps for
+// `@capacitor/preferences` (`PreferencesWeb`). Here we read/write `localStorage`
+// directly on web instead — using the plugin's own key scheme so existing stored
+// data and cross-plugin reads (`@capacitor/preferences` shares the same
+// `CapacitorStorage` group/prefix on web) stay byte-for-byte compatible.
+const isNative = (): boolean => {
+  const platform = Capacitor.getPlatform();
+  return platform === 'android' || platform === 'ios' || platform === 'electron';
+};
+
+// Matches @capacitor/storage's default web group ('CapacitorStorage'). No caller
+// in this app overrides it via configure({ group }).
+const WEB_KEY_PREFIX = 'CapacitorStorage.';
+
+export const Storage = {
+  async get({ key }: { key: string }): Promise<{ value: string | null }> {
+    if (isNative()) return CapacitorStorage.get({ key });
+    return { value: localStorage.getItem(WEB_KEY_PREFIX + key) };
+  },
+
+  async set({ key, value }: { key: string; value: string }): Promise<void> {
+    if (isNative()) {
+      await CapacitorStorage.set({ key, value });
+      return;
+    }
+    localStorage.setItem(WEB_KEY_PREFIX + key, value);
+  },
+
+  async remove({ key }: { key: string }): Promise<void> {
+    if (isNative()) {
+      await CapacitorStorage.remove({ key });
+      return;
+    }
+    localStorage.removeItem(WEB_KEY_PREFIX + key);
+  },
+};


### PR DESCRIPTION
## Problem
The learner-app Cloudflare production build (PR #2144 merge, commit `d0ed6c8`) **failed**:

```
Could not load .../src/utils/storage-plugin (imported by assessment-slide-viewer.tsx): ENOENT
error during build: ... code: 1
```

## Root cause
`src/utils/storage-plugin.ts` (a Capacitor web-shim) was imported by the already-committed `assessment-slide-viewer.tsx` but the file itself was **never committed to git** — it only existed on local disks. Local builds passed because the file was present; Cloudflare's clean clone had no such file → `ENOENT`.

## Fix
Commit the storage/network/app Capacitor web-shim set (`src/utils/{storage,network,app}-plugin.ts`). They only depend on `@capacitor/*` packages already in `package.json`.

## Verification
Built from a **clean git worktree** (only committed files, mirroring Cloudflare's clone):
```
✓ built in 3m 15s   (exit 0, no ENOENT)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)