### PR TITLE
chore(learner): bump OTA bundle version to 2.3.1

### DIFF
--- a/frontend-learner-dashboard-app/package.json
+++ b/frontend-learner-dashboard-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "capacitor-starter",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Records the version published to the Enark apps as OTA **v2.3.1**.

## Context
The `/dashboard` routing fix (#2177) and silent background OTA updates (#2179) are already on `main`. I built from `main` and published that bundle to the Enark apps (`io.enarkuplift.app`, `com.enarkuplift.app`) as version 2.3.1, but `package.json` on `main` still read `2.2.6`. This bump keeps the repo in sync so the next publish doesn't reuse 2.3.1.

## What Enark learners get
- Dashboard sidebar button works again (was a dead route for custom post-login-route institutes)
- Future updates apply silently in the background (this first one still shows the banner — silent behavior ships *inside* this bundle)

No code change — one line in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)