### PR TITLE
fix(payments): retire dropped payment plans on edit; charge renewals …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormService.java
@@ -44,6 +44,9 @@ public class EnrollmentFormService {
     @Autowired
     private CustomFieldValueService customFieldValueService;
 
+    @Autowired
+    private EnrollmentFormWhatsAppService enrollmentFormWhatsAppService;
+
     @Transactional
     public EnrollmentFormSubmitResponseDTO submitEnrollmentForm(EnrollmentFormSubmitDTO request) {
         log.info("Processing enrollment form submission for email: {}", 
@@ -109,6 +112,10 @@ public class EnrollmentFormService {
 
         log.info("Enrollment form submitted successfully for user: {}, created {} ABANDONED_CART entries",
                 createdUser.getId(), abandonedCartEntryIds.size());
+
+        // Step 6: Thank-you WhatsApp. Async and self-contained — the learner is already
+        // registered, so a messaging failure must not surface as a form-submit failure.
+        enrollmentFormWhatsAppService.sendFormFillThankYou(createdUser, request.getInstituteId());
 
         return EnrollmentFormSubmitResponseDTO.builder()
                 .userId(createdUser.getId())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormWhatsAppService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormWhatsAppService.java
@@ -1,0 +1,124 @@
+package vacademy.io.admin_core_service.features.enroll_invite.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
+import vacademy.io.admin_core_service.features.notification.dto.WhatsappRequest;
+import vacademy.io.admin_core_service.features.notification.util.PhoneCountryUtil;
+import vacademy.io.admin_core_service.features.notification_service.service.NotificationService;
+import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.institute.entity.Institute;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Sends the "thank you for registering" WhatsApp message right after a learner
+ * submits an enrollment form.
+ *
+ * The template is resolved per-institute from
+ * {@code setting.FORM_FILL_WHATSAPP_SETTING.data}:
+ *
+ * <pre>
+ * "FORM_FILL_WHATSAPP_SETTING": {
+ *   "data": {
+ *     "enabled": true,
+ *     "template_name": "suchbliss_testing_confirmation",
+ *     "language_code": "en"
+ *   }
+ * }
+ * </pre>
+ *
+ * An institute without that block simply gets no message — the feature is opt-in
+ * per institute, and a template approved for one WABA is meaningless for another.
+ */
+@Slf4j
+@Service
+public class EnrollmentFormWhatsAppService {
+
+    private static final String SETTING_KEY = "FORM_FILL_WHATSAPP_SETTING";
+    private static final String DEFAULT_LANGUAGE = "en";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private InstituteRepository instituteRepository;
+
+    @Autowired
+    private NotificationService notificationService;
+
+    /**
+     * Fire-and-forget: a WhatsApp failure must never fail the enrollment the
+     * learner just completed, so everything here is caught and logged.
+     */
+    @Async
+    public void sendFormFillThankYou(UserDTO user, String instituteId) {
+        try {
+            if (user == null || !StringUtils.hasText(instituteId)) {
+                return;
+            }
+
+            Optional<Institute> instituteOpt = instituteRepository.findById(instituteId);
+            if (instituteOpt.isEmpty()) {
+                return;
+            }
+            Institute institute = instituteOpt.get();
+
+            JsonNode config = readConfig(institute);
+            if (config == null || !config.path("enabled").asBoolean(true)) {
+                log.debug("Form-fill WhatsApp not enabled for institute {}", instituteId);
+                return;
+            }
+
+            String templateName = config.path("template_name").asText(null);
+            if (!StringUtils.hasText(templateName)) {
+                log.warn("FORM_FILL_WHATSAPP_SETTING for institute {} has no template_name", instituteId);
+                return;
+            }
+            String languageCode = config.path("language_code").asText(DEFAULT_LANGUAGE);
+
+            String phone = PhoneCountryUtil.normalizePhone(
+                    user.getMobileNumber(),
+                    PhoneCountryUtil.defaultsToIndia(institute.getCountry()));
+            if (!StringUtils.hasText(phone)) {
+                log.info("Skipping form-fill WhatsApp for user {} — no mobile number", user.getId());
+                return;
+            }
+
+            String name = StringUtils.hasText(user.getFullName()) ? user.getFullName() : "there";
+
+            WhatsappRequest request = new WhatsappRequest();
+            request.setTemplateName(templateName);
+            request.setLanguageCode(languageCode);
+            // {{1}} = learner name
+            request.setUserDetails(List.of(Map.of(phone, Map.of("1", name))));
+
+            notificationService.sendWhatsappViaUnified(request, instituteId);
+            log.info("Sent form-fill WhatsApp (template={}) to user {}", templateName, user.getId());
+        } catch (Exception e) {
+            log.error("Failed to send form-fill WhatsApp for user {} in institute {}: {}",
+                    user != null ? user.getId() : null, instituteId, e.getMessage(), e);
+        }
+    }
+
+    private JsonNode readConfig(Institute institute) {
+        String settingJson = institute.getSetting();
+        if (!StringUtils.hasText(settingJson)) {
+            return null;
+        }
+        try {
+            JsonNode data = objectMapper.readTree(settingJson)
+                    .path("setting").path(SETTING_KEY).path("data");
+            return data.isMissingNode() || data.isNull() ? null : data;
+        } catch (Exception e) {
+            log.warn("Could not parse {} for institute {}: {}", SETTING_KEY, institute.getId(), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
@@ -57,7 +57,10 @@ public class RenewalChargeService {
 
     public void processDueRenewals() {
         Date now = new Date();
-        List<UserPlan> due = userPlanRepository.findDueForRenewal(now);
+        // next_charge_at carries the enrollment's time-of-day, so a plan due "today" at
+        // 15:00 would be missed by this morning's run and only charge tomorrow. Sweep the
+        // whole day so a plan is always charged on the date it falls due.
+        List<UserPlan> due = userPlanRepository.findDueForRenewal(endOfDay(now));
         if (due.isEmpty()) {
             log.info("[RenewalCharge] No autopay plans due");
             return;
@@ -105,6 +108,17 @@ public class RenewalChargeService {
             log.error("[RenewalCharge] chargeNow failed for {}: {}", userPlanId, e.getMessage(), e);
             return "ERROR: " + e.getMessage();
         }
+    }
+
+    /** Last instant of the given day, so "due today" means due by this run. */
+    private static Date endOfDay(Date date) {
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(java.util.Calendar.HOUR_OF_DAY, 23);
+        cal.set(java.util.Calendar.MINUTE, 59);
+        cal.set(java.util.Calendar.SECOND, 59);
+        cal.set(java.util.Calendar.MILLISECOND, 999);
+        return cal.getTime();
     }
 
     private enum Outcome { CHARGED, FAILED, SKIPPED }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.user_subscription.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentPlanDTO;
 import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentOption;
 import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentPlan;
@@ -10,9 +11,11 @@ import vacademy.io.admin_core_service.features.user_subscription.repository.Paym
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -31,6 +34,7 @@ public class PaymentPlanService {
         Map<String,PaymentPlan>existingPaymentPlanMap = existingPaymentPlans.stream().
                 collect(Collectors.toMap(PaymentPlan::getId, Function.identity()));
         List<PaymentPlan>toSave = new ArrayList<>();
+        Set<String> retainedIds = new HashSet<>();
         for (PaymentPlanDTO paymentPlanDTO : paymentPlanDTOS) {
             if (StringUtils.hasText(paymentPlanDTO.getId())){
                 PaymentPlan paymentPlan = existingPaymentPlanMap.get(paymentPlanDTO.getId());
@@ -39,10 +43,20 @@ public class PaymentPlanService {
                 }else{
                     throw new VacademyException("Payment Plan with id " + paymentPlanDTO.getId() + " not found");
                 }
+                retainedIds.add(paymentPlanDTO.getId());
                 toSave.add(paymentPlan);
             }else{
                 toSave.add(new PaymentPlan(paymentPlanDTO,paymentOption));
             }
+        }
+        // Plans the edit dropped (or replaced by id-less copies) must be retired, or
+        // they stay ACTIVE alongside the new ones and learners see duplicate plans.
+        List<PaymentPlan> dropped = existingPaymentPlans.stream()
+                .filter(plan -> !retainedIds.contains(plan.getId()))
+                .toList();
+        if (!dropped.isEmpty()) {
+            dropped.forEach(plan -> plan.setStatus(StatusEnum.DELETED.name()));
+            paymentPlanRepository.saveAll(dropped);
         }
         return toSave;
     }


### PR DESCRIPTION
…on the due date

- editPaymentPlans left the previous plan rows ACTIVE when an edit re-sent plans without ids, so learners saw duplicate/stale intervals on the invite. Retire any existing plan the edit dropped (@Where already hides DELETED ones).
- Renewal sweep compared next_charge_at against the run instant, so a plan due today at 15:00 was missed by the 11:00 run and only charged the next day. Sweep to end-of-day so a plan is charged on the date it falls due.

feat(enrollment): thank-you WhatsApp on invite form submit

Template resolved per-institute from setting.FORM_FILL_WHATSAPP_SETTING (template_name + language_code); {{1}} = learner name. Async and fully guarded — a messaging failure can never fail the enrollment.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
