### PR TITLE
fix(payments): default autopay NOT NULL columns to avoid user_plan in…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/UserPlan.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/UserPlan.java
@@ -114,9 +114,13 @@ private String id;
     // user_institute_payment_gateway_mapping.payment_gateway_customer_data
     // JSON, keyed by this plan's id. These columns only drive the scheduler.
 
-    /** Only plans with this true are picked up by the auto-charge scheduler. */
+    /**
+     * Only plans with this true are picked up by the auto-charge scheduler.
+     * Initialised to false so the NOT NULL column is never sent an explicit NULL
+     * on insert (Hibernate includes mapped columns even when the DB has a default).
+     */
     @Column(name = "auto_renewal_enabled")
-    private Boolean autoRenewalEnabled;
+    private Boolean autoRenewalEnabled = false;
 
     /** Next date the scheduler should attempt a renewal charge (usually = endDate). */
     @Column(name = "next_charge_at")
@@ -124,11 +128,11 @@ private String id;
 
     /** True while in the free-trial window (access granted, no real charge yet). */
     @Column(name = "is_trial")
-    private Boolean isTrial;
+    private Boolean isTrial = false;
 
     /** Dunning: number of renewal charge attempts in the current cycle. */
     @Column(name = "renewal_attempt_count")
-    private Integer renewalAttemptCount;
+    private Integer renewalAttemptCount = 0;
 
     @Column(name = "last_renewal_attempt_at")
     private Date lastRenewalAttemptAt;


### PR DESCRIPTION
…sert failure

V369 added auto_renewal_enabled / is_trial / renewal_attempt_count as NOT NULL DEFAULT, but Hibernate maps the Boolean/Integer fields and sends an explicit NULL on insert (the DB default only applies when the column is omitted), which broke ALL user_plan inserts (every enrollment). Initialise the three fields to false/false/0 so inserts always carry a value; autopay still overrides auto_renewal_enabled to true via applyAutopaySetup.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
