### PR TITLE
feat: transaction history section in student side-view and sub-org an…

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
@@ -5,10 +5,11 @@ import { useInstituteDetailsStore } from '@/stores/students/students-list/useIns
 import {
     fetchUserInvoices,
     fetchUserAccountSummary,
+    fetchUserAccountLedger,
     markInvoicePaidManual,
     getInvoiceDownloadUrl,
 } from '@/services/invoice-service';
-import type { InvoiceDTO, UserAccountSummaryDTO } from '@/services/invoice-service';
+import type { InvoiceDTO, UserAccountSummaryDTO, UserAccountLedgerEntryDTO } from '@/services/invoice-service';
 import {
     FileText,
     Wallet,
@@ -19,6 +20,9 @@ import {
     Receipt,
     Copy,
     Check,
+    ClockCounterClockwise,
+    ArrowCircleUp,
+    ArrowCircleDown,
 } from '@phosphor-icons/react';
 import { MyButton } from '@/components/design-system/button';
 import { CpoInstallmentsEditor } from './cpo-installments-editor';
@@ -390,6 +394,118 @@ const InvoicesList = ({
     );
 };
 
+const LEDGER_EVENT_META: Record<string, { label: string; cls: string; isCredit: boolean }> = {
+    DEBIT_ACCRUAL:     { label: 'Invoice raised',   cls: 'bg-red-50 text-red-700 border-red-200',         isCredit: false },
+    CREDIT_PAYMENT:    { label: 'Payment received',  cls: 'bg-green-50 text-green-700 border-green-200',   isCredit: true  },
+    CREDIT_WAIVER:     { label: 'Waiver',            cls: 'bg-blue-50 text-blue-700 border-blue-200',      isCredit: true  },
+    CREDIT_ADJUSTMENT: { label: 'Adjustment',        cls: 'bg-amber-50 text-amber-700 border-amber-200',   isCredit: true  },
+    DEBIT_PENALTY:     { label: 'Penalty',           cls: 'bg-orange-50 text-orange-700 border-orange-200',isCredit: false },
+};
+
+const TransactionHistory = ({
+    userId,
+    instituteId,
+}: {
+    userId: string;
+    instituteId: string;
+}) => {
+    const [page, setPage] = useState(0);
+    const PAGE_SIZE = 10;
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['user-account-ledger', userId, instituteId, page],
+        queryFn: () => fetchUserAccountLedger(userId, instituteId, page, PAGE_SIZE),
+        staleTime: 60000,
+        enabled: !!userId && !!instituteId,
+    });
+
+    const entries: UserAccountLedgerEntryDTO[] = data?.content ?? [];
+    const totalPages = data?.totalPages ?? 1;
+
+    if (isLoading && entries.length === 0) {
+        return (
+            <div className="flex items-center justify-center p-4">
+                <div className="size-4 animate-spin rounded-full border-2 border-muted-foreground border-t-foreground" />
+                <span className="ml-2 text-xs text-muted-foreground">Loading transactions…</span>
+            </div>
+        );
+    }
+
+    if (!isLoading && entries.length === 0) {
+        return (
+            <p className="text-xs text-muted-foreground">No transaction history yet.</p>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <ul className="divide-y divide-neutral-100 overflow-hidden rounded-lg border border-neutral-200">
+                {entries.map((entry) => {
+                    const meta = LEDGER_EVENT_META[entry.event_type] ?? {
+                        label: entry.event_type,
+                        cls: 'bg-gray-50 text-gray-600 border-gray-200',
+                        isCredit: false,
+                    };
+                    const sym = entry.currency === 'USD' ? '$' : entry.currency === 'EUR' ? '€' : '₹';
+                    const amtStr = `${sym}${Number(entry.amount || 0).toLocaleString('en-IN', { minimumFractionDigits: 2 })}`;
+                    return (
+                        <li key={entry.id} className="flex items-start gap-2.5 px-3 py-2 hover:bg-neutral-50">
+                            <span className="mt-0.5 shrink-0">
+                                {meta.isCredit
+                                    ? <ArrowCircleUp className="size-4 text-green-600" weight="duotone" />
+                                    : <ArrowCircleDown className="size-4 text-red-500" weight="duotone" />
+                                }
+                            </span>
+                            <div className="min-w-0 flex-1">
+                                <div className="flex flex-wrap items-center gap-1.5">
+                                    <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium ${meta.cls}`}>
+                                        {meta.label}
+                                    </span>
+                                    {entry.remarks && (
+                                        <span className="truncate text-[11px] text-muted-foreground" title={entry.remarks}>
+                                            {entry.remarks}
+                                        </span>
+                                    )}
+                                </div>
+                                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                                    {formatDate(entry.created_at)}
+                                    {entry.source_type && <> · {entry.source_type.replace(/_/g, ' ')}</>}
+                                </p>
+                            </div>
+                            <span className={`shrink-0 text-sm font-semibold tabular-nums ${meta.isCredit ? 'text-green-700' : 'text-red-600'}`}>
+                                {meta.isCredit ? '+' : '-'}{amtStr}
+                            </span>
+                        </li>
+                    );
+                })}
+            </ul>
+            {totalPages > 1 && (
+                <div className="flex items-center justify-between px-1">
+                    <span className="text-xs text-muted-foreground">
+                        Page {page + 1} of {totalPages}
+                    </span>
+                    <div className="flex gap-1">
+                        <button
+                            onClick={() => setPage((p) => Math.max(0, p - 1))}
+                            disabled={page === 0}
+                            className="rounded p-1 text-neutral-500 hover:bg-neutral-100 disabled:opacity-40"
+                        >
+                            <CaretLeft className="size-3.5" />
+                        </button>
+                        <button
+                            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                            disabled={page >= totalPages - 1}
+                            className="rounded p-1 text-neutral-500 hover:bg-neutral-100 disabled:opacity-40"
+                        >
+                            <CaretRight className="size-3.5" />
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
 export const StudentPaymentHistory = () => {
     const { selectedStudent } = useStudentSidebar();
     const instituteDetails = useInstituteDetailsStore((state) => state.instituteDetails);
@@ -536,11 +652,17 @@ export const StudentPaymentHistory = () => {
                 )}
             </ProfileSectionCard>
 
-            {/* Payment Logs table removed per handoff PaymentHistorySection —
-                Invoices already shows the per-installment lifecycle (GENERATED
-                → SENT → PAID), so the raw payment-log audit trail is forensic
-                detail rather than counsellor surface. CpoInstallmentsEditor
-                continues to cover plan adjustments above. */}
+            {/* Transaction History — append-only ledger entries from user_account_ledger.
+                Shows every debit (invoice raised, penalty) and credit (payment, waiver,
+                adjustment) with sign-coded colours. Newest-first, server-paginated. */}
+            {selectedStudent?.user_id && instituteDetails?.id && (
+                <ProfileSectionCard icon={ClockCounterClockwise} heading="Transaction History">
+                    <TransactionHistory
+                        userId={selectedStudent.user_id}
+                        instituteId={instituteDetails.id}
+                    />
+                </ProfileSectionCard>
+            )}
         </div>
     );
 };

--- a/frontend-admin-dashboard/src/routes/manage-suborg-teams/-components/sub-org-analytics-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-suborg-teams/-components/sub-org-analytics-panel.tsx
@@ -23,9 +23,11 @@ import {
     getInvoiceDownloadUrl,
     fetchInvoiceById,
     fetchUserAccountSummary,
+    fetchUserAccountLedger,
     rejectInvoice,
     type InvoiceDTO,
     type UserAccountSummaryDTO,
+    type UserAccountLedgerEntryDTO,
 } from '@/services/invoice-service';
 import { getPaymentOptions } from '@/services/payment-options';
 import type { PaymentOptionApi } from '@/types/payment';
@@ -49,7 +51,7 @@ import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { isCallerSubOrgAdmin } from '@/lib/auth/facultyAccessUtils';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Bell, Copy, CopySimple, Plus, XCircle } from '@phosphor-icons/react';
+import { Bell, Copy, CopySimple, Plus, XCircle, ArrowCircleUp, ArrowCircleDown, ClockCounterClockwise } from '@phosphor-icons/react';
 import { toast } from 'sonner';
 import { useState } from 'react';
 import { MyButton } from '@/components/design-system/button';
@@ -247,6 +249,17 @@ export function SubOrgAnalyticsPanel({ subOrgId, subOrgName, restrictedView = fa
             currency,
         } as UserAccountSummaryDTO;
     })();
+
+    const [ledgerPage, setLedgerPage] = useState(0);
+    const LEDGER_PAGE_SIZE = 10;
+    const { data: ledgerData } = useQuery({
+        queryKey: ['sub-org-admin-ledger', adminUserId, instituteId, ledgerPage],
+        queryFn: () => fetchUserAccountLedger(adminUserId!, instituteId!, ledgerPage, LEDGER_PAGE_SIZE),
+        enabled: !!adminUserId && !!instituteId,
+        staleTime: 60000,
+    });
+    const ledgerEntries: UserAccountLedgerEntryDTO[] = ledgerData?.content ?? [];
+    const ledgerTotalPages = ledgerData?.totalPages ?? 1;
 
     const [showLedger, setShowLedger] = useState(false);
     const [activeTab, setActiveTab] = useState<'admin' | 'courses' | 'learners' | 'invoices' | 'team'>('admin');
@@ -486,6 +499,94 @@ export function SubOrgAnalyticsPanel({ subOrgId, subOrgName, restrictedView = fa
                         Account Summary
                     </h4>
                     <AccountSummaryGrid summary={effectiveAdminSummary} />
+                </div>
+            )}
+
+            {/* Transaction History — append-only ledger entries, always visible below summary. */}
+            {adminUserId && instituteId && (
+                <div className="rounded-lg border bg-white p-4">
+                    <h4 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <ClockCounterClockwise className="h-3.5 w-3.5" />
+                        Transaction History
+                    </h4>
+                    {ledgerEntries.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">No transactions recorded yet.</p>
+                    ) : (
+                        <div className="space-y-2">
+                            <ul className="divide-y divide-neutral-100 overflow-hidden rounded-lg border border-neutral-200">
+                                {ledgerEntries.map((entry) => {
+                                    const LEDGER_META: Record<string, { label: string; cls: string; isCredit: boolean }> = {
+                                        DEBIT_ACCRUAL:     { label: 'Invoice raised',   cls: 'bg-red-50 text-red-700 border-red-200',         isCredit: false },
+                                        CREDIT_PAYMENT:    { label: 'Payment received',  cls: 'bg-green-50 text-green-700 border-green-200',   isCredit: true  },
+                                        CREDIT_WAIVER:     { label: 'Waiver',            cls: 'bg-blue-50 text-blue-700 border-blue-200',      isCredit: true  },
+                                        CREDIT_ADJUSTMENT: { label: 'Adjustment',        cls: 'bg-amber-50 text-amber-700 border-amber-200',   isCredit: true  },
+                                        DEBIT_PENALTY:     { label: 'Penalty',           cls: 'bg-orange-50 text-orange-700 border-orange-200',isCredit: false },
+                                    };
+                                    const meta = LEDGER_META[entry.event_type] ?? {
+                                        label: entry.event_type,
+                                        cls: 'bg-gray-50 text-gray-600 border-gray-200',
+                                        isCredit: false,
+                                    };
+                                    const sym = entry.currency === 'USD' ? '$' : entry.currency === 'EUR' ? '€' : '₹';
+                                    const amtStr = `${sym}${Number(entry.amount || 0).toLocaleString('en-IN', { minimumFractionDigits: 2 })}`;
+                                    return (
+                                        <li key={entry.id} className="flex items-start gap-2.5 px-3 py-2 text-xs hover:bg-neutral-50">
+                                            <span className="mt-0.5 shrink-0">
+                                                {meta.isCredit
+                                                    ? <ArrowCircleUp className="size-4 text-green-600" weight="duotone" />
+                                                    : <ArrowCircleDown className="size-4 text-red-500" weight="duotone" />
+                                                }
+                                            </span>
+                                            <div className="min-w-0 flex-1">
+                                                <div className="flex flex-wrap items-center gap-1.5">
+                                                    <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium ${meta.cls}`}>
+                                                        {meta.label}
+                                                    </span>
+                                                    {entry.remarks && (
+                                                        <span className="truncate text-[11px] text-muted-foreground" title={entry.remarks}>
+                                                            {entry.remarks}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                                                    {fmtDate(entry.created_at)}
+                                                    {entry.source_type && <> · {entry.source_type.replace(/_/g, ' ')}</>}
+                                                </p>
+                                            </div>
+                                            <span className={`shrink-0 font-semibold tabular-nums ${meta.isCredit ? 'text-green-700' : 'text-red-600'}`}>
+                                                {meta.isCredit ? '+' : '-'}{amtStr}
+                                            </span>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                            {ledgerTotalPages > 1 && (
+                                <div className="flex items-center justify-between px-1">
+                                    <span className="text-[10px] text-muted-foreground">
+                                        Page {ledgerPage + 1} of {ledgerTotalPages}
+                                    </span>
+                                    <div className="flex gap-1">
+                                        <button
+                                            type="button"
+                                            onClick={() => setLedgerPage((p) => Math.max(0, p - 1))}
+                                            disabled={ledgerPage === 0}
+                                            className="rounded p-1 text-muted-foreground hover:bg-muted disabled:opacity-40"
+                                        >
+                                            <ChevronDown className="h-3.5 w-3.5 rotate-90" />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setLedgerPage((p) => Math.min(ledgerTotalPages - 1, p + 1))}
+                                            disabled={ledgerPage >= ledgerTotalPages - 1}
+                                            className="rounded p-1 text-muted-foreground hover:bg-muted disabled:opacity-40"
+                                        >
+                                            <ChevronDown className="h-3.5 w-3.5 -rotate-90" />
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/frontend-admin-dashboard/src/services/invoice-service.ts
+++ b/frontend-admin-dashboard/src/services/invoice-service.ts
@@ -8,6 +8,7 @@ import {
     POST_ADMIN_PREVIEW_INVOICE,
     POST_REJECT_INVOICE,
     GET_USER_ACCOUNT_SUMMARY,
+    GET_USER_ACCOUNT_LEDGER,
     POST_MARK_INVOICE_PAID_MANUAL,
 } from '@/constants/urls';
 
@@ -50,6 +51,28 @@ export interface InvoiceDTO {
     payment_link?: string | null;
 }
 
+export interface UserAccountLedgerEntryDTO {
+    id: string;
+    event_type: string; // DEBIT_ACCRUAL | CREDIT_PAYMENT | CREDIT_WAIVER | CREDIT_ADJUSTMENT | DEBIT_PENALTY
+    amount: number;
+    currency: string;
+    due_date: string | null;
+    source_type: string | null;
+    source_id: string | null;
+    invoice_id: string | null;
+    reference_id: string | null;
+    remarks: string | null;
+    created_at: string;
+}
+
+export interface LedgerPageResponse {
+    content: UserAccountLedgerEntryDTO[];
+    totalElements: number;
+    totalPages: number;
+    number: number;
+    last: boolean;
+}
+
 export interface UserAccountSummaryDTO {
     user_id: string;
     institute_id: string;
@@ -84,6 +107,19 @@ export async function fetchUserAccountSummary(
     const response = await authenticatedAxiosInstance.get<UserAccountSummaryDTO>(
         GET_USER_ACCOUNT_SUMMARY(userId),
         { params: { instituteId } }
+    );
+    return response.data;
+}
+
+export async function fetchUserAccountLedger(
+    userId: string,
+    instituteId: string,
+    page = 0,
+    size = 20
+): Promise<LedgerPageResponse> {
+    const response = await authenticatedAxiosInstance.get<LedgerPageResponse>(
+        GET_USER_ACCOUNT_LEDGER(userId),
+        { params: { instituteId, page, size } }
     );
     return response.data;
 }


### PR DESCRIPTION
…alytics panel

Adds a paginated ledger entry list (user_account_ledger rows) to both surfaces:
- invoice-service: UserAccountLedgerEntryDTO, LedgerPageResponse types, fetchUserAccountLedger(userId, instituteId, page, size) function
- student-payment-history: TransactionHistory component below Invoices section; green arrow + badge for credits (payment/waiver/adjustment), red arrow for debits (accrual/penalty); 10-per-page server pagination
- sub-org-analytics-panel: same ledger list always visible between the account summary card and the tabs; shared fmtDate helper, ChevronDown pagination

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
