### PR TITLE
fix(crm): transcribe private call recordings from the PRIVATE bucket

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/call_intelligence/dto/CallIntelligenceDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/call_intelligence/dto/CallIntelligenceDto.java
@@ -44,6 +44,16 @@ public class CallIntelligenceDto {
     private String schemaVersion;
     private Timestamp completedAt;
 
+    /**
+     * Why a FAILED row failed (the exception from the ai_service pipeline), and how
+     * many times it has been attempted. Without these a FAILED row is completely
+     * opaque — status=FAILED with skipReason=null and every analysis field empty —
+     * so there is no way to tell a bad recording from a model/JSON error without
+     * shell access to the DB. SKIPPED rows carry {@code skipReason} instead.
+     */
+    private String error;
+    private Integer attempts;
+
     public static CallIntelligenceDto from(CallIntelligence c) {
         return CallIntelligenceDto.builder()
                 .id(c.getId())
@@ -71,6 +81,8 @@ public class CallIntelligenceDto {
                 .creditsCharged(c.getCreditsCharged())
                 .schemaVersion(c.getSchemaVersion())
                 .completedAt(c.getCompletedAt())
+                .error(c.getError())
+                .attempts(c.getAttempts())
                 .build();
     }
 }

--- a/ai_service/app/services/call_intelligence_poller.py
+++ b/ai_service/app/services/call_intelligence_poller.py
@@ -62,17 +62,23 @@ def _claim_batch() -> List[Dict[str, Any]]:
         """), {"batch": BATCH_SIZE}).mappings().all()
         claimed = [dict(r) for r in rows]
 
-        # Enrich with the recording storage key (kept on the call log, not denormalized).
+        # Enrich with the recording storage key (kept on the call log, not denormalized)
+        # AND which bucket it lives in. Recordings are split across the PUBLIC and the
+        # PRIVATE media bucket (recording_private), and each has its own resolver route —
+        # handing a private file to the public resolver 404s, which fails the whole
+        # transcription job ("transcription failed: HTTP Error 404: Not Found").
         if claimed:
             ids = [c["call_log_id"] for c in claimed]
             recs = db.execute(text("""
-                SELECT id, recording_storage_key
+                SELECT id, recording_storage_key, recording_private
                 FROM telephony_call_log
                 WHERE id = ANY(:ids)
             """), {"ids": ids}).mappings().all()
             keys = {r["id"]: r["recording_storage_key"] for r in recs}
+            private = {r["id"]: r["recording_private"] for r in recs}
             for c in claimed:
                 c["recording_storage_key"] = keys.get(c["call_log_id"])
+                c["recording_private"] = bool(private.get(c["call_log_id"]))
     return claimed
 
 

--- a/ai_service/app/services/call_intelligence_service.py
+++ b/ai_service/app/services/call_intelligence_service.py
@@ -34,7 +34,7 @@ from ..schemas.credits import CreditCheckRequest, CreditDeductRequest
 from . import llm_json
 from .call_intelligence_prompt import PROMPT_VERSION, SCHEMA_VERSION, build_prompt
 from .credit_service import CreditService
-from .media_file_client import get_public_file_url
+from .media_file_client import get_file_url, get_public_file_url
 from .transcription_service import TranscriptionService
 
 logger = logging.getLogger(__name__)
@@ -322,9 +322,16 @@ async def process_one(claimed: Dict[str, Any]) -> None:
         if not storage_key:
             _mark(row_id, "SKIPPED", skip_reason="NO_RECORDING")
             return
-        # Recordings are stored in the PUBLIC media bucket (same as lead-profile
-        # playback). The private resolver 404s for them → transcription fails.
-        source_url = await get_public_file_url(storage_key)
+        # Recordings live in EITHER bucket and each has its own resolver route, so the
+        # bucket has to drive the choice (telephony_call_log.recording_private):
+        #   • public  (most telephony recordings, same as lead-profile playback)
+        #   • private (e.g. VACADEMY_AI / Plivo AI-call recordings)
+        # Hardcoding either one 404s for the other half and fails the transcription job
+        # with "transcription failed: HTTP Error 404: Not Found".
+        if claimed.get("recording_private"):
+            source_url = await get_file_url(storage_key)
+        else:
+            source_url = await get_public_file_url(storage_key)
 
         # 2. Settings (rubric + credit override).
         cfg = await asyncio.to_thread(_read_call_settings, institute_id)


### PR DESCRIPTION
Every Call Intelligence run has failed since 2452ab393 for one class of call:

    status=FAILED, skip_reason=NULL, error="transcription failed: HTTP Error 404: Not Found"

Evidence (prod, call_intelligence x telephony_call_log):
    COMPLETED  recording_private=false  181
    FAILED     recording_private=true    22   <- all VACADEMY_AI (Plivo AI calls)

Recordings live in EITHER media bucket and each has its own resolver route. 2452ab393 fixed the public ones by hardcoding get_public_file_url() for ALL recordings — which flipped the 404 onto the private ones. The public resolver 404s for a private file, the render worker can't download the audio, and the whole transcription job fails.

telephony_call_log.recording_private already records the bucket, but the poller never carried it, so process_one had no way to choose.

- poller: select recording_private alongside recording_storage_key and put it on the claimed row.
- service: resolve via get_file_url() when recording_private, else get_public_file_url().

Also expose call_intelligence.error + attempts on CallIntelligenceDto. The pipeline records the exception, but the DTO never mapped it, so a FAILED row came back with every field null and no reason — this outage was invisible from the API.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
