### PR TITLE
fix: counsellor workbench status toggle silently no-ops for pool-less…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/service/CounsellorWorkbenchService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/service/CounsellorWorkbenchService.java
@@ -339,6 +339,15 @@ public class CounsellorWorkbenchService {
         // response so the dialog can pre-populate.
         List<CounselorPoolMember> rows = counselorPoolMemberRepository
                 .findByInstituteAndCounselor(instituteId, userId);
+        if (rows.isEmpty()) {
+            // Nothing to flip — this counsellor has never been added as a member of
+            // any lead pool (the workbench roster is role-derived and independent of
+            // pool membership, so they can still show up here with zero rows). Without
+            // this check the call was a silent no-op that still returned 200, so the
+            // UI showed "Marked active" even though is_active stayed false forever.
+            throw new VacademyException(
+                    "This counsellor is not part of any lead pool yet. Add them to a pool from Settings > Leads > Pools before changing their status.");
+        }
         Set<String> affectedPoolIds = new HashSet<>();
         String upper = status.toUpperCase(Locale.ROOT);
         for (CounselorPoolMember m : rows) {

--- a/frontend-admin-dashboard/src/routes/counsellors/-components/CounsellorListRail.tsx
+++ b/frontend-admin-dashboard/src/routes/counsellors/-components/CounsellorListRail.tsx
@@ -92,7 +92,10 @@ function CounsellorCard({
                 );
             }
         },
-        onError: () => toast.error('Status update failed'),
+        onError: (e) => {
+            const msg = (e as { response?: { data?: { ex?: string } } })?.response?.data?.ex;
+            toast.error(msg ?? 'Status update failed');
+        },
     });
 
     return (


### PR DESCRIPTION
… counsellors

The workbench roster (/counsellors) lists everyone with the COUNSELLOR role, independent of lead-pool membership. Clicking "Mark Active" for someone who was never added to a pool flipped zero counselor_pool_member rows but still returned 200, so the UI showed success while is_active stayed false forever. Now the endpoint rejects the no-op with a clear error, and the frontend surfaces the real backend message instead of a generic failure toast.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
