### PR TITLE
fix: Guardian Tab display-setting toggle silently dropped on save/fetch

### DIFF
--- a/frontend-admin-dashboard/src/services/display-settings.ts
+++ b/frontend-admin-dashboard/src/services/display-settings.ts
@@ -508,6 +508,7 @@ function mergeDisplayWithDefaults(
         applicationTab: false,
         leadTab: false,
         fullHistoryTab: false,
+        parentTab: false,
     };
     merged.studentSideView = {
         overviewTab: incoming?.studentSideView?.overviewTab ?? defStudentSideView.overviewTab,
@@ -533,6 +534,7 @@ function mergeDisplayWithDefaults(
         leadTab: incoming?.studentSideView?.leadTab ?? defStudentSideView.leadTab,
         fullHistoryTab:
             incoming?.studentSideView?.fullHistoryTab ?? defStudentSideView.fullHistoryTab ?? false,
+        parentTab: incoming?.studentSideView?.parentTab ?? defStudentSideView.parentTab ?? false,
         // Preserve user-supplied ordering and default-tab choice; fall back to
         // the role's defaults so older saved settings (which lacked these
         // fields) still render in a sensible order.


### PR DESCRIPTION
mergeDisplayWithDefaults()'s studentSideView block (services/display-settings.ts) reconstructs the object from a hand-written field list on every save AND every fetch (including the post-save cache write). parentTab was missing from that list, so it was silently stripped immediately after saving and on every subsequent read — regardless of what actually reached the backend. The toggle UI itself (StudentSideViewSettingsCard) was already correct; this was purely a merge-layer bug, separate from the earlier PARENT_SETTING read-path fix.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
