### PR TITLE
feat(payments): wire Razorpay recurring-mandate checkout for autopay …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
@@ -225,6 +225,19 @@ public class SubscriptionPaymentOptionOperation implements PaymentOptionOperatio
                         enrollInvite,
                         userPlan,
                         extraData);
+            } else if (Boolean.TRUE.equals(userPlan.getAutoRenewalEnabled())) {
+                // Autopay subscription: register a recurring mandate so the learner
+                // authorizes future auto-charges. Routes to initiateMandatePayment,
+                // whose response carries recurring:1 + customerId for the frontend to
+                // open Razorpay Checkout in mandate mode (UPI Autopay / card e-mandate).
+                var mandateRequest = learnerPackageSessionsEnrollDTO.getPaymentInitiationRequest();
+                applyMandateMaxAmount(mandateRequest, enrollInvite, paymentPlan);
+                paymentResponseDTO = paymentService.handleMandatePayment(
+                        user,
+                        instituteId,
+                        enrollInvite,
+                        userPlan,
+                        mandateRequest);
             } else {
                 paymentResponseDTO = paymentService.handlePayment(
                         user,
@@ -294,6 +307,37 @@ public class SubscriptionPaymentOptionOperation implements PaymentOptionOperatio
             detailsList.add(detail);
         }
         return detailsList;
+    }
+
+    /**
+     * Sets the Razorpay mandate max_amount (per-charge cap) from the invite's
+     * AUTOPAY_SETTING.MAX_AMOUNT (admin-configured), falling back to the plan
+     * price. No-op for non-Razorpay requests (eWay tokenizes on the first card
+     * payment and has no native cap).
+     */
+    private void applyMandateMaxAmount(PaymentInitiationRequestDTO request,
+                                       EnrollInvite enrollInvite, PaymentPlan paymentPlan) {
+        if (request == null || request.getRazorpayRequest() == null) {
+            return;
+        }
+        Double maxAmount = null;
+        try {
+            if (enrollInvite != null && enrollInvite.getSettingJson() != null
+                    && !enrollInvite.getSettingJson().isBlank()) {
+                com.fasterxml.jackson.databind.JsonNode ap = new com.fasterxml.jackson.databind.ObjectMapper()
+                        .readTree(enrollInvite.getSettingJson()).path("setting").path("AUTOPAY_SETTING");
+                if (ap.has("MAX_AMOUNT") && !ap.get("MAX_AMOUNT").isNull()) {
+                    maxAmount = ap.get("MAX_AMOUNT").asDouble();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not read AUTOPAY_SETTING.MAX_AMOUNT for invite {}: {}",
+                    enrollInvite != null ? enrollInvite.getId() : null, e.getMessage());
+        }
+        if (maxAmount == null && paymentPlan != null) {
+            maxAmount = paymentPlan.getActualPrice();
+        }
+        request.getRazorpayRequest().setMandateMaxAmount(maxAmount);
     }
 
 }

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/razorpay-checkout-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/razorpay-checkout-form.tsx
@@ -14,6 +14,10 @@ export interface RazorpayCheckoutFormRef {
     currency: string;
     contact: string;
     email: string;
+    // Autopay/mandate: when the backend registered a recurring mandate, these
+    // make Razorpay Checkout open in mandate mode (UPI Autopay / card e-mandate).
+    recurring?: number;
+    customerId?: string;
   }) => void;
 }
 
@@ -104,6 +108,8 @@ export const RazorpayCheckoutForm = forwardRef<
         currency: string;
         contact: string;
         email: string;
+        recurring?: number;
+        customerId?: string;
       }) => {
         if (!isScriptLoaded) {
           console.error("Razorpay script not loaded");
@@ -126,6 +132,15 @@ export const RazorpayCheckoutForm = forwardRef<
           amount: orderDetails.amount,
           currency: orderDetails.currency,
           order_id: orderDetails.razorpayOrderId,
+          // Autopay: run Checkout in recurring/mandate mode so the learner
+          // authorizes UPI Autopay / a card e-mandate (needs a customer_id + an
+          // order created with a token block, both from the backend).
+          ...(orderDetails.recurring
+            ? {
+                recurring: orderDetails.recurring,
+                customer_id: orderDetails.customerId,
+              }
+            : {}),
           name: courseName,
           description: courseDescription,
           handler: function (response: {

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -1892,6 +1892,10 @@ const EnrollByInvite = ({
             currency: orderDetails.currency || "INR",
             contact: orderDetails.contact || "",
             email: orderDetails.email || "",
+            // Autopay: present when the backend registered a recurring mandate;
+            // drives Checkout into UPI-Autopay / card-mandate mode.
+            recurring: orderDetails.recurring,
+            customerId: orderDetails.customerId,
           });
         } else {
           throw new Error("Razorpay component not ready");


### PR DESCRIPTION
…enrollment

Subscription enrollments with autopay now register a recurring mandate:
- SubscriptionPaymentOptionOperation routes to PaymentService.handleMandatePayment (initiateMandatePayment) when userPlan.auto_renewal_enabled, setting the mandate max_amount from the invite's AUTOPAY_SETTING.MAX_AMOUNT (fallback: plan price).
- Learner checkout (razorpay-checkout-form + enroll-form) passes recurring:1 + customer_id so Razorpay Checkout opens in UPI-Autopay / card-mandate mode.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
