### PR TITLE
feat(payments): autopay consent + free-trial Rs.1 mandate authorization

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
@@ -231,6 +231,17 @@ public class SubscriptionPaymentOptionOperation implements PaymentOptionOperatio
                 // whose response carries recurring:1 + customerId for the frontend to
                 // open Razorpay Checkout in mandate mode (UPI Autopay / card e-mandate).
                 var mandateRequest = learnerPackageSessionsEnrollDTO.getPaymentInitiationRequest();
+                // Free trial: take only a Rs.1 authorization at signup to register the
+                // mandate (cards require >= Rs.1; UPI accepts it too). The first REAL
+                // plan charge happens at trial-end via RenewalChargeService, since
+                // applyAutopaySetup set next_charge_at = now + trialDays. The mandate
+                // cap (max_amount) still comes from AUTOPAY_SETTING below, so future
+                // renewals of the full plan price are authorized.
+                if (Boolean.TRUE.equals(userPlan.getIsTrial())) {
+                    mandateRequest.setAmount(1.0);
+                    log.info("Trial enrollment: taking Rs.1 mandate authorization for user {} plan {} (first real charge at trial end)",
+                            user.getId(), userPlan.getId());
+                }
                 applyMandateMaxAmount(mandateRequest, enrollInvite, paymentPlan);
                 paymentResponseDTO = paymentService.handleMandatePayment(
                         user,

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -2654,13 +2654,32 @@ const EnrollByInvite = ({
                 onChange={(e) => setAutopayConsent(e.target.checked)}
               />
               <span>
-                I agree to auto-renewal:{" "}
-                <span className="font-semibold">
-                  {enrollmentData.selectedPayment?.currency || "INR"}{" "}
-                  {getSelectedPaymentPrice(enrollmentData.selectedPayment)}
-                </span>{" "}
-                will be charged to my saved payment method each billing period. I
-                can cancel anytime from my profile.
+                {autopayConfig?.TRIAL_DAYS ? (
+                  <>
+                    I agree: a <span className="font-semibold">₹1</span>{" "}
+                    authorization today starts my{" "}
+                    <span className="font-semibold">
+                      {autopayConfig.TRIAL_DAYS}-day free trial
+                    </span>
+                    , then{" "}
+                    <span className="font-semibold">
+                      {enrollmentData.selectedPayment?.currency || "INR"}{" "}
+                      {getSelectedPaymentPrice(enrollmentData.selectedPayment)}
+                    </span>{" "}
+                    will be charged to my saved payment method each billing
+                    period. I can cancel anytime from my profile.
+                  </>
+                ) : (
+                  <>
+                    I agree to auto-renewal:{" "}
+                    <span className="font-semibold">
+                      {enrollmentData.selectedPayment?.currency || "INR"}{" "}
+                      {getSelectedPaymentPrice(enrollmentData.selectedPayment)}
+                    </span>{" "}
+                    will be charged to my saved payment method each billing
+                    period. I can cancel anytime from my profile.
+                  </>
+                )}
               </span>
             </label>
           )}


### PR DESCRIPTION
- Learner enrollment: explicit auto-renewal consent checkbox on the Review step gating submit; disclosure is trial-aware (Rs.1 today -> N-day trial -> plan price).
- Trial: charge a Rs.1 mandate authorization at signup instead of the full plan price when TRIAL_DAYS>0; the first real plan charge happens at trial-end via RenewalChargeService (next_charge_at = now + trialDays).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
