### PR TITLE
ci(notification): hardcode SES_VERIFICATION_ENABLED=true (secret/var channels don't resolve)

### DIFF
--- a/.github/workflows/maven-publish-notification-service.yml
+++ b/.github/workflows/maven-publish-notification-service.yml
@@ -150,7 +150,7 @@ jobs:
             INBOUND_EMAIL_AWS_SECRET_KEY=${{ secrets.INBOUND_EMAIL_AWS_SECRET_KEY }} \
             INBOUND_EMAIL_SQS_QUEUE_NAME=${{ secrets.INBOUND_EMAIL_SQS_QUEUE_NAME }} \
             INBOUND_EMAIL_S3_BUCKET=${{ secrets.INBOUND_EMAIL_S3_BUCKET }} \
-            SES_VERIFICATION_ENABLED=${{ vars.SES_VERIFICATION_ENABLED }} \
+            SES_VERIFICATION_ENABLED=true \
             SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 


### PR DESCRIPTION
## Why
`SES_VERIFICATION_ENABLED` must be `true` on notification-service for the self-serve SES sender verification feature. But on this **public** repo none of the config channels deliver it:
- Repo **secrets** are at the 100-secret cap (can't add one).
- The **org secret** isn't exposed to public repos.
- A repo **Variable** (`vars.`) resolves to empty in the workflow — **verified**: the `vars.`-sourced value never appeared in the deployment's env spec, while `secrets.`-sourced `true` values (`AWS_SQS_ENABLED` etc.) did.

## Change
One line: `${{ vars.SES_VERIFICATION_ENABLED }}` → literal `true`. It's a non-sensitive single-environment on/off flag, so a literal is safe and reliable (renders exactly like the working `AWS_SQS_ENABLED=true`).

## Verified working
Set live on the cluster + confirmed: deployment spec `SES_VERIFICATION_ENABLED=true`, pod `VERDICT=EXACT_TRUE`, `/email-verification/enabled` → `{"enabled":true}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)