### PR TITLE
fix(leads): return status label (not key) in API; fix disposition rep…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -2599,11 +2599,14 @@ public class AudienceService {
                 .filter(Objects::nonNull)
                 .distinct()
                 .collect(Collectors.toList());
+        // Use label (human-readable display name) rather than status_key so the
+        // lead_status field in the API response / CSV export shows "New", "DNP", etc.
+        // rather than internal codes like "LEAD", "DNP_KEY".
         Map<String, String> leadStatusIdToKey = leadStatusIds.isEmpty() ? Collections.emptyMap()
                 : leadStatusRepository.findAllById(leadStatusIds).stream()
                         .collect(Collectors.toMap(
                                 vacademy.io.admin_core_service.features.audience.entity.LeadStatus::getId,
-                                vacademy.io.admin_core_service.features.audience.entity.LeadStatus::getStatusKey,
+                                vacademy.io.admin_core_service.features.audience.entity.LeadStatus::getLabel,
                                 (a, b) -> a));
 
         // Batch fetch all custom field values for these responses

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/ReportScopeResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/ReportScopeResolver.java
@@ -99,8 +99,11 @@ public class ReportScopeResolver {
             return callerScope;
         }
 
-        List<String> counsellors = counsellorScopeService.allCounsellorUserIds(instituteId);
-        return counsellors.isEmpty() ? null : counsellors; // empty = setup mode — no scope filter
+        // Pure admin with no explicit counsellor/team filter: return null (no restriction).
+        // Returning the counsellor-role list would silently drop changes made by admin users
+        // who have ADMIN role but not COUNSELLOR role, causing those counsellors to always
+        // show zero dispositions even when they manually changed lead statuses.
+        return null;
     }
 
     private static String trimToNull(String s) {


### PR DESCRIPTION
…ort scope for admins

AudienceService: map lead_status_id → label instead of status_key so the lead_status field in list/recent-leads responses shows human-readable values ("New", "Did Not Pick") rather than internal codes ("LEAD", "DNP") — this fixes the CSV export showing "LEAD" instead of "New".

ReportScopeResolver: pure admin callers with no counsellor/team filter now get null scope (no restriction) instead of the counsellor-role user list. Returning the counsellor list silently excluded status changes made by users who have ADMIN role but not COUNSELLOR role, causing those users' manual status changes to always show as zero in the disposition report.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
