### PR TITLE
Make all template type lookups case-insensitive (EMAIL/email both match)

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/TemplateRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/TemplateRepository.java
@@ -17,11 +17,14 @@ public interface TemplateRepository extends JpaRepository<Template, String> {
     // Find templates by institute ID
     List<Template> findByInstituteId(String instituteId);
 
-    // Find templates by institute ID and type
-    List<Template> findByInstituteIdAndType(String instituteId, String type);
+    // Find templates by institute ID and type (case-insensitive: "EMAIL"/"email" both match)
+    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND UPPER(t.type) = UPPER(:type)")
+    List<Template> findByInstituteIdAndType(@Param("instituteId") String instituteId, @Param("type") String type);
 
-    // Find templates by institute ID, type, and vendor ID
-    List<Template> findByInstituteIdAndTypeAndVendorId(String instituteId, String type, String vendorId);
+    // Find templates by institute ID, type, and vendor ID (case-insensitive type)
+    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND UPPER(t.type) = UPPER(:type) AND t.vendorId = :vendorId")
+    List<Template> findByInstituteIdAndTypeAndVendorId(@Param("instituteId") String instituteId,
+            @Param("type") String type, @Param("vendorId") String vendorId);
 
     // Find template by institute ID and name
     Optional<Template> findByInstituteIdAndName(String instituteId, String name);
@@ -29,8 +32,9 @@ public interface TemplateRepository extends JpaRepository<Template, String> {
     // Find templates by vendor ID
     List<Template> findByVendorId(String vendorId);
 
-    // Find templates by type
-    List<Template> findByType(String type);
+    // Find templates by type (case-insensitive)
+    @Query("SELECT t FROM Template t WHERE UPPER(t.type) = UPPER(:type)")
+    List<Template> findByType(@Param("type") String type);
 
     // Find templates that can be deleted
     List<Template> findByCanDeleteTrue();
@@ -56,8 +60,9 @@ public interface TemplateRepository extends JpaRepository<Template, String> {
     List<Template> findBySubjectContainingIgnoreCase(@Param("instituteId") String instituteId,
             @Param("searchText") String searchText);
 
-    // Count templates by institute ID and type
-    long countByInstituteIdAndType(String instituteId, String type);
+    // Count templates by institute ID and type (case-insensitive)
+    @Query("SELECT COUNT(t) FROM Template t WHERE t.instituteId = :instituteId AND UPPER(t.type) = UPPER(:type)")
+    long countByInstituteIdAndType(@Param("instituteId") String instituteId, @Param("type") String type);
 
     // Count templates by institute ID
     long countByInstituteId(String instituteId);
@@ -70,20 +75,21 @@ public interface TemplateRepository extends JpaRepository<Template, String> {
     @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId ORDER BY t.createdAt DESC")
     Page<Template> findByInstituteIdOrderByCreatedAtDescPageable(@Param("instituteId") String instituteId, Pageable pageable);
 
-    // Find templates by institute ID with pagination, optionally filtered by type and/or a name/subject search term.
-    // Bind params are always wrapped in COALESCE (never a bare ":param IS NULL") so Postgres can always infer
-    // their type from the surrounding comparison — a bare "? IS NULL" with no other typed usage in that branch
-    // is a known source of "could not determine data type of parameter" errors from the PG JDBC driver.
+    // Find templates by institute ID with pagination, optionally filtered by type (case-insensitive) and/or a
+    // name/subject search term.
+    // Bind params are always wrapped in COALESCE/UPPER (never a bare ":param IS NULL") so Postgres can always
+    // infer their type from the surrounding comparison — a bare "? IS NULL" with no other typed usage in that
+    // branch is a known source of "could not determine data type of parameter" errors from the PG JDBC driver.
     @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId " +
-            "AND t.type = COALESCE(:type, t.type) " +
+            "AND UPPER(t.type) = COALESCE(UPPER(:type), UPPER(t.type)) " +
             "AND (LOWER(t.name) LIKE LOWER(CONCAT('%', COALESCE(:searchText, ''), '%')) " +
             "OR LOWER(t.subject) LIKE LOWER(CONCAT('%', COALESCE(:searchText, ''), '%'))) " +
             "ORDER BY t.createdAt DESC")
     Page<Template> findByInstituteIdAndTypeAndSearchPageable(@Param("instituteId") String instituteId,
             @Param("type") String type, @Param("searchText") String searchText, Pageable pageable);
 
-    // Find templates by institute ID and type with pagination support
-    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND t.type = :type ORDER BY t.createdAt DESC")
+    // Find templates by institute ID and type with pagination support (case-insensitive type)
+    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND UPPER(t.type) = UPPER(:type) ORDER BY t.createdAt DESC")
     List<Template> findByInstituteIdAndTypeOrderByCreatedAtDesc(@Param("instituteId") String instituteId,
             @Param("type") String type);
 
@@ -120,7 +126,13 @@ public interface TemplateRepository extends JpaRepository<Template, String> {
     // Count templates by institute ID, status, and template category
     long countByInstituteIdAndStatusAndTemplateCategory(String instituteId, String status, String templateCategory);
 
-    Optional<Template> findByInstituteIdAndNameAndTypeAndStatus(String instituteId, String name, String type,String status);
+    // Case-insensitive type match ("EMAIL"/"email" both match)
+    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND t.name = :name AND UPPER(t.type) = UPPER(:type) AND t.status = :status")
+    Optional<Template> findByInstituteIdAndNameAndTypeAndStatus(@Param("instituteId") String instituteId,
+            @Param("name") String name, @Param("type") String type, @Param("status") String status);
 
-    Optional<Template>findByInstituteIdAndNameAndType(String instituteId,String name,String type);
+    // Case-insensitive type match ("EMAIL"/"email" both match)
+    @Query("SELECT t FROM Template t WHERE t.instituteId = :instituteId AND t.name = :name AND UPPER(t.type) = UPPER(:type)")
+    Optional<Template> findByInstituteIdAndNameAndType(@Param("instituteId") String instituteId,
+            @Param("name") String name, @Param("type") String type);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/TemplateService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/TemplateService.java
@@ -290,7 +290,7 @@ public class TemplateService {
 
         // Apply additional filters using stream chaining
         return templates.stream()
-                .filter(t -> request.getType() == null || t.getType().equals(request.getType()))
+                .filter(t -> request.getType() == null || t.getType().equalsIgnoreCase(request.getType()))
                 .filter(t -> request.getVendorId() == null || request.getVendorId().equals(t.getVendorId()))
                 .filter(t -> request.getCanDelete() == null || t.getCanDelete().equals(request.getCanDelete()))
                 .filter(t -> request.getContentType() == null || request.getContentType().equals(t.getContentType()))


### PR DESCRIPTION
Template.type is stored as a free-text string and different code paths have written it in different cases over time (workflow/doubt-notification code already worked around this by trying both "EMAIL" and "email"). Every repository method that filters by type compared it with case-sensitive equality, so a row stored as lowercase "email" was invisible to a caller querying "EMAIL" and vice versa.

Converted every type-filtering query (find/count/exists by type, with or without institute/name/vendor/status) to compare UPPER(t.type) against UPPER(:type), and the in-memory searchTemplates() filter to equalsIgnoreCase. The paginated list query keeps the COALESCE-based null handling from the previous 500 fix, just wrapped in UPPER().

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
