### PR TITLE
Feat/lead soft delete

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
@@ -167,10 +167,30 @@ public class AudienceController {
                 audienceService.getLeadCustomFieldValues(instituteId, customFieldId, search, pageNo, pageSize));
     }
 
-    @DeleteMapping("/lead/{responseId}")
-    public ResponseEntity<String> deleteLead(@PathVariable String responseId) {
-        audienceService.deleteLead(responseId);
-        return ResponseEntity.ok("Lead deleted successfully");
+    /**
+     * Soft-delete one or more leads. Replaces the previous
+     * {@code DELETE /lead/{responseId}}, which hard-deleted the row with no authorization
+     * check and was never wired to any UI.
+     *
+     * <p>Body-based because a delete needs three things a path param can't carry: the id LIST
+     * (bulk), the {@code scope} (this response vs the whole person), and the
+     * {@code institute_id} the ADMIN check is made against.</p>
+     */
+    @PostMapping("/leads/delete")
+    public ResponseEntity<Map<String, Object>> deleteLeads(
+            @RequestBody LeadDeleteRequestDTO request,
+            @RequestAttribute("user") CustomUserDetails user) {
+        int deleted = audienceService.deleteLeads(request, user);
+        return ResponseEntity.ok(Map.of("deleted", deleted));
+    }
+
+    /** Restore soft-deleted leads — the inverse of {@link #deleteLeads}. ADMIN only. */
+    @PostMapping("/leads/restore")
+    public ResponseEntity<Map<String, Object>> restoreLeads(
+            @RequestBody LeadDeleteRequestDTO request,
+            @RequestAttribute("user") CustomUserDetails user) {
+        int restored = audienceService.restoreLeads(request, user);
+        return ResponseEntity.ok(Map.of("restored", restored));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadDeleteRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadDeleteRequestDTO.java
@@ -1,0 +1,41 @@
+package vacademy.io.admin_core_service.features.audience.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Request body for soft-deleting leads.
+ *
+ * <p>A "lead" in the list is one {@code audience_response} row, but the same person can hold
+ * several — 341 users in production hold more than one, one of them 21 — so the caller has to
+ * say which they mean:</p>
+ * <ul>
+ *   <li>{@code RESPONSE} (default) — delete only the given {@code response_ids}. This is what a
+ *       row in the list represents, and what bulk-select operates on.</li>
+ *   <li>{@code USER} — delete every lead belonging to the same people, across all campaigns.
+ *       This is the "remove the person entirely" choice in the confirm dialog.</li>
+ * </ul>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LeadDeleteRequestDTO {
+
+    /** The audience_response ids to act on. Required for both scopes — under USER scope these
+     *  identify the people whose leads get removed. */
+    private List<String> responseIds;
+
+    /** RESPONSE (default) | USER. See the class javadoc. */
+    private String scope;
+
+    /** Required: soft-delete is institute-scoped and the admin check is per institute. */
+    private String instituteId;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadFilterDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/LeadFilterDTO.java
@@ -55,6 +55,13 @@ public class LeadFilterDTO {
     // 'ONLY_CONVERTED' shows only converted leads. 'ALL' shows everything.
     private String conversionStatusFilter;
 
+    /**
+     * Soft-delete visibility: EXCLUDE_DELETED (default) | ONLY_DELETED | ALL.
+     * Null/blank behaves as EXCLUDE_DELETED, so deleted leads stay hidden unless asked for —
+     * ONLY_DELETED backs the "show deleted leads" view that restore is driven from.
+     */
+    private String audienceStatusFilter;
+
     // ── SLA-state filter ──
     // Filters by audience_response.tat_reminder_stage — the stage the SLA scheduler last
     // emitted for the lead. Same values shown in the leads-table badges:

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/UserAudienceMembershipDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/dto/UserAudienceMembershipDTO.java
@@ -29,6 +29,14 @@ public class UserAudienceMembershipDTO {
     @JsonProperty("overall_status")
     private String overallStatus;
 
+    /**
+     * ACTIVE | INACTIVE. Surfaced so the delete dialog's campaign picker can show which of the
+     * person's leads are already deleted (and offer Restore) instead of silently omitting them —
+     * the backing query intentionally returns deleted rows too.
+     */
+    @JsonProperty("audience_status")
+    private String audienceStatus;
+
     @JsonProperty("source_type")
     private String sourceType;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/entity/AudienceResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/entity/AudienceResponse.java
@@ -81,6 +81,16 @@ public class AudienceResponse {
     @Column(name = "overall_status", length = 50)
     private String overallStatus;
 
+    /**
+     * Soft-delete lifecycle — {@link vacademy.io.admin_core_service.features.audience.enums.AudienceStatusEnum}
+     * as a bare String, matching how the other status columns on this row are stored.
+     * NOT NULL DEFAULT 'ACTIVE' in the DB (V359), so existing rows and any insert path that
+     * doesn't set it explicitly are ACTIVE.
+     */
+    @Column(name = "audience_status", length = 50, nullable = false)
+    @Builder.Default
+    private String audienceStatus = "ACTIVE";
+
     // ── Deduplication fields ──────────────────────────────────
 
     /** SHA-256 hash of normalized email+phone for dedup within campaign */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/enums/AudienceStatusEnum.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/enums/AudienceStatusEnum.java
@@ -1,0 +1,22 @@
+package vacademy.io.admin_core_service.features.audience.enums;
+
+/**
+ * Soft-delete lifecycle of a single lead ({@code audience_response}) row.
+ *
+ * <p>Deliberately separate from the three status columns already on the row:
+ * <ul>
+ *   <li>{@code overall_status} — engagement/opt-out ({@code OPTED_OUT} means the LEAD asked
+ *       us to stop contacting them; it is the person's own choice)</li>
+ *   <li>{@code conversion_status} — where they are in the funnel</li>
+ *   <li>{@code lead_status_id} — the institute's custom pipeline stage</li>
+ * </ul>
+ * This column is the ADMIN's curation decision — "I don't want this row in my CRM" — which is a
+ * different axis from all three. A lead can be opted-out but still visible; a deleted lead is
+ * hidden regardless of consent.</p>
+ */
+public enum AudienceStatusEnum {
+    /** Normal, visible, eligible for sends. */
+    ACTIVE,
+    /** Admin soft-deleted: hidden from lead views and from every send recipient list. */
+    INACTIVE
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -24,9 +24,28 @@ import java.util.Optional;
 public interface AudienceResponseRepository extends JpaRepository<AudienceResponse, String> {
 
         /**
-         * Find all leads for a specific campaign
+         * Find all leads for a specific campaign, INCLUDING soft-deleted ones.
+         *
+         * <p>Use {@link #findActiveByAudienceId(String)} for anything that contacts a lead or
+         * shows it to a user. This raw variant is for whole-campaign maintenance (e.g. score
+         * recalculation), where a deleted lead's derived data should still be kept correct in
+         * case it is restored.</p>
          */
         List<AudienceResponse> findByAudienceId(String audienceId);
+
+        /**
+         * Live leads for a campaign — soft-deleted rows excluded.
+         *
+         * <p>This is the safe default for send/dial recipient selection. Deliberately has no
+         * "include deleted" parameter: there is no legitimate reason to blast a lead an admin
+         * has deleted, so the option should not exist.</p>
+         */
+        @Query("""
+                            SELECT ar FROM AudienceResponse ar
+                            WHERE ar.audienceId = :audienceId
+                            AND ar.audienceStatus = 'ACTIVE'
+                        """)
+        List<AudienceResponse> findActiveByAudienceId(@Param("audienceId") String audienceId);
 
         /**
          * Lead lookup by phone number for telephony attribution: the most recent
@@ -98,13 +117,13 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
         /**
          * Find all converted leads (with user_id)
          */
-        @Query("SELECT ar FROM AudienceResponse ar WHERE ar.audienceId = :audienceId AND ar.userId IS NOT NULL AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')")
+        @Query("SELECT ar FROM AudienceResponse ar WHERE ar.audienceId = :audienceId AND ar.userId IS NOT NULL AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT') AND ar.audienceStatus = 'ACTIVE'")
         List<AudienceResponse> findConvertedLeads(@Param("audienceId") String audienceId);
 
         /**
          * Find all unconverted leads (without user_id)
          */
-        @Query("SELECT ar FROM AudienceResponse ar WHERE ar.audienceId = :audienceId AND ar.userId IS NULL AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')")
+        @Query("SELECT ar FROM AudienceResponse ar WHERE ar.audienceId = :audienceId AND ar.userId IS NULL AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT') AND ar.audienceStatus = 'ACTIVE'")
         List<AudienceResponse> findUnconvertedLeads(@Param("audienceId") String audienceId);
 
         /**
@@ -178,6 +197,25 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 OR (
                                   :conversionStatusFilter = 'ONLY_CONVERTED'
                                   AND ulp.conversion_status = 'CONVERTED'
+                                )
+                              )
+                              -- Soft-delete filter. Mirrors conversionStatusFilter above:
+                              -- EXCLUDE_DELETED (default) / ONLY_DELETED / ALL, so the UI can
+                              -- offer a "show deleted leads" view without a second query.
+                              -- Kept as its OWN unconditional AND rather than folded into the
+                              -- overall_status OR block above: that block disables its own
+                              -- OPTED_OUT guard whenever :overallStatusStr is set, and a
+                              -- soft-deleted lead must stay hidden regardless of what else the
+                              -- caller filters by.
+                              AND (
+                                COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'ALL'
+                                OR (
+                                  COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'EXCLUDE_DELETED'
+                                  AND ar.audience_status = 'ACTIVE'
+                                )
+                                OR (
+                                  :audienceStatusFilter = 'ONLY_DELETED'
+                                  AND ar.audience_status = 'INACTIVE'
                                 )
                               )
                               -- SLA-state filter. Aligned with the row-level badges + the new
@@ -318,6 +356,25 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                   AND ulp.conversion_status = 'CONVERTED'
                                 )
                               )
+                              -- Soft-delete filter. Mirrors conversionStatusFilter above:
+                              -- EXCLUDE_DELETED (default) / ONLY_DELETED / ALL, so the UI can
+                              -- offer a "show deleted leads" view without a second query.
+                              -- Kept as its OWN unconditional AND rather than folded into the
+                              -- overall_status OR block above: that block disables its own
+                              -- OPTED_OUT guard whenever :overallStatusStr is set, and a
+                              -- soft-deleted lead must stay hidden regardless of what else the
+                              -- caller filters by.
+                              AND (
+                                COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'ALL'
+                                OR (
+                                  COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'EXCLUDE_DELETED'
+                                  AND ar.audience_status = 'ACTIVE'
+                                )
+                                OR (
+                                  :audienceStatusFilter = 'ONLY_DELETED'
+                                  AND ar.audience_status = 'INACTIVE'
+                                )
+                              )
                               -- SLA-state filter. Aligned with the row-level badges + the new
                               -- column semantics:
                               --   * Reach-out buckets use submitted_at + tatHours AND a NOT EXISTS
@@ -403,6 +460,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                         @Param("overallStatusStr") String overallStatusStr,
                         @Param("customFieldMatchedIdsCsv") String customFieldMatchedIdsCsv,
                         @Param("conversionStatusFilter") String conversionStatusFilter,
+                        @Param("audienceStatusFilter") String audienceStatusFilter,
                         @Param("slaFilter") String slaFilter,
                         @Param("tatHours") Integer tatHours,
                         @Param("sortBy") String sortBy,
@@ -417,6 +475,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             JOIN Audience a ON a.id = ar.audienceId
                             WHERE a.instituteId = :instituteId
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                             ORDER BY ar.submittedAt DESC
                         """)
         Page<AudienceResponse> findAllLeadsForInstitute(
@@ -487,6 +546,25 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 OR (
                                   :conversionStatusFilter = 'ONLY_CONVERTED'
                                   AND ulp.conversion_status = 'CONVERTED'
+                                )
+                              )
+                              -- Soft-delete filter. Mirrors conversionStatusFilter above:
+                              -- EXCLUDE_DELETED (default) / ONLY_DELETED / ALL, so the UI can
+                              -- offer a "show deleted leads" view without a second query.
+                              -- Kept as its OWN unconditional AND rather than folded into the
+                              -- overall_status OR block above: that block disables its own
+                              -- OPTED_OUT guard whenever :overallStatusStr is set, and a
+                              -- soft-deleted lead must stay hidden regardless of what else the
+                              -- caller filters by.
+                              AND (
+                                COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'ALL'
+                                OR (
+                                  COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'EXCLUDE_DELETED'
+                                  AND ar.audience_status = 'ACTIVE'
+                                )
+                                OR (
+                                  :audienceStatusFilter = 'ONLY_DELETED'
+                                  AND ar.audience_status = 'INACTIVE'
                                 )
                               )
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
@@ -614,6 +692,25 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                   AND ulp.conversion_status = 'CONVERTED'
                                 )
                               )
+                              -- Soft-delete filter. Mirrors conversionStatusFilter above:
+                              -- EXCLUDE_DELETED (default) / ONLY_DELETED / ALL, so the UI can
+                              -- offer a "show deleted leads" view without a second query.
+                              -- Kept as its OWN unconditional AND rather than folded into the
+                              -- overall_status OR block above: that block disables its own
+                              -- OPTED_OUT guard whenever :overallStatusStr is set, and a
+                              -- soft-deleted lead must stay hidden regardless of what else the
+                              -- caller filters by.
+                              AND (
+                                COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'ALL'
+                                OR (
+                                  COALESCE(:audienceStatusFilter, 'EXCLUDE_DELETED') = 'EXCLUDE_DELETED'
+                                  AND ar.audience_status = 'ACTIVE'
+                                )
+                                OR (
+                                  :audienceStatusFilter = 'ONLY_DELETED'
+                                  AND ar.audience_status = 'INACTIVE'
+                                )
+                              )
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
                               -- SLA-state filter. Aligned with the row-level badges + the new
                               -- column semantics:
@@ -694,6 +791,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                         @Param("isUnassigned") Boolean isUnassigned,
                         @Param("allowedAudienceIdsCsv") String allowedAudienceIdsCsv,
                         @Param("conversionStatusFilter") String conversionStatusFilter,
+                        @Param("audienceStatusFilter") String audienceStatusFilter,
                         @Param("slaFilter") String slaFilter,
                         @Param("tatHours") Integer tatHours,
                         @Param("customFieldMatchedIdsCsv") String customFieldMatchedIdsCsv,
@@ -764,6 +862,15 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
         boolean existsByAudienceIdAndUserId(String audienceId, String userId);
 
         /**
+         * This person's leads in this campaign with the given audience_status. Backs
+         * reactivate-on-resubmit: {@link #existsByAudienceIdAndUserId} above is derived and so
+         * cannot see status, which is exactly why a soft-deleted lead would otherwise trip the
+         * duplicate guard forever and never come back.
+         */
+        List<AudienceResponse> findByAudienceIdAndUserIdAndAudienceStatus(
+                        String audienceId, String userId, String audienceStatus);
+
+        /**
          * Check if a child (student) has already been submitted for this audience campaign.
          * Used for parent+child flows where the same parent can submit for multiple children.
          */
@@ -779,6 +886,49 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
          * Used for fetching all applications related to a parent/child
          */
         List<AudienceResponse> findByUserIdOrStudentUserId(String userId, String studentUserId);
+
+        /**
+         * These specific leads, but ONLY the ones that belong to this institute.
+         *
+         * <p>Security boundary for delete/restore: the caller supplies both the response ids and
+         * the institute the ADMIN check is made against, so those two MUST be reconciled against
+         * the data — otherwise an admin of institute A can pass their own institute_id (clearing
+         * the role check) together with institute B's response ids and mutate another tenant's
+         * leads. Resolving the targets through the institute join makes that impossible by
+         * construction rather than by a follow-up check someone can forget.</p>
+         *
+         * <p>The join is INNER, matching the leads-list queries: a response with no audience
+         * (admission/application rows) can't be attributed to an institute here and isn't listable
+         * either, so it is correctly not deletable through this endpoint.</p>
+         *
+         * <p>Does not filter audience_status — delete needs the ACTIVE rows and restore needs the
+         * INACTIVE ones.</p>
+         */
+        @Query("""
+                            SELECT ar FROM AudienceResponse ar
+                            JOIN Audience a ON a.id = ar.audienceId
+                            WHERE a.instituteId = :instituteId
+                            AND ar.id IN :responseIds
+                        """)
+        List<AudienceResponse> findAllByInstituteAndIds(
+                        @Param("instituteId") String instituteId,
+                        @Param("responseIds") List<String> responseIds);
+
+        /**
+         * Every lead belonging to these users within one institute, whatever its
+         * audience_status. Backs the USER-scoped soft-delete ("remove the person
+         * entirely") and its restore counterpart, so it must NOT filter on
+         * audience_status: delete needs the ACTIVE rows, restore needs the INACTIVE ones.
+         */
+        @Query("""
+                            SELECT ar FROM AudienceResponse ar
+                            JOIN Audience a ON a.id = ar.audienceId
+                            WHERE a.instituteId = :instituteId
+                            AND ar.userId IN :userIds
+                        """)
+        List<AudienceResponse> findAllByInstituteAndUserIds(
+                        @Param("instituteId") String instituteId,
+                        @Param("userIds") List<String> userIds);
 
         /**
          * Find audience response by parent mobile number for pre-fill lookup
@@ -806,7 +956,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
          */
         @Query("SELECT DISTINCT ar.userId FROM AudienceResponse ar " +
                         "WHERE ar.audienceId IN :audienceIds AND ar.userId IS NOT NULL " +
-                        "AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')")
+                        "AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT') AND ar.audienceStatus = 'ACTIVE'")
         List<String> findDistinctUserIdsByAudienceIds(@Param("audienceIds") List<String> audienceIds);
 
         /**
@@ -822,7 +972,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
          */
         @Query("SELECT DISTINCT ar.userId FROM AudienceResponse ar " +
                         "WHERE ar.audienceId IN :audienceIds AND ar.userId IN :userIds AND ar.userId IS NOT NULL " +
-                        "AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')")
+                        "AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT') AND ar.audienceStatus = 'ACTIVE'")
         List<String> findDistinctUserIdsByAudienceIdsAndUserIds(
                         @Param("audienceIds") List<String> audienceIds,
                         @Param("userIds") List<String> userIds);
@@ -834,6 +984,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.audienceId = :audienceId
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByAudienceAndDateRange(
                         @Param("instituteId") String instituteId,
@@ -855,6 +1006,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND ar.conversionStatus = :conversionStatus
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByAudienceDateRangeAndConversionStatus(
                         @Param("instituteId") String instituteId,
@@ -874,6 +1026,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND ar.userId IS NOT NULL
                             AND ar.parentMobile IS NOT NULL
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findActiveLeadsByAudienceIds(
                         @Param("audienceIds") List<String> audienceIds);
@@ -889,6 +1042,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             WHERE a.instituteId = :instituteId
                             AND ar.workflowActivateDayAt >= :startDate AND ar.workflowActivateDayAt <= :endDate
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND ar.audienceStatus = 'ACTIVE'
                         """)
         List<AudienceResponse> findLeadsByInstituteAndDateRange(
                         @Param("instituteId") String instituteId,
@@ -1065,6 +1219,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             FROM audience_response ar
                             JOIN audience a ON a.id = ar.audience_id
                             WHERE (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                            AND ar.audience_status = 'ACTIVE'
                         """, nativeQuery = true)
         List<String> findInstituteIdsWithActiveLeads();
 
@@ -1109,6 +1264,7 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                 ON ulp.user_id = ar.user_id AND ulp.institute_id = a.institute_id
                             WHERE a.institute_id = :instituteId
                               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                              AND ar.audience_status = 'ACTIVE'
                               AND (ulp.conversion_status IS NULL OR ulp.conversion_status != 'CONVERTED')
                               AND COALESCE(lu.user_id, ulp.assigned_counselor_id) IS NOT NULL
                         """, nativeQuery = true)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -62,7 +62,9 @@ import vacademy.io.admin_core_service.features.audience.enums.CustomFieldValueSo
 import vacademy.io.admin_core_service.features.common.service.CustomFieldValueService;
 import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.notification.dto.GenericEmailRequest;
+import vacademy.io.admin_core_service.features.audience.enums.AudienceStatusEnum;
 import vacademy.io.common.exceptions.ConflictException;
+import vacademy.io.common.exceptions.ForbiddenException;
 import vacademy.io.common.exceptions.InvalidRequestException;
 import vacademy.io.common.exceptions.ResourceNotFoundException;
 import vacademy.io.common.exceptions.VacademyException;
@@ -522,6 +524,9 @@ public class AudienceService {
         // 2. Dedup per person per campaign (same behaviour as submitLeadV2).
         if (StringUtils.hasText(userId)
                 && audienceResponseRepository.existsByAudienceIdAndUserId(audience.getId(), userId)) {
+            // Their lead may have been soft-deleted — revive it rather than leaving them
+            // permanently invisible. Return either way: this is still a duplicate submission.
+            reactivateSoftDeletedLeads(audience.getId(), userId);
             return "You have already submitted your response for this campaign";
         }
 
@@ -784,6 +789,8 @@ public class AudienceService {
                 // Duplicate submission guard: same audience + same user
                 if (StringUtils.hasText(userId) &&
                         audienceResponseRepository.existsByAudienceIdAndUserId(requestDTO.getAudienceId(), userId)) {
+                    // Revive a soft-deleted lead instead of blackholing the resubmission.
+                    reactivateSoftDeletedLeads(requestDTO.getAudienceId(), userId);
                     return "You have already submitted your response for this campaign";
                 }
 
@@ -1238,6 +1245,8 @@ public class AudienceService {
                 // Duplicate submission guard: same audience + same user
                 if (StringUtils.hasText(userId) &&
                         audienceResponseRepository.existsByAudienceIdAndUserId(requestDTO.getAudienceId(), userId)) {
+                    // Revive a soft-deleted lead instead of blackholing the resubmission.
+                    reactivateSoftDeletedLeads(requestDTO.getAudienceId(), userId);
                     return "You have already submitted your response for this campaign";
                 }
 
@@ -1762,9 +1771,19 @@ public class AudienceService {
             java.util.Optional<AudienceResponse> existingPrimary = leadDeduplicationService
                     .findDuplicate(requestDTO.getAudienceId(), dedupeKey);
             if (existingPrimary.isPresent()) {
-                leadDeduplicationService.markDuplicate(response, existingPrimary.get(), requestDTO.getSourceType());
+                // Unlike the guards above, this path always inserts and merely flags the new row
+                // as a duplicate of the primary. If that primary was soft-deleted, revive it —
+                // otherwise the person's original lead (and its history) stays hidden forever
+                // while a duplicate-flagged row accumulates beside it.
+                AudienceResponse primary = existingPrimary.get();
+                if (AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(primary.getAudienceStatus())) {
+                    primary.setAudienceStatus(AudienceStatusEnum.ACTIVE.name());
+                    audienceResponseRepository.save(primary);
+                    logger.info("Reactivated soft-deleted primary lead {} on re-submission", primary.getId());
+                }
+                leadDeduplicationService.markDuplicate(response, primary, requestDTO.getSourceType());
                 logger.info("Duplicate lead detected for campaign {}, primary={}",
-                        requestDTO.getAudienceId(), existingPrimary.get().getId());
+                        requestDTO.getAudienceId(), primary.getId());
             }
         }
 
@@ -2324,6 +2343,10 @@ public class AudienceService {
         // listing. Callers must opt into ONLY_CONVERTED or ALL to see them.
         String conversionStatusFilter = filterDTO.getConversionStatusFilter();
 
+        // Soft-delete filter — EXCLUDE_DELETED unless the caller explicitly asks otherwise, so
+        // every existing caller (and every new one that forgets) hides deleted leads by default.
+        String audienceStatusFilter = filterDTO.getAudienceStatusFilter();
+
         // Cross-service search expansion. Leads created via the simple submit flow
         // store the user's name/email/mobile on the User row in auth_service, not
         // on audience_response.parent_*. So a substring search like "cold" against
@@ -2400,6 +2423,7 @@ public class AudienceService {
                     filterDTO.getIsUnassigned(),
                     allowedAudienceIdsCsv,
                     conversionStatusFilter,
+                    audienceStatusFilter,
                     filterDTO.getSlaFilter(),
                     filterTatHours,
                     customFieldMatchedIdsCsv,
@@ -2427,6 +2451,7 @@ public class AudienceService {
                 overallStatusStr,
                 customFieldMatchedIdsCsv,
                 conversionStatusFilter,
+                audienceStatusFilter,
                 filterDTO.getSlaFilter(),
                 filterTatHours,
                 filterDTO.getSortBy(),
@@ -2835,14 +2860,200 @@ public class AudienceService {
     }
 
     /**
-     * Delete a single lead (audience response) by response ID.
+     * Soft-delete one or more leads.
+     *
+     * <p>Sets {@code audience_status = INACTIVE} instead of removing the row, so the lead
+     * disappears from lead views and — the point of the feature — from every promotional and
+     * automated send recipient list, while call history, admission records and reports keep
+     * referring to a row that still exists.</p>
+     *
+     * <p>Restricted to ADMIN. A lead that has already converted cannot be deleted (409): the
+     * row is now the head of an admission/payment trail, and hiding it would strand that trail.</p>
+     *
+     * <p>Deliberately does NOT touch {@code user_lead_profile}: that is one row per person and
+     * carries the counsellor assignment, while this is per response. Deleting one of a person's
+     * leads must not drop their assignment. The workbench derives its own visibility instead.</p>
+     *
+     * @return the number of leads actually flipped ACTIVE -> INACTIVE.
      */
     @Transactional
-    public void deleteLead(String responseId) {
-        AudienceResponse response = audienceResponseRepository.findById(responseId)
-                .orElseThrow(() -> new VacademyException("Lead not found"));
-        audienceResponseRepository.delete(response);
-        logger.info("Deleted lead: {}", responseId);
+    public int deleteLeads(LeadDeleteRequestDTO request, CustomUserDetails actor) {
+        List<AudienceResponse> targets = resolveDeleteTargets(request, actor);
+
+        // Block converted leads BEFORE mutating anything, so a bulk delete containing one
+        // converted lead fails whole rather than half-applying.
+        for (AudienceResponse response : targets) {
+            String leadUserId = response.getUserId() != null ? response.getUserId() : response.getStudentUserId();
+            if (leadUserId != null && isConverted(leadUserId)) {
+                throw new ConflictException(
+                        "This lead has already converted and cannot be deleted.");
+            }
+        }
+
+        int deleted = 0;
+        for (AudienceResponse response : targets) {
+            if (AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(response.getAudienceStatus())) {
+                continue; // already deleted — idempotent
+            }
+            response.setAudienceStatus(AudienceStatusEnum.INACTIVE.name());
+            audienceResponseRepository.save(response);
+            logLeadCurationEvent(response, actor, LeadJourneyActionType.LEAD_DELETED,
+                    "Lead deleted", "Lead removed from the CRM", request.getScope());
+            deleted++;
+        }
+        logger.info("Soft-deleted {} lead(s) (scope={}) by user {}",
+                deleted, resolveScope(request), actor.getUserId());
+        return deleted;
+    }
+
+    /**
+     * Restore soft-deleted leads — the inverse of {@link #deleteLeads}. ADMIN only.
+     *
+     * @return the number of leads actually flipped INACTIVE -> ACTIVE.
+     */
+    @Transactional
+    public int restoreLeads(LeadDeleteRequestDTO request, CustomUserDetails actor) {
+        List<AudienceResponse> targets = resolveDeleteTargets(request, actor);
+
+        int restored = 0;
+        for (AudienceResponse response : targets) {
+            if (!AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(response.getAudienceStatus())) {
+                continue; // already active — idempotent
+            }
+            response.setAudienceStatus(AudienceStatusEnum.ACTIVE.name());
+            audienceResponseRepository.save(response);
+            logLeadCurationEvent(response, actor, LeadJourneyActionType.LEAD_RESTORED,
+                    "Lead restored", "Lead restored to the CRM", request.getScope());
+            restored++;
+        }
+        logger.info("Restored {} lead(s) (scope={}) by user {}",
+                restored, resolveScope(request), actor.getUserId());
+        return restored;
+    }
+
+    /**
+     * Revive any soft-deleted lead this person holds in this campaign, on re-submission.
+     *
+     * <p>Without this, a delete is a permanent blackhole. The intake guards ask
+     * {@code existsByAudienceIdAndUserId}, which is a derived query and therefore status-blind:
+     * it matches the INACTIVE row, the guard early-returns "you have already submitted", and no
+     * insert and no un-hide ever happen. The person could resubmit forever and stay invisible.</p>
+     *
+     * <p>Callers must return immediately after this, exactly as they do today for a live
+     * duplicate — NOT fall through to the insert. Falling through would both create a duplicate
+     * row and re-run {@code autoAssignCounsellorOnIntake}, which would advance the pool's
+     * round-robin pointer and re-roll a counsellor the lead already had.</p>
+     *
+     * @return true if at least one row was revived (for logging only; the caller returns either way).
+     */
+    private boolean reactivateSoftDeletedLeads(String audienceId, String userId) {
+        if (!StringUtils.hasText(audienceId) || !StringUtils.hasText(userId)) {
+            return false;
+        }
+        List<AudienceResponse> hidden = audienceResponseRepository
+                .findByAudienceIdAndUserIdAndAudienceStatus(
+                        audienceId, userId, AudienceStatusEnum.INACTIVE.name());
+        if (CollectionUtils.isEmpty(hidden)) {
+            return false;
+        }
+        hidden.forEach(lead -> {
+            lead.setAudienceStatus(AudienceStatusEnum.ACTIVE.name());
+            audienceResponseRepository.save(lead);
+            logger.info("Reactivated soft-deleted lead {} on re-submission", lead.getId());
+        });
+        return true;
+    }
+
+    /**
+     * Resolve the rows a delete/restore acts on, enforcing the ADMIN check.
+     *
+     * <p>Under RESPONSE scope the given ids ARE the targets. Under USER scope they only identify
+     * the people, and every lead those people hold in this institute is swept in.</p>
+     */
+    private List<AudienceResponse> resolveDeleteTargets(LeadDeleteRequestDTO request, CustomUserDetails actor) {
+        if (request == null || CollectionUtils.isEmpty(request.getResponseIds())) {
+            throw new InvalidRequestException("At least one response id is required");
+        }
+        if (!StringUtils.hasText(request.getInstituteId())) {
+            throw new InvalidRequestException("instituteId is required");
+        }
+        if (!hasAdminRole(actor, request.getInstituteId())) {
+            throw new ForbiddenException("Only an admin can delete or restore a lead");
+        }
+
+        // Resolve the targets THROUGH the institute, never by raw id. The role check above only
+        // proves the caller administers the institute they named — it says nothing about who owns
+        // the rows they asked for. Fetching by id alone would let an admin pass their own
+        // institute_id (satisfying that check) with another tenant's response ids and delete them.
+        List<AudienceResponse> found = audienceResponseRepository
+                .findAllByInstituteAndIds(request.getInstituteId(), request.getResponseIds());
+        if (found.size() != new HashSet<>(request.getResponseIds()).size()) {
+            // Some id was unknown, or belongs to another institute. Same 404 either way: telling
+            // the caller which would confirm the existence of a lead they may not be entitled to see.
+            throw new ResourceNotFoundException("Lead not found");
+        }
+
+        if (!"USER".equalsIgnoreCase(resolveScope(request))) {
+            return found;
+        }
+
+        // USER scope — expand to every lead these people hold in this institute.
+        List<String> userIds = found.stream()
+                .map(r -> r.getUserId() != null ? r.getUserId() : r.getStudentUserId())
+                .filter(StringUtils::hasText)
+                .distinct()
+                .toList();
+        if (userIds.isEmpty()) {
+            return found;
+        }
+        return audienceResponseRepository.findAllByInstituteAndUserIds(request.getInstituteId(), userIds);
+    }
+
+    private String resolveScope(LeadDeleteRequestDTO request) {
+        return StringUtils.hasText(request.getScope()) ? request.getScope().toUpperCase() : "RESPONSE";
+    }
+
+    /** True when this user's lead profile is marked CONVERTED. */
+    private boolean isConverted(String leadUserId) {
+        return userLeadProfileRepository.findByUserId(leadUserId)
+                .map(p -> "CONVERTED".equalsIgnoreCase(p.getConversionStatus()))
+                .orElse(false);
+    }
+
+    /** Best-effort audit trail — a delete must be attributable, but must not fail over logging. */
+    private void logLeadCurationEvent(AudienceResponse response, CustomUserDetails actor,
+            LeadJourneyActionType actionType, String title, String description, String scope) {
+        String leadUserId = response.getUserId() != null ? response.getUserId() : response.getStudentUserId();
+        if (!StringUtils.hasText(leadUserId)) {
+            return;
+        }
+        try {
+            String campaignName = response.getAudienceId() == null ? null
+                    : audienceRepository.findById(response.getAudienceId())
+                            .map(Audience::getCampaignName).orElse(null);
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("response_id", response.getId());
+            metadata.put("scope", scope != null ? scope.toUpperCase() : "RESPONSE");
+            metadata.put("campaign_name", campaignName != null ? campaignName : "");
+            metadata.put("actor", actor.getUsername() != null ? actor.getUsername() : "");
+            timelineEventService.logJourneyEvent(
+                    "USER_LEAD_PROFILE", leadUserId, actionType,
+                    "ADMIN", actor.getUserId(), actor.getUsername(),
+                    title, description, metadata, leadUserId);
+        } catch (Exception e) {
+            logger.warn("Failed to log {} event for response {}: {}",
+                    actionType, response.getId(), e.getMessage());
+        }
+    }
+
+    /**
+     * True when the caller carries the ADMIN role FOR THIS INSTITUTE. Roles are per-institute,
+     * so this defers to the same resolver the rest of the audience feature uses rather than
+     * scanning the authorities flat — otherwise an admin of institute A could delete institute
+     * B's leads.
+     */
+    private boolean hasAdminRole(CustomUserDetails user, String instituteId) {
+        return audienceRoleAccessService.resolvedCallerRoles(user, instituteId).contains("ADMIN");
     }
 
     /**
@@ -3580,6 +3791,10 @@ public class AudienceService {
         // Duplicate submission guard
         if (audienceResponseRepository.existsByAudienceIdAndUserId(audienceId, userId)) {
             logger.warn("Duplicate submission for audienceId={}, userId={}", audienceId, userId);
+            // Revive a soft-deleted lead instead of blackholing the resubmission. This path is
+            // the Meta/Zoho/Google form webhooks, so it's the most likely to re-deliver a lead
+            // an admin has since deleted.
+            reactivateSoftDeletedLeads(audienceId, userId);
             return "You have already submitted your response for this campaign";
         }
 
@@ -4735,9 +4950,10 @@ public class AudienceService {
         Audience audience = audienceRepository.findById(request.getAudienceId())
                 .orElseThrow(() -> new VacademyException("Audience not found: " + request.getAudienceId()));
 
-        // 2. Fetch all leads for this audience (TODO: apply filters from
-        // request.getFilters())
-        List<AudienceResponse> allResponses = audienceResponseRepository.findByAudienceId(request.getAudienceId());
+        // 2. Fetch this audience's live leads (TODO: apply filters from request.getFilters()).
+        // ACTIVE-only, hardcoded: a soft-deleted lead must never receive a campaign send.
+        List<AudienceResponse> allResponses = audienceResponseRepository
+                .findActiveByAudienceId(request.getAudienceId());
         if (CollectionUtils.isEmpty(allResponses)) {
             throw new VacademyException("No leads found for audience: " + request.getAudienceId());
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/UserLeadProfileService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/UserLeadProfileService.java
@@ -595,6 +595,7 @@ public class UserLeadProfileService {
                     .campaignStatus(aud != null ? aud.getStatus() : null)
                     .responseId(r.getId())
                     .overallStatus(r.getOverallStatus())
+                    .audienceStatus(r.getAudienceStatus())
                     .sourceType(r.getSourceType())
                     .submittedAt(r.getSubmittedAt())
                     .leadScore(score != null ? score.getRawScore() : null)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/repository/WorkbenchLeadRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/repository/WorkbenchLeadRepository.java
@@ -91,6 +91,11 @@ public class WorkbenchLeadRepository {
             "    ORDER BY ar.created_at DESC LIMIT 1" +
             ") latest_ar ON true " +
             "WHERE ulp.institute_id = ? " +
+            // Hide soft-deleted leads: the profile is one row per PERSON while the delete is
+            // per response, so a person stays visible until every lead they hold is deleted.
+            "  AND EXISTS (SELECT 1 FROM audience_response ar_live " +
+            "              WHERE ar_live.user_id = ulp.user_id " +
+            "                AND ar_live.audience_status = 'ACTIVE') " +
             "  AND ulp.assigned_counselor_id IN (" + placeholders + ") " +
             (conversionStatus != null ? "  AND ulp.conversion_status = ? " : "") +
             "ORDER BY ta.assigned_at DESC NULLS LAST " +
@@ -122,6 +127,11 @@ public class WorkbenchLeadRepository {
         String placeholders = counsellorIds.stream().map(c -> "?").collect(Collectors.joining(","));
         String sql = "SELECT COUNT(*) FROM user_lead_profile ulp " +
                      "WHERE ulp.institute_id = ? " +
+                     // Hide soft-deleted leads: the profile is one row per PERSON while the delete is
+                     // per response, so a person stays visible until every lead they hold is deleted.
+                     "  AND EXISTS (SELECT 1 FROM audience_response ar_live " +
+                     "              WHERE ar_live.user_id = ulp.user_id " +
+                     "                AND ar_live.audience_status = 'ACTIVE') " +
                      "  AND ulp.assigned_counselor_id IN (" + placeholders + ") " +
                      (conversionStatus != null ? "  AND ulp.conversion_status = ? " : "");
         Object[] args = buildCountArgs(instituteId, counsellorIds, conversionStatus);
@@ -138,6 +148,11 @@ public class WorkbenchLeadRepository {
         Long n = jdbc.queryForObject(
                 "SELECT COUNT(*) FROM user_lead_profile ulp " +
                         "WHERE ulp.institute_id = ? " +
+                        // Hide soft-deleted leads: the profile is one row per PERSON while the delete is
+                        // per response, so a person stays visible until every lead they hold is deleted.
+                        "  AND EXISTS (SELECT 1 FROM audience_response ar_live " +
+                        "              WHERE ar_live.user_id = ulp.user_id " +
+                        "                AND ar_live.audience_status = 'ACTIVE') " +
                         "  AND ulp.assigned_counselor_id = ? " +
                         "  AND (ulp.conversion_status IS NULL OR ulp.conversion_status != 'CONVERTED')",
                 Long.class, instituteId, counsellorUserId);
@@ -184,6 +199,11 @@ public class WorkbenchLeadRepository {
             "      AND te.action_type = 'COUNSELOR_ASSIGNED' " +
             ") ta ON true " +
             "WHERE ulp.institute_id = ? " +
+            // Hide soft-deleted leads: the profile is one row per PERSON while the delete is
+            // per response, so a person stays visible until every lead they hold is deleted.
+            "  AND EXISTS (SELECT 1 FROM audience_response ar_live " +
+            "              WHERE ar_live.user_id = ulp.user_id " +
+            "                AND ar_live.audience_status = 'ACTIVE') " +
             "  AND ulp.assigned_counselor_id = ? " +
             "  AND (ulp.conversion_status IS NULL OR ulp.conversion_status != 'CONVERTED') " +
             "ORDER BY ta.assigned_at DESC NULLS LAST " +

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/InstituteStudentRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/InstituteStudentRepository.java
@@ -1256,6 +1256,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
                 WHERE ar.user_id = s.user_id
                   AND ar.audience_id IN (:audienceIds)
                   AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                  AND ar.audience_status = 'ACTIVE'
               )
             )
           GROUP BY ssigm.user_id
@@ -1297,6 +1298,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
             WHERE ar.user_id = s.user_id
               AND ar.audience_id IN (:audienceIds)
               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+              AND ar.audience_status = 'ACTIVE'
           )
         )
       """)
@@ -1356,6 +1358,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
                 WHERE ar.user_id = s.user_id
                   AND ar.audience_id IN (:audienceIds)
                   AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                  AND ar.audience_status = 'ACTIVE'
               )
             )
             AND (
@@ -1409,6 +1412,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
             WHERE ar.user_id = s.user_id
               AND ar.audience_id IN (:audienceIds)
               AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+              AND ar.audience_status = 'ACTIVE'
           )
         )
         AND (
@@ -1486,6 +1490,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
                 WHERE ar.user_id = s.user_id
                   AND ar.audience_id IN (:audienceIds)
                   AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                  AND ar.audience_status = 'ACTIVE'
               )
             )
             AND (
@@ -1512,6 +1517,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
             AND a.institute_id IN (:instituteIds)
             AND ar.user_id IS NOT NULL
             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+            AND ar.audience_status = 'ACTIVE'
             AND (:#{#audienceIds == null || #audienceIds.isEmpty()} = true OR ar.audience_id IN (:audienceIds))
             AND (:#{#gender == null || #gender.isEmpty()} = true OR s.gender IN (:gender))
             AND (
@@ -1572,6 +1578,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
                 WHERE ar.user_id = s.user_id
                   AND ar.audience_id IN (:audienceIds)
                   AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                  AND ar.audience_status = 'ACTIVE'
               )
             )
             AND (
@@ -1597,6 +1604,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
             AND a.institute_id IN (:instituteIds)
             AND ar.user_id IS NOT NULL
             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+            AND ar.audience_status = 'ACTIVE'
             AND (:#{#audienceIds == null || #audienceIds.isEmpty()} = true OR ar.audience_id IN (:audienceIds))
             AND (:#{#gender == null || #gender.isEmpty()} = true OR s.gender IN (:gender))
             AND (
@@ -1693,6 +1701,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
           WHERE a.institute_id = :instituteId
             AND ar.user_id IS NOT NULL
             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+            AND ar.audience_status = 'ACTIVE'
             AND (:#{#audienceIds == null || #audienceIds.isEmpty()} = true OR ar.audience_id IN (:audienceIds))
             AND (:#{#genders == null || #genders.isEmpty()} = true OR sg.gender IN (:genders))
             AND (
@@ -1760,6 +1769,7 @@ public interface InstituteStudentRepository extends CrudRepository<Student, Stri
           WHERE a.institute_id = :instituteId
             AND ar.user_id IS NOT NULL
             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+            AND ar.audience_status = 'ACTIVE'
             AND (:#{#audienceIds == null || #audienceIds.isEmpty()} = true OR ar.audience_id IN (:audienceIds))
             AND (:#{#genders == null || #genders.isEmpty()} = true OR sg.gender IN (:genders))
             AND (

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallCampaignService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallCampaignService.java
@@ -78,7 +78,8 @@ public class AiCallCampaignService {
             throw new VacademyException("No default Campaign ID set in AI Calling settings.");
         }
 
-        List<AudienceResponse> leads = audienceResponseRepository.findByAudienceId(audienceId);
+        // ACTIVE-only, hardcoded: a soft-deleted lead must never be dialled by a bulk campaign.
+        List<AudienceResponse> leads = audienceResponseRepository.findActiveByAudienceId(audienceId);
         // Eligible = has a user id; the phone is resolved at call time (parent_mobile
         // first, then the user's profile number), so we don't pre-filter on phone.
         List<LeadRef> refs = leads.stream()

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
+import vacademy.io.admin_core_service.features.audience.enums.AudienceStatusEnum;
 import vacademy.io.admin_core_service.features.audience.entity.UserLeadProfile;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
 import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
@@ -24,6 +25,7 @@ import vacademy.io.admin_core_service.features.telephony.persistence.repository.
 import vacademy.io.admin_core_service.features.telephony.spi.dto.AiCallHandle;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.AiCallSpec;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.CallSubjectType;
+import vacademy.io.common.exceptions.ConflictException;
 import vacademy.io.common.exceptions.VacademyException;
 
 import java.time.Duration;
@@ -119,9 +121,20 @@ public class AiCallService {
         String userId = req.getUserId();
         String phone = req.getPhoneNumber();
         // Resolve phone/userId from the lead when the caller supplied only a responseId.
-        if ((isBlank(userId) || isBlank(phone)) && !isBlank(req.getResponseId())) {
+        if (!isBlank(req.getResponseId())) {
             AudienceResponse ar = audienceResponseRepository.findById(req.getResponseId()).orElse(null);
             if (ar != null) {
+                // Last line of defence for soft-deleted leads. The recipient LISTS are filtered
+                // at selection time, but a workflow retry sequence resolves its lead from context
+                // captured days earlier and re-enters here on each attempt — so a lead deleted
+                // mid-sequence would keep being dialled without this check.
+                if (AudienceStatusEnum.INACTIVE.name().equalsIgnoreCase(ar.getAudienceStatus())) {
+                    log.info("Skipping AI call for soft-deleted lead {}", ar.getId());
+                    // 409, not the bare VacademyException the older throws in this class use —
+                    // that maps to 510 NOT_EXTENDED. The lead exists; its state conflicts with
+                    // the request, which is the same shape as refusing to delete a converted lead.
+                    throw new ConflictException("This lead has been deleted and cannot be called.");
+                }
                 if (isBlank(userId)) userId = ar.getUserId();
                 if (isBlank(phone)) phone = ar.getParentMobile();
             }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/timeline/enums/LeadJourneyActionType.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/timeline/enums/LeadJourneyActionType.java
@@ -17,6 +17,13 @@ public enum LeadJourneyActionType {
     /** A duplicate submission was detected and merged into this lead. */
     DUPLICATE_MERGED,
 
+    // ── Curation ─────────────────────────────────────────────────────────────
+    /** An admin soft-deleted this lead (metadata: scope, campaign_name, deleted_by). */
+    LEAD_DELETED,
+
+    /** A soft-deleted lead was restored, by an admin or by the person re-submitting. */
+    LEAD_RESTORED,
+
     // ── Assignment ───────────────────────────────────────────────────────────
     /** A counselor was assigned (or reassigned) to this lead. */
     COUNSELOR_ASSIGNED,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_resolution/service/CentralizedRecipientResolutionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_resolution/service/CentralizedRecipientResolutionService.java
@@ -243,9 +243,13 @@ public class CentralizedRecipientResolutionService {
             }
 
             case "AUDIENCE": {
+                // audience_status = 'ACTIVE' is hardcoded, not a filter option: this resolver
+                // decides who RECEIVES an announcement, and a soft-deleted lead must never be
+                // a recipient.
                 QueryWithParams q = new QueryWithParams(
                         "SELECT DISTINCT ar.user_id FROM audience_response ar " +
-                        "WHERE ar.audience_id = ?" + paramOffset + " AND ar.user_id IS NOT NULL");
+                        "WHERE ar.audience_id = ?" + paramOffset + " AND ar.user_id IS NOT NULL " +
+                        "AND ar.audience_status = 'ACTIVE'");
                 q.params.add(recipientId);
                 return narrowByFilters(q, filters, paramOffset + q.params.size());
             }

--- a/admin_core_service/src/main/resources/db/migration/V376__Add_user_audience_status_index.sql
+++ b/admin_core_service/src/main/resources/db/migration/V376__Add_user_audience_status_index.sql
@@ -1,0 +1,18 @@
+-- Composite index supporting the lead soft-delete reads added alongside it.
+--
+-- V359 added audience_status + a standalone index on it. That index alone is not
+-- selective enough for the Counsellor Workbench guard, which asks per profile row:
+--     EXISTS (SELECT 1 FROM audience_response ar
+--              WHERE ar.user_id = ulp.user_id AND ar.audience_status = 'ACTIVE')
+-- With only (user_id) and (audience_status) available separately, that probe costs
+-- ~2.4x on a paginated workbench page and ~6.6x on an aggregate. Measured on a
+-- 59,782-profile institute: 10.2ms -> 24.7ms paginated, 6.4ms -> 42.3ms aggregate.
+-- With this composite index the same probes land at 14.9ms and 27.7ms — the
+-- paginated workbench path (the one that actually gets the guard) drops to ~+4.7ms
+-- over baseline, which is what makes deriving the flag cheaper than denormalizing
+-- it onto user_lead_profile.
+--
+-- Column order matters: user_id first (high cardinality, the join key), then
+-- audience_status (2 values) as the filtering suffix.
+CREATE INDEX IF NOT EXISTS idx_audience_response_user_audience_status
+ON audience_response (user_id, audience_status);

--- a/frontend-admin-dashboard/src/components/shared/leads/delete-leads-dialog.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/delete-leads-dialog.tsx
@@ -1,0 +1,249 @@
+/**
+ * DeleteLeadsDialog — the confirm step for soft-deleting leads.
+ *
+ * Two shapes in one dialog, because they are the same decision at different scale:
+ *
+ *  - **Single lead** — the person may appear in several campaigns, and a row in the list is only
+ *    ONE of them. So we ask what "delete" means here: just this campaign, or the person entirely.
+ *    Their other campaigns are listed so the choice is informed rather than a guess.
+ *  - **Bulk** — the selection already names the exact responses, so there is nothing to
+ *    disambiguate; we only confirm the count.
+ *
+ * Deleting is reversible (leads are hidden, not removed) but it silently stops every campaign
+ * send to that person, so the copy leads with consequence rather than mechanics.
+ */
+
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Warning, Trash } from '@phosphor-icons/react';
+import { toast } from 'sonner';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyButton } from '@/components/design-system/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { GET_USER_AUDIENCES } from '@/constants/urls';
+import {
+    deleteAudienceLeads,
+    type LeadDeleteScope,
+} from '@/routes/audience-manager/list/-services/delete-audience-lead';
+import { cn } from '@/lib/utils';
+
+/** One campaign the lead belongs to — mirrors UserAudienceMembershipDTO. */
+interface AudienceMembership {
+    audience_id: string;
+    campaign_name: string | null;
+    response_id: string;
+    audience_status?: string | null;
+}
+
+interface DeleteLeadsDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    instituteId: string;
+    /** The responses to delete. One entry = the single-lead flow; more = the bulk flow. */
+    responseIds: string[];
+    /** Used to look up the person's other campaigns in the single-lead flow. */
+    userId?: string | null;
+    /** Shown in the single-lead confirmation so the admin knows who they're removing. */
+    leadName?: string;
+    /** Fired after a successful delete (refetch + clear selection + close the sidebar). */
+    onSuccess?: (deletedCount: number) => void;
+}
+
+export const DeleteLeadsDialog = ({
+    open,
+    onOpenChange,
+    instituteId,
+    responseIds,
+    userId,
+    leadName,
+    onSuccess,
+}: DeleteLeadsDialogProps) => {
+    const isBulk = responseIds.length > 1;
+    const [scope, setScope] = useState<LeadDeleteScope>('RESPONSE');
+
+    // The person's other campaigns — only needed for the single-lead scope choice. The endpoint
+    // returns deleted memberships too, so they're filtered out here: they're already gone and
+    // re-deleting them is a no-op that would only inflate the count.
+    const { data: memberships, isLoading } = useQuery({
+        queryKey: ['user-audiences', userId],
+        queryFn: async (): Promise<AudienceMembership[]> => {
+            const res = await authenticatedAxiosInstance({
+                method: 'GET',
+                url: GET_USER_AUDIENCES,
+                params: { userId },
+            });
+            return res?.data ?? [];
+        },
+        enabled: open && !isBulk && !!userId,
+    });
+
+    const liveMemberships = (memberships ?? []).filter(
+        (m) => (m.audience_status ?? 'ACTIVE').toUpperCase() !== 'INACTIVE'
+    );
+    const otherCampaignCount = Math.max(0, liveMemberships.length - 1);
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            deleteAudienceLeads({
+                responseIds,
+                instituteId,
+                scope: isBulk ? 'RESPONSE' : scope,
+            }),
+        onSuccess: (deleted) => {
+            toast.success(deleted === 1 ? 'Lead deleted' : `${deleted} leads deleted`);
+            onSuccess?.(deleted);
+            onOpenChange(false);
+        },
+        onError: (error: unknown) => {
+            // A converted lead can't be deleted — surface the backend's reason verbatim rather
+            // than a generic failure, since it's actionable ("this one converted").
+            const message =
+                (error as { response?: { data?: { ex?: string } } })?.response?.data?.ex ??
+                'Failed to delete. Please try again.';
+            toast.error(message);
+        },
+    });
+
+    const scopeOptions: { value: LeadDeleteScope; label: string; hint: string }[] = [
+        {
+            value: 'RESPONSE',
+            label: 'This campaign only',
+            hint: otherCampaignCount
+                ? `Keeps their ${otherCampaignCount} other campaign${otherCampaignCount > 1 ? 's' : ''}.`
+                : 'Removes this lead from the campaign it came from.',
+        },
+        {
+            value: 'USER',
+            label: 'Remove them entirely',
+            hint: liveMemberships.length
+                ? `Deletes all ${liveMemberships.length} of their leads across every campaign.`
+                : 'Deletes every lead this person has, across every campaign.',
+        },
+    ];
+
+    return (
+        <MyDialog
+            heading={isBulk ? 'Delete leads' : 'Delete lead'}
+            open={open}
+            onOpenChange={onOpenChange}
+            dialogWidth="max-w-md"
+            footer={
+                <div className="flex w-full items-center justify-end gap-2">
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={() => onOpenChange(false)}
+                        disable={mutation.isPending}
+                    >
+                        Cancel
+                    </MyButton>
+                    <MyButton
+                        buttonType="primary"
+                        scale="medium"
+                        onClick={() => mutation.mutate()}
+                        disable={mutation.isPending}
+                        className="bg-danger-600 hover:bg-danger-700"
+                    >
+                        {mutation.isPending ? 'Deleting…' : 'Delete'}
+                    </MyButton>
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-4 p-4">
+                <div className="flex items-start gap-3 rounded-md border border-danger-200 bg-danger-50 p-3">
+                    <Warning weight="fill" className="mt-0.5 size-5 shrink-0 text-danger-600" />
+                    <div className="flex flex-col gap-1">
+                        <p className="text-subtitle font-semibold text-danger-700">
+                            {isBulk
+                                ? `Delete ${responseIds.length} leads?`
+                                : `Delete ${leadName || 'this lead'}?`}
+                        </p>
+                        <p className="text-caption text-danger-700">
+                            They will stop receiving campaign emails, WhatsApp messages and calls.
+                            Deleted leads are hidden, not erased — you can restore them later.
+                        </p>
+                    </div>
+                </div>
+
+                {!isBulk && (
+                    <div className="flex flex-col gap-2">
+                        {isLoading ? (
+                            <p className="text-caption text-neutral-400">Loading campaigns…</p>
+                        ) : (
+                            <>
+                                <p className="text-caption font-medium uppercase tracking-wider text-neutral-500">
+                                    What should we remove?
+                                </p>
+                                <RadioGroup
+                                    value={scope}
+                                    onValueChange={(v) => setScope(v as LeadDeleteScope)}
+                                    className="flex flex-col gap-2"
+                                >
+                                    {scopeOptions.map((opt) => (
+                                        <label
+                                            key={opt.value}
+                                            htmlFor={`scope-${opt.value}`}
+                                            className={cn(
+                                                'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
+                                                scope === opt.value
+                                                    ? 'border-primary-300 bg-primary-50'
+                                                    : 'border-neutral-200 hover:bg-neutral-50'
+                                            )}
+                                        >
+                                            <RadioGroupItem
+                                                value={opt.value}
+                                                id={`scope-${opt.value}`}
+                                                className="mt-0.5"
+                                            />
+                                            <div className="flex flex-col gap-0.5">
+                                                <Label className="cursor-pointer text-body font-medium text-neutral-800">
+                                                    {opt.label}
+                                                </Label>
+                                                <span className="text-caption text-neutral-500">
+                                                    {opt.hint}
+                                                </span>
+                                            </div>
+                                        </label>
+                                    ))}
+                                </RadioGroup>
+
+                                {scope === 'USER' && liveMemberships.length > 1 && (
+                                    <div className="flex flex-col gap-1 rounded-md border border-neutral-200 bg-neutral-50 p-3">
+                                        <p className="text-caption font-medium uppercase tracking-wider text-neutral-500">
+                                            Campaigns affected
+                                        </p>
+                                        {liveMemberships.map((m) => (
+                                            <span
+                                                key={m.response_id}
+                                                className="truncate text-caption text-neutral-700"
+                                            >
+                                                · {m.campaign_name || 'Unnamed campaign'}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+        </MyDialog>
+    );
+};
+
+/** Icon-only trigger used in the sidebar header. */
+export const DeleteLeadTrigger = ({ onClick }: { onClick: () => void }) => (
+    <button
+        type="button"
+        onClick={onClick}
+        title="Delete lead"
+        aria-label="Delete lead"
+        className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-danger-50 hover:text-danger-600"
+    >
+        <Trash className="size-4" />
+    </button>
+);
+
+export default DeleteLeadsDialog;

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -264,8 +264,10 @@ export const TELEPHONY_VOICE_CONFIG = (instituteId: string) =>
 // Lead Reports endpoints — use BASE_URL so they work across dev/stage/prod.
 export const GET_LEAD_REPORT_SUMMARY = `${BASE_URL}/admin-core-service/v1/reports/leads/summary`;
 export const GET_COUNSELOR_PERFORMANCE = `${BASE_URL}/admin-core-service/v1/reports/counselor-performance`;
-export const DELETE_AUDIENCE_LEAD = (responseId: string) =>
-    `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}`;
+/** Soft-delete leads (ADMIN only). Body: { response_ids, scope: RESPONSE|USER, institute_id }. */
+export const DELETE_AUDIENCE_LEADS = `${BASE_URL}/admin-core-service/v1/audience/leads/delete`;
+/** Restore soft-deleted leads (ADMIN only). Same body shape as DELETE_AUDIENCE_LEADS. */
+export const RESTORE_AUDIENCE_LEADS = `${BASE_URL}/admin-core-service/v1/audience/leads/restore`;
 export const UPDATE_LEAD_PROFILE = (responseId: string) =>
     `${BASE_URL}/admin-core-service/v1/audience/lead/${responseId}/profile`;
 export const GET_ENQUIRIES = `${BASE_URL}/admin-core-service/v1/audience/enquiries`;

--- a/frontend-admin-dashboard/src/lib/auth/roleUtils.ts
+++ b/frontend-admin-dashboard/src/lib/auth/roleUtils.ts
@@ -1,0 +1,17 @@
+import { TokenKey } from '@/constants/auth/tokens';
+import { getTokenDecodedData, getTokenFromCookie } from './sessionUtility';
+
+/**
+ * Whether the signed-in user holds the ADMIN role for a given institute.
+ *
+ * Roles are per-institute — the token's `authorities` map is keyed by institute id — so an admin
+ * of one institute is not an admin of another. Always pass the institute the action targets.
+ *
+ * This gates UI affordances only; the server re-checks the same role and is the real boundary.
+ */
+export const isAdminForInstitute = (instituteId?: string | null): boolean => {
+    if (!instituteId) return false;
+    const tokenData = getTokenDecodedData(getTokenFromCookie(TokenKey.accessToken));
+    const roles = tokenData?.authorities?.[instituteId]?.roles;
+    return Array.isArray(roles) && roles.includes('ADMIN');
+};

--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-services/delete-audience-lead.ts
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-services/delete-audience-lead.ts
@@ -1,15 +1,49 @@
-import { DELETE_AUDIENCE_LEAD } from '@/constants/urls';
+import { DELETE_AUDIENCE_LEADS, RESTORE_AUDIENCE_LEADS } from '@/constants/urls';
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 
-export const deleteAudienceLead = async (responseId: string): Promise<string> => {
-    if (!responseId) {
-        throw new Error('Response ID is required to delete a lead.');
+/**
+ * What a delete acts on. A row in the leads list is one campaign response, but the same person
+ * can hold several — so the caller has to say which they mean.
+ *
+ * - `RESPONSE`: just the given responses (what a row, or a bulk selection, represents).
+ * - `USER`: every lead those people hold, across all campaigns ("remove them entirely").
+ */
+export type LeadDeleteScope = 'RESPONSE' | 'USER';
+
+export interface LeadDeleteParams {
+    responseIds: string[];
+    instituteId: string;
+    scope?: LeadDeleteScope;
+}
+
+const buildBody = ({ responseIds, instituteId, scope = 'RESPONSE' }: LeadDeleteParams) => ({
+    response_ids: responseIds,
+    institute_id: instituteId,
+    scope,
+});
+
+/** Soft-delete leads. Returns how many rows actually flipped to deleted. */
+export const deleteAudienceLeads = async (params: LeadDeleteParams): Promise<number> => {
+    if (!params.responseIds?.length) {
+        throw new Error('At least one lead is required to delete.');
     }
-
     const response = await authenticatedAxiosInstance({
-        method: 'DELETE',
-        url: DELETE_AUDIENCE_LEAD(responseId),
+        method: 'POST',
+        url: DELETE_AUDIENCE_LEADS,
+        data: buildBody(params),
     });
+    return response?.data?.deleted ?? 0;
+};
 
-    return response?.data;
+/** Restore soft-deleted leads. Returns how many rows actually came back. */
+export const restoreAudienceLeads = async (params: LeadDeleteParams): Promise<number> => {
+    if (!params.responseIds?.length) {
+        throw new Error('At least one lead is required to restore.');
+    }
+    const response = await authenticatedAxiosInstance({
+        method: 'POST',
+        url: RESTORE_AUDIENCE_LEADS,
+        data: buildBody(params),
+    });
+    return response?.data?.restored ?? 0;
 };

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
@@ -1,9 +1,12 @@
-import { getActiveRoleDisplaySettingsKey } from '@/lib/auth/instituteUtils';
+import { getActiveRoleDisplaySettingsKey, getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { Sidebar, SidebarContent, SidebarHeader } from '@/components/ui/sidebar';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useCompactMode } from '@/hooks/use-compact-mode';
-import { X, ArrowsOutSimple, CaretLeft, CaretRight } from '@phosphor-icons/react';
+import { X, ArrowsOutSimple, CaretLeft, CaretRight, Trash } from '@phosphor-icons/react';
+import { DeleteLeadsDialog } from '@/components/shared/leads/delete-leads-dialog';
+import { isAdminForInstitute } from '@/lib/auth/roleUtils';
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import DummyProfile from '@/assets/svgs/dummy_profile_photo.svg';
 import { StatusChips } from '@/components/design-system/chips';
 import { StudentOverview } from './student-overview/student-overview';
@@ -136,9 +139,19 @@ export const StudentSidebar = ({
         setOpen(false);
         setOpenMobile(false);
     };
+    const [deleteOpen, setDeleteOpen] = useState(false);
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [faceLoader, setFaceLoader] = useState(false);
-    const { selectedStudent, openOverlay, isOverlayOpen } = useStudentSidebar();
+    const { selectedStudent, setSelectedStudent, openOverlay, isOverlayOpen } = useStudentSidebar();
+    const queryClient = useQueryClient();
+    // `_response_id` marks a row that came from a lead surface (the lead lists map a lead into
+    // StudentTable shape to reuse this sheet). Contacts never carry it, so it doubles as the
+    // "is this a lead" test — and only a lead can be deleted here.
+    const leadResponseId =
+        ((selectedStudent as unknown as Record<string, unknown>)?._response_id as string | null) ??
+        null;
+    const currentInstituteId = getCurrentInstituteId();
+    const canDeleteLead = isAdminForInstitute(currentInstituteId);
     const [tabSettings, setTabSettings] = useState<StudentSideViewSettings | null>(null);
     /**
      * navStyle — selects between the horizontal tab bar (default) and the
@@ -345,6 +358,19 @@ export const StudentSidebar = ({
                                 evaluation submission tabs — don't supply `openOverlay`,
                                 so we hide the expand affordance there instead of crashing
                                 on click (TypeError: openOverlay is not a function). */}
+                            {/* Delete is offered only for leads (rows carrying a `_response_id`)
+                                and only to admins — a contact's row here is a real enrolled
+                                learner, which this endpoint deliberately can't touch. */}
+                            {leadResponseId && canDeleteLead && (
+                                <button
+                                    onClick={() => setDeleteOpen(true)}
+                                    className="flex size-9 shrink-0 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-danger-50 hover:text-danger-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger-400"
+                                    aria-label="Delete lead"
+                                    title="Delete lead"
+                                >
+                                    <Trash className="size-5" />
+                                </button>
+                            )}
                             {typeof openOverlay === 'function' && (
                                 <button
                                     onClick={() => openOverlay()}
@@ -670,6 +696,30 @@ export const StudentSidebar = ({
                 </div>
                 </div>
             </SidebarContent>
+
+            {leadResponseId && currentInstituteId && (
+                <DeleteLeadsDialog
+                    open={deleteOpen}
+                    onOpenChange={setDeleteOpen}
+                    instituteId={currentInstituteId}
+                    responseIds={[leadResponseId]}
+                    userId={selectedStudent?.user_id}
+                    leadName={selectedStudent?.full_name}
+                    onSuccess={() => {
+                        // The lead is gone from every list — close the sheet rather than leave
+                        // it showing a row that no longer exists, and refetch the lists behind it.
+                        // These keys must match the lists' own useQuery keys exactly (prefix
+                        // matching only helps within a key, not across a different first element),
+                        // so they mirror what the tables invalidate after a status change.
+                        queryClient.invalidateQueries({ queryKey: ['recent-leads'] });
+                        queryClient.invalidateQueries({ queryKey: ['campaignUsers'] });
+                        queryClient.invalidateQueries({ queryKey: ['user-lead-profile'] });
+                        queryClient.invalidateQueries({ queryKey: ['lead-profiles-batch'] });
+                        setSelectedStudent(null);
+                        closeSidebar();
+                    }}
+                />
+            )}
         </Sidebar>
     );
 };


### PR DESCRIPTION
## Summary of Changes

Admins can now delete a lead from the CRM. The lead is **hidden, not erased** (`audience_response.audience_status` → `INACTIVE`), so it stops being contacted while call history, admission records and reports keep working.

The endpoint this replaces — `DELETE /lead/{responseId}` — **hard-deleted the row with no authorization check whatsoever**, and no UI ever called it. It's gone.

**Backend:**
- `AudienceStatusEnum` + `AudienceResponse.audienceStatus`. The column and its index shipped in V359; **V376** adds a composite `(user_id, audience_status)` index for the workbench's per-row visibility check (measured on a 59,782-profile institute: +4.7 ms with the index vs +14.5 ms without).
- `POST /v1/audience/leads/delete` and `/leads/restore`. ADMIN-only (403), **409** if the lead has converted, **400** on a malformed body. Body-based because a delete needs three things a path param can't carry: the id list (bulk), the `scope`, and the `institute_id` the admin check is made against.
- **Scope**: `RESPONSE` (default) deletes only the given responses — what a row in the list actually *is*. `USER` deletes every lead that person holds across all campaigns. 341 people in production hold more than one lead (one holds 21), so this had to be an explicit choice rather than a guess.
- **Targets are resolved *through* the institute** (`findAllByInstituteAndIds`, INNER JOIN on `audience.institute_id`), never by raw id. The role check only proves the caller administers the institute they *named*; without this, an admin could pass their own `institute_id` with another tenant's response ids. Unknown and out-of-scope ids both 404, so the endpoint can't be used to probe other institutes' data.
- **Reactivate-on-resubmit.** The intake guards use `existsByAudienceIdAndUserId`, a derived query that can't see status — so a deleted lead's resubmission would hit "you have already submitted" and stay invisible **forever**. All four intake paths (including the Meta/Zoho/Google webhook) plus the `dedupe_key` merge path now revive the row. They **reactivate and return**, never falling through to the insert: falling through would create a duplicate *and* re-run auto-assignment, advancing the pool's round-robin pointer.
- **`audienceStatusFilter`** (`EXCLUDE_DELETED` default / `ONLY_DELETED` / `ALL`) on lead views, as its own unconditional clause — deliberately not folded into the `overall_status` OR block, which switches itself off when `overallStatusStr` is set.
- **Send paths hardcode ACTIVE**, with no parameter to opt in: campaign message blast, bulk AI dialer, and the centralized recipient resolver (which previously had no status filter at all). `findByAudienceId` is split into `findActiveByAudienceId` for send/dial, leaving the raw variant for score recalculation. `AiCallService.placeCall` also refuses a deleted lead (409) — a workflow retry sequence resolves its lead from context captured days earlier, so list-time filtering alone wouldn't stop it.
- **Counsellor Workbench** derives visibility via `EXISTS (… audience_status='ACTIVE')`. No column was added to `user_lead_profile`: it's one row per *person* while a delete is per *response*, so the flag would be a derived AND that drifts — and unlike its existing denormalized fields (`campaign_count` etc., which only ever show a wrong number), a stale visibility gate silently loses live leads.
- **Audit trail** — new `LEAD_DELETED` / `LEAD_RESTORED` journey events, attributed to the actor.
- **Deliberately NOT filtered**: dedup/identity lookups (they must see deleted rows for revival to work), reports/dashboards/admission/payments (deleting a lead must not rewrite last quarter's numbers), the pool reassign-on-deactivation query, and the assignment trigger-context enrichment.

**Frontend:**
- Delete action in the lead sidebar header, gated on ADMIN **and** on the row being a lead (`_response_id`) — a contact is a real enrolled learner and this endpoint can't touch one.
- Confirm dialog leading with consequence ("they will stop receiving campaign emails, WhatsApp messages and calls"), plus the scope choice, with the person's campaigns fetched from the existing `user-audiences` endpoint. The 409 message is surfaced verbatim.
- `isAdminForInstitute` helper — roles are per-institute, so an admin of one institute isn't an admin of another.

**Counsellor assignment is untouched.** Both assignment engines (`counselor_pool` and `LeadDistributionService`) contain zero references to `audience_response`; both round-robins are cursor/counter-based rather than lead-count-based, and the only load count reads `linked_users`. No assignment code was modified.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change — `DELETE /lead/{responseId}` is removed (it hard-deleted with no auth check; nothing in the product called it)
- [ ] Documentation update

## How Has This Been Tested?

Driven against a local `admin_core_service` on :8072 with Postgres restored from a prod dump (65k leads), auth pointed at stage, plus a real browser (Playwright) for the UI. **An independent session then re-tested the whole feature against a written spec** and filed `.samar/docs/lead-soft-delete-test-report.md`.

That review found **a critical cross-tenant hole** — the delete resolved rows by raw id, so an admin could pass their own `institute_id` with another institute's response ids and delete them (reproduced: `200 {"deleted":1}`, foreign row flipped). Now fixed and re-verified: that repro returns **404** and the row survives; the same attack via `/leads/restore`, via `scope=USER`, and as a mixed batch (one own + one foreign) all 404, with the mixed batch touching neither. It also found a stale-cache invalidation key and an AI-retry path that could still dial a deleted lead — both fixed, both re-verified, no regressions.

- **Blackhole (the core promise)**: delete → resubmit via the public endpoint → lead revives to ACTIVE, **exactly 1 row**, RR cursor unmoved, no auto-assign fired.
- **Scope**: one response id under `USER` deleted both of a person's leads across two campaigns; under `RESPONSE`, only the targeted one.
- **Sends**: with the campaign's only lead deleted, the old query would have selected **1 recipient**; every filtered path now selects **0**. Verified by inspecting what the recipient queries select — no real send or call was fired.
- **Filters**: default/`ONLY_DELETED`/`ALL` → 2/1/3. Filtering by `overall_statuses` does not un-hide a deleted lead.
- **Status codes**: 409 converted (generic "converted" wording, not "student"), 403 unauthenticated, 400 malformed, 409 on AI-calling a deleted lead.
- **Restore + idempotency**: re-restore returns 0; audit rows written with the actor.
- **Contacts unaffected**: a learner's sidebar shows no delete affordance; a lead's does.
- **V376** applied cleanly to a prod-dump DB.
- `admin_core_service` compiles (`BUILD SUCCESS`); frontend `tsc --noEmit` 0 errors; `design-lint` clean.

Not covered: non-admin 403 was verified by code only (one ADMIN test account available); the Workbench guard was verified at the SQL level, not clicked through; campaign-send exclusion is code-inspection only by design.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
