### PR TITLE
ci(notification): enable SES sender verification flag in LKE deploy

### DIFF
--- a/.github/workflows/maven-publish-notification-service.yml
+++ b/.github/workflows/maven-publish-notification-service.yml
@@ -150,6 +150,7 @@ jobs:
             INBOUND_EMAIL_AWS_SECRET_KEY=${{ secrets.INBOUND_EMAIL_AWS_SECRET_KEY }} \
             INBOUND_EMAIL_SQS_QUEUE_NAME=${{ secrets.INBOUND_EMAIL_SQS_QUEUE_NAME }} \
             INBOUND_EMAIL_S3_BUCKET=${{ secrets.INBOUND_EMAIL_S3_BUCKET }} \
+            SES_VERIFICATION_ENABLED=${{ secrets.SES_VERIFICATION_ENABLED }} \
             SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 


### PR DESCRIPTION
## What
Adds `SES_VERIFICATION_ENABLED` to the `kubectl set env` block of the **Deploy Notification to LKE** workflow, so the self-serve SES sender-verification feature can be switched on for notification-service.

## Why
The feature (`features/email_verification`) is already merged and deployed but ships **gated off** (`aws.ses.verification.enabled` defaults to `false`). The LKE deploy never passed the flag, so `/v1/email-verification/enabled` returns `false` and the admin dashboard shows the old 'contact support' notice with no Verify button.

## Change
One line — injects the flag from a GitHub secret:
```
SES_VERIFICATION_ENABLED=${{ secrets.SES_VERIFICATION_ENABLED }} \
```

## Activation checklist (outside this PR)
- [x] GitHub **org secret** `SES_VERIFICATION_ENABLED=true` created
- [x] IAM policy `ses-sender-verification` attached to `SQS_notification_service` user (ses:VerifyEmailIdentity, GetIdentityVerificationAttributes)
- [ ] Merge this PR, then **manually run** the workflow (Actions → Deploy Notification to LKE → Run workflow) — note the `push` trigger only fires on `notification_service/**` paths, so this `.github/` change won't auto-deploy
- [ ] Verify `/notification-service/v1/email-verification/enabled` → `{"enabled": true}`

## Safety
If the secret were unset, the flag injects empty → feature stays off. No app source code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)