### PR TITLE
fix: pending count over-counts when audienceId filter is set

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
@@ -258,6 +258,11 @@ public class PipelineReportService {
             WHERE ulp.institute_id = :instituteId
               AND ulp.assigned_counselor_id IS NOT NULL
               AND (:scopeCsv IS NULL OR ulp.assigned_counselor_id = ANY(STRING_TO_ARRAY(:scopeCsv, ',')))
+              AND (:audienceId IS NULL OR EXISTS (
+                  SELECT 1 FROM audience_response ar2
+                  WHERE (ar2.user_id = ulp.user_id OR ar2.student_user_id = ulp.user_id)
+                    AND ar2.audience_id = :audienceId
+              ))
               AND NOT EXISTS (
                   SELECT 1
                   FROM audience_response ar


### PR DESCRIPTION
PENDING_LEADS_SQL counted all institute leads with no history in the selected campaign, including leads not in that campaign at all. Added an EXISTS guard so when audienceId is provided, only leads who have an audience_response in that campaign are eligible for the pending count.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
