### PR TITLE
fix: use canonical PhoneInputField for guardian/student mobile number

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/GuardianLinkPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/GuardianLinkPanel.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { MyInput } from '@/components/design-system/input';
+import PhoneInputField from '@/components/design-system/phone-input-field';
 import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import { useAutosuggestUsers } from '../../../-hooks/useAutosuggestUsers';
 import { AutosuggestUser, ParentLinkPersonInput } from '../../../-types/bulk-assign-types';
@@ -12,6 +13,8 @@ import { AutosuggestUser, ParentLinkPersonInput } from '../../../-types/bulk-ass
 const createNewSchema = z.object({
     fullName: z.string().min(1, 'Name is required'),
     email: z.string().email('Enter a valid email'),
+    // PhoneInputField (react-phone-input-2) already restricts entry to
+    // digits and formats per country — no extra numeric regex needed here.
     mobileNumber: z.string().optional(),
 });
 type CreateNewFormValues = z.infer<typeof createNewSchema>;
@@ -46,20 +49,18 @@ export const GuardianLinkPanel = ({ instituteId, personLabel, searchRoles, value
         },
     });
 
-    const emitCreateNew = <K extends keyof CreateNewFormValues>(field: K, fieldValue: string) => {
+    const emitCreateNew = <K extends 'fullName' | 'email'>(field: K, fieldValue: string) => {
         // react-hook-form's setValue overload resolves PathValueImpl<K> from a
         // literal key — it can't be satisfied through a generic K (no `as`
         // cast survives it either), so dispatch to a literal call per field
-        // instead of a single generic call.
+        // instead of a single generic call. mobileNumber is handled separately
+        // below (PhoneInputField writes straight into RHF state via `control`).
         switch (field) {
             case 'fullName':
                 form.setValue('fullName', fieldValue, { shouldValidate: true });
                 break;
             case 'email':
                 form.setValue('email', fieldValue, { shouldValidate: true });
-                break;
-            case 'mobileNumber':
-                form.setValue('mobileNumber', fieldValue, { shouldValidate: true });
                 break;
         }
         const next = { ...form.getValues(), [field]: fieldValue };
@@ -70,6 +71,24 @@ export const GuardianLinkPanel = ({ instituteId, personLabel, searchRoles, value
             mobileNumber: next.mobileNumber || '',
         });
     };
+
+    // PhoneInputField owns `mobileNumber` directly via RHF `control` (its
+    // onChange never goes through emitCreateNew above), so bubble it up to
+    // the parent's ParentLinkPersonInput separately. Only while this tab is
+    // actually active, so switching to "Link Existing" can't get silently
+    // clobbered back to a create_new value by a stray watch tick.
+    const watchedMobile = form.watch('mobileNumber');
+    useEffect(() => {
+        if (tab !== 'create_new') return;
+        const next = form.getValues();
+        onChange({
+            kind: 'create_new',
+            fullName: next.fullName || '',
+            email: next.email || '',
+            mobileNumber: next.mobileNumber || '',
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [watchedMobile, tab]);
 
     const { data: suggestedUsers, isFetching } = useAutosuggestUsers({
         instituteId,
@@ -123,14 +142,14 @@ export const GuardianLinkPanel = ({ instituteId, personLabel, searchRoles, value
                             onChangeFunction={(e) => emitCreateNew('email', e.target.value)}
                             error={form.formState.errors.email?.message}
                         />
-                        <MyInput
-                            label="Mobile (optional)"
-                            size="small"
-                            inputType="tel"
-                            inputPlaceholder="9876543210"
-                            input={form.watch('mobileNumber')}
-                            onChangeFunction={(e) => emitCreateNew('mobileNumber', e.target.value)}
-                        />
+                        <div className="w-full sm:w-auto sm:min-w-[220px]">
+                            <PhoneInputField
+                                label="Mobile (optional)"
+                                name="mobileNumber"
+                                control={form.control}
+                                placeholder="9876543210"
+                            />
+                        </div>
                     </div>
                 </TabsContent>
 


### PR DESCRIPTION
The create-new sub-form (GuardianLinkPanel, used for both "Add Student" and "Add Guardian") had a hand-rolled MyInput inputType="tel" field — free text, no numeric restriction. Replaced with the same PhoneInputField (react-phone-input-2 + RHF `control`) already used for mobile_number in the manual-enroll form, which enforces digit-only entry and a country-code picker natively. PhoneInputField writes directly into RHF state, so its value is bubbled up to the parent's ParentLinkPersonInput via a watch effect (guarded to the active "create_new" tab) instead of the onChangeFunction path used for the plain text fields.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
