### PR TITLE
fix(learner): download evaluated copy in its true format (not the stored name's extension)

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/file-preview.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/file-preview.tsx
@@ -3,18 +3,22 @@ import SimplePDFViewer from "@/components/common/simple-pdf-viewer";
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|heic|heif|avif)$/i;
 
 /**
- * Whether a file should be shown as an image. Prefers the MIME type from
- * media-service; falls back to the filename extension. Admin uploads for
- * answer sheets allow PDF / JPEG / PNG, so anything non-image is treated as a
- * PDF for rendering.
+ * Whether a file should be shown as an image. The real content type
+ * (media-service file_type) is authoritative — a stored filename can carry a
+ * stale/wrong extension. Only when the type is absent/unknown do we fall back
+ * to the filename. Admin answer-sheet uploads allow PDF / JPEG / PNG, so a
+ * confident non-image type (e.g. PDF) renders in the PDF viewer.
  */
 export function isImageFile(
   fileType?: string | null,
   fileName?: string | null
 ): boolean {
-  if (fileType && fileType.toLowerCase().startsWith("image/")) return true;
-  if (fileName && IMAGE_EXT.test(fileName.trim())) return true;
-  return false;
+  const t = (fileType || "").toLowerCase().split(";")[0].trim();
+  if (t.startsWith("image/")) return true;
+  if (t === "application/pdf" || t === "pdf") return false;
+  // file_type may be a bare extension like "png"; treat it like one.
+  if (t && IMAGE_EXT.test(`.${t}`)) return true;
+  return fileName ? IMAGE_EXT.test(fileName.trim()) : false;
 }
 
 interface FilePreviewProps {

--- a/frontend-learner-dashboard-app/src/components/common/simple-pdf-viewer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/simple-pdf-viewer.tsx
@@ -20,10 +20,17 @@ const PDF_WORKER_URL =
 // Evaluated-copy / submission PDFs are served from S3 signed URLs whose object
 // keys carry no ".pdf" extension. react-pdf-viewer's default download derives
 // the filename from that URL, so the saved file has no extension and won't open
-// on the device. Force a ".pdf" name on every download.
+// on the device. This viewer only ever renders PDFs, so force a ".pdf" name —
+// replacing a mislabeled image extension rather than doubling it up
+// (e.g. "answer.jpg" → "answer.pdf", not "answer.jpg.pdf").
 const ensurePdfName = (name?: string): string => {
     const base = (name || 'document').trim() || 'document';
-    return /\.pdf$/i.test(base) ? base : `${base}.pdf`;
+    if (/\.pdf$/i.test(base)) return base;
+    const stripped = base.replace(
+        /\.(jpe?g|png|gif|webp|bmp|svg|heic|heif|avif|tiff?)$/i,
+        ''
+    );
+    return `${stripped}.pdf`;
 };
 
 interface SimplePDFViewerProps {

--- a/frontend-learner-dashboard-app/src/services/upload_file.ts
+++ b/frontend-learner-dashboard-app/src/services/upload_file.ts
@@ -188,8 +188,8 @@ export const getFileDetail = async (
     };
 };
 
-// Common MIME → extension map for the formats an evaluated copy can be
-// (admin allows PDF / JPEG / PNG; a few extra images kept for safety).
+// Formats an evaluated copy / submission can be (admin allows PDF / JPEG / PNG;
+// a few extra images kept for safety).
 const MIME_TO_EXT: Record<string, string> = {
     "application/pdf": "pdf",
     "image/jpeg": "jpg",
@@ -202,27 +202,49 @@ const MIME_TO_EXT: Record<string, string> = {
     "image/heic": "heic",
     "image/heif": "heif",
     "image/avif": "avif",
+    "image/tiff": "tiff",
 };
 
-const hasFileExtension = (name: string): boolean =>
-    /\.[a-z0-9]{1,5}$/i.test(name.trim());
+const KNOWN_EXTS = new Set<string>([
+    "pdf", "jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "heic", "heif",
+    "avif", "tiff", "tif",
+]);
 
-const extensionFromMime = (mime?: string | null): string | undefined => {
-    if (!mime) return undefined;
-    const key = mime.toLowerCase().split(";")[0].trim();
-    if (MIME_TO_EXT[key]) return MIME_TO_EXT[key];
-    // Generic fallback: "image/xyz" → "xyz".
-    const sub = key.includes("/") ? key.slice(key.indexOf("/") + 1) : "";
-    return /^[a-z0-9]+$/.test(sub) ? sub : undefined;
+// Treat equivalent spellings as the same format so we don't needlessly rename a
+// user's ".jpeg" to ".jpg" (same format, different spelling).
+const canonicalExt = (ext: string): string => {
+    const e = ext.toLowerCase();
+    if (e === "jpeg") return "jpg";
+    if (e === "tif") return "tiff";
+    return e;
 };
 
 /**
- * Download a file to the device with a real, extension-bearing name. Fetches
- * the bytes and saves via a Blob so the saved file keeps its correct extension
- * even though the S3 signed URL has none (a plain link would save an
- * un-openable, extension-less file). If the given name has no extension, one is
- * derived from the passed MIME type, falling back to the downloaded blob's own
- * type — so the file is openable whatever format the admin uploaded.
+ * Resolve a KNOWN extension from a media-service file_type (normally a MIME like
+ * "application/pdf", occasionally a bare "pdf") or a blob's own content type.
+ * Returns undefined for anything we can't confidently classify, so we never
+ * overwrite a good filename with a guess.
+ */
+const extensionFromType = (type?: string | null): string | undefined => {
+    if (!type) return undefined;
+    const t = type.toLowerCase().split(";")[0].trim();
+    if (!t) return undefined;
+    if (t.includes("/")) return MIME_TO_EXT[t];
+    return KNOWN_EXTS.has(t) ? canonicalExt(t) : undefined;
+};
+
+const splitExtension = (name: string): { base: string; ext: string | null } => {
+    const m = name.match(/^(.*)\.([A-Za-z0-9]{1,5})$/);
+    return m ? { base: m[1], ext: m[2].toLowerCase() } : { base: name, ext: null };
+};
+
+/**
+ * Download a file to the device in its true format. The file's real content
+ * type is authoritative for the extension — the stored filename can carry a
+ * stale/wrong extension, so we normalise the saved name to match the actual
+ * bytes: media-service file_type first, then the downloaded blob's own S3
+ * Content-Type. Fetching via a Blob is also what lets the download carry any
+ * extension at all (the S3 signed URL has none).
  */
 export const downloadFileWithName = async (
     url: string,
@@ -232,10 +254,16 @@ export const downloadFileWithName = async (
     const response = await axios.get(url, { responseType: "blob" });
     const blob: Blob = response.data;
     let name = (fileName || "download").trim() || "download";
-    if (!hasFileExtension(name)) {
-        const ext = extensionFromMime(fileType) || extensionFromMime(blob?.type);
-        if (ext) name = `${name}.${ext}`;
+
+    const trueExt = extensionFromType(fileType) || extensionFromType(blob?.type);
+    if (trueExt) {
+        const { base, ext } = splitExtension(name);
+        // Replace a missing or format-mismatched extension; keep an equivalent one.
+        if (!ext || canonicalExt(ext) !== canonicalExt(trueExt)) {
+            name = `${base}.${trueExt}`;
+        }
     }
+
     const objectUrl = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = objectUrl;


### PR DESCRIPTION
## Problem
After downloading an evaluated copy / submission, **the format was not the same** as uploaded — the saved file could carry a mismatched or misleading extension.

## Root cause
The download used the extension of media-service's stored `file_name`, and only appended an extension when the name had *none*. If the stored name carried a **stale or wrong extension** (e.g. an evaluated PDF stored under an original `.jpg` answer-sheet name), the download kept that wrong extension → OS opens it as the wrong format.

## Fix
Make the file's **real content type authoritative**, not the filename:
- Derive the extension from `file_type` (media-service MIME), falling back to the **fetched blob's S3 `Content-Type`**.
- Normalise the saved name to that extension — replacing a missing *or* mismatched one, while keeping format-equivalent spellings (`.jpeg`≡`.jpg`).
- Only override when we can classify the type confidently, so a good name is never clobbered by a guess.
- Apply the same content-type-first rule to **image-vs-PDF display** detection (so a mislabeled name still renders correctly), and stop the PDF viewer from producing `answer.jpg.pdf`.

## Verification
- `tsc --noEmit`: **0 errors**
- `design-lint`: clean
- Traced cases: PDF w/ correct name → `.pdf`; PDF w/ wrong `.jpg` name → `.pdf`; PNG w/ no ext → `.png`; `.jpeg` kept as-is; unknown type → filename trusted.

> Note: merge **after** #2145 (the missing-plugin-shims build fix) — this branch is off `main` and doesn't include those shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)