### PR TITLE
fix: remove apostrophe in SQL comment breaking admin_core_service sta…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionParticipantRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionParticipantRepository.java
@@ -453,7 +453,7 @@ public interface LiveSessionParticipantRepository extends JpaRepository<LiveSess
        AND m.user_id = :userId
        -- Enrolment status is deliberately NOT restricted to ACTIVE. A report for a past term is
        -- generated after the mapping has flipped to EXPIRED/INACTIVE (or the learner moved to the
-       -- next year's batch) — requiring ACTIVE returned ZERO sessions for a learner with a full
+       -- next years batch) -- requiring ACTIVE returned ZERO sessions for a learner with a full
        -- attendance history. They *were* enrolled when those sessions ran, which is what matters.
        -- INVITED (never enrolled) and DELETED are still excluded.
        AND m.status NOT IN ('INVITED', 'DELETED')


### PR DESCRIPTION
…rtup

An apostrophe in a native @Query's inline `--` comment ("next year's batch") was misread as opening a quoted string literal by Spring Data's native-query parameter parser, which doesn't understand SQL comments. This left the quote unterminated, throwing IllegalArgumentException during JpaRepositoryFactoryBean initialization and crash-looping the pod on every boot.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
