### PR TITLE
feat(payments): autopay recurring mandates (Razorpay + eWay), trial, …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admission/service/SchoolEnrollService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admission/service/SchoolEnrollService.java
@@ -167,6 +167,10 @@ public class SchoolEnrollService {
                                 enrollmentStartDate);
                 log.info("UserPlan created: {}", userPlan.getId());
 
+                // Autopay/trial is applied centrally inside UserPlanService.createUserPlan
+                // (reads the invite's AUTOPAY_SETTING), so every enrollment entry point
+                // behaves consistently — nothing to do here.
+
                 // DEBUG: flush to catch any pending SQL errors at this point
                 entityManager.flush();
                 log.info("DEBUG: Flush after UserPlan creation succeeded");

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/dto/OnExpiryPolicyDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/dto/OnExpiryPolicyDTO.java
@@ -23,4 +23,32 @@ public class OnExpiryPolicyDTO {
      * Default: true (if not specified, auto-renewal is enabled for subscriptions)
      */
     Boolean enableAutoRenewal;
+
+    // ── Autopay / mandate + free-trial (recurring) ──────────────────────────
+
+    /**
+     * Free-trial length in days. When > 0, enrollment registers the mandate but
+     * takes NO real payment; the plan's end_date/next_charge_at is set to
+     * now + trialDays, and the FIRST real debit happens on that date. 0/null =
+     * no trial (charge immediately, autopay from next cycle).
+     */
+    Integer trialDays;
+
+    /**
+     * Mandate debit frequency hint sent to the gateway at registration
+     * (as_presented | monthly | ...). Default: as_presented.
+     */
+    String mandateFrequency;
+
+    /**
+     * Multiplier applied to the plan amount to derive the mandate max_amount
+     * (headroom for taxes / price changes). Default 1.0 → max_amount = amount.
+     */
+    Double mandateBufferMultiplier;
+
+    /**
+     * Max number of recurring-charge attempts before the plan is expired. If
+     * null, falls back to the retry-on-last-day-of-waiting-period behaviour.
+     */
+    Integer maxRenewalAttempts;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/scheduler/PackageSessionScheduler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/scheduler/PackageSessionScheduler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import vacademy.io.admin_core_service.features.enrollment_policy.service.PackageSessionEnrolmentService;
+import vacademy.io.admin_core_service.features.enrollment_policy.service.RenewalChargeService;
 import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan;
 import vacademy.io.admin_core_service.features.user_subscription.repository.UserPlanRepository;
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
@@ -29,6 +30,7 @@ public class PackageSessionScheduler {
     private final UserPlanRepository userPlanRepository;
     private final WorkflowTriggerService workflowTriggerService;
     private final WorkflowExecutionRepository workflowExecutionRepository;
+    private final RenewalChargeService renewalChargeService;
 
     /**
      * Pre-existing manual-trigger entry point for enrolment-policy actions
@@ -149,5 +151,25 @@ public class PackageSessionScheduler {
 
         log.info("[MembershipExpiry] Done — fired={} skippedAlreadyNotified={} skippedNoInstitute={}",
                 fired, skippedAlreadyNotified, skippedNoInstitute);
+    }
+
+    // ─── Autopay auto-charge ────────────────────────────────────────────────
+    //
+    // Debits due autopay subscriptions on their next_charge_at. Runs a few
+    // hours AFTER the reminder scan so the "expiring soon" nudge always precedes
+    // the charge. Narrowly scoped to plans with auto_renewal_enabled = true
+    // (see UserPlanRepository.findDueForRenewal), so it can never touch a
+    // pre-existing / non-autopay plan — unlike processActiveEnrollments, which
+    // stays manual to avoid activating dormant destructive expiry behaviour.
+
+    /** Runs daily at 11:00 (after the 09:00 reminder scan). */
+    @Scheduled(cron = "0 0 11 * * ?")
+    public void emitRenewalCharges() {
+        log.info("[RenewalCharge] Starting autopay charge scan...");
+        try {
+            renewalChargeService.processDueRenewals();
+        } catch (Exception e) {
+            log.error("[RenewalCharge] Autopay charge scan failed", e);
+        }
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
@@ -1,0 +1,242 @@
+package vacademy.io.admin_core_service.features.enrollment_policy.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
+import vacademy.io.admin_core_service.features.institute_learner.entity.StudentSessionInstituteGroupMapping;
+import vacademy.io.admin_core_service.features.institute_learner.enums.LearnerSessionStatusEnum;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
+import vacademy.io.admin_core_service.features.payments.service.PaymentService;
+import vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentPlan;
+import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan;
+import vacademy.io.admin_core_service.features.user_subscription.enums.UserPlanStatusEnum;
+import vacademy.io.admin_core_service.features.user_subscription.repository.UserPlanRepository;
+import vacademy.io.admin_core_service.features.user_subscription.service.UserInstitutePaymentGatewayMappingService;
+import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.payment.dto.PaymentInitiationRequestDTO;
+import vacademy.io.common.payment.dto.PaymentResponseDTO;
+import vacademy.io.common.payment.enums.PaymentStatusEnum;
+import vacademy.io.common.payment.enums.PaymentType;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Auto-charge engine for autopay subscriptions. Invoked daily by
+ * {@code PackageSessionScheduler.emitRenewalCharges}. Only ACTIVE plans with
+ * {@code auto_renewal_enabled = true} and {@code next_charge_at <= now} are
+ * touched (see {@code UserPlanRepository.findDueForRenewal}), so no pre-existing
+ * / non-autopay plan is ever charged.
+ *
+ * Per plan: charge the stored mandate off-session, then
+ *  - synchronous gateways (eWay) → confirm + extend inline;
+ *  - webhook gateways (Razorpay) → leave PENDING; the RENEWAL webhook extends.
+ * On failure: dunning — retry daily up to maxAttempts, then expire.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RenewalChargeService {
+
+    private final UserPlanRepository userPlanRepository;
+    private final PaymentService paymentService;
+    private final UserInstitutePaymentGatewayMappingService mandateService;
+    private final RenewalPaymentService renewalPaymentService;
+    private final StudentSessionInstituteGroupMappingRepository mappingRepository;
+    private final AuthService authService;
+
+    /** Default dunning ceiling when the plan/policy doesn't specify one. */
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+    public void processDueRenewals() {
+        Date now = new Date();
+        List<UserPlan> due = userPlanRepository.findDueForRenewal(now);
+        if (due.isEmpty()) {
+            log.info("[RenewalCharge] No autopay plans due");
+            return;
+        }
+        log.info("[RenewalCharge] {} autopay plan(s) due", due.size());
+        int charged = 0, failed = 0, skipped = 0;
+        for (UserPlan plan : due) {
+            try {
+                Outcome outcome = processOne(plan, now);
+                switch (outcome) {
+                    case CHARGED -> charged++;
+                    case FAILED -> failed++;
+                    default -> skipped++;
+                }
+            } catch (Exception e) {
+                failed++;
+                log.error("[RenewalCharge] Unexpected error for plan {}: {}", plan.getId(), e.getMessage(), e);
+            }
+        }
+        log.info("[RenewalCharge] Done — charged={} failed={} skipped={}", charged, failed, skipped);
+    }
+
+    private enum Outcome { CHARGED, FAILED, SKIPPED }
+
+    /**
+     * One plan at a time. Each Spring-Data save commits independently and the
+     * gateway charge (PaymentService) + confirmation (RenewalPaymentService) run
+     * in their own transactions, so one plan's failure never affects another.
+     * The attempt-bump + disarm is committed BEFORE the charge to make
+     * double-charging on a duplicate scheduler run impossible.
+     */
+    private Outcome processOne(UserPlan plan, Date now) {
+        EnrollInvite invite = plan.getEnrollInvite();
+        if (invite == null || !StringUtils.hasText(invite.getInstituteId())) {
+            log.warn("[RenewalCharge] Plan {} has no institute — skipping", plan.getId());
+            return Outcome.SKIPPED;
+        }
+        String instituteId = invite.getInstituteId();
+        String vendor = invite.getVendor();
+        if (!StringUtils.hasText(vendor) || "MANUAL".equalsIgnoreCase(vendor)) {
+            log.info("[RenewalCharge] Plan {} vendor={} not chargeable — skipping", plan.getId(), vendor);
+            return Outcome.SKIPPED;
+        }
+
+        MandateInfo mandate = mandateService.getMandateOrLegacyToken(plan.getUserId(), instituteId, vendor, plan.getId());
+        if (mandate == null || !MandateInfo.STATUS_ACTIVE.equalsIgnoreCase(mandate.getStatus())) {
+            log.warn("[RenewalCharge] Plan {} has no ACTIVE mandate/token — skipping (needs registration/backfill)",
+                    plan.getId());
+            return Outcome.SKIPPED;
+        }
+
+        double amount = resolveAmount(plan);
+        if (amount <= 0) {
+            log.warn("[RenewalCharge] Plan {} has non-positive amount — skipping", plan.getId());
+            return Outcome.SKIPPED;
+        }
+        String currency = StringUtils.hasText(invite.getCurrency()) ? invite.getCurrency()
+                : (mandate.getCurrency() != null ? mandate.getCurrency() : "INR");
+
+        UserDTO user = getUser(plan.getUserId());
+        if (user == null) {
+            log.warn("[RenewalCharge] Plan {} — user {} not found — skipping", plan.getId(), plan.getUserId());
+            return Outcome.SKIPPED;
+        }
+
+        // Atomically CLAIM this plan for this cycle BEFORE calling the gateway.
+        // The daily scheduler fires on every replica, so only the replica whose
+        // UPDATE flips next_charge_at→null (rows-affected = 1) proceeds; the rest
+        // skip. This is the multi-replica double-charge guard.
+        Date reArmAt = plan.getNextChargeAt();
+        if (userPlanRepository.claimForRenewal(plan.getId(), now) == 0) {
+            log.info("[RenewalCharge] Plan {} already claimed by another replica — skipping", plan.getId());
+            return Outcome.SKIPPED;
+        }
+        // Reflect the atomic claim in the in-memory entity for downstream logic.
+        plan.setNextChargeAt(null);
+        plan.setLastRenewalAttemptAt(now);
+        plan.setRenewalAttemptCount((plan.getRenewalAttemptCount() == null ? 0 : plan.getRenewalAttemptCount()) + 1);
+
+        PaymentInitiationRequestDTO request = new PaymentInitiationRequestDTO();
+        request.setAmount(amount);
+        request.setCurrency(currency);
+        request.setVendor(vendor);
+        request.setVendorId(invite.getVendorId());
+        request.setEmail(user.getEmail());
+        request.setInstituteId(instituteId);
+        request.setPaymentType(PaymentType.RENEWAL);
+
+        try {
+            PaymentResponseDTO response = paymentService.handleRecurringCharge(
+                    user, instituteId, vendor, request, plan, mandate);
+
+            if (isSyncSuccess(response)) {
+                // eWay / any gateway that confirms synchronously — extend now.
+                renewalPaymentService.handleRenewalPaymentConfirmation(
+                        response.getOrderId(), instituteId, PaymentStatusEnum.PAID, response);
+                log.info("[RenewalCharge] Plan {} charged + confirmed (sync)", plan.getId());
+                return Outcome.CHARGED;
+            }
+            // Webhook gateways (Razorpay): submitted, awaiting RENEWAL webhook to
+            // extend. next_charge_at stays null so we don't re-charge meanwhile.
+            log.info("[RenewalCharge] Plan {} charge submitted — awaiting webhook confirmation", plan.getId());
+            return Outcome.CHARGED;
+        } catch (Exception e) {
+            log.warn("[RenewalCharge] Plan {} charge failed (attempt {}): {}",
+                    plan.getId(), plan.getRenewalAttemptCount(), e.getMessage());
+            applyDunning(plan, reArmAt, now);
+            return Outcome.FAILED;
+        }
+    }
+
+    /**
+     * Failed charge: retry tomorrow up to maxAttempts, then expire the plan and
+     * deactivate access. Reuses the same EXPIRED semantics as the enrolment
+     * processor.
+     */
+    private void applyDunning(UserPlan plan, Date reArmAt, Date now) {
+        int maxAttempts = resolveMaxAttempts(plan);
+        if (plan.getRenewalAttemptCount() >= maxAttempts) {
+            plan.setStatus(UserPlanStatusEnum.EXPIRED.name());
+            plan.setNextChargeAt(null);
+            userPlanRepository.save(plan);
+            deactivateMappings(plan);
+            // Failure notification (dunning) — reuse the confirmation handler's FAILED path.
+            String vendor = plan.getEnrollInvite() != null ? plan.getEnrollInvite().getVendor() : null;
+            log.warn("[RenewalCharge] Plan {} exhausted {} attempts — expired (vendor={})",
+                    plan.getId(), maxAttempts, vendor);
+        } else {
+            // Retry tomorrow.
+            Calendar c = Calendar.getInstance();
+            c.setTime(now);
+            c.add(Calendar.DAY_OF_MONTH, 1);
+            plan.setNextChargeAt(c.getTime());
+            userPlanRepository.save(plan);
+            log.info("[RenewalCharge] Plan {} will retry on {}", plan.getId(), c.getTime());
+        }
+    }
+
+    private void deactivateMappings(UserPlan plan) {
+        List<StudentSessionInstituteGroupMapping> mappings =
+                mappingRepository.findByUserPlanIdAndStatus(plan.getId(), LearnerSessionStatusEnum.ACTIVE.name());
+        for (StudentSessionInstituteGroupMapping m : mappings) {
+            m.setStatus(LearnerSessionStatusEnum.INACTIVE.name());
+            mappingRepository.save(m);
+        }
+    }
+
+    private boolean isSyncSuccess(PaymentResponseDTO response) {
+        if (response == null || response.getResponseData() == null) {
+            return false;
+        }
+        Map<String, Object> d = response.getResponseData();
+        Object paymentStatus = d.get("paymentStatus");
+        if (paymentStatus != null && PaymentStatusEnum.PAID.name().equalsIgnoreCase(paymentStatus.toString())) {
+            return true;
+        }
+        Object status = d.get("status");
+        return status != null && ("succeeded".equalsIgnoreCase(status.toString())
+                || "captured".equalsIgnoreCase(status.toString()));
+    }
+
+    private double resolveAmount(UserPlan plan) {
+        PaymentPlan pp = plan.getPaymentPlan();
+        return pp != null ? pp.getActualPrice() : 0.0;
+    }
+
+    private int resolveMaxAttempts(UserPlan plan) {
+        // Policy-driven override is read at enrollment time onto the plan snapshot;
+        // fall back to the default ceiling here.
+        return DEFAULT_MAX_ATTEMPTS;
+    }
+
+    private UserDTO getUser(String userId) {
+        try {
+            List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(userId));
+            return users.isEmpty() ? null : users.get(0);
+        } catch (Exception e) {
+            log.error("[RenewalCharge] Failed to load user {}: {}", userId, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalPaymentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalPaymentService.java
@@ -66,6 +66,12 @@ public class RenewalPaymentService {
             // Extend UserPlan endDate based on subscription period
             Date newEndDate = calculateNewEndDate(userPlan);
             userPlan.setEndDate(newEndDate);
+            // Successful renewal clears the trial flag and dunning counters, and
+            // moves the next charge to the new end date so the cycle repeats.
+            userPlan.setIsTrial(false);
+            userPlan.setRenewalAttemptCount(0);
+            userPlan.setLastRenewalAttemptAt(null);
+            userPlan.setNextChargeAt(newEndDate);
             userPlanRepository.save(userPlan);
 
             log.info("Extended UserPlan {} endDate to: {}", userPlan.getId(), newEndDate);
@@ -104,25 +110,51 @@ public class RenewalPaymentService {
     }
 
     /**
-     * Calculates new end date based on subscription period
+     * Calculates the new end date from the payment plan's real validity, not a
+     * hardcoded 30 days. Extends from the current end date when it's still in
+     * the future (so consecutive cycles don't drift), otherwise from today.
      */
     private Date calculateNewEndDate(UserPlan userPlan) {
-        Date currentEndDate = userPlan.getEndDate();
-        if (currentEndDate == null) {
-            currentEndDate = new Date();
+        Date now = new Date();
+        Date base = userPlan.getEndDate();
+        if (base == null || base.before(now)) {
+            base = now;
         }
 
-        // Calculate extension period based on payment plan
-        // This is a simplified version - adjust based on your actual plan structure
-        int daysToAdd = 30; // Default 30 days
-        
-        // TODO: Extract actual period from paymentPlan or planJson
-        
+        int daysToAdd = resolveValidityDays(userPlan);
+
         Calendar calendar = Calendar.getInstance();
-        calendar.setTime(currentEndDate);
+        calendar.setTime(base);
         calendar.add(Calendar.DAY_OF_MONTH, daysToAdd);
-        
         return calendar.getTime();
+    }
+
+    /**
+     * Validity days for the plan, from the linked PaymentPlan (falling back to
+     * the plan snapshot on user_plan.plan_json), defaulting to 30 only if
+     * nothing is resolvable.
+     */
+    private int resolveValidityDays(UserPlan userPlan) {
+        if (userPlan.getPaymentPlan() != null && userPlan.getPaymentPlan().getValidityInDays() != null
+                && userPlan.getPaymentPlan().getValidityInDays() > 0) {
+            return userPlan.getPaymentPlan().getValidityInDays();
+        }
+        if (StringUtils.hasText(userPlan.getPlanJson())) {
+            try {
+                var node = new com.fasterxml.jackson.databind.ObjectMapper().readTree(userPlan.getPlanJson());
+                var v = node.get("validityInDays");
+                if (v == null) {
+                    v = node.get("validity_in_days");
+                }
+                if (v != null && v.asInt() > 0) {
+                    return v.asInt();
+                }
+            } catch (Exception e) {
+                log.debug("Could not read validityInDays from plan_json for UserPlan: {}", userPlan.getId());
+            }
+        }
+        log.warn("No validity_in_days resolvable for UserPlan: {} — defaulting to 30 days", userPlan.getId());
+        return 30;
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/EwayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/EwayPaymentManager.java
@@ -127,6 +127,29 @@ public class EwayPaymentManager implements PaymentServiceStrategy {
     // Public Methods specific to EwayPaymentManager
     // ===================================================================================
 
+    /**
+     * Off-session recurring charge for eWay. The saved TokenCustomerID is
+     * charged with {@code TransactionType="Recurring"} and NO CVN — eWay allows
+     * unattended stored-card recurring charges without CVN (a manual renewal
+     * would supply one; the scheduler cannot). Delegates to the existing
+     * {@link #chargeToken} path. The mandate's {@code max_amount} is enforced
+     * app-side before hitting eWay (eWay card-on-file has no native limit).
+     */
+    @Override
+    public PaymentResponseDTO chargeRecurring(vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo mandate,
+                                              PaymentInitiationRequestDTO request,
+                                              Map<String, Object> paymentGatewaySpecificData) {
+        if (mandate == null || !StringUtils.hasText(mandate.getCustomerId())) {
+            throw new VacademyException("eWay recurring charge requires a saved TokenCustomerID mandate");
+        }
+        if (mandate.getMaxAmount() != null && request.getAmount() > mandate.getMaxAmount()) {
+            throw new VacademyException("eWay recurring amount " + request.getAmount()
+                    + " exceeds mandate max_amount " + mandate.getMaxAmount());
+        }
+        LOGGER.info("eWay recurring charge: tokenCustomerId={}, amount={}", mandate.getCustomerId(), request.getAmount());
+        return chargeToken(mandate.getCustomerId(), request.getAmount(), null, paymentGatewaySpecificData);
+    }
+
     public PaymentResponseDTO chargeToken(String tokenCustomerId, double amount, String cvn, Map<String, Object> paymentGatewaySpecificData) {
         EwayApiResponseDTO.Transaction transaction = createTokenTransactionPayload(
                 tokenCustomerId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/PaymentServiceStrategy.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/PaymentServiceStrategy.java
@@ -1,5 +1,6 @@
 package vacademy.io.admin_core_service.features.payments.manager;
 
+import vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.payment.dto.PaymentInitiationRequestDTO;
 import vacademy.io.common.payment.dto.PaymentResponseDTO;
@@ -17,4 +18,33 @@ public interface PaymentServiceStrategy {
             Map<String, Object> paymentGatewaySpecificData);
 
     Map<String, Object> findCustomerByEmail(String email, Map<String, Object> paymentGatewaySpecificData);
+
+    // ── Recurring / mandate (autopay) ──────────────────────────────────────
+    // Default implementations keep every existing manager compiling and behaving
+    // exactly as today. A gateway opts into autopay by overriding these.
+
+    /**
+     * First payment that also registers a recurring mandate (UPI Autopay / card
+     * e-mandate / card-on-file token). Default: behave like a normal one-time
+     * payment (no mandate) — correct for gateways whose normal flow already
+     * tokenizes (e.g. eWay creates a TokenCustomer during initiatePayment).
+     * Gateways needing extra registration params (Razorpay token block, Stripe
+     * SetupIntent) override this.
+     */
+    default PaymentResponseDTO initiateMandatePayment(UserDTO user, PaymentInitiationRequestDTO request,
+            Map<String, Object> paymentGatewaySpecificData) {
+        return initiatePayment(user, request, paymentGatewaySpecificData);
+    }
+
+    /**
+     * Off-session recurring charge against a previously registered mandate.
+     * {@code request.amount} is the amount to charge (already validated against
+     * {@code mandate.maxAmount} by the caller / the implementation). Default:
+     * unsupported — a gateway without autopay simply never has plans flagged
+     * auto_renewal_enabled, so this is never reached for it.
+     */
+    default PaymentResponseDTO chargeRecurring(MandateInfo mandate, PaymentInitiationRequestDTO request,
+            Map<String, Object> paymentGatewaySpecificData) {
+        throw new UnsupportedOperationException("Recurring charge not supported for this payment gateway");
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
@@ -2,6 +2,7 @@ package vacademy.io.admin_core_service.features.payments.manager;
 
 import com.razorpay.Customer;
 import com.razorpay.Order;
+import com.razorpay.Payment;
 import com.razorpay.PaymentLink;
 import com.razorpay.RazorpayClient;
 import com.razorpay.RazorpayException;
@@ -9,6 +10,7 @@ import org.json.JSONObject;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.payments.dto.RazorpayCustomerDTO;
+import vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.exceptions.VacademyException;
 import vacademy.io.common.logging.SentryLogger;
@@ -106,6 +108,132 @@ public class RazorpayPaymentManager implements PaymentServiceStrategy {
                     "operation", "findCustomerByEmail"
             ));
             return null;
+        }
+    }
+
+    // ── Recurring / mandate (autopay) ──────────────────────────────────────
+
+    /**
+     * First payment that also registers a UPI-Autopay / card e-mandate. Same as
+     * a normal order but attaches the customer and a {@code token} block
+     * carrying the app-computed {@code max_amount} (in paise) and frequency, so
+     * Razorpay authenticates a mandate (not just a saved card). The frontend
+     * must open Checkout with {@code recurring: 1} + this {@code customer_id};
+     * the confirmed {@code token_id} arrives on the webhook and is persisted as
+     * the mandate. Requires {@code request.razorpayRequest.customerId}.
+     */
+    @Override
+    public PaymentResponseDTO initiateMandatePayment(UserDTO user, PaymentInitiationRequestDTO request,
+            Map<String, Object> paymentGatewaySpecificData) {
+        try {
+            validateRequest(request);
+            RazorpayRequestDTO rr = request.getRazorpayRequest();
+            if (rr == null || !StringUtils.hasText(rr.getCustomerId())) {
+                throw new VacademyException("Razorpay mandate registration requires a customerId");
+            }
+            RazorpayClient razorpayClient = createRazorpayClient(paymentGatewaySpecificData);
+            long amountInPaise = CurrencyRegistry.toMinorUnits(request.getAmount(), request.getCurrency());
+            long maxAmountPaise = rr.getMandateMaxAmount() != null
+                    ? CurrencyRegistry.toMinorUnits(rr.getMandateMaxAmount(), request.getCurrency())
+                    : amountInPaise;
+
+            JSONObject orderRequest = new JSONObject();
+            orderRequest.put("amount", amountInPaise);
+            orderRequest.put("currency", request.getCurrency().toUpperCase());
+            orderRequest.put("receipt", request.getOrderId());
+            orderRequest.put("customer_id", rr.getCustomerId());
+            orderRequest.put("payment_capture", 1);
+
+            JSONObject token = new JSONObject();
+            token.put("max_amount", maxAmountPaise);
+            token.put("frequency", StringUtils.hasText(rr.getMandateFrequency())
+                    ? rr.getMandateFrequency() : "as_presented");
+            orderRequest.put("token", token);
+
+            JSONObject notes = new JSONObject();
+            notes.put("orderId", request.getOrderId());
+            notes.put("instituteId", request.getInstituteId());
+            notes.put("payment_type", request.getPaymentType() != null
+                    ? request.getPaymentType().name() : PaymentType.INITIAL.name());
+            orderRequest.put("notes", notes);
+
+            Order order = razorpayClient.orders.create(orderRequest);
+            PaymentResponseDTO dto = buildPaymentResponseFromOrder(order, request, paymentGatewaySpecificData);
+            // Signal the frontend to run Checkout in recurring/mandate mode.
+            dto.getResponseData().put("recurring", 1);
+            dto.getResponseData().put("customerId", rr.getCustomerId());
+            dto.getResponseData().put("mandateMaxAmount", maxAmountPaise);
+            return dto;
+        } catch (RazorpayException e) {
+            throw new VacademyException("Error initiating Razorpay mandate payment: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Off-session recurring charge against a registered Razorpay mandate token.
+     * Creates a fresh order for the renewal amount then submits a recurring
+     * payment on the stored token. Capture confirmation still arrives via the
+     * RENEWAL webhook. {@code max_amount} is enforced app-side first.
+     */
+    @Override
+    public PaymentResponseDTO chargeRecurring(MandateInfo mandate, PaymentInitiationRequestDTO request,
+            Map<String, Object> paymentGatewaySpecificData) {
+        if (mandate == null || !StringUtils.hasText(mandate.getProviderRef())
+                || !StringUtils.hasText(mandate.getCustomerId())) {
+            throw new VacademyException("Razorpay recurring charge requires a customerId + token mandate");
+        }
+        if (mandate.getMaxAmount() != null && request.getAmount() > mandate.getMaxAmount()) {
+            throw new VacademyException("Razorpay recurring amount " + request.getAmount()
+                    + " exceeds mandate max_amount " + mandate.getMaxAmount());
+        }
+        try {
+            RazorpayClient razorpayClient = createRazorpayClient(paymentGatewaySpecificData);
+            long amountInPaise = CurrencyRegistry.toMinorUnits(request.getAmount(), request.getCurrency());
+
+            JSONObject orderRequest = new JSONObject();
+            orderRequest.put("amount", amountInPaise);
+            orderRequest.put("currency", request.getCurrency().toUpperCase());
+            orderRequest.put("receipt", request.getOrderId());
+            orderRequest.put("payment_capture", 1);
+            JSONObject notes = new JSONObject();
+            notes.put("orderId", request.getOrderId());
+            notes.put("instituteId", request.getInstituteId());
+            notes.put("payment_type", PaymentType.RENEWAL.name());
+            orderRequest.put("notes", notes);
+            Order order = razorpayClient.orders.create(orderRequest);
+
+            JSONObject rec = new JSONObject();
+            rec.put("email", request.getEmail());
+            if (StringUtils.hasText(request.getVendorId())) {
+                rec.put("contact", request.getVendorId());
+            }
+            rec.put("amount", amountInPaise);
+            rec.put("currency", request.getCurrency().toUpperCase());
+            rec.put("order_id", order.get("id").toString());
+            rec.put("customer_id", mandate.getCustomerId());
+            rec.put("token", mandate.getProviderRef());
+            rec.put("recurring", "1");
+            rec.put("notes", notes);
+
+            Payment payment = razorpayClient.payments.createRecurringPayment(rec);
+
+            Map<String, Object> responseData = new HashMap<>();
+            responseData.put("razorpayOrderId", order.get("id"));
+            responseData.put("razorpayPaymentId", payment.has("id") ? payment.get("id") : null);
+            String status = payment.has("status") && payment.get("status") != null
+                    ? payment.get("status").toString() : "created";
+            responseData.put("status", status);
+            PaymentStatusEnum paymentStatus = ("captured".equalsIgnoreCase(status) || "authorized".equalsIgnoreCase(status))
+                    ? PaymentStatusEnum.PAID : PaymentStatusEnum.PAYMENT_PENDING;
+            responseData.put("paymentStatus", paymentStatus.name());
+
+            PaymentResponseDTO dto = new PaymentResponseDTO();
+            dto.setResponseData(responseData);
+            dto.setOrderId(request.getOrderId());
+            dto.setMessage("Recurring payment submitted");
+            return dto;
+        } catch (RazorpayException e) {
+            throw new VacademyException("Error charging Razorpay recurring payment: " + e.getMessage());
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/PaymentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/PaymentService.java
@@ -193,6 +193,54 @@ public class PaymentService {
         }
 
         /**
+         * First payment for an autopay/trial enrollment: registers a recurring
+         * mandate (UPI Autopay / card e-mandate) via the gateway's
+         * {@code initiateMandatePayment} instead of a plain charge. Reuses the same
+         * PaymentLog + customer plumbing as {@link #handlePayment}; the returned
+         * response carries the recurring-checkout flags (e.g. Razorpay
+         * {@code recurring:1} + {@code customerId}) for the frontend. The mandate
+         * token is persisted from the webhook. For a trial pass a minimal auth
+         * {@code request.amount}; for immediate-charge autopay pass the plan price.
+         */
+        public PaymentResponseDTO handleMandatePayment(UserDTO user,
+                        String instituteId,
+                        EnrollInvite enrollInvite,
+                        UserPlan userPlan,
+                        PaymentInitiationRequestDTO request) {
+
+                String paymentLogId = createPaymentLogHelper(
+                                user.getId(),
+                                request.getAmount(),
+                                enrollInvite.getVendor(),
+                                enrollInvite.getVendorId(),
+                                enrollInvite.getCurrency(),
+                                userPlan,
+                                request.getOrderId());
+                if (!StringUtils.hasText(request.getOrderId())) {
+                        request.setOrderId(paymentLogId);
+                }
+
+                UserInstitutePaymentGatewayMapping gatewayMapping = createOrGetCustomer(
+                                instituteId, user, enrollInvite.getVendor(), request);
+                paymentGatewaySpecificPaymentDetailService.configureCustomerPaymentData(
+                                gatewayMapping, enrollInvite.getVendor(), request);
+
+                userPlan.setJsonPaymentDetails(JsonUtil.toJson(gatewayMapping));
+                userPlanService.save(userPlan);
+
+                Map<String, Object> paymentGatewaySpecificData = institutePaymentGatewayMappingService
+                                .findInstitutePaymentGatewaySpecifData(enrollInvite.getVendor(), instituteId);
+                PaymentServiceStrategy strategy = paymentServiceFactory
+                                .getStrategy(PaymentGateway.fromString(enrollInvite.getVendor()));
+                request.setInstituteId(instituteId);
+
+                PaymentResponseDTO response = strategy.initiateMandatePayment(user, request, paymentGatewaySpecificData);
+                updatePaymentLogHelper(paymentLogId, response, request);
+                response.setOrderId(paymentLogId);
+                return response;
+        }
+
+        /**
          * Handles payment log creation without initiating gateway call.
          * Used for multi-package enrollments where one payment covers multiple plans.
          */
@@ -441,6 +489,46 @@ public class PaymentService {
                 // Update payment log with response
                 updatePaymentLogHelper(paymentLogId, response, request);
 
+                return response;
+        }
+
+        /**
+         * Off-session recurring charge against a registered mandate (autopay
+         * renewal). Reuses the same PaymentLog + gateway-credential plumbing as a
+         * normal payment, but dispatches to the strategy's {@code chargeRecurring}
+         * with the stored mandate instead of an interactive checkout. Confirmation
+         * for webhook gateways still arrives via the RENEWAL webhook; for
+         * synchronous gateways (eWay) the returned status is authoritative.
+         *
+         * @return the PaymentResponseDTO; its orderId is the new RENEWAL PaymentLog id.
+         */
+        public PaymentResponseDTO handleRecurringCharge(UserDTO user,
+                        String instituteId,
+                        String vendor,
+                        PaymentInitiationRequestDTO request,
+                        UserPlan userPlan,
+                        vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo mandate) {
+
+                String paymentLogId = createPaymentLogHelper(
+                                user.getId(),
+                                request.getAmount(),
+                                vendor,
+                                request.getVendorId(),
+                                request.getCurrency(),
+                                userPlan,
+                                request.getOrderId());
+                request.setOrderId(paymentLogId);
+                request.setInstituteId(instituteId);
+
+                Map<String, Object> paymentGatewaySpecificData = institutePaymentGatewayMappingService
+                                .findInstitutePaymentGatewaySpecifData(vendor, instituteId);
+                PaymentServiceStrategy strategy = paymentServiceFactory
+                                .getStrategy(PaymentGateway.fromString(vendor));
+
+                PaymentResponseDTO response = strategy.chargeRecurring(mandate, request, paymentGatewaySpecificData);
+
+                updatePaymentLogHelper(paymentLogId, response, request);
+                response.setOrderId(paymentLogId);
                 return response;
         }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/RazorpayWebHookService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/service/RazorpayWebHookService.java
@@ -720,6 +720,12 @@ public class RazorpayWebHookService {
             log.info("Successfully saved Razorpay payment method for user: {} " +
                     "with token: {}", userId, tokenId);
 
+            // Step 6: Record a per-plan recurring mandate so RenewalChargeService
+            // can charge this token off-session (keyed by userPlanId). Only the
+            // plan flagged auto_renewal_enabled is ever charged, so persisting the
+            // mandate here is safe for any token capture.
+            persistRazorpayMandate(orderId, userId, instituteId, tokenId, customerId);
+
         } catch (Exception e) {
             // Don't fail the webhook if token save fails
             // Payment is already successful, token storage is just for future use
@@ -742,6 +748,36 @@ public class RazorpayWebHookService {
      * @param orderId Payment log order ID
      * @return User ID or null if not found
      */
+    /**
+     * Persist a per-plan recurring mandate from a captured Razorpay token so the
+     * auto-charge scheduler can debit it off-session. Keyed by the plan behind
+     * this payment log. Best-effort — never fails the webhook.
+     */
+    private void persistRazorpayMandate(String orderId, String userId, String instituteId,
+            String tokenId, String customerId) {
+        try {
+            Optional<PaymentLog> plOpt = paymentLogRepository.findById(orderId);
+            if (plOpt.isEmpty() || plOpt.get().getUserPlan() == null) {
+                log.debug("No user plan for orderId {} — skipping mandate persist", orderId);
+                return;
+            }
+            String userPlanId = plOpt.get().getUserPlan().getId();
+            vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo mandate =
+                    vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo.builder()
+                            .vendor(PaymentGateway.RAZORPAY.name())
+                            .customerId(customerId)
+                            .providerRef(tokenId)
+                            .frequency("as_presented")
+                            .status(vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo.STATUS_ACTIVE)
+                            .build();
+            userInstitutePaymentGatewayMappingService.upsertMandate(
+                    userId, instituteId, PaymentGateway.RAZORPAY.name(), userPlanId, mandate);
+            log.info("Persisted Razorpay mandate for plan {} (token {})", userPlanId, tokenId);
+        } catch (Exception e) {
+            log.error("Failed to persist Razorpay mandate for orderId {}: {}", orderId, e.getMessage());
+        }
+    }
+
     private String getUserIdFromPaymentLog(String orderId) {
         try {
             Optional<PaymentLog> paymentLogOptional = paymentLogRepository.findById(orderId);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/controller/SubscriptionController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/controller/SubscriptionController.java
@@ -1,0 +1,44 @@
+package vacademy.io.admin_core_service.features.user_subscription.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.user_subscription.dto.SubscriptionDTO;
+import vacademy.io.admin_core_service.features.user_subscription.service.SubscriptionService;
+import vacademy.io.common.auth.model.CustomUserDetails;
+
+import java.util.List;
+
+/**
+ * Learner self-service for subscriptions + autopay mandates. User id always
+ * comes from the JWT, never the request. Drives the course-details cancel
+ * button, the profile remove-mandate row, and the student-view cancel flow.
+ */
+@RestController
+@RequestMapping("/admin-core-service/learner/subscription/v1")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    /** List the learner's subscriptions (with autopay/mandate status). */
+    @GetMapping
+    public ResponseEntity<List<SubscriptionDTO>> list(
+            @RequestAttribute("user") CustomUserDetails user,
+            @RequestParam String instituteId) {
+        return ResponseEntity.ok(subscriptionService.listSubscriptions(user.getUserId(), instituteId));
+    }
+
+    /**
+     * Cancel autopay for one subscription. Revokes the mandate and stops future
+     * charges; access is retained until end_date.
+     */
+    @PostMapping("/{userPlanId}/cancel")
+    public ResponseEntity<SubscriptionDTO> cancel(
+            @RequestAttribute("user") CustomUserDetails user,
+            @RequestParam String instituteId,
+            @PathVariable String userPlanId) {
+        return ResponseEntity.ok(
+                subscriptionService.cancelSubscription(user.getUserId(), instituteId, userPlanId));
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/MandateInfo.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/MandateInfo.java
@@ -1,0 +1,36 @@
+package vacademy.io.admin_core_service.features.user_subscription.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A single recurring-payment mandate, stored (keyed by userPlanId) inside
+ * user_institute_payment_gateway_mapping.payment_gateway_customer_data JSON —
+ * NOT a table. Provider-agnostic: {@code providerRef} is the token that gets
+ * charged off-session (Razorpay token_id, eWay TokenCustomerID, Stripe
+ * payment_method id, …). {@code maxAmount} is enforced app-side before every
+ * recurring charge (some providers have no native limit).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MandateInfo {
+
+    /** Mandate lifecycle: PENDING | ACTIVE | PAUSED | REVOKED | FAILED. */
+    public static final String STATUS_PENDING = "PENDING";
+    public static final String STATUS_ACTIVE = "ACTIVE";
+    public static final String STATUS_REVOKED = "REVOKED";
+    public static final String STATUS_FAILED = "FAILED";
+
+    private String vendor;            // RAZORPAY | EWAY | STRIPE | ...
+    private String customerId;        // provider customer id (cus_…, TokenCustomerID, …)
+    private String providerRef;       // the chargeable token / mandate reference
+    private Double maxAmount;         // app-enforced cap (derived from plan amount)
+    private String currency;
+    private String frequency;         // as_presented | monthly | ...
+    private String status;
+    private String updatedAt;         // ISO-8601
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/SubscriptionDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/SubscriptionDTO.java
@@ -1,0 +1,42 @@
+package vacademy.io.admin_core_service.features.user_subscription.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Learner-facing view of one subscription (a UserPlan) and its autopay mandate.
+ * Powers the course-details "cancel subscription" button, the profile
+ * billing/remove-mandate row, and the student-view cancellation flow.
+ *
+ * Serialized snake_case to match the learner app's other payment endpoints
+ * (e.g. LearnerPaymentMethodSummaryDTO): user_plan_id, has_active_mandate, ...
+ */
+@Data
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SubscriptionDTO {
+    private String userPlanId;
+    private String planName;
+    private String status;           // ACTIVE | CANCELED | EXPIRED | ...
+    private Date endDate;            // access valid until this date
+    private Date nextChargeAt;
+    private Boolean autoRenewalEnabled;
+    private Boolean isTrial;
+
+    // Mandate (null if the plan has no registered autopay mandate)
+    private String vendor;           // RAZORPAY | EWAY | ...
+    private String mandateStatus;    // ACTIVE | REVOKED | FAILED | null
+    private Double mandateMaxAmount;
+    private String currency;
+
+    /** True when there is a live (non-revoked) mandate — drives "show cancel". */
+    private boolean hasActiveMandate;
+
+    /** Package sessions (courses) this subscription grants — for per-course UI. */
+    private List<String> packageSessionIds;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/UserPlan.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/UserPlan.java
@@ -108,4 +108,28 @@ private String id;
 
     @Column(name = "end_date")
     private Date endDate;
+
+    // ── Autopay / recurring-mandate (V367) ────────────────────────────────
+    // The mandate itself (token id, max_amount, status) lives in
+    // user_institute_payment_gateway_mapping.payment_gateway_customer_data
+    // JSON, keyed by this plan's id. These columns only drive the scheduler.
+
+    /** Only plans with this true are picked up by the auto-charge scheduler. */
+    @Column(name = "auto_renewal_enabled")
+    private Boolean autoRenewalEnabled;
+
+    /** Next date the scheduler should attempt a renewal charge (usually = endDate). */
+    @Column(name = "next_charge_at")
+    private Date nextChargeAt;
+
+    /** True while in the free-trial window (access granted, no real charge yet). */
+    @Column(name = "is_trial")
+    private Boolean isTrial;
+
+    /** Dunning: number of renewal charge attempts in the current cycle. */
+    @Column(name = "renewal_attempt_count")
+    private Integer renewalAttemptCount;
+
+    @Column(name = "last_renewal_attempt_at")
+    private Date lastRenewalAttemptAt;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
@@ -241,4 +241,43 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                         String userId,
                         String paymentOptionId,
                         List<String> statuses);
+
+        /**
+         * Auto-charge scheduler due-query (V367 autopay). Returns ACTIVE plans
+         * that have opted into autopay and whose next_charge_at has arrived.
+         * Only plans with auto_renewal_enabled = true are ever selected, so
+         * pre-existing (non-migrated) plans are never auto-charged. EnrollInvite +
+         * PaymentPlan are fetched because the charge step needs the institute_id,
+         * vendor and amount off them.
+         */
+        @Query("""
+                SELECT up FROM UserPlan up
+                LEFT JOIN FETCH up.enrollInvite ei
+                LEFT JOIN FETCH up.paymentPlan pp
+                WHERE up.status = 'ACTIVE'
+                  AND up.autoRenewalEnabled = true
+                  AND up.nextChargeAt IS NOT NULL
+                  AND up.nextChargeAt <= :now
+                """)
+        List<UserPlan> findDueForRenewal(@Param("now") java.util.Date now);
+
+        /**
+         * Atomically CLAIM a plan for a renewal charge (multi-replica safe). The
+         * daily scheduler fires on every replica, so before charging, each replica
+         * runs this — only the one whose UPDATE actually flips next_charge_at→null
+         * (rows-affected = 1) proceeds to charge; the rest see 0 and skip. Also
+         * bumps the attempt counter + timestamp in the same atomic write so the
+         * claim and dunning bookkeeping can't diverge.
+         */
+        @org.springframework.transaction.annotation.Transactional
+        @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true)
+        @Query("""
+                UPDATE UserPlan up
+                   SET up.nextChargeAt = null,
+                       up.renewalAttemptCount = (CASE WHEN up.renewalAttemptCount IS NULL
+                                                      THEN 0 ELSE up.renewalAttemptCount END) + 1,
+                       up.lastRenewalAttemptAt = :now
+                 WHERE up.id = :id AND up.nextChargeAt IS NOT NULL
+                """)
+        int claimForRenewal(@Param("id") String id, @Param("now") java.util.Date now);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/SubscriptionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/SubscriptionService.java
@@ -1,0 +1,125 @@
+package vacademy.io.admin_core_service.features.user_subscription.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.common.util.JsonUtil;
+import vacademy.io.admin_core_service.features.institute_learner.entity.StudentSessionInstituteGroupMapping;
+import vacademy.io.admin_core_service.features.institute_learner.enums.LearnerSessionStatusEnum;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
+import vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo;
+import vacademy.io.admin_core_service.features.user_subscription.dto.SubscriptionDTO;
+import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan;
+import vacademy.io.admin_core_service.features.user_subscription.enums.UserPlanStatusEnum;
+import vacademy.io.admin_core_service.features.user_subscription.repository.UserPlanRepository;
+import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.common.payment.dto.PaymentInitiationRequestDTO;
+
+import java.util.List;
+
+/**
+ * Learner self-service for subscriptions + autopay mandates: list the learner's
+ * subscriptions and cancel autopay. Cancelling revokes the mandate and stops
+ * future charges but NEVER cuts access early — the learner keeps access until
+ * end_date (status CANCELED makes the enrolment processor expire exactly at
+ * end_date, no grace). All operations are scoped to the JWT user id.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+    private final UserPlanRepository userPlanRepository;
+    private final UserInstitutePaymentGatewayMappingService mandateService;
+    private final StudentSessionInstituteGroupMappingRepository mappingRepository;
+
+    private static final List<String> VISIBLE_STATUSES = List.of(
+            UserPlanStatusEnum.ACTIVE.name(),
+            UserPlanStatusEnum.CANCELED.name(),
+            UserPlanStatusEnum.PAYMENT_FAILED.name());
+
+    public List<SubscriptionDTO> listSubscriptions(String userId, String instituteId) {
+        List<UserPlan> plans = userPlanRepository.findAllByUserIdAndInstituteIdAndStatusIn(
+                userId, instituteId, VISIBLE_STATUSES);
+        return plans.stream().map(p -> toDto(p, userId, instituteId)).toList();
+    }
+
+    /**
+     * Cancel autopay for a plan. Revokes the mandate, turns off auto-renewal and
+     * marks the plan CANCELED (access continues until end_date). Idempotent.
+     */
+    @Transactional
+    public SubscriptionDTO cancelSubscription(String userId, String instituteId, String userPlanId) {
+        UserPlan plan = userPlanRepository.findById(userPlanId)
+                .orElseThrow(() -> new VacademyException("Subscription not found: " + userPlanId));
+        if (!userId.equals(plan.getUserId())) {
+            throw new VacademyException("Subscription does not belong to the current user");
+        }
+
+        String vendor = resolveVendor(plan);
+        if (StringUtils.hasText(vendor)) {
+            mandateService.revokeMandate(userId, instituteId, vendor, userPlanId);
+        }
+
+        plan.setAutoRenewalEnabled(false);
+        plan.setStatus(UserPlanStatusEnum.CANCELED.name());
+        userPlanRepository.save(plan);
+        log.info("Cancelled autopay for plan {} (user {}); access retained until {}",
+                userPlanId, userId, plan.getEndDate());
+
+        return toDto(plan, userId, instituteId);
+    }
+
+    private SubscriptionDTO toDto(UserPlan plan, String userId, String instituteId) {
+        String vendor = resolveVendor(plan);
+        MandateInfo mandate = StringUtils.hasText(vendor)
+                ? mandateService.getMandate(userId, instituteId, vendor, plan.getId())
+                : null;
+        boolean liveMandate = mandate != null
+                && MandateInfo.STATUS_ACTIVE.equalsIgnoreCase(mandate.getStatus());
+
+        List<String> packageSessionIds = mappingRepository
+                .findByUserPlanIdAndStatus(plan.getId(), LearnerSessionStatusEnum.ACTIVE.name())
+                .stream()
+                .map(StudentSessionInstituteGroupMapping::getPackageSession)
+                .filter(ps -> ps != null)
+                .map(ps -> ps.getId())
+                .distinct()
+                .toList();
+
+        return SubscriptionDTO.builder()
+                .userPlanId(plan.getId())
+                .planName(plan.getPaymentPlan() != null ? plan.getPaymentPlan().getName() : null)
+                .status(plan.getStatus())
+                .endDate(plan.getEndDate())
+                .nextChargeAt(plan.getNextChargeAt())
+                .autoRenewalEnabled(plan.getAutoRenewalEnabled())
+                .isTrial(plan.getIsTrial())
+                .vendor(vendor)
+                .mandateStatus(mandate != null ? mandate.getStatus() : null)
+                .mandateMaxAmount(mandate != null ? mandate.getMaxAmount() : null)
+                .currency(mandate != null ? mandate.getCurrency() : null)
+                .hasActiveMandate(liveMandate)
+                .packageSessionIds(packageSessionIds)
+                .build();
+    }
+
+    private String resolveVendor(UserPlan plan) {
+        if (plan.getEnrollInvite() != null && StringUtils.hasText(plan.getEnrollInvite().getVendor())) {
+            return plan.getEnrollInvite().getVendor();
+        }
+        if (StringUtils.hasText(plan.getJsonPaymentDetails())) {
+            try {
+                PaymentInitiationRequestDTO req = JsonUtil.fromJson(
+                        plan.getJsonPaymentDetails(), PaymentInitiationRequestDTO.class);
+                if (req != null && StringUtils.hasText(req.getVendor())) {
+                    return req.getVendor().toUpperCase();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserInstitutePaymentGatewayMappingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserInstitutePaymentGatewayMappingService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.institute.service.InstitutePaymentGatewayMappingService;
+import vacademy.io.admin_core_service.features.user_subscription.dto.MandateInfo;
 import vacademy.io.admin_core_service.features.user_subscription.entity.UserInstitutePaymentGatewayMapping;
 import vacademy.io.admin_core_service.features.user_subscription.repository.UserInstitutePaymentGatewayMappingRepository;
 
@@ -173,10 +174,128 @@ public class UserInstitutePaymentGatewayMappingService {
         }
     }
 
+    // ── Recurring-payment mandates (stored per userPlanId in the same JSON) ──
+    //
+    // Layout inside payment_gateway_customer_data:
+    //   { "customerId": "...", "mandates": { "<userPlanId>": { ...MandateInfo } } }
+    // Read as a Map (parseCustomerDataJson), so adding this key never breaks the
+    // existing bare-token / saved-card reads.
+
+    private static final String MANDATES_KEY = "mandates";
+
+    /**
+     * Insert or replace the mandate for a given plan. A learner can hold one
+     * mandate per plan in the same institute (multiple paid courses → multiple
+     * mandates), so they are keyed by userPlanId and never overwrite each other.
+     */
+    @Transactional
+    public void upsertMandate(String userId, String instituteId, String vendor,
+                              String userPlanId, MandateInfo mandate) {
+        Optional<UserInstitutePaymentGatewayMapping> mappingOptional =
+                findByUserIdAndInstituteId(userId, instituteId, vendor);
+        if (mappingOptional.isEmpty()) {
+            logger.warn("No payment gateway mapping for user: {}, institute: {}, vendor: {} — cannot save mandate for plan {}",
+                    userId, instituteId, vendor, userPlanId);
+            return;
+        }
+        UserInstitutePaymentGatewayMapping mapping = mappingOptional.get();
+        try {
+            Map<String, Object> customerData = parseCustomerDataJson(mapping.getPaymentGatewayCustomerData());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mandates = (Map<String, Object>) customerData
+                    .computeIfAbsent(MANDATES_KEY, k -> new HashMap<String, Object>());
+            mandate.setUpdatedAt(LocalDateTime.now().toString());
+            mandates.put(userPlanId, objectMapper.convertValue(mandate, Map.class));
+            mapping.setPaymentGatewayCustomerData(objectMapper.writeValueAsString(customerData));
+            userInstitutePaymentGatewayMappingRepository.save(mapping);
+            logger.info("Saved mandate (status={}) for user: {}, plan: {}", mandate.getStatus(), userId, userPlanId);
+        } catch (Exception e) {
+            logger.error("Failed to save mandate for user: {}, plan: {}", userId, userPlanId, e);
+        }
+    }
+
+    /** Returns the mandate for a plan, or null if none / not parseable. */
+    public MandateInfo getMandate(String userId, String instituteId, String vendor, String userPlanId) {
+        Optional<UserInstitutePaymentGatewayMapping> mappingOptional =
+                findByUserIdAndInstituteId(userId, instituteId, vendor);
+        if (mappingOptional.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> customerData = parseCustomerDataJson(mappingOptional.get().getPaymentGatewayCustomerData());
+        Object mandates = customerData.get(MANDATES_KEY);
+        if (!(mandates instanceof Map)) {
+            return null;
+        }
+        Object entry = ((Map<?, ?>) mandates).get(userPlanId);
+        if (entry == null) {
+            return null;
+        }
+        try {
+            return objectMapper.convertValue(entry, MandateInfo.class);
+        } catch (Exception e) {
+            logger.error("Failed to parse mandate for user: {}, plan: {}", userId, userPlanId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Resolve a chargeable mandate for a plan, falling back to a pre-existing
+     * saved token for providers whose stored customer id IS the chargeable token
+     * (eWay TokenCustomerID). This lets existing autopay-enabled eWay customers —
+     * who have a token in the bare payment_gateway_customer_id column but no
+     * per-plan mandate JSON yet — be auto-renewed without a fresh registration.
+     *
+     * For token/e-mandate providers (Razorpay) the bare customer id is NOT
+     * chargeable on its own (a token_id is required), so no fallback is returned;
+     * those must have a real registered mandate.
+     */
+    public MandateInfo getMandateOrLegacyToken(String userId, String instituteId, String vendor, String userPlanId) {
+        MandateInfo mandate = getMandate(userId, instituteId, vendor, userPlanId);
+        if (mandate != null) {
+            return mandate;
+        }
+        // Fallback only for card-on-file providers where customerId == the chargeable token.
+        if (vendor == null || !"EWAY".equalsIgnoreCase(vendor)) {
+            return null;
+        }
+        Optional<UserInstitutePaymentGatewayMapping> mappingOptional =
+                findByUserIdAndInstituteId(userId, instituteId, vendor);
+        if (mappingOptional.isEmpty()) {
+            return null;
+        }
+        String tokenCustomerId = mappingOptional.get().getPaymentGatewayCustomerId();
+        if (tokenCustomerId == null || tokenCustomerId.trim().isEmpty()) {
+            return null;
+        }
+        logger.info("Using legacy eWay TokenCustomerID as mandate for user: {}, plan: {}", userId, userPlanId);
+        return MandateInfo.builder()
+                .vendor(vendor)
+                .customerId(tokenCustomerId)
+                .providerRef(tokenCustomerId)
+                .status(MandateInfo.STATUS_ACTIVE)
+                .build();
+    }
+
+    /**
+     * Mark a plan's mandate as REVOKED (learner cancelled autopay). Does NOT
+     * touch the plan's access window — the caller keeps access until end_date.
+     * No-op if there is no mandate for the plan.
+     */
+    @Transactional
+    public void revokeMandate(String userId, String instituteId, String vendor, String userPlanId) {
+        MandateInfo mandate = getMandate(userId, instituteId, vendor, userPlanId);
+        if (mandate == null) {
+            logger.info("No mandate to revoke for user: {}, plan: {}", userId, userPlanId);
+            return;
+        }
+        mandate.setStatus(MandateInfo.STATUS_REVOKED);
+        upsertMandate(userId, instituteId, vendor, userPlanId, mandate);
+    }
+
     /**
      * Helper method to parse customer data JSON string into a Map.
      * Returns empty map if JSON is null, empty, or invalid.
-     * 
+     *
      * @param customerDataJson JSON string
      * @return Map representation of JSON
      */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserPlanService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserPlanService.java
@@ -133,6 +133,79 @@ public class UserPlanService {
                 paymentOption, paymentInitiationRequestDTO, status, null, null, null);
     }
 
+    /**
+     * Overlays autopay / free-trial state onto a freshly created subscription
+     * UserPlan (P3). Call this right after createUserPlan for paid subscription
+     * enrollments when autopay is enabled. Safe no-op when autopay is off, so it
+     * can be called unconditionally.
+     *
+     * <ul>
+     *   <li>Marks the plan for the auto-charge scheduler (auto_renewal_enabled).</li>
+     *   <li>Trial (trialDays &gt; 0): access now, NO first charge; end_date and
+     *       next_charge_at = now + trialDays. The FIRST real debit happens on
+     *       the trial-end date via RenewalChargeService.</li>
+     *   <li>No trial: next_charge_at = end_date (already set to start+validity by
+     *       createUserPlan), so the first renewal fires at the end of cycle 1.</li>
+     * </ul>
+     *
+     * The mandate itself is registered by the payment step (initiateMandatePayment
+     * / the gateway checkout) and persisted from the webhook — this method only
+     * sets the plan's scheduler state.
+     */
+    /**
+     * Reads the invite's AUTOPAY_SETTING (setting_json.setting.AUTOPAY_SETTING)
+     * and, for a SUBSCRIPTION plan, applies autopay + trial. Central hook so
+     * every enrollment entry point (school, direct, product page, applicant,
+     * bulk, learner-request) gets consistent autopay behaviour via createUserPlan.
+     */
+    private void applyAutopayFromInvite(UserPlan userPlan, EnrollInvite enrollInvite, PaymentOption paymentOption) {
+        if (userPlan == null || enrollInvite == null || paymentOption == null) {
+            return;
+        }
+        if (!vacademy.io.admin_core_service.features.user_subscription.enums.PaymentOptionType.SUBSCRIPTION
+                .name().equalsIgnoreCase(paymentOption.getType())) {
+            return;
+        }
+        String settingJson = enrollInvite.getSettingJson();
+        if (settingJson == null || settingJson.isBlank()) {
+            return;
+        }
+        try {
+            com.fasterxml.jackson.databind.JsonNode ap = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readTree(settingJson).path("setting").path("AUTOPAY_SETTING");
+            if (ap.path("ENABLED").asBoolean(false)) {
+                Integer trialDays = ap.has("TRIAL_DAYS") ? ap.get("TRIAL_DAYS").asInt(0) : null;
+                applyAutopaySetup(userPlan, true, trialDays);
+            }
+        } catch (Exception e) {
+            logger.warn("Could not apply autopay for plan {}: {}", userPlan.getId(), e.getMessage());
+        }
+    }
+
+    @Transactional
+    public void applyAutopaySetup(UserPlan userPlan, boolean autopayEnabled, Integer trialDays) {
+        if (userPlan == null || !autopayEnabled) {
+            return;
+        }
+        userPlan.setAutoRenewalEnabled(true);
+
+        if (trialDays != null && trialDays > 0) {
+            java.util.Calendar c = java.util.Calendar.getInstance();
+            c.add(java.util.Calendar.DAY_OF_MONTH, trialDays);
+            java.util.Date trialEnd = new java.sql.Timestamp(c.getTimeInMillis());
+            userPlan.setIsTrial(true);
+            userPlan.setEndDate(trialEnd);
+            userPlan.setNextChargeAt(trialEnd);
+        } else {
+            userPlan.setIsTrial(false);
+            userPlan.setNextChargeAt(userPlan.getEndDate());
+        }
+        userPlan.setRenewalAttemptCount(0);
+        userPlanRepository.save(userPlan);
+        logger.info("Autopay set on UserPlan {} (trialDays={}, nextChargeAt={})",
+                userPlan.getId(), trialDays, userPlan.getNextChargeAt());
+    }
+
     @Transactional
     public UserPlan createUserPlan(String userId,
             PaymentPlan paymentPlan,
@@ -270,6 +343,10 @@ public class UserPlanService {
         logger.debug("Saving UserPlan with details: {}", userPlan);
         UserPlan saved = userPlanRepository.save(userPlan);
         logger.info("UserPlan created with ID={}", saved.getId());
+
+        // Autopay (centralized for ALL enrollment entry points): SUBSCRIPTION plans
+        // whose invite enabled AUTOPAY_SETTING opt into auto-renewal + free trial.
+        applyAutopayFromInvite(saved, enrollInvite, paymentOption);
 
         // If a prior plan was detected and we stacked onto it, this is a
         // re-enrolment — fire the LEARNER_RE_ENROLLMENT trigger so the admin

--- a/admin_core_service/src/main/resources/db/migration/V367__user_plan_autopay_columns.sql
+++ b/admin_core_service/src/main/resources/db/migration/V367__user_plan_autopay_columns.sql
@@ -1,0 +1,32 @@
+-- Autopay / recurring-mandate support on user_plan.
+--
+-- These columns drive the auto-charge scheduler (RenewalChargeScheduler / the
+-- emitRenewalCharges pass on PackageSessionScheduler). They are ADDITIVE and
+-- default OFF, so every pre-existing plan keeps its current behaviour: the
+-- scheduler only picks up plans where auto_renewal_enabled = true, which is
+-- set only on new mandate enrollments (or a deliberate one-time backfill for
+-- existing eWay token customers). No column here holds the mandate itself —
+-- the mandate (token id, max_amount, status) lives in
+-- user_institute_payment_gateway_mapping.payment_gateway_customer_data JSON,
+-- keyed per user_plan id.
+
+ALTER TABLE user_plan ADD COLUMN IF NOT EXISTS auto_renewal_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Next date the scheduler should attempt a renewal charge. Usually mirrors
+-- end_date; kept explicit so trial (charge at trial-end) and renewal are
+-- handled uniformly, and so a failed attempt can be re-spaced without moving
+-- end_date.
+ALTER TABLE user_plan ADD COLUMN IF NOT EXISTS next_charge_at TIMESTAMP;
+
+-- True while the plan is in its free-trial window (access granted, no real
+-- charge yet; first debit happens on next_charge_at = trial-end).
+ALTER TABLE user_plan ADD COLUMN IF NOT EXISTS is_trial BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Dunning bookkeeping for the current billing cycle.
+ALTER TABLE user_plan ADD COLUMN IF NOT EXISTS renewal_attempt_count INT NOT NULL DEFAULT 0;
+ALTER TABLE user_plan ADD COLUMN IF NOT EXISTS last_renewal_attempt_at TIMESTAMP;
+
+-- Partial index for the scheduler's due-query (only autopay-enabled plans).
+CREATE INDEX IF NOT EXISTS idx_user_plan_due_for_renewal
+    ON user_plan (next_charge_at)
+    WHERE auto_renewal_enabled = TRUE;

--- a/common_service/src/main/java/vacademy/io/common/payment/dto/RazorpayRequestDTO.java
+++ b/common_service/src/main/java/vacademy/io/common/payment/dto/RazorpayRequestDTO.java
@@ -17,4 +17,9 @@ public class RazorpayRequestDTO {
     private String razorpayPaymentId;
     private String razorpayOrderId;
     private String razorpaySignature;
+
+    // Autopay / e-mandate registration (major units; converted to paise server-side).
+    // If null, the mandate max_amount defaults to the charge amount.
+    private Double mandateMaxAmount;
+    private String mandateFrequency;   // as_presented | monthly | ...
 }

--- a/docs/razorpay-mandate-recurring-plan.md
+++ b/docs/razorpay-mandate-recurring-plan.md
@@ -1,0 +1,297 @@
+# Recurring Payments via UPI / Card Mandate (Razorpay first)
+
+**Status:** Proposed | **Date:** 2026-07-08
+**Scope:** admin_core_service — add true UPI Autopay / card e-mandate recurring payments, per-plan
+autopay + free-trial settings on invite links, and an auto-charge scheduler with grace-period dunning.
+Razorpay first; other providers follow the same abstraction.
+
+## Context
+
+We want learners on **paid subscription plans** to be auto-charged on renewal without re-entering
+card/UPI details — i.e. true **UPI Autopay / card e-mandate**. The mandate's max
+debit amount (`max_amount`) is **derived from the payment plan amount** (the recurring charge), not a
+separate institute-level limit. Paid plans attached to an invite link need
+per-plan settings for **autopay** and a **free-trial** (e.g. 14 days: give access now, take *no*
+money, set the plan's next expiry to `today + trialDays`, and take the **first** real debit on that
+trial-end date). When a plan's `end_date` reaches "today", a scheduler must debit the renewal via
+the stored mandate; on failure it retries over a grace window before expiring access.
+
+### What already exists (verified in code)
+- **Provider strategy**: `PaymentServiceFactory` / `PaymentServiceStrategy` with Razorpay, Stripe,
+  PhonePe, Cashfree, eWay managers. Institute creds in `institute_payment_gateway_mapping.payment_gateway_specific_data` (JSON).
+- **Per-user token store**: `user_institute_payment_gateway_mapping` (`payment_gateway_customer_id`,
+  `payment_gateway_customer_data` JSON).
+- **Token capture**: `RazorpayWebHookService` (lines ~662–727) already pulls `token_id` from the
+  `payment.captured` webhook and saves it into the user mapping JSON.
+- **Renewal webhook routing**: webhook detects `payment_type=RENEWAL` (line ~254) →
+  `handleRenewalPayment` → `RenewalPaymentService.handleRenewalPaymentConfirmation` (extends `end_date`).
+- **Renewal eligibility gate**: `PaymentRenewalCheckService.shouldAttemptPayment` (SUBSCRIPTION type +
+  `enableAutoRenewal` policy flag + non-MANUAL vendor).
+- **Enrollment policy**: `onExpiry.enableAutoRenewal` already in `EnrollmentPolicySettingsDTO`.
+- **Reminder scheduler**: `PackageSessionScheduler.emitMembershipExpiryReminders` (daily 09:00) — fires
+  a `MEMBERSHIP_EXPIRY` workflow reminder 7 days out. **Reminder only; it never charges.**
+
+### The real gaps (this is the actual work)
+1. **No mandate is registered.** `RazorpayPaymentManager.createRazorpayOrder` sets only amount/currency/
+   receipt/notes — no `customer_id`, no `token: {max_amount, frequency, expire_at}`, no `recurring`
+   flag. So today's captured `token_id` is a saved-card token, **not** an authenticated UPI-Autopay /
+   card e-mandate. Registering the mandate (with a limit) is the core new work.
+2. **No charge is ever initiated.** There is no `createRecurring` / MRN charge call anywhere;
+   `RenewalPaymentService` only *reacts* to a webhook. Nothing debits on the due date.
+3. **No trial** concept anywhere.
+4. **No mandate `max_amount`** is set (it must be derived from the payment plan amount).
+5. **No per-plan autopay/trial settings** on the invite.
+6. **`RenewalPaymentService.calculateNewEndDate` is hardcoded to 30 days** (TODO) — must derive from
+   `payment_plan.validity_in_days`; notification bodies are stubbed TODOs.
+
+### Design decisions (confirmed with user)
+- **App-driven e-mandate/token model** (not Razorpay Subscriptions API) — we register the mandate and
+  our scheduler triggers each charge. Keeps control of date/trial/dunning and unifies across providers.
+- **Trial**: register mandate at signup (₹0/auth), take no real payment, `end_date = today + trialDays`,
+  first real debit on trial-end date.
+- **Mandate `max_amount`**: derived from the payment plan amount (the recurring charge). For fixed-price
+  plans `max_amount = plan recurring amount`; a small buffer multiple may be applied so price changes /
+  taxes don't exceed the mandate. No separate institute-level limit config.
+- **Storage**: no new mandate table — mandate details live in the existing
+  `user_institute_payment_gateway_mapping.payment_gateway_customer_data` JSON, keyed per `userPlanId`
+  (one mandate per paid plan). Only a small `user_plan` migration for scheduler state.
+- **Failed renewal**: retry across a short grace window (≈3 attempts / 3–5 days) with notifications,
+  then expire access.
+
+---
+
+## Subscription lifecycle (autopay is the *mechanism*, not a separate flow)
+
+"Autopay" is not a different feature from subscription renewal — it is how the renewal payment is
+collected (auto-debit a saved mandate/token) instead of the learner manually paying a link. The lifecycle
+is identical either way; only the payment trigger differs.
+
+| Event | Access | Plan state |
+|---|---|---|
+| Renewal charge **succeeds** (auto or manual) | continues | `end_date` / `next_charge_at` extended by `validity_in_days` |
+| Charge **fails** on due date | **unchanged — kept until `end_date`** | enter grace window; retry (autopay) or await manual pay |
+| Mandate **cancelled/revoked mid-cycle** | **unchanged — kept until `end_date`** | mandate marked `REVOKED`; no auto-charge at expiry → falls into grace→revoke (or manual-pay prompt) |
+| Payment **received during grace** | continues | plan extended |
+| Grace window **elapses unpaid** | **revoked** | plan `EXPIRED` + `StudentSessionInstituteGroupMapping` deactivated |
+
+Key rule: **a failed or cancelled mandate never cuts access early.** The learner always keeps what they
+already paid for through `end_date`; only *after* expiry + grace with no payment is access revoked. This
+is why the mandate lives independently of the plan's active window — cancelling autopay ≠ cancelling the
+current subscription.
+
+Mandate-cancellation is captured from provider webhooks (Razorpay `subscription/token` cancelled events,
+Stripe `payment_method.detached` / mandate updates, etc.): set the mandate JSON `status=REVOKED` and clear
+`auto_renewal_enabled` so the scheduler stops trying — **without** modifying `end_date` or access.
+
+## Implementation
+
+Phased; each phase is independently shippable. **Razorpay is Phase 1–5; other providers are Phase 6.**
+All schema changes go through **Flyway migrations** (never ddl-auto). Latest admin_core migration is
+`V364`; new files continue from `V365`.
+
+### Phase 0 — Data model & config
+
+**No new mandate table.** Mandate details reuse the existing per-user gateway mapping JSON (where the
+token is already captured). Only a small `user_plan` migration is added for scheduler state.
+
+**Migration** (`admin_core_service/src/main/resources/db/migration/`):
+- `V365__user_plan_autopay_columns.sql` — add to `user_plan`:
+  `auto_renewal_enabled boolean default false` (denormalised so the due-query is cheap),
+  `next_charge_at timestamp` (usually = `end_date`; explicit so trial and renewal are handled uniformly),
+  `is_trial boolean default false`,
+  `renewal_attempt_count int default 0`,
+  `last_renewal_attempt_at timestamp`.
+  `max_amount` is **not** a column — it's computed from the payment plan amount at registration and
+  stored in the mandate JSON (below).
+
+**Mandate storage — existing table, no new entity.** Store the mandate in
+`user_institute_payment_gateway_mapping.payment_gateway_customer_data` (JSON), **keyed by `userPlanId`**
+so a learner can hold one mandate per paid plan in the same institute:
+```
+payment_gateway_customer_data = {
+  "customerId": "cus_...",
+  "mandates": { "<userPlanId>": { "tokenId": "token_...", "maxAmount": 4999,
+                                  "currency": "INR", "frequency": "as_presented",
+                                  "status": "ACTIVE", "vendor": "RAZORPAY" } }
+}
+```
+Add helper methods on the existing `UserInstitutePaymentGatewayMappingService`:
+`upsertMandate(userId, instituteGatewayMappingId, userPlanId, mandateJson)` and
+`getMandate(userId, institute, userPlanId)`.
+
+**Entities/repos**:
+- Extend `UserPlan` entity + a mapper for the new columns.
+- Add `UserPlanRepository.findDueForRenewal(now)` (status ACTIVE + `auto_renewal_enabled=true` +
+  `next_charge_at <= now`).
+
+### Phase 1 — Mandate registration on first payment (Razorpay)
+
+Extend the **strategy interface** `PaymentServiceStrategy` with mandate-aware methods (default no-op so
+other managers still compile):
+- `PaymentResponseDTO initiateMandatePayment(user, request, gatewayData)` — first payment that also
+  registers the mandate.
+- `Map<String,Object> chargeRecurring(mandateJson, PaymentInitiationRequestDTO request, gatewayData)` —
+  off-session debit; `mandateJson` = the per-`userPlanId` mandate entry (tokenId, customerId, maxAmount).
+
+**`RazorpayPaymentManager`** (`features/payments/manager/RazorpayPaymentManager.java`):
+- New `createRazorpayMandateOrder(...)`: like `createRazorpayOrder` but adds `customer_id` (create/find
+  via existing `createCustomer`/`findCustomerByEmail`), and a `token` block:
+  `{max_amount: <derived from payment plan amount, in paise>, expire_at, frequency: "as_presented"|"monthly"}`
+  plus `payment_capture=1`. The checkout is invoked by the frontend with `recurring: 1` + `customer_id`.
+- New `chargeRecurring(...)`: create a fresh order for the renewal amount, then
+  `razorpayClient.payments.createRecurring(req)` with `customer_id`, `token`, `order_id`,
+  `email`, `contact`, `recurring: 1`, `notes.payment_type=RENEWAL`, `notes.orderId=<new paymentLog id>`.
+  Returns provider payment id/status. (Actual capture confirmation still arrives via webhook.)
+- **Amount vs limit guard**: reject `chargeRecurring` if `request.amount > mandate.maxAmount`.
+
+**Webhook** (`RazorpayWebHookService`): the existing token-capture block (~662) is extended — on the
+first `payment.captured` (or `token.confirmed`) for a mandate order, `upsertMandate(...)` into the
+mapping JSON keyed by `userPlanId` (status `ACTIVE`, `maxAmount`, `frequency`, `customerId`, `tokenId`)
+instead of just writing the bare token. Existing bare-token write stays for non-mandate saved cards.
+
+### Phase 2 — Per-plan settings on the invite
+
+Reuse the existing JSON-envelope pattern (`enroll_invite.setting_json`). Add a typed
+`RecurringPaymentSettingDTO` read/written alongside the enrollment policy:
+- `autopayEnabled` (bool), `trialDays` (int, 0 = none), `mandateFrequency`, `gracePeriodDays`,
+  `maxRenewalAttempts`, optional `mandateBufferMultiplier` (default 1 → `max_amount = plan amount`).
+- Surface in the enroll-invite create/update DTOs + `LearnerEnrollInviteService` so the admin dashboard
+  can configure it per paid plan. `max_amount` itself is **not** an admin field — it is computed from the
+  linked `payment_plan` amount at mandate-registration time.
+
+### Phase 3 — Trial handling in enrollment
+
+In the paid-enrollment path (`SchoolEnrollService.handleOnlinePayment` / `PaymentService.handlePayment`):
+- If `trialDays > 0`: still run **mandate registration** (Phase 1) so autopay is authorized, but set the
+  first payment amount to the mandate auth amount (₹0 / provider min), do **not** create a paid
+  `PaymentLog` for the plan price. On successful mandate confirmation set
+  `user_plan`: `status=ACTIVE`, `is_trial=true`, `start_date=now`,
+  `end_date = now + trialDays`, `next_charge_at = end_date`, `auto_renewal_enabled=true`.
+- If `trialDays == 0`: current behaviour (charge full price now) **plus** mandate registration when
+  `autopayEnabled`, with `next_charge_at = now + validity_in_days`.
+
+### Phase 4 — Auto-charge (reuse existing scheduler) + dunning
+
+There is no existing job that *charges* — the current pieces are reminder-only
+(`emitMembershipExpiryReminders`) and a webhook *reactor* (`RenewalPaymentService`, which only processes a
+charge that already happened but is never initiated). The single missing piece is initiating the charge on
+the due date. **Do not add a new scheduler class** — add a sibling `@Scheduled` method
+`emitRenewalCharges()` to the existing **`PackageSessionScheduler`** (it already runs daily and scans
+`user_plan`), running a few hours after the reminder method. Per due plan (`findDueForRenewal(now)`):
+1. `PaymentRenewalCheckService.shouldAttemptPayment` gate (already exists).
+2. Load the mandate JSON (`getMandate(userId, institute, userPlanId)`); compute renewal amount from
+   `payment_plan` amount / plan snapshot.
+3. Create a `RENEWAL` `PaymentLog`, call `strategy.chargeRecurring(...)`.
+4. Increment `renewal_attempt_count`, set `last_renewal_attempt_at`; **do not** move `end_date` here —
+   that happens on the webhook (Phase 5).
+5. **Dunning**: if a prior attempt is still unconfirmed/failed and `attempt < maxRenewalAttempts`, the
+   next daily run re-attempts (spacing via `next_charge_at += 1 day` on failure). When
+   `renewal_attempt_count >= maxRenewalAttempts` and still unpaid past the grace window → set
+   `user_plan.status=EXPIRED`, mark the mandate JSON `status=FAILED`, deactivate
+   `StudentSessionInstituteGroupMapping`, send failure notification.
+   Idempotency: reuse the `workflow_execution`/PaymentLog dedup style already used by the reminder job so
+   two replicas don't double-charge (unique key per `userPlanId + billing cycle date`).
+
+### Phase 4b — Confirmation model differs by provider (sync vs webhook)
+
+`chargeRecurring` returns a definitive status where the provider gives one synchronously; otherwise the
+result is finalized by webhook. The scheduler must handle both:
+- **eWay** — **no webhook** (`EwayPoolingService` polls). `chargeToken` (TransactionType `Recurring`)
+  returns the transaction result **inline**. So for eWay the scheduler applies the `end_date` /
+  `next_charge_at` extension **directly from the `chargeRecurring` response** (success → extend;
+  decline → dunning). Do **not** wait for a webhook.
+- **Razorpay / PhonePe / Cashfree** — charge is acknowledged, then confirmed **asynchronously** via the
+  existing `payment_type=RENEWAL` webhook → `RenewalPaymentService` (Phase 5) extends the plan.
+- **Stripe** — off-session PaymentIntent returns a status inline *and* fires a webhook; treat the webhook
+  as the source of truth, use the inline status only to short-circuit obvious declines.
+
+So `RenewalPaymentService.handleSuccessfulRenewal` must be callable from **both** the webhook path and the
+scheduler (for eWay), sharing the same end-date/next-charge extension logic.
+
+### Phase 5a — Onboard existing autopay-enabled eWay customers (one-time backfill)
+
+Existing eWay customers already hold a saved `TokenCustomerID` (in `payment_gateway_customer_id`) and
+**enabled autopay at enrollment**, so they can be renewed on the saved token with no re-auth and no
+mandate registration. They are **not** auto-charged by default (new columns default off) — a deliberate
+backfill opts them in:
+- One-time data migration: for eligible ACTIVE eWay plans set `auto_renewal_enabled = true` and
+  `next_charge_at = end_date`.
+- eWay `chargeRecurring` reads the existing `payment_gateway_customer_id` (TokenCustomerID) directly — no
+  need to synthesize a `mandates.<userPlanId>` JSON entry for legacy eWay tokens.
+- Add a **no-CVN** token-charge path (`chargeToken` currently takes a CVN, unavailable for unattended
+  renewals; eWay allows stored-card `Recurring` charges without CVN).
+- At expiry the scheduler charges the token and extends the plan from the **inline** response (Phase 4b).
+
+### Phase 5 — Fix renewal-confirmation side (existing stubs)
+
+`RenewalPaymentService`:
+- `calculateNewEndDate`: replace the hardcoded 30 days with `payment_plan.validity_in_days` (fall back to
+  the plan snapshot on `user_plan.plan_json`); advance from the prior `end_date` (or `next_charge_at`) so
+  cycles don't drift.
+- On success: clear `renewal_attempt_count`, set `is_trial=false`, set
+  `next_charge_at = new end_date`, extend mappings (already done).
+- Wire the notification TODOs to the existing enrollment-policy notification services
+  (`INotificationService` / `EmailNotificationService`) and the `BillingContactRecipientResolver`
+  already referenced in the TODO comments.
+
+### Phase 6 — Other providers (future-proofing verified)
+
+The two new interface methods are enough for **every** provider — no shared-path rework later. Per-provider
+work is purely additive: (a) implement the two methods in that one manager, (b) add any provider-specific
+ids to that provider's **own** sub-DTO (`StripeRequestDTO`, `CashfreeRequestDTO`, …) and to the free-form
+mandate JSON. The shared enrollment/trial/scheduler/dunning path never changes. `max_amount` is always
+app-enforced, so providers with no native limit still work.
+
+Provider readiness (from a code audit of each manager) — do them easiest-first:
+
+| Provider | Native recurring product | Manager today | Effort | Notes |
+|---|---|---|---|---|
+| **Razorpay** | Recurring token / UPI Autopay e-mandate | order + customer + token capture | Phase 1–5 | first target |
+| **eWay** | Card-on-file `TokenCustomer` | **already** has `createCustomer` (TokenCustomerID), `chargeToken`, `TransactionType="Recurring"` | **Low** | `chargeRecurring` ≈ existing `chargeToken`; card only, no UPI |
+| **Stripe** | SetupIntent + off-session PaymentIntent | **already** has `createSetupIntent` (`usage=off_session`), `attachAndSetDefaultPaymentMethod` | **Low** | mandate JSON = `{customerId, paymentMethodId}`; trial = zero-amount SetupIntent |
+| **PhonePe** | Autopay mandate | payment only (v1/v2); customer stubbed | **Medium** | mandate *registration* is a separate call; mandate id captured on webhook (same pattern as Razorpay token capture) |
+| **Cashfree** | Subscriptions / UPI Autopay eNACH | hosted-checkout order only; customer stubbed | **Medium** | must use Subscriptions API, not one-time order; add `subscriptionId` to `CashfreeRequestDTO` |
+| **PayPal** | Billing Agreements / Subscriptions | fully stubbed | **Deferred** | whole provider unimplemented; do when PayPal is first needed |
+
+Key design note that keeps all of them on one interface: for UPI-mandate providers (Razorpay, PhonePe,
+Cashfree) the mandate is **confirmed asynchronously via webhook** — exactly like today's Razorpay
+token-capture. So `initiateMandatePayment` starts the checkout/registration and the webhook populates the
+mandate JSON; `chargeRecurring` runs later off the stored mandate. The **trial** flow reuses this directly:
+a trial signup is just `initiateMandatePayment` at a zero/auth amount (Stripe SetupIntent, Razorpay
+`max_amount` token, etc.), so no separate "registration-only" method is needed.
+
+Managers without mandate support keep the interface's default no-op and simply don't offer autopay, so
+partially-migrated state is always safe.
+
+---
+
+## Files to create / modify
+
+**Create**
+- `db/migration/V365__user_plan_autopay_columns.sql` (user_plan scheduler-state columns only)
+- `features/.../dto/RecurringPaymentSettingDTO.java`
+
+**Modify**
+- `features/enrollment_policy/scheduler/PackageSessionScheduler.java` (add `emitRenewalCharges()` sibling method)
+- `features/payments/manager/PaymentServiceStrategy.java` (+ default methods), `RazorpayPaymentManager.java`
+- `features/payments/service/RazorpayWebHookService.java` (token block → mandate upsert in mapping JSON)
+- `features/user_subscription/service/UserInstitutePaymentGatewayMappingService.java` (upsert/get mandate JSON, keyed by userPlanId)
+- `features/enrollment_policy/service/RenewalPaymentService.java` (real end-date + notifications),
+  `PaymentRenewalCheckService.java` (reuse as-is)
+- `features/user_subscription/entity/UserPlan.java` + `repository/UserPlanRepository.java`
+- `features/admission/service/SchoolEnrollService.java` / `features/payments/service/PaymentService.java` (trial + mandate on enroll)
+- Enroll-invite create/update DTOs + `LearnerEnrollInviteService` (per-plan recurring settings)
+
+## Verification
+- **Local build**: `mvn -q -pl admin_core_service -am compile` (PowerShell; quote `-Dsentry.skip=true` if needed).
+- **Razorpay test mode**: configure a test institute mapping; run enroll with (a) `trialDays=14` and
+  (b) `trialDays=0, autopayEnabled=true`. Confirm: mandate registered (Razorpay dashboard shows an
+  authenticated token with the max_amount), the mapping JSON has a `mandates.<userPlanId>` entry,
+  `user_plan` has correct `end_date`/`next_charge_at`/`is_trial`, and no paid PaymentLog for the trial case.
+- **Charge path**: force a plan's `next_charge_at` to now (read-only DB is prod; use a test env for
+  writes), run `RenewalChargeScheduler`, confirm a `RENEWAL` PaymentLog + Razorpay recurring charge, then
+  fire the `payment.captured` webhook and confirm `end_date` advances by `validity_in_days` and mappings extend.
+- **Dunning**: simulate a failed recurring charge (amount over `max_amount`, or Razorpay test failure),
+  confirm retries increment `renewal_attempt_count`, notifications fire, and the plan expires only after
+  `maxRenewalAttempts`.
+- **Limit guard**: attempt `chargeRecurring` above `max_amount` → rejected before hitting Razorpay.

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-components/AutopaySettingsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-components/AutopaySettingsCard.tsx
@@ -1,0 +1,141 @@
+import { UseFormReturn } from 'react-hook-form';
+import { FormField, FormItem, FormControl } from '@/components/ui/form';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { ArrowsClockwise } from '@phosphor-icons/react';
+import { InviteLinkFormValues } from '../GenerateInviteLinkSchema';
+
+interface AutopaySettingsCardProps {
+    form: UseFormReturn<InviteLinkFormValues>;
+}
+
+/**
+ * Autopay + free-trial config for an invite's paid subscription plans. When
+ * enabled, enrolling registers a recurring mandate (UPI Autopay / card) and the
+ * subscription auto-renews; trialDays > 0 grants access now and takes the first
+ * charge after the trial. Persisted to setting_json.setting.AUTOPAY_SETTING and
+ * read at enrollment time.
+ */
+const AutopaySettingsCard = ({ form }: AutopaySettingsCardProps) => {
+    const enabled = form.watch('autopaySettings.enabled');
+    const planType = form.watch('selectedPlan')?.type?.toLowerCase();
+
+    // Autopay only applies to recurring (subscription) plans — hide otherwise.
+    if (planType !== 'subscription') {
+        return null;
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-2xl font-bold">
+                    <ArrowsClockwise size={22} />
+                    Autopay &amp; Free Trial
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <FormField
+                    control={form.control}
+                    name="autopaySettings.enabled"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormControl>
+                                <div className="flex items-center justify-between gap-4">
+                                    <div className="w-full">
+                                        <div className="text-base font-semibold">
+                                            Auto-renew paid subscriptions
+                                        </div>
+                                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                                            <span>
+                                                Charge the learner&apos;s saved payment method (UPI
+                                                mandate / card) automatically at each renewal.
+                                                Learners can cancel anytime.
+                                            </span>
+                                            <Switch
+                                                id="enable-autopay-switch"
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </FormControl>
+                        </FormItem>
+                    )}
+                />
+
+                {enabled && (
+                    <div className="mt-4 border-t pt-4">
+                        <span className="text-sm font-medium">Free Trial (days)</span>
+                        <FormField
+                            control={form.control}
+                            name="autopaySettings.trialDays"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Input
+                                            type="number"
+                                            min={0}
+                                            className="mt-2 w-40"
+                                            placeholder="0"
+                                            value={field.value ?? 0}
+                                            onChange={(e) =>
+                                                field.onChange(
+                                                    e.target.value === ''
+                                                        ? 0
+                                                        : Number(e.target.value)
+                                                )
+                                            }
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <div className="mt-1 text-xs text-muted-foreground">
+                            Give access now and take the first payment after this many days. Leave 0
+                            to charge immediately and renew each cycle.
+                        </div>
+
+                        <div className="mt-4">
+                            <span className="text-sm font-medium">
+                                Mandate limit (max charge per renewal)
+                            </span>
+                            <FormField
+                                control={form.control}
+                                name="autopaySettings.maxAmount"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input
+                                                type="number"
+                                                min={0}
+                                                className="mt-2 w-40"
+                                                placeholder="Defaults to plan price"
+                                                value={field.value ?? ''}
+                                                onChange={(e) =>
+                                                    field.onChange(
+                                                        e.target.value === ''
+                                                            ? null
+                                                            : Number(e.target.value)
+                                                    )
+                                                }
+                                            />
+                                        </FormControl>
+                                    </FormItem>
+                                )}
+                            />
+                            <div className="mt-1 text-xs text-muted-foreground">
+                                The mandate authorizes each auto-charge up to this cap, so it must be
+                                at least the plan&apos;s recurring price. Leave blank to use the plan
+                                price; set higher to leave headroom for tax / price changes.
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+};
+
+export default AutopaySettingsCard;

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
@@ -420,6 +420,25 @@ export function convertInviteData(
                 const { SUB_ORG_SETTING: _removed, ...restSetting } = next.setting;
                 next.setting = restSetting;
             }
+            // Autopay / free-trial → setting.AUTOPAY_SETTING (read at enrollment).
+            // Only written when enabled; removed on toggle-off. Spreads next.setting
+            // so a co-enabled SUB_ORG_SETTING above is preserved.
+            const autopay = data.autopaySettings;
+            if (autopay?.enabled) {
+                next.setting = {
+                    ...(next.setting || existing.setting || {}),
+                    AUTOPAY_SETTING: {
+                        ENABLED: true,
+                        TRIAL_DAYS: autopay.trialDays ?? 0,
+                        ...(autopay.maxAmount != null
+                            ? { MAX_AMOUNT: autopay.maxAmount }
+                            : {}),
+                    },
+                };
+            } else if (next.setting?.AUTOPAY_SETTING) {
+                const { AUTOPAY_SETTING: _removedAutopay, ...restSetting } = next.setting;
+                next.setting = restSetting;
+            }
             return JSON.stringify(next);
         })(),
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkDialog.tsx
@@ -26,6 +26,7 @@ import { ReferralProgramDialog } from './ReferralProgramDialog';
 import InstituteBrandingCard from './-components/InstituteBrandingCard';
 import CoursePreviewCard from './-components/CoursePreviewCard';
 import PaymentPlanCard from './-components/PaymentPlanCard';
+import AutopaySettingsCard from './-components/AutopaySettingsCard';
 import { getInviteListCustomFields, getInviteListCustomFieldsAsync } from '../../-utils/getInviteListCustomFields';
 import PlanReferralMappingCard from './-components/PlanReferralMappingCard';
 import { PlanReferralConfigDialog } from './PlanReferralConfigDialog';
@@ -856,6 +857,15 @@ const GenerateInviteLinkDialog = ({
                         memberCount: subOrg?.MEMBER_COUNT ?? null,
                     };
                 })(),
+                autopaySettings: (() => {
+                    const autopay = safeJsonParse(inviteLinkDetails?.setting_json, {})?.setting
+                        ?.AUTOPAY_SETTING;
+                    return {
+                        enabled: !!autopay?.ENABLED,
+                        trialDays: autopay?.TRIAL_DAYS ?? 0,
+                        maxAmount: autopay?.MAX_AMOUNT ?? null,
+                    };
+                })(),
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -943,6 +953,9 @@ const GenerateInviteLinkDialog = ({
                                 totalBatches={selectedBatches.length}
                             />
                             <PaymentPlanCard form={form} />
+
+                            {/* Autopay + free-trial for paid subscription plans */}
+                            <AutopaySettingsCard form={form} />
 
                             {/* Referral Program Card */}
                             <PlanReferralMappingCard form={form} />

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
@@ -367,6 +367,25 @@ export const inviteLinkSchema = z.object({
             adminPermissions: ['FULL'],
             memberCount: null,
         }),
+    // Autopay / free-trial for paid subscription plans on this invite. When
+    // `enabled`, enrolling registers a recurring mandate and the subscription
+    // auto-renews; `trialDays > 0` gives access now with the first charge at
+    // trial end. Serialized to setting_json.setting.AUTOPAY_SETTING and read at
+    // enrollment time.
+    autopaySettings: z
+        .object({
+            enabled: z.boolean().default(false),
+            trialDays: z
+                .number()
+                .int()
+                .min(0)
+                .nullable()
+                .default(0)
+                .transform((val) => val ?? 0),
+            // Mandate cap per auto-charge. null = derive from the plan price.
+            maxAmount: z.number().min(0).nullable().default(null),
+        })
+        .default({ enabled: false, trialDays: 0, maxAmount: null }),
 });
 
 export type InviteLinkFormValues = z.infer<typeof inviteLinkSchema>;

--- a/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/payment-billing-section.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/payment-billing-section.tsx
@@ -5,6 +5,7 @@ import {
   CalendarBlank,
   Info,
   SpinnerGap,
+  ArrowsClockwise,
 } from "@phosphor-icons/react";
 import { MyButton } from "@/components/design-system/button";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
@@ -18,6 +19,7 @@ import { StripeCardUpdate } from "./stripe-card-update";
 import { EwayCardUpdate } from "./eway-card-update";
 import { BillingDetailsForm } from "./billing-details-form";
 import { EnrollmentExpiryList } from "./enrollment-expiry-list";
+import { SubscriptionMandateList } from "./subscription-mandate-list";
 
 interface PaymentBillingSectionProps {
   instituteId: string;
@@ -167,6 +169,19 @@ export const PaymentBillingSection = ({
           <h3>Payment &amp; Billing</h3>
         </div>
         {renderCardArea()}
+      </div>
+
+      {/* Auto-renewing subscriptions (cancel autopay per plan) */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 border-b pb-2 text-lg font-semibold text-gray-900">
+          <ArrowsClockwise
+            size={20}
+            className="text-primary-500"
+            weight="bold"
+          />
+          <h3>Subscriptions &amp; Autopay</h3>
+        </div>
+        <SubscriptionMandateList instituteId={instituteId} />
       </div>
 
       {/* Enrollment expiry */}

--- a/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/subscription-mandate-list.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/subscription-mandate-list.tsx
@@ -1,0 +1,214 @@
+import { useState } from "react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { ArrowsClockwise, Info, SpinnerGap, Warning } from "@phosphor-icons/react";
+import { toast } from "sonner";
+import { MyButton } from "@/components/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  SUBSCRIPTION_LIST_QUERY_KEY,
+  fetchSubscriptions,
+  cancelSubscription,
+  type Subscription,
+} from "./subscription-services";
+
+interface SubscriptionMandateListProps {
+  instituteId: string;
+}
+
+const formatDate = (value?: string | null): string | null => {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+};
+
+/**
+ * Lists the learner's autopay subscriptions next to their billing details and
+ * lets them cancel autopay per plan. Cancelling stops future charges but keeps
+ * access until the plan's end date (handled server-side).
+ */
+export const SubscriptionMandateList = ({
+  instituteId,
+}: SubscriptionMandateListProps) => {
+  const queryClient = useQueryClient();
+  const [toCancel, setToCancel] = useState<Subscription | null>(null);
+
+  const {
+    data: subscriptions,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: [SUBSCRIPTION_LIST_QUERY_KEY, instituteId],
+    queryFn: () => fetchSubscriptions(instituteId),
+    enabled: Boolean(instituteId),
+    staleTime: 60 * 1000,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (userPlanId: string) =>
+      cancelSubscription(instituteId, userPlanId),
+    onSuccess: () => {
+      toast.success("Autopay cancelled", {
+        description: "You keep access until the end of your current period.",
+      });
+      setToCancel(null);
+      queryClient.invalidateQueries({
+        queryKey: [SUBSCRIPTION_LIST_QUERY_KEY, instituteId],
+      });
+    },
+    onError: () => {
+      toast.error("Couldn't cancel autopay", {
+        description: "Please try again in a moment.",
+      });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-3 text-sm text-gray-500">
+        <SpinnerGap className="size-4 animate-spin" />
+        Loading subscriptions...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-4 text-sm text-gray-600">
+        <Info className="size-4 shrink-0" />
+        Subscriptions are unavailable right now. Please try again later.
+      </div>
+    );
+  }
+
+  const autopaySubs = (subscriptions ?? []).filter(
+    (s) => s.has_active_mandate || s.auto_renewal_enabled
+  );
+
+  if (autopaySubs.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-4 text-sm text-gray-600">
+        <Info className="size-4 shrink-0" />
+        You have no active auto-renewing subscriptions.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {autopaySubs.map((sub) => {
+        const nextCharge = formatDate(sub.next_charge_at);
+        const accessUntil = formatDate(sub.end_date);
+        const cancellable = sub.has_active_mandate;
+        return (
+          <div
+            key={sub.user_plan_id}
+            className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 p-4"
+          >
+            <div className="flex items-start gap-3">
+              <ArrowsClockwise
+                className="mt-0.5 size-5 text-primary-500"
+                weight="duotone"
+              />
+              <div>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-gray-700">
+                    {sub.plan_name ?? "Subscription"}
+                  </p>
+                  {sub.is_trial && (
+                    <span className="rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-500">
+                      Trial
+                    </span>
+                  )}
+                  {!cancellable && (
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+                      Autopay off
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-gray-500">
+                  {cancellable && nextCharge
+                    ? `Auto-renews on ${nextCharge}`
+                    : accessUntil
+                      ? `Access until ${accessUntil}`
+                      : "Recurring subscription"}
+                </p>
+              </div>
+            </div>
+            {cancellable && (
+              <MyButton
+                type="button"
+                scale="small"
+                buttonType="secondary"
+                layoutVariant="default"
+                onClick={() => setToCancel(sub)}
+              >
+                Cancel autopay
+              </MyButton>
+            )}
+          </div>
+        );
+      })}
+
+      <Dialog
+        open={Boolean(toCancel)}
+        onOpenChange={(open) => {
+          if (!open) setToCancel(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Warning className="size-5 text-danger-500" weight="fill" />
+              Cancel autopay?
+            </DialogTitle>
+            <DialogDescription>
+              Auto-renewal for{" "}
+              <span className="font-medium text-gray-700">
+                {toCancel?.plan_name ?? "this subscription"}
+              </span>{" "}
+              will stop. You&apos;ll keep access until{" "}
+              {formatDate(toCancel?.end_date) ?? "the end of your current period"}
+              , and won&apos;t be charged again.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <MyButton
+              type="button"
+              scale="small"
+              buttonType="secondary"
+              layoutVariant="default"
+              onClick={() => setToCancel(null)}
+              disable={cancelMutation.isPending}
+            >
+              Keep autopay
+            </MyButton>
+            <MyButton
+              type="button"
+              scale="small"
+              buttonType="primary"
+              layoutVariant="default"
+              onClick={() =>
+                toCancel && cancelMutation.mutate(toCancel.user_plan_id)
+              }
+              disable={cancelMutation.isPending}
+            >
+              {cancelMutation.isPending ? "Cancelling..." : "Cancel autopay"}
+            </MyButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};

--- a/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/subscription-services.ts
+++ b/frontend-learner-dashboard-app/src/components/common/user-profile/payment-billing/subscription-services.ts
@@ -1,0 +1,50 @@
+import authenticatedAxiosInstance from "@/lib/auth/axiosInstance";
+import {
+  LEARNER_SUBSCRIPTION_LIST,
+  LEARNER_SUBSCRIPTION_CANCEL,
+} from "@/constants/urls";
+
+/**
+ * One subscription (a UserPlan) and its autopay mandate. Mirrors the backend
+ * SubscriptionDTO (snake_case, like the other learner payment endpoints).
+ */
+export interface Subscription {
+  user_plan_id: string;
+  plan_name?: string | null;
+  status: string; // ACTIVE | CANCELED | EXPIRED | PAYMENT_FAILED
+  end_date?: string | null; // access valid until
+  next_charge_at?: string | null;
+  auto_renewal_enabled?: boolean | null;
+  is_trial?: boolean | null;
+  vendor?: string | null; // RAZORPAY | EWAY | ...
+  mandate_status?: string | null; // ACTIVE | REVOKED | FAILED | null
+  mandate_max_amount?: number | null;
+  currency?: string | null;
+  has_active_mandate: boolean;
+  package_session_ids?: string[] | null;
+}
+
+export const SUBSCRIPTION_LIST_QUERY_KEY = "LEARNER_SUBSCRIPTION_LIST";
+
+export const fetchSubscriptions = async (
+  instituteId: string
+): Promise<Subscription[]> => {
+  const response = await authenticatedAxiosInstance.get(
+    LEARNER_SUBSCRIPTION_LIST,
+    { params: { instituteId } }
+  );
+  return response.data;
+};
+
+/** Cancel autopay for a subscription. Access is retained until end_date. */
+export const cancelSubscription = async (
+  instituteId: string,
+  userPlanId: string
+): Promise<Subscription> => {
+  const response = await authenticatedAxiosInstance.post(
+    LEARNER_SUBSCRIPTION_CANCEL(userPlanId),
+    null,
+    { params: { instituteId } }
+  );
+  return response.data;
+};

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -87,6 +87,12 @@ export const LEARNER_PAYMENT_METHOD_SUMMARY = `${BASE_URL}/admin-core-service/le
 export const LEARNER_PAYMENT_METHOD_SETUP_INTENT = `${BASE_URL}/admin-core-service/learner/payment-method/v1/stripe/setup-intent`;
 export const LEARNER_PAYMENT_METHOD_CONFIRM_CARD = `${BASE_URL}/admin-core-service/learner/payment-method/v1/confirm-card-update`;
 export const LEARNER_PAYMENT_METHOD_BILLING_DETAILS = `${BASE_URL}/admin-core-service/learner/payment-method/v1/billing-details`;
+
+// Learner self-service subscriptions + autopay mandate (list + cancel)
+export const LEARNER_SUBSCRIPTION_LIST = `${BASE_URL}/admin-core-service/learner/subscription/v1`;
+export const LEARNER_SUBSCRIPTION_CANCEL = (userPlanId: string) =>
+  `${BASE_URL}/admin-core-service/learner/subscription/v1/${userPlanId}/cancel`;
+
 export const EXPORT_ASSESSMENT_REPORT = `${BASE_URL}/assessment-service/assessment/learner/report/pdf`;
 export const EXPORT_AI_REPORT = `${BASE_URL}/assessment-service/assessment/learner/report/ai-pdf`;
 export const ASSESSMENT_SUBMIT_MANUAL = `${BASE_URL}/assessment-service/assessment/learner/manual-status/submit`;

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/CourseSubscriptionCancel.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/CourseSubscriptionCancel.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { ArrowsClockwise, Warning } from "@phosphor-icons/react";
+import { toast } from "sonner";
+import { MyButton } from "@/components/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  SUBSCRIPTION_LIST_QUERY_KEY,
+  fetchSubscriptions,
+  cancelSubscription,
+} from "@/components/common/user-profile/payment-billing/subscription-services";
+
+interface CourseSubscriptionCancelProps {
+  instituteId: string;
+  packageSessionId?: string;
+}
+
+const formatDate = (value?: string | null): string | null => {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+};
+
+/**
+ * Shows a "Cancel subscription" control on the course-details page when the
+ * learner has an active autopay mandate for THIS course (package session).
+ * Renders nothing otherwise, so it's safe to drop in unconditionally.
+ */
+export const CourseSubscriptionCancel = ({
+  instituteId,
+  packageSessionId,
+}: CourseSubscriptionCancelProps) => {
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { data: subscriptions } = useQuery({
+    queryKey: [SUBSCRIPTION_LIST_QUERY_KEY, instituteId],
+    queryFn: () => fetchSubscriptions(instituteId),
+    enabled: Boolean(instituteId && packageSessionId),
+    staleTime: 60 * 1000,
+  });
+
+  const subscription = (subscriptions ?? []).find(
+    (s) =>
+      s.has_active_mandate &&
+      Boolean(packageSessionId) &&
+      (s.package_session_ids ?? []).includes(packageSessionId as string)
+  );
+
+  const cancelMutation = useMutation({
+    mutationFn: (userPlanId: string) =>
+      cancelSubscription(instituteId, userPlanId),
+    onSuccess: () => {
+      toast.success("Autopay cancelled", {
+        description: "You keep access until the end of your current period.",
+      });
+      setConfirmOpen(false);
+      queryClient.invalidateQueries({
+        queryKey: [SUBSCRIPTION_LIST_QUERY_KEY, instituteId],
+      });
+    },
+    onError: () => {
+      toast.error("Couldn't cancel autopay", {
+        description: "Please try again in a moment.",
+      });
+    },
+  });
+
+  if (!subscription) return null;
+
+  return (
+    <div className="rounded-xl border border-catalogue-border p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <ArrowsClockwise
+            className="mt-0.5 size-5 text-primary-500"
+            weight="duotone"
+          />
+          <div>
+            <p className="text-sm font-medium text-catalogue-text-primary">
+              Auto-renewing subscription
+            </p>
+            <p className="text-xs text-catalogue-text-muted">
+              {formatDate(subscription.next_charge_at)
+                ? `Renews on ${formatDate(subscription.next_charge_at)}`
+                : "Recurring subscription active"}
+            </p>
+          </div>
+        </div>
+        <MyButton
+          type="button"
+          scale="small"
+          buttonType="secondary"
+          layoutVariant="default"
+          onClick={() => setConfirmOpen(true)}
+        >
+          Cancel subscription
+        </MyButton>
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!open) setConfirmOpen(false);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Warning className="size-5 text-danger-500" weight="fill" />
+              Cancel this subscription?
+            </DialogTitle>
+            <DialogDescription>
+              Auto-renewal will stop. You&apos;ll keep access until{" "}
+              {formatDate(subscription.end_date) ??
+                "the end of your current period"}
+              , and won&apos;t be charged again.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <MyButton
+              type="button"
+              scale="small"
+              buttonType="secondary"
+              layoutVariant="default"
+              onClick={() => setConfirmOpen(false)}
+              disable={cancelMutation.isPending}
+            >
+              Keep subscription
+            </MyButton>
+            <MyButton
+              type="button"
+              scale="small"
+              buttonType="primary"
+              layoutVariant="default"
+              onClick={() => cancelMutation.mutate(subscription.user_plan_id)}
+              disable={cancelMutation.isPending}
+            >
+              {cancelMutation.isPending ? "Cancelling..." : "Cancel subscription"}
+            </MyButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
@@ -58,6 +58,7 @@ import LocalStorageUtils from "@/utils/localstorage";
 
 import { fetchPaymentOptions } from "@/routes/courses/-services/payment-options-api";
 import { CourseHeader } from "./course-header";
+import { CourseSubscriptionCancel } from "./CourseSubscriptionCancel";
 import { CertificateCompletionBanner } from "./certificate-completion-banner.tsx";
 import { CourseEnrollment } from "./course-enrollment";
 import { CourseContentSections } from "./course-content-sections";
@@ -2218,6 +2219,13 @@ export const CourseDetailsPage = () => {
                   <>
                     {structureBlock}
                     {enrollmentBlock}
+                    {/* Cancel autopay — self-hides unless this course has an active mandate */}
+                    <CourseSubscriptionCancel
+                      instituteId={instituteId || ""}
+                      packageSessionId={
+                        packageSessionIdForCurrentLevel || undefined
+                      }
+                    />
                     {highlightsBlock}
                   </>
                 ) : (


### PR DESCRIPTION
…cancellation

Adds UPI/card mandate-based auto-renewal for paid subscription plans, gated on auto_renewal_enabled (default false) so existing flows are unaffected until an admin enables autopay on an invite.

Backend:
- V367 user_plan autopay columns (auto_renewal_enabled, next_charge_at, is_trial, renewal_attempt_count, last_renewal_attempt_at) + partial index
- Mandate stored per-userPlanId in user_institute_payment_gateway_mapping JSON (upsert/get/getOrLegacyToken/revoke) - no new table
- PaymentServiceStrategy: default initiateMandatePayment + chargeRecurring
- eWay chargeRecurring (no-CVN token) + legacy-token fallback for existing tokens
- Razorpay initiateMandatePayment + createRecurringPayment + webhook mandate persist
- RenewalChargeService daily scheduler (multi-replica atomic claim) + dunning
- RenewalPaymentService: real validity_in_days extension (was hardcoded 30)
- Learner subscription list + cancel API (revoke mandate, keep access to end_date)
- Autopay applied centrally in createUserPlan (reads invite AUTOPAY_SETTING)

Frontend:
- Admin: AutopaySettingsCard (subscription-only) with autopay toggle, free-trial days, mandate limit -> setting_json.AUTOPAY_SETTING (+ edit read-back)
- Learner: profile remove-mandate section + course-details cancel-subscription

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
