### PR TITLE
feat(learner): apply OTA updates silently on native apps

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/__root.tsx
+++ b/frontend-learner-dashboard-app/src/routes/__root.tsx
@@ -20,6 +20,8 @@ import { useOtaUpdate } from "@/stores/useOtaUpdate";
 import {
   checkForOtaUpdate,
   downloadAndApplyUpdate,
+  downloadAndStageUpdate,
+  isSilentOtaApp,
   notifyUpdateSuccess,
 } from "@/services/ota-update";
 import { Preferences } from "@capacitor/preferences";
@@ -292,6 +294,22 @@ const RootComponent = () => {
       try {
         const result = await checkForOtaUpdate();
         if (result.update_available && result.bundle_download_url) {
+          // Native apps update silently: download in the background and stage the
+          // bundle for the next restart/resume. No banner, no toast, no mid-session
+          // reload — a reload here would wipe a learner's in-progress attempt.
+          if (await isSilentOtaApp()) {
+            try {
+              await downloadAndStageUpdate(
+                result.bundle_download_url,
+                result.version!,
+                result.checksum!,
+              );
+            } catch (stageErr) {
+              console.error("OTA silent stage failed:", stageErr);
+            }
+            return;
+          }
+
           setOtaUpdate({
             otaUpdateAvailable: true,
             otaVersion: result.version ?? null,

--- a/frontend-learner-dashboard-app/src/services/ota-update.ts
+++ b/frontend-learner-dashboard-app/src/services/ota-update.ts
@@ -1,9 +1,39 @@
 import { CapacitorUpdater } from "@capgo/capacitor-updater";
-import { App } from "@capacitor/app";
+import { App } from "@/utils/app-plugin";
 import { Capacitor } from "@capacitor/core";
 import { BACKEND_BASE_URL } from "@/config/baseUrl";
 
 const OTA_CHECK_URL = `${BACKEND_BASE_URL}/admin-core-service/public/ota/v1/check`;
+
+// App ids that OPT OUT of OTA entirely — they are distributed only via the app
+// store and must never ride the shared learner OTA stream (whose fleet-wide
+// "all apps" bundles would otherwise surface as an update banner). Sadbhavana
+// is a newly-registered App Store app the user releases manually, not via OTA.
+const OTA_DISABLED_APP_IDS = new Set<string>([
+  "io.sadbhavana.com",
+]);
+
+// ALL native institute apps apply OTA updates SILENTLY in the background: the
+// new bundle is downloaded and staged with next() so it activates on the next
+// natural app restart/resume — NO banner, NO toast, NO mid-session reload. This
+// is deliberate for a learner/exam app: an immediate set() reload would wipe a
+// student's in-progress attempt. Apps that must not OTA at all are handled
+// earlier via OTA_DISABLED_APP_IDS (checkForOtaUpdate returns no-update for
+// them, so they never reach the silent path).
+//
+// NOTE (bootstrap): the silent behavior ships IN the bundle, so the FIRST OTA a
+// device receives is still handled by whatever JS it currently runs; every
+// update AFTER that is silent.
+
+/**
+ * Whether the running app should apply OTA updates silently (download + stage
+ * for next restart) instead of surfacing a banner/toast. True for every native
+ * build; web/electron return false (no OTA there).
+ */
+export async function isSilentOtaApp(): Promise<boolean> {
+  const platform = Capacitor.getPlatform();
+  return platform === "android" || platform === "ios";
+}
 
 export interface OtaCheckResponse {
   update_available: boolean;
@@ -26,13 +56,24 @@ export async function checkForOtaUpdate(): Promise<OtaCheckResponse> {
   }
 
   const appInfo = await App.getInfo();
+
+  // Opt-out apps (e.g. Sadbhavana) never show the OTA banner.
+  if (OTA_DISABLED_APP_IDS.has(appInfo.id)) {
+    return { update_available: false };
+  }
+
   const current = await CapacitorUpdater.current();
 
-  // If the plugin has an active OTA bundle, use its version.
-  // Otherwise fall back to the native app version (first run / no OTA yet).
+  // If the plugin has an active OTA bundle, use its version. Otherwise (first
+  // run / no OTA applied yet) fall back to the EMBEDDED JS bundle version
+  // (__APP_VERSION__, injected from package.json) — NOT the native app version.
+  // The native version (e.g. iOS MARKETING_VERSION 1.0.x) lives in a different
+  // numbering space than OTA bundles (2.2.x); using it made every published
+  // bundle look newer and surfaced a false "update available" banner that, if
+  // tapped, would downgrade the embedded JS.
   const currentBundleVersion =
     current.bundle.version === "builtin"
-      ? appInfo.version
+      ? __APP_VERSION__
       : current.bundle.version;
 
   const params = new URLSearchParams({
@@ -65,6 +106,27 @@ export async function downloadAndApplyUpdate(
 
   // set() applies the bundle and reloads the WebView immediately
   await CapacitorUpdater.set(bundle);
+}
+
+/**
+ * Download a bundle zip and STAGE it for the next app restart/resume via next().
+ * Unlike downloadAndApplyUpdate (set = immediate reload), this never reloads the
+ * WebView mid-session — the staged bundle activates silently the next time the
+ * app is backgrounded/relaunched. No UI is shown. Used by the silent OTA path.
+ */
+export async function downloadAndStageUpdate(
+  bundleDownloadUrl: string,
+  version: string,
+  checksum: string,
+): Promise<void> {
+  const bundle = await CapacitorUpdater.download({
+    url: bundleDownloadUrl,
+    version,
+    checksum,
+  });
+
+  // next() activates the bundle on the next app background/relaunch — no reload now.
+  await CapacitorUpdater.next({ id: bundle.id });
 }
 
 /**

--- a/frontend-learner-dashboard-app/src/vite-env.d.ts
+++ b/frontend-learner-dashboard-app/src/vite-env.d.ts
@@ -8,3 +8,6 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Injected by Vite `define` from package.json — the embedded JS bundle version.
+declare const __APP_VERSION__: string;

--- a/frontend-learner-dashboard-app/vite.config.ts
+++ b/frontend-learner-dashboard-app/vite.config.ts
@@ -3,10 +3,23 @@ import { defineConfig } from "vite";
 import viteReact from "@vitejs/plugin-react";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import path from "path";
+import { readFileSync } from "fs";
 import svgr from "vite-plugin-svgr";
+
+// Embedded JS bundle version, read from package.json at build time. The OTA
+// check uses this as the "current bundle version" on a fresh install (before
+// any OTA bundle is applied), so it compares JS-to-JS instead of falling back
+// to the native app version — whose numbering space (1.0.x) differs from the
+// OTA bundle scheme (2.2.x) and would make every published bundle look newer.
+const pkgVersion: string = JSON.parse(
+    readFileSync(path.resolve(__dirname, "package.json"), "utf-8"),
+).version;
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    define: {
+        __APP_VERSION__: JSON.stringify(pkgVersion),
+    },
     plugins: [
         TanStackRouterVite(),
         viteReact(),


### PR DESCRIPTION
Native institute apps (Enark, etc.) now download a new OTA bundle in the background and stage it with CapacitorUpdater.next(), so it activates on the next natural restart/resume. No banner, no toast, no mid-session reload — an immediate set() reload would wipe a learner's in-progress exam attempt.

- ota-update.ts: add isSilentOtaApp() (true for any android/ios build) and downloadAndStageUpdate() (download + next(), vs set()'s instant reload).
- ota-update.ts: add OTA_DISABLED_APP_IDS opt-out (io.sadbhavana.com is released manually via the App Store and must not ride the shared OTA stream).
- ota-update.ts: fall back to the EMBEDDED JS version (__APP_VERSION__) rather than the native app version when no OTA bundle is active. The native version (iOS MARKETING_VERSION 1.0.x) is a different numbering space from OTA bundles (2.x), which made every published bundle look newer and surfaced a false "update available" banner that would downgrade the embedded JS if tapped.
- vite.config.ts / vite-env.d.ts: define + declare __APP_VERSION__.
- __root.tsx: route native OTA through the silent stage-for-next-restart path.

Bootstrap caveat: the silent behavior ships IN the bundle, so the FIRST OTA a device receives is still handled by the JS it currently runs; every update after that is silent.

Verified: vite build succeeds.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
