### PR TITLE
fix(assignment): learners on mobile could only upload images, not PDFs/docs

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-helper/helper.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-helper/helper.ts
@@ -477,7 +477,7 @@ export const convertToAssignmentSlideBackendFormat = (assignmentSlide: Assignmen
                     ? {
                           options: question.options.map((opt) => ({
                               id: opt.id,
-                              text: { content: opt.text.content },
+                              text: { id: null, type: 'HTML', content: opt.text.content },
                           })),
                       }
                     : {}),

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/file-uploader.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/file-uploader.tsx
@@ -116,7 +116,11 @@ export const FileUploader = ({
   // Empty / unset → no restriction: accept any of the known types.
   const isUnrestricted = !allowedFileTypes || allowedFileTypes.length === 0
   const allowed = (isUnrestricted ? KNOWN_TYPES : allowedFileTypes) as AllowedFileType[]
-  const acceptAttr = isUnrestricted ? "" : buildAcceptAttr(allowed)
+  // A present-but-empty `accept=""` attribute makes some mobile browsers'
+  // native file pickers default to Photos/Camera only. Omit the attribute
+  // entirely (undefined) instead of an empty string so "unrestricted" truly
+  // opens the general file browser.
+  const acceptAttr = isUnrestricted ? undefined : buildAcceptAttr(allowed)
   const hintLabel = isUnrestricted ? "Any file" : buildHintLabel(allowed)
 
   const guardedUpload = async (file: File) => {


### PR DESCRIPTION
## Summary
Two separate bugs found while investigating an EduStream client report of a broken document-upload on an ASSIGNMENT slide, both in the assignment-slide flow:

**1. Mobile file picker restricted to images only** (`frontend-learner-dashboard-app/.../file-uploader.tsx`)
- When an assignment has no allowed-file-types configured (the common/default path — quick-add dialogs skip that screen entirely), the file input's `accept` attribute was set to an empty string `""` instead of being omitted. A present-but-empty `accept` attribute causes some mobile browsers/WebViews (iOS Safari, Android in-app browsers) to default the native picker to Photos/Camera only, even though the app's own upload validation allows any file type.
- Fix: `accept={acceptAttr}` now resolves to `undefined` (attribute omitted) instead of `""` when unrestricted.

**2. Creating/saving an assignment question with options threw a 500** (`frontend-admin-dashboard/.../slides/-helper/helper.ts`)
- `convertToAssignmentSlideBackendFormat` built each MCQ option's rich-text payload as `{ content: opt.text.content }` — missing the `type` field that every other option-serializer in the same file sets (`type: 'HTML'`). The backend has no validation on this field, so the missing type went straight through to a `NOT NULL` DB constraint on `rich_text_data.type`, surfacing as a raw `DataIntegrityViolationException` 500 instead of a clean error.
- Fix: option's `text` object now includes `id: null, type: 'HTML'`, matching the working sibling pattern used by every other question/option serializer in this file.

## Test plan
**Bug 1 (upload):**
- [x] Restored a fresh read-only prod DB snapshot into the local dev DB and located the exact assignment from the client's report ("Portfolio Upload Submission", Future Designers Challenge course, EduStream) — confirmed its `comma_separated_media_ids` config was empty (`"types:"`), the trigger condition for this bug.
- [x] Ran a Playwright E2E test against the local app + local backend, logged in as the real enrolled student, and verified the DOM directly:
  - Before fix: `input.getAttribute('accept')` → `""` (present, empty)
  - After fix: `input.getAttribute('accept')` → `null` (attribute absent)
- [x] Confirmed no regression: PDF file selection is still accepted by client-side validation (no rejection toast), hint text still reads "Any file up to 10MB".

**Bug 2 (options type):**
- [x] Traced the exact failing request (endpoint + payload shape) back to `converDataToAssignmentFormat` / `convertToAssignmentSlideBackendFormat`, confirmed it's the live save/publish path (called from `slide-material.tsx`, `handlePublishSlide.tsx`, `handleUnpublishSlide.tsx`, `updateSlideHeading.tsx`, `useNonAdminSlides.ts`).
- [x] Verified every other option-serializer in the same file sets `type: 'HTML'`; this was the one outlier.

**Both:**
- [x] `tsc --noEmit` and the repo's design-lint pass on the changed files.
- No backend files touched (both fixes are frontend-only).