### PR TITLE
Feat/lead edit profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ vacademy_devops/hetzner/topology.env
 
 # Hetzner migration: operator-filled prod values overlay (real secrets)
 vacademy_devops/hetzner/values-prod-hetzner.yaml
+
+# Local dev config per service (hardcoded secrets for terminal runs) — never commit
+**/src/main/resources/application-local.properties

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
@@ -174,6 +174,20 @@ public class AudienceController {
     }
 
     /**
+     * Edit a lead's profile from the CRM. The learner-profile endpoint cannot serve
+     * a lead: it resolves the caller against the {@code student} table, and a lead
+     * that never enrolled has no row there. This writes only where a lead is actually
+     * read from — the auth user, the {@code audience_response} parent/guardian fields,
+     * and the lead's custom field values. It never touches {@code student}.
+     */
+    @PutMapping("/lead/{responseId}/profile")
+    public ResponseEntity<String> updateLeadProfile(@PathVariable String responseId,
+                                                    @RequestBody LeadProfileEditRequestDTO request) {
+        audienceService.updateLeadProfile(responseId, request);
+        return ResponseEntity.ok("Lead profile updated");
+    }
+
+    /**
      * Send a message to audience campaign leads.
      */
     @PostMapping("/campaign/{audienceId}/send")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadProfileEditRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadProfileEditRequestDTO.java
@@ -1,0 +1,43 @@
+package vacademy.io.admin_core_service.features.audience.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import vacademy.io.admin_core_service.features.common.dto.request.CustomFieldValueDto;
+import vacademy.io.common.auth.dto.UserDTO;
+
+import java.util.List;
+
+/**
+ * Request body for editing a lead's profile from the CRM (admin dashboard).
+ *
+ * <p>Deliberately scoped to exactly what a lead reads/round-trips:
+ * <ul>
+ *   <li>{@code user_details} → the lead's own auth user (name / email / mobile,
+ *       plus any other {@link UserDTO} field if sent)</li>
+ *   <li>{@code parent_*} → the guardian fields on the {@code audience_response} row</li>
+ *   <li>{@code custom_field_values} → the lead's form answers (source AUDIENCE_RESPONSE)</li>
+ * </ul>
+ * It does NOT touch the {@code student} table — leads have no student row.</p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LeadProfileEditRequestDTO {
+
+    /** Identity fields written back to the lead's auth user. */
+    private UserDTO userDetails;
+
+    /** Guardian fields written back to audience_response. */
+    private String parentName;
+    private String parentEmail;
+    private String parentMobile;
+
+    /** Lead form answers; each entry should carry source_type=AUDIENCE_RESPONSE and source_id=responseId. */
+    private List<CustomFieldValueDto> customFieldValues;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/scheduler/LeadAutomationScheduler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/scheduler/LeadAutomationScheduler.java
@@ -169,6 +169,9 @@ public class LeadAutomationScheduler {
         ctxBuilder.put(ctx, "leadName", c.getParentName());
         ctxBuilder.put(ctx, "leadEmail", c.getParentEmail());
         ctxBuilder.put(ctx, "leadMobile", c.getParentMobile());
+        // parent_* is null for an ordinary campaign lead — fill the lead-* keys from the
+        // lead's own auth user so the reminder still has a name and a recipient to send to.
+        ctxBuilder.enrichLeadContact(ctx, c.getUserId());
         ctxBuilder.put(ctx, "tatStage", emission.canonicalStage);
         ctxBuilder.put(ctx, "stageLabel", emission.stageLabel);
         if (notifyRoles != null && !notifyRoles.isEmpty()) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -58,8 +58,13 @@ import vacademy.io.admin_core_service.features.notification_service.service.Noti
 import vacademy.io.admin_core_service.features.common.entity.CustomFields;
 import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
+import vacademy.io.admin_core_service.features.audience.enums.CustomFieldValueSourceType;
+import vacademy.io.admin_core_service.features.common.service.CustomFieldValueService;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.notification.dto.GenericEmailRequest;
+import vacademy.io.common.exceptions.ConflictException;
+import vacademy.io.common.exceptions.InvalidRequestException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -89,6 +94,9 @@ public class AudienceService {
 
     @Autowired
     private AudienceResponseRepository audienceResponseRepository;
+
+    @Autowired
+    private CustomFieldValueService customFieldValueService;
 
     @Autowired
     private AudienceCommunicationRepository audienceCommunicationRepository;
@@ -2835,6 +2843,95 @@ public class AudienceService {
                 .orElseThrow(() -> new VacademyException("Lead not found"));
         audienceResponseRepository.delete(response);
         logger.info("Deleted lead: {}", responseId);
+    }
+
+    /**
+     * Edit a lead's profile from the CRM.
+     *
+     * <p>Writes only where a lead is actually read from — the auth user
+     * (name / email / mobile), the {@code audience_response} parent/guardian
+     * fields, and the lead's custom field values. It never touches the
+     * {@code student} table: a lead that never enrolled has no row there, which
+     * is why the learner-profile endpoint cannot serve this case.</p>
+     *
+     * <p>If the edit moves email/phone onto an identity that another lead in the
+     * same campaign already owns, it is rejected (409) so two leads cannot
+     * collide on one {@code dedupe_key}.</p>
+     */
+    @Transactional
+    public void updateLeadProfile(String responseId, LeadProfileEditRequestDTO request) {
+        if (request == null) {
+            throw new InvalidRequestException("Request body is required");
+        }
+
+        AudienceResponse response = audienceResponseRepository.findById(responseId)
+                .orElseThrow(() -> new ResourceNotFoundException("Lead not found"));
+
+        UserDTO updates = request.getUserDetails();
+
+        // 1) The lead's identity lives on the auth user — merge the edits over the
+        // existing record so unsent fields aren't blanked.
+        String leadUserId = response.getUserId() != null ? response.getUserId() : response.getStudentUserId();
+        if (updates != null && StringUtils.hasText(leadUserId)) {
+            String newEmail = updates.getEmail();
+            String newPhone = updates.getMobileNumber();
+            if (StringUtils.hasText(newEmail) || StringUtils.hasText(newPhone)) {
+                String newKey = leadDeduplicationService.generateDedupeKey(newEmail, newPhone);
+                if (newKey != null && response.getAudienceId() != null) {
+                    leadDeduplicationService.findDuplicate(response.getAudienceId(), newKey)
+                            .filter(existing -> !existing.getId().equals(responseId))
+                            .ifPresent(existing -> {
+                                throw new ConflictException(
+                                        "A lead already exists with this phone number or email.");
+                            });
+                    response.setDedupeKey(newKey);
+                }
+            }
+
+            List<UserDTO> existingUsers = authService.getUsersFromAuthServiceByUserIds(List.of(leadUserId));
+            UserDTO existing = (existingUsers != null && !existingUsers.isEmpty()) ? existingUsers.get(0) : null;
+            UserDTO merged = (existing != null) ? mergeUserDTO(existing, updates) : updates;
+            merged.setId(leadUserId);
+            authService.updateUser(merged, leadUserId);
+        }
+
+        // 2) Parent/guardian fields on the audience_response row. A cleared field arrives
+        // as "" from the form; store it as NULL rather than an empty string, otherwise
+        // queries that gate on `parent_mobile IS NOT NULL` would start matching leads that
+        // have no parent contact at all.
+        if (request.getParentName() != null) {
+            response.setParentName(blankToNull(request.getParentName()));
+        }
+        if (request.getParentEmail() != null) {
+            response.setParentEmail(blankToNull(request.getParentEmail()));
+        }
+        if (request.getParentMobile() != null) {
+            response.setParentMobile(blankToNull(request.getParentMobile()));
+        }
+        // dedupe_key may also have changed above.
+        audienceResponseRepository.save(response);
+
+        // 3) The lead's form answers.
+        if (!CollectionUtils.isEmpty(request.getCustomFieldValues())) {
+            request.getCustomFieldValues().forEach(cfv -> {
+                if (cfv != null) {
+                    if (!StringUtils.hasText(cfv.getSourceType())) {
+                        cfv.setSourceType(CustomFieldValueSourceType.AUDIENCE_RESPONSE.name());
+                    }
+                    if (!StringUtils.hasText(cfv.getSourceId())) {
+                        cfv.setSourceId(responseId);
+                    }
+                }
+            });
+            customFieldValueService.upsertCustomFieldValues(request.getCustomFieldValues());
+        }
+
+        logger.info("Lead profile updated for response {}", responseId);
+    }
+
+    /** Trim a form-supplied value, mapping "" (a cleared field) to NULL. */
+    private String blankToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadTriggerContextBuilder.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadTriggerContextBuilder.java
@@ -89,6 +89,43 @@ public class LeadTriggerContextBuilder {
         }
     }
 
+    /**
+     * Fall back to the lead's own auth user for any lead-* contact key the
+     * audience_response row didn't supply.
+     *
+     * <p>The {@code parent_*} columns are only populated by the enquiry/admission,
+     * walk-in and inbound-call paths. A lead captured by an ordinary campaign form
+     * leaves them null and carries its contact details on the auth user alone — so
+     * without this fallback {{leadEmail}} / {{leadMobile}} / {{leadName}} render empty
+     * and SEND_EMAIL / SEND_WHATSAPP have no recipient to resolve. Parent-sourced
+     * values still win when present, which keeps "contact the parent first" intact.
+     * Best-effort; never throws into the emit path.</p>
+     */
+    public void enrichLeadContact(Map<String, Object> ctx, String leadUserId) {
+        if (leadUserId == null || leadUserId.isBlank()) return;
+        if (hasText(ctx.get("leadName")) && hasText(ctx.get("leadEmail")) && hasText(ctx.get("leadMobile"))) {
+            return;
+        }
+        try {
+            List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(leadUserId));
+            if (users == null || users.isEmpty()) return;
+            UserDTO u = users.get(0);
+            putIfBlank(ctx, "leadName", u.getFullName());
+            putIfBlank(ctx, "leadEmail", u.getEmail());
+            putIfBlank(ctx, "leadMobile", u.getMobileNumber());
+        } catch (Exception e) {
+            log.warn("[LeadTrigger] Failed to enrich lead contact for {}: {}", leadUserId, e.getMessage());
+        }
+    }
+
+    private void putIfBlank(Map<String, Object> ctx, String key, Object value) {
+        if (!hasText(ctx.get(key))) put(ctx, key, value);
+    }
+
+    private static boolean hasText(Object value) {
+        return value instanceof String s ? !s.isBlank() : value != null;
+    }
+
     /** Context anchored on a specific lead row (audience_response). */
     public Map<String, Object> forLead(AudienceResponse ar, String instituteId, String campaignName,
                                        String counselorId, String counselorName) {
@@ -111,6 +148,9 @@ public class LeadTriggerContextBuilder {
             put(ctx, "leadName", ar.getParentName());
             put(ctx, "leadEmail", ar.getParentEmail());
             put(ctx, "leadMobile", ar.getParentMobile());
+            // parent_* is null for an ordinary campaign lead — fill the lead-* keys from
+            // the lead's own auth user so templates still resolve a name and a recipient.
+            enrichLeadContact(ctx, ar.getUserId());
             // If the caller didn't pass a campaignName, look it up from the audience so
             // {{campaignName}} resolves for every forLead path (not just the SLA scheduler
             // which already passes it from LeadSlaCandidate).

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerService.java
@@ -13,6 +13,7 @@ import vacademy.io.admin_core_service.features.learner.dto.LearnerDetailsEditDTO
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.auth.dto.learner.LearnerExtraDetails;
 import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.UserNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.List;
@@ -35,7 +36,7 @@ public class LearnerService {
             throw new VacademyException("Invalid request");
         }
         Student student = instituteStudentRepository.findTopByUserId(learnerDetailsEditDTO.getUserId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
         // Captured before mutation: the LMS sync looks the user up by their
         // CURRENT email on the LMS, and only fires when name/email changed.
         String previousEmail = student.getEmail();
@@ -102,7 +103,7 @@ public class LearnerService {
     public String updateFaceFileId(String faceFileId, CustomUserDetails userDetails) {
         if (StringUtils.hasText(userDetails.getId()) && StringUtils.hasText(faceFileId)) {
             Student student = instituteStudentRepository.findTopByUserId(userDetails.getId())
-                    .orElseThrow(() -> new VacademyException("User not found"));
+                    .orElseThrow(() -> new UserNotFoundException("User not found"));
             student.setFaceFileId(faceFileId);
             instituteStudentRepository.save(student);
             return "success";
@@ -123,7 +124,7 @@ public class LearnerService {
 
     public String updateLearnerDetail(UserDTO userDTO, LearnerExtraDetails learnerExtraDetails) {
         Student student = instituteStudentRepository.findTopByUserId(userDTO.getId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         student.setUsername(userDTO.getUsername());
         student.setFullName(userDTO.getFullName());
@@ -149,7 +150,7 @@ public class LearnerService {
 
     public String updateLearnerDetail(UserDTO userDTO) {
         Student student = instituteStudentRepository.findTopByUserId(userDTO.getId())
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         if (StringUtils.hasText(userDTO.getUsername())) {
             student.setUsername(userDTO.getUsername());
@@ -194,7 +195,7 @@ public class LearnerService {
         }
 
         Student student = instituteStudentRepository.findTopByUserId(userId)
-                .orElseThrow(() -> new VacademyException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
 
         if (StringUtils.hasText(learnerExtraDetails.getFathersName())) {
             student.setFatherName(learnerExtraDetails.getFathersName());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
@@ -1835,6 +1835,31 @@ public class QueryServiceImpl implements QueryNodeHandler.QueryService {
                         .collect(Collectors.groupingBy(CustomFieldValues::getSourceId));
             }
 
+            // The parent_* columns are null for an ordinary campaign lead, whose contact
+            // details live on the auth user instead. Resolve those users in bulk so a lead
+            // is reached at its CURRENT address — the custom-field answers below preserve
+            // only what was submitted originally, so a lead edited in the CRM would
+            // otherwise keep being mailed at its old address.
+            Map<String, UserDTO> userById = new HashMap<>();
+            List<String> leadUserIds = allResponses.stream()
+                    .map(AudienceResponse::getUserId)
+                    .filter(id -> id != null && !id.isBlank())
+                    .distinct()
+                    .collect(Collectors.toList());
+            if (!leadUserIds.isEmpty()) {
+                try {
+                    List<UserDTO> leadUsers = authService.getUsersFromAuthServiceByUserIds(leadUserIds);
+                    if (leadUsers != null) {
+                        leadUsers.stream()
+                                .filter(u -> u != null && u.getId() != null)
+                                .forEach(u -> userById.put(u.getId(), u));
+                    }
+                } catch (Exception e) {
+                    log.warn("Lead contact enrichment failed for {} users: {}",
+                            leadUserIds.size(), e.getMessage());
+                }
+            }
+
             List<Map<String, Object>> leads = new ArrayList<>();
             for (AudienceResponse resp : allResponses) {
                 Map<String, Object> lead = new LinkedHashMap<>();
@@ -1846,6 +1871,18 @@ public class QueryServiceImpl implements QueryNodeHandler.QueryService {
                 lead.put("parentEmail", resp.getParentEmail());
                 lead.put("parentName", resp.getParentName());
                 lead.put("mobileNumber", resp.getParentMobile());
+
+                // Fall back to the lead's own auth user where parent_* didn't supply a
+                // value. Parent-sourced values still win, so "contact the parent first"
+                // is unchanged; this only fills the gap for leads that have no parent row.
+                UserDTO leadUser = resp.getUserId() == null ? null : userById.get(resp.getUserId());
+                if (leadUser != null) {
+                    if (isBlankString(lead.get("email"))) lead.put("email", leadUser.getEmail());
+                    if (isBlankString(lead.get("mobileNumber")))
+                        lead.put("mobileNumber", leadUser.getMobileNumber());
+                    if (isBlankString(lead.get("parentName")))
+                        lead.put("parentName", leadUser.getFullName());
+                }
 
                 List<CustomFieldValues> cfvs = cfvByResponseId.getOrDefault(resp.getId(), List.of());
                 for (CustomFieldValues cfv : cfvs) {

--- a/common_service/src/main/java/vacademy/io/common/core/exception/GlobalExceptionHandler.java
+++ b/common_service/src/main/java/vacademy/io/common/core/exception/GlobalExceptionHandler.java
@@ -6,6 +6,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import vacademy.io.common.exceptions.ConflictException;
+import vacademy.io.common.exceptions.ForbiddenException;
+import vacademy.io.common.exceptions.InvalidRequestException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
+import vacademy.io.common.exceptions.UserNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.Date;
@@ -13,6 +18,36 @@ import java.util.Date;
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorInfo> handleUserNotFound(HttpServletRequest req, UserNotFoundException ex) {
+        log.warn("User Not Found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.NOT_FOUND), new Date()));
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorInfo> handleResourceNotFound(HttpServletRequest req, ResourceNotFoundException ex) {
+        log.warn("Resource Not Found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.NOT_FOUND), new Date()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorInfo> handleForbidden(HttpServletRequest req, ForbiddenException ex) {
+        log.warn("Forbidden: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.FORBIDDEN), new Date()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorInfo> handleConflict(HttpServletRequest req, ConflictException ex) {
+        log.warn("Conflict: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.CONFLICT), new Date()));
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorInfo> handleInvalidRequest(HttpServletRequest req, InvalidRequestException ex) {
+        log.warn("Invalid Request: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorInfo(req.getRequestURL().toString(), ex.getLocalizedMessage(), String.valueOf(HttpStatus.BAD_REQUEST), new Date()));
+    }
+
     @ExceptionHandler(VacademyException.class)
     public ResponseEntity<ErrorInfo> handleExceptionForOthers(HttpServletRequest req, VacademyException ex) {
         log.error("Vacademy Error: {} Stack Trace: {}", ex, ex.getStackTrace());

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ConflictException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ConflictException.java
@@ -1,0 +1,12 @@
+package vacademy.io.common.exceptions;
+
+/**
+ * Thrown when a request conflicts with the current state of a resource
+ * (e.g. a duplicate, or an action disallowed by the resource's status).
+ * Maps to HTTP 409.
+ */
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ForbiddenException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ForbiddenException.java
@@ -1,0 +1,8 @@
+package vacademy.io.common.exceptions;
+
+/** Thrown when the caller lacks permission for an action. Maps to HTTP 403. */
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ResourceNotFoundException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package vacademy.io.common.exceptions;
+
+/** Thrown when a requested resource does not exist. Maps to HTTP 404. */
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/frontend-admin-dashboard/src/components/shared/leads/lead-view-model.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/lead-view-model.ts
@@ -65,18 +65,16 @@ export const formatSubmitted = (iso: string | undefined | null): string => {
 
 // ── Display helpers (mirror the originals from both pages) ────────────────────
 
+// A lead's OWN identity lives on its auth user. The `parent_*` columns are the
+// parent/guardian's contact — a separate person — and are editable as such from the
+// CRM, so they must never stand in for the lead's own name/email/phone: doing so
+// would print the guardian's number in the lead's Phone column. Every path that
+// populates `parent_mobile` (enquiry, walk-in, inbound call) also puts that same
+// number on the auth user, so nothing is lost by reading the auth user alone.
 export const recentLeadName = (lead: RecentLeadDetail) =>
-    lead.user?.full_name ||
-    lead.parent_name ||
-    lead.user?.email ||
-    lead.parent_email ||
-    lead.user?.mobile_number ||
-    lead.parent_mobile ||
-    'Unknown lead';
-export const recentLeadEmail = (lead: RecentLeadDetail) =>
-    lead.user?.email || lead.parent_email || '-';
-export const recentLeadPhone = (lead: RecentLeadDetail) =>
-    lead.user?.mobile_number || lead.parent_mobile || '-';
+    lead.user?.full_name || lead.user?.email || lead.user?.mobile_number || 'Unknown lead';
+export const recentLeadEmail = (lead: RecentLeadDetail) => lead.user?.email || '-';
+export const recentLeadPhone = (lead: RecentLeadDetail) => lead.user?.mobile_number || '-';
 export const recentLeadAudience = (lead: RecentLeadDetail) =>
     lead.campaign_name || lead.source_audience_name || '-';
 
@@ -117,10 +115,12 @@ export const mapRecentLeadToStudent = (lead: RecentLeadDetail): StudentTable => 
     const result: StudentTable = {
         id: userId,
         user_id: userId,
-        full_name: u.full_name || lead.parent_name || '',
-        email: u.email || lead.parent_email || '',
+        // The lead's own identity — auth user only. See recentLeadName above: the
+        // parent_* columns belong to the guardian and are surfaced separately below.
+        full_name: u.full_name || '',
+        email: u.email || '',
         username: null,
-        mobile_number: u.mobile_number || lead.parent_mobile || '',
+        mobile_number: u.mobile_number || '',
         gender: '',
         region: null,
         city: '',
@@ -130,10 +130,12 @@ export const mapRecentLeadToStudent = (lead: RecentLeadDetail): StudentTable => 
         attendance_percent: 0,
         referral_count: 0,
         pin_code: '',
-        fathers_name: '',
+        // Guardian rows — a lead's guardian lives on audience_response.parent_*.
+        // Surfaced here so the Overview shows them and EditLeadDetails round-trips.
+        fathers_name: lead.parent_name || '',
         mothers_name: '',
-        father_mobile_number: '',
-        father_email: '',
+        father_mobile_number: lead.parent_mobile || '',
+        father_email: lead.parent_email || '',
         mother_mobile_number: '',
         mother_email: '',
         linked_institute_name: null,

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -266,6 +266,8 @@ export const GET_LEAD_REPORT_SUMMARY = `${BASE_URL}/admin-core-service/v1/report
 export const GET_COUNSELOR_PERFORMANCE = `${BASE_URL}/admin-core-service/v1/reports/counselor-performance`;
 export const DELETE_AUDIENCE_LEAD = (responseId: string) =>
     `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}`;
+export const UPDATE_LEAD_PROFILE = (responseId: string) =>
+    `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}/profile`;
 export const GET_ENQUIRIES = `${BASE_URL}/admin-core-service/v1/audience/enquiries`;
 // Distinct values a custom field holds across the institute's leads — searchable
 // + paginated. Powers the multi-select custom-field dropdowns in the leads filter bar.

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditLeadDetails.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/EditLeadDetails.tsx
@@ -1,0 +1,391 @@
+import { MyButton } from '@/components/design-system/button';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyInput } from '@/components/design-system/input';
+import PhoneInputField from '@/components/design-system/phone-input-field';
+import { FormControl, FormField, FormItem } from '@/components/ui/form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, FormProvider } from 'react-hook-form';
+import { z } from 'zod';
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { UPDATE_LEAD_PROFILE } from '@/constants/urls';
+import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
+import {
+    PencilSimple,
+    UserCircle,
+    Phone,
+    UsersThree,
+    SlidersHorizontal,
+    type Icon as PhosphorIcon,
+} from '@phosphor-icons/react';
+
+// A lead is read from auth-users (name/email/mobile) + audience_response.parent_*
+// (guardian) + custom field answers. This dialog edits exactly those — nothing the
+// lead doesn't have (no enrollment/student fields). Branch into it from the shared
+// sidebar when the selected row carries a `_response_id` (i.e. it's a lead).
+
+const EditLeadFormSchema = z.object({
+    full_name: z.string().min(1, 'This field is required'),
+    email: z.string().email('Invalid email address'),
+    contact_number: z.string().optional().or(z.literal('')),
+    guardian_name: z.string().optional(),
+    guardian_mobile: z.string().optional(),
+    guardian_email: z.string().email('Invalid email').optional().or(z.literal('')),
+    custom_fields: z.record(z.string()).optional(),
+});
+
+type EditLeadFormValues = z.infer<typeof EditLeadFormSchema>;
+
+interface LeadResponseField {
+    id: string;
+    name: string;
+    type: string;
+    rawValue: string | null;
+}
+
+const FormCard = ({
+    icon: Icon,
+    title,
+    helper,
+    children,
+}: {
+    icon: PhosphorIcon;
+    title: string;
+    helper?: string;
+    children: React.ReactNode;
+}) => (
+    <section className="rounded-lg border border-neutral-200 bg-white p-5">
+        <header className="mb-4 flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary-50 text-primary-600">
+                <Icon className="size-5" weight="duotone" />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col">
+                <h3 className="text-base font-semibold text-neutral-900">{title}</h3>
+                {helper && <p className="mt-0.5 text-xs text-neutral-500">{helper}</p>}
+            </div>
+        </header>
+        <div className="flex flex-col gap-4">{children}</div>
+    </section>
+);
+
+const PHONE_INPUT_OVERRIDE_CSS = `
+.elp-phone > div { display: flex; flex-direction: column; row-gap: 4px; }
+.elp-phone .react-tel-input { width: 100% !important; font-size: 14px !important; }
+.elp-phone .react-tel-input .form-control {
+  width: 100% !important;
+  height: 36px !important;
+  padding: 4px 12px 4px 52px !important;
+  font-size: 14px !important;
+  line-height: 1.2 !important;
+}
+.elp-phone .react-tel-input .flag-dropdown,
+.elp-phone .react-tel-input .selected-flag { height: 36px !important; }
+`;
+
+export const EditLeadDetails = () => {
+    const { selectedStudent, setSelectedStudent } = useStudentSidebar();
+    const queryClient = useQueryClient();
+    const [openDialog, setOpenDialog] = useState(false);
+
+    const responseId =
+        (selectedStudent as unknown as Record<string, unknown>)?._response_id as string | null;
+    const allResponseFields =
+        ((selectedStudent as unknown as Record<string, unknown>)?._response_fields as
+            | LeadResponseField[]
+            | undefined) ?? [];
+
+    // Lead forms usually capture Full Name / Email / Phone as custom-field answers
+    // too, so those show up in _response_fields AND as the system fields we already
+    // edit at the top. Drop the identity mirrors here so they aren't rendered (and
+    // editable) twice — match by field type/name, then by value as a fallback.
+    const digits = (s?: string | null) => (s ?? '').replace(/\D/g, '');
+    const norm = (s?: string | null) => (s ?? '').trim().toLowerCase();
+    const isIdentityMirror = (f: LeadResponseField): boolean => {
+        const t = (f.type ?? '').toLowerCase().trim();
+        const n = (f.name ?? '').toLowerCase();
+        const v = norm(f.rawValue);
+        // Email
+        if (t === 'email' || /e-?mail/.test(n)) return true;
+        if (v && v === norm(selectedStudent?.email)) return true;
+        // Phone / mobile
+        if (['phone', 'mobile', 'telephone'].includes(t) || /\bphone\b|\bmobile\b|\btelephone\b/.test(n))
+            return true;
+        if (digits(f.rawValue) && digits(f.rawValue) === digits(selectedStudent?.mobile_number))
+            return true;
+        // Full name
+        if (/\bfull\s*name\b|^name$/.test(n)) return true;
+        if (v && v === norm(selectedStudent?.full_name)) return true;
+        return false;
+    };
+    const responseFields = allResponseFields.filter((f) => !isIdentityMirror(f));
+
+    const form = useForm<EditLeadFormValues>({
+        resolver: zodResolver(EditLeadFormSchema),
+        defaultValues: {},
+    });
+
+    // Seed from the same values the sidebar reads, so the edit round-trips.
+    useEffect(() => {
+        if (!selectedStudent || !openDialog) return;
+        const customFields: Record<string, string> = {};
+        responseFields.forEach((f) => {
+            customFields[f.id] = f.rawValue ?? '';
+        });
+        form.reset({
+            full_name: selectedStudent.full_name || '',
+            email: selectedStudent.email || '',
+            contact_number: selectedStudent.mobile_number || '',
+            guardian_name: selectedStudent.fathers_name || '',
+            guardian_mobile: selectedStudent.father_mobile_number || '',
+            guardian_email: selectedStudent.father_email || '',
+            custom_fields: customFields,
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedStudent, openDialog]);
+
+    const mutation = useMutation({
+        mutationFn: (values: EditLeadFormValues) => {
+            const customFieldValues = Object.entries(values.custom_fields ?? {}).map(
+                ([custom_field_id, value]) => ({
+                    source_type: 'AUDIENCE_RESPONSE',
+                    source_id: responseId,
+                    custom_field_id,
+                    value: value || '',
+                })
+            );
+            const payload = {
+                user_details: {
+                    id: selectedStudent?.user_id,
+                    full_name: values.full_name,
+                    email: values.email,
+                    mobile_number: values.contact_number || '',
+                },
+                parent_name: values.guardian_name || '',
+                parent_email: values.guardian_email || '',
+                parent_mobile: values.guardian_mobile || '',
+                custom_field_values: customFieldValues,
+            };
+            return authenticatedAxiosInstance.put(UPDATE_LEAD_PROFILE(responseId || ''), payload);
+        },
+        onSuccess: (_data, values) => {
+            toast.success('Lead profile updated');
+            // Reflect the edit in the open sidebar immediately.
+            if (selectedStudent) {
+                setSelectedStudent(
+                    {
+                        ...selectedStudent,
+                        full_name: values.full_name,
+                        email: values.email,
+                        mobile_number: values.contact_number || '',
+                        fathers_name: values.guardian_name || '',
+                        father_mobile_number: values.guardian_mobile || '',
+                        father_email: values.guardian_email || '',
+                    },
+                    { openOverlay: false }
+                );
+            }
+            queryClient.invalidateQueries({ queryKey: ['recent-leads'] });
+            queryClient.invalidateQueries({ queryKey: ['leads'] });
+            setOpenDialog(false);
+        },
+        onError: () => {
+            toast.error('Failed to update lead profile');
+        },
+    });
+
+    const onSubmit = (values: EditLeadFormValues) => mutation.mutate(values);
+
+    if (!selectedStudent || !responseId) return null;
+
+    const footer = (
+        <div className="flex w-full items-center justify-end gap-3">
+            <MyButton
+                type="button"
+                buttonType="secondary"
+                scale="medium"
+                onClick={() => setOpenDialog(false)}
+            >
+                Cancel
+            </MyButton>
+            <MyButton
+                type="button"
+                buttonType="primary"
+                scale="medium"
+                disable={mutation.isPending}
+                onClick={() => form.handleSubmit(onSubmit)()}
+            >
+                {mutation.isPending ? 'Saving…' : 'Save Changes'}
+            </MyButton>
+        </div>
+    );
+
+    return (
+        <MyDialog
+            trigger={
+                <MyButton buttonType="secondary" scale="medium">
+                    <PencilSimple className="size-4" />
+                    Edit Details
+                </MyButton>
+            }
+            footer={footer}
+            heading="Edit Lead Profile"
+            open={openDialog}
+            onOpenChange={setOpenDialog}
+            dialogWidth="max-w-2xl"
+        >
+            <FormProvider {...form}>
+                <style dangerouslySetInnerHTML={{ __html: PHONE_INPUT_OVERRIDE_CSS }} />
+                <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-5">
+                    {/* IDENTITY */}
+                    <FormCard icon={UserCircle} title="Identity" helper="Their name and basic info.">
+                        <FormField
+                            control={form.control}
+                            name="full_name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Full Name"
+                                            required
+                                            inputType="text"
+                                            inputPlaceholder="Full name"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.full_name?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* CONTACT */}
+                    <FormCard icon={Phone} title="Contact" helper="Primary channels for reach-out.">
+                        <FormField
+                            control={form.control}
+                            name="email"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Email"
+                                            required
+                                            inputType="text"
+                                            inputPlaceholder="name@example.com"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.email?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name="contact_number"
+                            render={() => (
+                                <FormItem>
+                                    <FormControl>
+                                        <div className="elp-phone w-full">
+                                            <PhoneInputField
+                                                label="Mobile Number"
+                                                placeholder="123 456 7890"
+                                                name="contact_number"
+                                                control={form.control}
+                                                required={false}
+                                            />
+                                        </div>
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* GUARDIAN */}
+                    <FormCard
+                        icon={UsersThree}
+                        title="Guardian"
+                        helper="Parent / guardian contact (optional)."
+                    >
+                        <FormField
+                            control={form.control}
+                            name="guardian_name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Guardian Name"
+                                            inputType="text"
+                                            inputPlaceholder="Guardian name"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <div className="elp-phone w-full">
+                            <PhoneInputField
+                                label="Guardian Mobile"
+                                placeholder="123 456 7890"
+                                name="guardian_mobile"
+                                control={form.control}
+                                required={false}
+                            />
+                        </div>
+                        <FormField
+                            control={form.control}
+                            name="guardian_email"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <MyInput
+                                            label="Guardian Email"
+                                            inputType="text"
+                                            inputPlaceholder="guardian@example.com"
+                                            input={field.value ?? ''}
+                                            onChangeFunction={(e) => field.onChange(e.target.value)}
+                                            error={form.formState.errors.guardian_email?.message}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </FormCard>
+
+                    {/* CUSTOM FIELDS (the lead's form answers) */}
+                    {responseFields.length > 0 && (
+                        <FormCard
+                            icon={SlidersHorizontal}
+                            title="Additional Details"
+                            helper="Answers captured on the lead form."
+                        >
+                            {responseFields.map((f) => (
+                                <FormField
+                                    key={f.id}
+                                    control={form.control}
+                                    name={`custom_fields.${f.id}` as const}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormControl>
+                                                <MyInput
+                                                    label={f.name}
+                                                    inputType="text"
+                                                    inputPlaceholder={f.name}
+                                                    input={field.value ?? ''}
+                                                    onChangeFunction={(e) => field.onChange(e.target.value)}
+                                                />
+                                            </FormControl>
+                                        </FormItem>
+                                    )}
+                                />
+                            ))}
+                        </FormCard>
+                    )}
+                </form>
+            </FormProvider>
+        </MyDialog>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
@@ -25,6 +25,7 @@ import type { FieldGroup } from '@/services/custom-field-settings';
 import { getPublicUrl } from '@/services/upload_file';
 import { ProfileSectionCard, ProfileFieldRow, ProfileEmpty } from '../profile-ui';
 import { EditStudentDetails } from './EditStudentDetails';
+import { EditLeadDetails } from './EditLeadDetails';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 
@@ -223,9 +224,17 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
 
     return (
         <div className="flex flex-col gap-3 text-card-foreground">
-            {/* Single primary action — edit the learner's profile. */}
+            {/* Single primary action — edit the profile. This sidebar is shared between
+                Manage Contacts (real students) and the lead surfaces, which feed it a
+                lead mapped into StudentTable shape. A lead has no `student` row, so the
+                learner-profile endpoint 404s for it; rows carrying a `_response_id`
+                marker therefore get the lead-shaped editor instead. */}
             <div className="flex justify-end">
-                <EditStudentDetails />
+                {(selectedStudent as unknown as Record<string, unknown>)?._response_id ? (
+                    <EditLeadDetails />
+                ) : (
+                    <EditStudentDetails />
+                )}
             </div>
 
             {/* Detail sections — clean label/value cards (General Details,


### PR DESCRIPTION
## Summary of Changes

Editing a lead from the CRM returned `510 NOT_EXTENDED / "User not found"`. The leads list and the contacts list are separate surfaces but share one `StudentSidebar`, and the leads page maps a lead into `StudentTable` shape to feed it. The sidebar's Edit button was hardcoded to the *contact* editor, which PUTs to `/learner/info/v1/profile` — an endpoint that resolves the caller against the `student` table. A lead that never enrolled has no `student` row, so the lookup always threw. The user really was in the list (it's a UNION that includes audience respondents); they were never in `student`.

Leads are now edited through a lead-shaped endpoint that writes only where a lead is actually read from. This also closes a related gap found while fixing it: the workflow/automation layer resolved a lead's contact from `audience_response.parent_*` with **no fallback**, so for an ordinary campaign lead (where `parent_*` is NULL) `{{leadName}}` / `{{leadEmail}}` / `{{leadMobile}}` rendered empty, and `SEND_EMAIL` fell through to the lead's original form answers — meaning a lead edited in the CRM kept being mailed at its **old** address. Parent-sourced values still take precedence throughout, so "contact the parent first, else the lead" is preserved.

**Backend:**
- New `PUT /admin-core-service/v1/audience/lead/{responseId}/profile` (`AudienceService.updateLeadProfile` + `LeadProfileEditRequestDTO`). Writes the auth user (name/email/mobile), the `audience_response` parent/guardian fields, and the lead's `custom_field_values`. Never touches `student`. Rejects an edit that would collide with another lead's `dedupe_key` in the same campaign (409).
- Cleared guardian fields store as `NULL` rather than `""`, so queries gating on `parent_mobile IS NOT NULL` don't start matching leads with no parent contact.
- Automation layer now falls back to the lead's own auth user for `leadName` / `leadEmail` / `leadMobile` when `parent_*` is absent — in `LeadTriggerContextBuilder`, `LeadAutomationScheduler`, and the bulk `QueryServiceImpl` lead-fetch (batched lookup, no N+1).
- Typed exceptions: added `ResourceNotFoundException` (404), `ForbiddenException` (403), `ConflictException` (409). Wired these plus the previously **unhandled** `UserNotFoundException` and `InvalidRequestException` into `GlobalExceptionHandler` — both were falling through to the `RuntimeException` handler and returning `511`.
- `LearnerService`'s "User not found" throws now return 404 instead of the default 510.

**Frontend:**
- New `EditLeadDetails` dialog (identity, contact, guardian, and the lead's real form fields), submitting to the new endpoint.
- `student-overview.tsx` branches on the `_response_id` marker: leads get the lead editor, contacts keep `EditStudentDetails` and the learner endpoint unchanged.
- `lead-view-model.ts`: a lead's own name/email/phone now come from its auth user only. The `parent_*` columns are the guardian's contact and are editable as such, so they must not stand in for the lead's own details — otherwise the guardian's number would surface in the lead's Phone column. Every path that populates `parent_mobile` (enquiry, walk-in, inbound call) also sets the same number on the auth user, so nothing is lost.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

Driven end-to-end in a real browser (Playwright/Chromium) against a local `admin_core` on :8072 with a local Postgres restored from a prod dump, auth pointed at stage.

- **The reported bug:** editing the lead from the original 510 report (`audience_response 8a2438b7…`, user `3b360af0…`, which has no `student` row) now opens the lead editor and saves with **HTTP 200**, not `510 / "User not found"`.
- **Correct editor per surface:** a lead gets `Edit Lead Profile`; a real learner in Manage Contacts still gets `Edit Learner Profile` and the unchanged learner endpoint (regression check).
- **Persistence:** the auth user's name/email/mobile update; `audience_response.parent_*` receives the guardian values; `custom_field_values` (the original submission record) is left untouched.
- **Cleared guardian fields store as `NULL`, not `""`** — verified via `parent_email IS NULL`, so `parent_mobile IS NOT NULL` predicates are unaffected.
- **Automation fallback, verified by controlled comparison** on the same lead and data: with `QueryServiceImpl` reverted to `main`, the workflow `SEND_EMAIL` recipient resolved to the **stale** form-answer address; with the fix it resolves to the lead's **current** auth-user address. `mobileNumber` still prefers `parent_mobile` where present.
- `admin_core` compiles (`BUILD SUCCESS`); frontend `tsc --noEmit` reports 0 errors; `design-lint` clean.

Not covered: the 409 dedupe-collision path, and a lead carrying non-identity custom fields.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
