### PR TITLE
feat: invoice payment history UI + fix learner redirect after Razorpay

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
@@ -425,6 +425,38 @@ export const StudentPaymentHistory = () => {
     const invalidateInvoices = () =>
         queryClient.invalidateQueries({ queryKey: ['user-invoices', selectedStudent?.user_id] });
 
+    // Client-side fallback summary computed from the invoice list.
+    // Used when the ledger API returns all-zeros (migration not yet applied,
+    // or invoices created before the DEBIT_ACCRUAL recording was wired up).
+    // The ledger summary takes precedence once it has real data.
+    const invoiceList = invoicesData || [];
+    const fallbackSummary: UserAccountSummaryDTO | null = invoiceList.length > 0
+        ? (() => {
+              const currency = invoiceList[0]?.currency || 'INR';
+              const totalAccrued = invoiceList.reduce((s, inv) => s + (inv.total_amount ?? 0), 0);
+              const totalPaid = invoiceList
+                  .filter((inv) => String(inv.status || '').toUpperCase() === 'PAID')
+                  .reduce((s, inv) => s + (inv.total_amount ?? 0), 0);
+              const balance = Math.max(0, totalAccrued - totalPaid);
+              const now = Date.now();
+              const overdue = invoiceList
+                  .filter((inv) => {
+                      const st = String(inv.status || '').toUpperCase();
+                      const isPending = st === 'PENDING_PAYMENT' || st === 'GENERATED' || st === 'SENT';
+                      const pastDue = inv.due_date ? new Date(inv.due_date).getTime() < now : false;
+                      return isPending && pastDue;
+                  })
+                  .reduce((s, inv) => s + (inv.total_amount ?? 0), 0);
+              return { user_id: selectedStudent?.user_id || '', institute_id: instituteDetails?.id || '', total_accrued: totalAccrued, total_paid: totalPaid, balance, overdue, currency };
+          })()
+        : null;
+
+    // Prefer ledger data when non-zero; fall back to invoice-derived summary.
+    const effectiveSummary: UserAccountSummaryDTO | null =
+        accountSummary && (accountSummary.total_accrued > 0 || accountSummary.total_paid > 0)
+            ? accountSummary
+            : fallbackSummary;
+
     if (!selectedStudent?.user_id) {
         return (
             <ProfileEmpty
@@ -438,11 +470,13 @@ export const StudentPaymentHistory = () => {
     return (
         <div className="flex flex-col gap-3">
             {/* Account summary — total accrued / paid / balance / overdue.
-                Only shown when the ledger has data (non-zero totals). Leads
-                without any invoices/payments will see this section empty. */}
-            {accountSummary && (accountSummary.total_accrued > 0 || accountSummary.total_paid > 0) && (
+                Ledger data is authoritative; falls back to client-side totals
+                computed from the invoice list (covers old invoices / fresh installs
+                before the migration writes ledger rows). Hidden only when there
+                are no invoices at all. */}
+            {effectiveSummary && (
                 <ProfileSectionCard icon={Wallet} heading="Account Summary">
-                    <AccountSummaryGrid summary={accountSummary} />
+                    <AccountSummaryGrid summary={effectiveSummary} />
                 </ProfileSectionCard>
             )}
 

--- a/frontend-admin-dashboard/src/routes/manage-suborg-teams/-components/sub-org-analytics-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-suborg-teams/-components/sub-org-analytics-panel.tsx
@@ -209,6 +209,45 @@ export function SubOrgAnalyticsPanel({ subOrgId, subOrgName, restrictedView = fa
         return psId;
     };
 
+    // Effective account summary — ledger data when available, client-side fallback otherwise.
+    // Computed here (component level) so it's accessible both above the tabs and inside them.
+    const effectiveAdminSummary: UserAccountSummaryDTO | null = (() => {
+        const hasLedger =
+            adminAccountSummary
+            && (adminAccountSummary.total_accrued > 0 || adminAccountSummary.total_paid > 0);
+        if (hasLedger) return adminAccountSummary!;
+        // Fallback: derive totals from the invoices list (covers old invoices / pre-migration installs)
+        if (invoices.length === 0) return null;
+        const currency = (invoices[0]?.currency as string | undefined) || 'INR';
+        const totalAccrued = invoices.reduce(
+            (s, inv) => s + ((inv.total_amount ?? inv.totalAmount ?? 0) as number), 0
+        );
+        const totalPaid = invoices
+            .filter((inv) => String(inv.status || '').toUpperCase() === 'PAID')
+            .reduce((s, inv) => s + ((inv.total_amount ?? inv.totalAmount ?? 0) as number), 0);
+        const balance = Math.max(0, totalAccrued - totalPaid);
+        const now = Date.now();
+        const overdue = invoices
+            .filter((inv) => {
+                const st = String(inv.status || '').toUpperCase();
+                const isPending = st === 'PENDING_PAYMENT' || st === 'GENERATED' || st === 'SENT';
+                const pastDue = inv.due_date
+                    ? new Date(String(inv.due_date)).getTime() < now
+                    : false;
+                return isPending && pastDue;
+            })
+            .reduce((s, inv) => s + ((inv.total_amount ?? inv.totalAmount ?? 0) as number), 0);
+        return {
+            user_id: adminUserId || '',
+            institute_id: instituteId || '',
+            total_accrued: totalAccrued,
+            total_paid: totalPaid,
+            balance,
+            overdue,
+            currency,
+        } as UserAccountSummaryDTO;
+    })();
+
     const [showLedger, setShowLedger] = useState(false);
     const [activeTab, setActiveTab] = useState<'admin' | 'courses' | 'learners' | 'invoices' | 'team'>('admin');
     const [drawer, setDrawer] = useState<{
@@ -438,6 +477,18 @@ export function SubOrgAnalyticsPanel({ subOrgId, subOrgName, restrictedView = fa
                 )}
             </div>
 
+            {/* Account Summary — always visible above tabs so it's reachable from any tab.
+                Ledger data is authoritative; falls back to client-side totals from invoices. */}
+            {effectiveAdminSummary && (
+                <div className="rounded-lg border bg-white p-4">
+                    <h4 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <Wallet className="h-3.5 w-3.5" />
+                        Account Summary
+                    </h4>
+                    <AccountSummaryGrid summary={effectiveAdminSummary} />
+                </div>
+            )}
+
             {/* Horizontal tabs — each tab renders its own dataset lazily on click. */}
             <Tabs
                 value={activeTab}
@@ -622,18 +673,6 @@ export function SubOrgAnalyticsPanel({ subOrgId, subOrgName, restrictedView = fa
                         )}
                     </section>
 
-                    {/* Ledger summary — total accrued / paid / balance / overdue for the
-                        admin's account. Only rendered when the ledger has data (first
-                        payment or invoice will populate it). */}
-                    {adminAccountSummary && (adminAccountSummary.total_accrued > 0 || adminAccountSummary.total_paid > 0) && (
-                        <div className="mt-3 rounded-lg border bg-white p-4">
-                            <h4 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                <Wallet className="h-3.5 w-3.5" />
-                                Account Summary
-                            </h4>
-                            <AccountSummaryGrid summary={adminAccountSummary} />
-                        </div>
-                    )}
 
                     {/* Direct "Add admin user" form — CPO installment editor + discount
                         card live in this section. Lets the institute admin enroll the

--- a/frontend-learner-dashboard-app/src/routes/pay/invoice/$invoiceId/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/pay/invoice/$invoiceId/index.tsx
@@ -203,7 +203,12 @@ function InvoicePaymentPage() {
   };
 
   const handlePaymentReady = () => {
-    setPaymentInitiated(true);
+    // Navigate to the polling confirmation page; source=invoice skips gateway-specific status checks
+    if (pendingOrderId.current && invoice?.institute_id) {
+      window.location.href = `/payment-result?orderId=${pendingOrderId.current}&source=invoice&instituteId=${invoice.institute_id}`;
+    } else {
+      setPaymentInitiated(true);
+    }
   };
 
   // ── Shared outer wrapper ───────────────────────────────────────────────────

--- a/frontend-learner-dashboard-app/src/routes/payment-result/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/payment-result/index.tsx
@@ -132,9 +132,12 @@ function PaymentResultPage() {
     queryStatus === "cancelled";
   const isPending = !isPaid && !isFailed && (!!orderId || isLoading);
 
+  // Invoice payments: just show the success screen, no enrollment redirect.
+  // The invoice page is public; the learner may not have a dashboard session.
+
   // When payment is successful: auto-login via tokens from status API, or fallback to stored creds + login API
   useEffect(() => {
-    if (!isPaid || hasRedirectedRef.current) return;
+    if (!isPaid || hasRedirectedRef.current || isInvoicePayment) return;
 
     // PhonePe order is settled — drop the pending marker so a later visit doesn't
     // resurrect a stale order id.
@@ -288,20 +291,29 @@ function PaymentResultPage() {
             <h1 className="text-xl font-semibold text-gray-900 mb-2">
               Payment Successful!
             </h1>
-            <p className="text-gray-600 mb-6">
-              Your enrollment has been confirmed. Redirecting you to your
-              courses...
-            </p>
-            <a
-              href={
-                typeof window !== "undefined"
-                  ? `${window.location.origin}/study-library/courses`
-                  : `${BASE_URL_LEARNER_DASHBOARD}/study-library/courses`
-              }
-              className="inline-flex items-center justify-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/90 font-medium"
-            >
-              Go to My Courses
-            </a>
+            {isInvoicePayment ? (
+              <p className="text-gray-600 mb-6">
+                Your invoice has been paid. A confirmation email will be sent to
+                you shortly.
+              </p>
+            ) : (
+              <p className="text-gray-600 mb-6">
+                Your enrollment has been confirmed. Redirecting you to your
+                courses...
+              </p>
+            )}
+            {isInvoicePayment ? null : (
+              <a
+                href={
+                  typeof window !== "undefined"
+                    ? `${window.location.origin}/study-library/courses`
+                    : `${BASE_URL_LEARNER_DASHBOARD}/study-library/courses`
+                }
+                className="inline-flex items-center justify-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/90 font-medium"
+              >
+                Go to My Courses
+              </a>
+            )}
           </div>
         ) : isFailed ? (
           <>


### PR DESCRIPTION
Admin dashboard:
- Student payment history: account summary card (accrued/paid/balance/overdue) with client-side fallback from invoice list when ledger is empty
- Source-based invoice actions: ADMIN_MANUAL gets mark-paid + copy link, USER_PLAN gets copy link only, SFP rows get remind only
- Colored source badges (purple=Admin Invoice, blue=Subscription, amber=CPO)
- Sub-org analytics panel: same summary card + source-based actions, card placed above tabs so it's always visible regardless of active tab
- InvoiceSummary type enriched with source, source_id, due_date fields

Learner frontend:
- Fix: handlePaymentReady now navigates to /payment-result instead of showing a static Redirecting... card that never redirected; orderId + instituteId are passed so the polling page confirms the Razorpay webhook arrival
- /payment-result: skip enrollment-redirect flow for source=invoice payments (no login/courses redirect); show invoice-specific success copy instead

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
