### PR TITLE
fix: guardian settings not persisting across refresh

### DIFF
--- a/frontend-admin-dashboard/src/hooks/use-parent-settings.ts
+++ b/frontend-admin-dashboard/src/hooks/use-parent-settings.ts
@@ -38,7 +38,11 @@ async function fetchParentSettings(): Promise<ParentSettingsConfig> {
             url: GET_INSITITUTE_SETTINGS,
             params: { instituteId, settingKey: SETTING_KEY },
         });
-        const data: ParentSettingsConfig | undefined = response.data?.data?.[SETTING_KEY]?.data;
+        // GET returns the SettingDto itself ({key, name, data}) — response.data IS
+        // the SettingDto, so its content is one level down at response.data.data
+        // (matches LeadSettings.tsx's fetchLeadSettings, verified working — NOT
+        // nested under an extra settingKey property).
+        const data: ParentSettingsConfig | undefined = response.data?.data;
         if (!data) return PARENT_SETTINGS_DEFAULTS;
         // Merge with defaults so any newly added keys are present even if not
         // yet saved (backward-compatible config evolution).

--- a/frontend-admin-dashboard/src/routes/settings/-components/GuardianSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/GuardianSettings.tsx
@@ -48,7 +48,10 @@ const fetchGuardianSettings = async (): Promise<GuardianSettingsData> => {
         url: GET_INSITITUTE_SETTINGS,
         params: { instituteId, settingKey: SETTING_KEY },
     });
-    const saved = response.data?.data?.[SETTING_KEY]?.data as Partial<GuardianSettingsData> | undefined;
+    // GET returns the SettingDto itself ({key, name, data}) — response.data IS
+    // the SettingDto, so its content is one level down at response.data.data
+    // (matches LeadSettings.tsx's fetchLeadSettings, verified working).
+    const saved = response.data?.data as Partial<GuardianSettingsData> | undefined;
     if (!saved) return DEFAULT_GUARDIAN_SETTINGS;
     return { ...DEFAULT_GUARDIAN_SETTINGS, ...saved };
 };


### PR DESCRIPTION
fetchGuardianSettings/fetchParentSettings read the wrong JSON path: response.data.data.PARENT_SETTING.data, but the single-key GET endpoint returns the SettingDto directly (response.data IS {key, name, data}) — confirmed against LeadSettings.tsx's working fetchLeadSettings, which uses response.data.data with the same comment explaining the shape. The extra [SETTING_KEY] level meant the read always missed the saved value and silently fell back to the disabled default, everywhere useParentSettings() is consumed (bulk-assign dialog, side-view tab, backfill gating) — not just on the settings page itself.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
