### PR TITLE
Feat/lead bulk delete

### DIFF
--- a/frontend-admin-dashboard/src/components/shared/leads/bulk-assign-counsellor-dialog.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/bulk-assign-counsellor-dialog.tsx
@@ -76,11 +76,24 @@ export function BulkAssignCounsellorDialog({
     open,
     onOpenChange,
     instituteId,
-    leads,
+    leads: selectedLeads,
     counsellorOptions,
     initialMode = 'ROUND_ROBIN',
     onSuccess,
 }: BulkAssignCounsellorDialogProps) {
+    // Assignment is per PERSON (it writes user_lead_profile.assigned_counselor_id, one row per
+    // user), but the caller's selection is per campaign response — so the same person arrives
+    // once per selected row. Collapse them here rather than at each call site: duplicates would
+    // send the same user_id twice AND, under round-robin, hand one person to two different
+    // counsellors via the index-based rotation below, leaving the winner to chance.
+    const leads = useMemo(() => {
+        const byUser = new Map<string, BulkAssignLead>();
+        selectedLeads.forEach((l) => {
+            if (l.userId && !byUser.has(l.userId)) byUser.set(l.userId, l);
+        });
+        return Array.from(byUser.values());
+    }, [selectedLeads]);
+
     const [mode, setMode] = useState<Mode>(initialMode);
     const [singleTarget, setSingleTarget] = useState<string>('');
     // Round-robin participants — all counsellors pre-checked; admin can deselect.

--- a/frontend-admin-dashboard/src/components/shared/leads/lead-table.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/lead-table.tsx
@@ -68,11 +68,18 @@ interface LeadTableProps {
     extraColumns?: LeadTableExtraColumn[];
     /** Enables a leading checkbox column for multi-select (bulk actions). */
     selectable?: boolean;
-    /** Selected lead user ids (selection is keyed on vm.userId). */
+    /**
+     * Selected lead RESPONSE ids (selection is keyed on vm.responseId).
+     *
+     * Keyed per response, not per user: a row IS one campaign response, and the same person can
+     * hold several — keying on userId collapsed those into one checkbox, so ticking one of a
+     * person's rows silently ticked them all. Bulk actions that operate per-person (assign) must
+     * therefore de-duplicate userIds from the selection themselves.
+     */
     selectedIds?: Set<string>;
-    /** Toggle a single row. Only fired for rows that have a userId. */
-    onToggleRow?: (userId: string, vm: LeadCardVM) => void;
-    /** Toggle all selectable (userId-bearing) rows currently rendered. */
+    /** Toggle a single row. Only fired for rows with both a userId and a responseId. */
+    onToggleRow?: (responseId: string, vm: LeadCardVM) => void;
+    /** Toggle all selectable rows currently rendered. */
     onToggleAll?: (checked: boolean, selectableVms: LeadCardVM[]) => void;
 }
 
@@ -223,10 +230,13 @@ export function LeadTable({
     const profOf = (vm: LeadCardVM) => (vm.userId ? profiles[vm.userId] : undefined);
     const notesOf = (vm: LeadCardVM) => (vm.userId ? notes?.[vm.userId] : undefined);
 
-    // Rows that can participate in bulk selection (need a user id to assign).
-    const selectableVms = vms.filter((v) => !!v.userId);
+    // Rows that can participate in bulk selection. Needs a user id (assign targets a person)
+    // AND a response id (that's the selection key, and what delete targets). response_id is the
+    // audience_response primary key so it's always present on a lead row; the check is a guard,
+    // not a narrowing — the selectable set is the same rows as before.
+    const selectableVms = vms.filter((v) => !!v.userId && !!v.responseId);
     const allSelected =
-        selectableVms.length > 0 && selectableVms.every((v) => selectedIds?.has(v.userId!));
+        selectableVms.length > 0 && selectableVms.every((v) => selectedIds?.has(v.responseId!));
 
     const allCols: Col[] = [
         {
@@ -236,10 +246,10 @@ export function LeadTable({
             show: selectable,
             interactive: true,
             render: (vm) =>
-                vm.userId ? (
+                vm.userId && vm.responseId ? (
                     <Checkbox
-                        checked={!!selectedIds?.has(vm.userId)}
-                        onCheckedChange={() => onToggleRow?.(vm.userId!, vm)}
+                        checked={!!selectedIds?.has(vm.responseId)}
+                        onCheckedChange={() => onToggleRow?.(vm.responseId!, vm)}
                         aria-label={`Select ${vm.name}`}
                     />
                 ) : (

--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-components/campaign-users/campaign-users-table.tsx
@@ -24,6 +24,7 @@ import {
     X,
     Clock,
     CaretDown,
+    Trash,
 } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -70,6 +71,8 @@ import {
 import { MyDropdown } from '@/components/design-system/dropdown';
 import type { LeadCardVM } from '@/components/shared/leads/lead-view-model';
 import { MyButton } from '@/components/design-system/button';
+import { isAdminForInstitute } from '@/lib/auth/roleUtils';
+import { DeleteLeadsDialog } from '@/components/shared/leads/delete-leads-dialog';
 import { AssignCounselorToLeadDialog } from '@/components/shared/assign-counselor-to-lead-dialog';
 import {
     LeadEmptyState,
@@ -510,10 +513,17 @@ const CampaignUsersContent = ({
     };
 
     // ── Bulk assign / remove counsellor (multi-select, every view) ──
-    const [selectedLeads, setSelectedLeads] = useState<Map<string, { userId: string; name: string }>>(
+    // Keyed by RESPONSE id, not user id: a row is one campaign response and the same person
+    // can hold several, so keying by user collapsed their rows into one checkbox. The value
+    // carries the userId too, because the assign actions operate per person.
+    const [selectedLeads, setSelectedLeads] = useState<
+        Map<string, { userId: string; responseId: string; name: string }>
+    >(
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+    const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+    const canDeleteLeads = isAdminForInstitute(instituteId);
     // Which flow the "Bulk actions" menu opened: assign (round-robin default)
     // or unassign (REMOVE).
     const [bulkActionMode, setBulkActionMode] = useState<BulkAssignMode>('ROUND_ROBIN');
@@ -525,11 +535,11 @@ const CampaignUsersContent = ({
         setSelectedLeads(new Map());
     }, [counsellorFilters]);
 
-    const toggleLeadRow = (userId: string, vm: LeadCardVM) =>
+    const toggleLeadRow = (responseId: string, vm: LeadCardVM) =>
         setSelectedLeads((prev) => {
             const next = new Map(prev);
-            if (next.has(userId)) next.delete(userId);
-            else next.set(userId, { userId, name: vm.name });
+            if (next.has(responseId)) next.delete(responseId);
+            else if (vm.userId) next.set(responseId, { userId: vm.userId, responseId, name: vm.name });
             return next;
         });
 
@@ -537,9 +547,10 @@ const CampaignUsersContent = ({
         setSelectedLeads((prev) => {
             const next = new Map(prev);
             selectableVms.forEach((v) => {
-                if (!v.userId) return;
-                if (checked) next.set(v.userId, { userId: v.userId, name: v.name });
-                else next.delete(v.userId);
+                if (!v.userId || !v.responseId) return;
+                if (checked)
+                    next.set(v.responseId, { userId: v.userId, responseId: v.responseId, name: v.name });
+                else next.delete(v.responseId);
             });
             return next;
         });
@@ -557,11 +568,17 @@ const CampaignUsersContent = ({
         try {
             setSelectAllLoading(true);
             const res = await fetchCampaignLeads({ ...leadsPayload, page: 0, size: totalElements });
-            const map = new Map<string, { userId: string; name: string }>();
+            const map = new Map<string, { userId: string; responseId: string; name: string }>();
             (res.content ?? []).forEach((lead) => {
                 const uid = lead.user?.id || lead.user_id;
-                if (!uid) return;
-                map.set(uid, { userId: uid, name: lead.user?.full_name || lead.parent_name || uid });
+                // Keyed by response id to match the per-row selection — a person with several
+                // responses is several selected rows, not one.
+                if (!uid || !lead.response_id) return;
+                map.set(lead.response_id, {
+                    userId: uid,
+                    responseId: lead.response_id,
+                    name: lead.user?.full_name || lead.parent_name || uid,
+                });
             });
             setSelectedLeads(map);
         } catch {
@@ -1157,8 +1174,24 @@ const CampaignUsersContent = ({
                                             value: 'unassign',
                                             icon: <UserMinus className="size-4" />,
                                         },
+                                        // Delete is admin-only, matching the endpoint's own check.
+                                        ...(canDeleteLeads
+                                            ? [
+                                                  {
+                                                      label: 'Delete leads',
+                                                      value: 'delete',
+                                                      icon: (
+                                                          <Trash className="size-4 text-danger-600" />
+                                                      ),
+                                                  },
+                                              ]
+                                            : []),
                                     ]}
                                     onSelect={(value) => {
+                                        if (value === 'delete') {
+                                            setBulkDeleteOpen(true);
+                                            return;
+                                        }
                                         setBulkActionMode(
                                             value === 'unassign' ? 'REMOVE' : 'ROUND_ROBIN'
                                         );
@@ -1227,6 +1260,17 @@ const CampaignUsersContent = ({
                     counsellorOptions={assignableCounsellorOptions}
                     initialMode={bulkActionMode}
                     onSuccess={handleBulkAssignSuccess}
+                />
+
+                <DeleteLeadsDialog
+                    open={bulkDeleteOpen}
+                    onOpenChange={setBulkDeleteOpen}
+                    instituteId={instituteId ?? ''}
+                    responseIds={Array.from(selectedLeads.keys())}
+                    onSuccess={() => {
+                        setSelectedLeads(new Map());
+                        handleStatusUpdated();
+                    }}
                 />
 
                 {noteTarget && (

--- a/frontend-admin-dashboard/src/routes/audience-manager/list/-services/get-recent-leads.ts
+++ b/frontend-admin-dashboard/src/routes/audience-manager/list/-services/get-recent-leads.ts
@@ -73,6 +73,12 @@ export interface RecentLeadsRequest {
     // Conversion-state filter — defaults to EXCLUDE_CONVERTED on the backend so
     // leads that have been enrolled into a course don't pollute the active list.
     conversion_status_filter?: 'EXCLUDE_CONVERTED' | 'ONLY_CONVERTED' | 'ALL';
+    /**
+     * Soft-delete visibility — defaults to EXCLUDE_DELETED on the backend, so deleted leads stay
+     * hidden unless explicitly asked for. ONLY_DELETED backs the "Deleted leads" view that restore
+     * is driven from.
+     */
+    audience_status_filter?: 'EXCLUDE_DELETED' | 'ONLY_DELETED' | 'ALL';
     /** Filter by SLA stage (the badge shown in the table). 'ANY_OVERDUE' = TAT_OVERDUE OR FOLLOW_UP_OVERDUE. */
     sla_filter?:
         | 'TAT_BEFORE'

--- a/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
+++ b/frontend-admin-dashboard/src/routes/audience-manager/recent-leads/-components/recent-leads-page.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { convertToLocalDateTime } from '@/constants/helper';
-import { parseHtmlToString } from '@/lib/utils';
+import { cn, parseHtmlToString } from '@/lib/utils';
 import {
     DownloadSimple,
     MagnifyingGlass,
@@ -63,7 +63,16 @@ import {
 import { MyDropdown } from '@/components/design-system/dropdown';
 import type { LeadCardVM } from '@/components/shared/leads/lead-view-model';
 import { MyButton } from '@/components/design-system/button';
-import { CaretDown, UserMinus, UserPlus } from '@phosphor-icons/react';
+import { isAdminForInstitute } from '@/lib/auth/roleUtils';
+import { DeleteLeadsDialog } from '@/components/shared/leads/delete-leads-dialog';
+import { restoreAudienceLeads } from '@/routes/audience-manager/list/-services/delete-audience-lead';
+import {
+    ArrowCounterClockwise,
+    CaretDown,
+    Trash,
+    UserMinus,
+    UserPlus,
+} from '@phosphor-icons/react';
 import {
     LeadEmptyState,
     LeadTable,
@@ -402,6 +411,33 @@ const RecentLeadsContent = () => {
             : leadStatusFilters.includes(ALL_CONVERTED_VALUE)
               ? 'ONLY_CONVERTED'
               : 'ALL';
+    // "Deleted leads" view — deleted leads are hidden everywhere by default; this is the one
+    // place they can be seen, and the only way to restore one from the UI.
+    const [showDeleted, setShowDeleted] = useState(false);
+    // Undefined (not EXCLUDE_DELETED) when off, so the backend's own default applies and the
+    // param stays absent from the normal request.
+    const audienceStatusFilter: 'ONLY_DELETED' | undefined = showDeleted ? 'ONLY_DELETED' : undefined;
+
+    // Restore needs no confirm dialog: unlike delete it's additive, and the rows are already
+    // sitting in a view the admin had to opt into.
+    const restoreMutation = useMutation({
+        mutationFn: () =>
+            restoreAudienceLeads({
+                responseIds: Array.from(selectedLeads.keys()),
+                instituteId: instituteId ?? '',
+            }),
+        onSuccess: (restored: number) => {
+            toast.success(restored === 1 ? 'Lead restored' : `${restored} leads restored`);
+            setSelectedLeads(new Map());
+            handleStatusUpdated();
+        },
+        onError: (error: unknown) => {
+            const message =
+                (error as { response?: { data?: { ex?: string } } })?.response?.data?.ex ??
+                'Failed to restore. Please try again.';
+            toast.error(message);
+        },
+    });
     const nonUnassignedCounsellorIds = counsellorFilters.filter(
         (v) => v !== UNASSIGNED_COUNSELLOR_VALUE
     );
@@ -421,6 +457,7 @@ const RecentLeadsContent = () => {
             leadStatusFilters.join(','),
             leadStatusId,
             conversionFilter,
+            audienceStatusFilter,
             slaFilters.join(','),
             counsellorFilters.join(','),
             sourceFilter,
@@ -439,6 +476,7 @@ const RecentLeadsContent = () => {
                 lead_tier: tierFilters.length > 0 ? tierFilters.join(',') : undefined,
                 lead_status_id: leadStatusId,
                 conversion_status_filter: conversionFilter,
+                audience_status_filter: audienceStatusFilter,
                 sla_filter:
                     slaFilters.length > 0 ? (slaFilters.join(',') as SlaFilter) : undefined,
                 assigned_counselor_id:
@@ -530,10 +568,18 @@ const RecentLeadsContent = () => {
     };
 
     // ── Bulk assign / remove counsellor (multi-select, every view) ──
-    const [selectedLeads, setSelectedLeads] = useState<Map<string, { userId: string; name: string }>>(
+    // Keyed by RESPONSE id, not user id: a row is one campaign response and the same person
+    // can hold several, so keying by user collapsed their rows into one checkbox. The value
+    // carries the userId too, because the assign actions operate per person.
+    const [selectedLeads, setSelectedLeads] = useState<
+        Map<string, { userId: string; responseId: string; name: string }>
+    >(
         new Map()
     );
     const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+
+    const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+    const canDeleteLeads = isAdminForInstitute(instituteId);
     // Which flow the "Bulk actions" menu opened: assign (round-robin default)
     // or unassign (REMOVE).
     const [bulkActionMode, setBulkActionMode] = useState<BulkAssignMode>('ROUND_ROBIN');
@@ -546,11 +592,11 @@ const RecentLeadsContent = () => {
         setSelectedLeads(new Map());
     }, [counsellorFilters]);
 
-    const toggleLeadRow = (userId: string, vm: LeadCardVM) =>
+    const toggleLeadRow = (responseId: string, vm: LeadCardVM) =>
         setSelectedLeads((prev) => {
             const next = new Map(prev);
-            if (next.has(userId)) next.delete(userId);
-            else next.set(userId, { userId, name: vm.name });
+            if (next.has(responseId)) next.delete(responseId);
+            else if (vm.userId) next.set(responseId, { userId: vm.userId, responseId, name: vm.name });
             return next;
         });
 
@@ -558,9 +604,10 @@ const RecentLeadsContent = () => {
         setSelectedLeads((prev) => {
             const next = new Map(prev);
             selectableVms.forEach((v) => {
-                if (!v.userId) return;
-                if (checked) next.set(v.userId, { userId: v.userId, name: v.name });
-                else next.delete(v.userId);
+                if (!v.userId || !v.responseId) return;
+                if (checked)
+                    next.set(v.responseId, { userId: v.userId, responseId: v.responseId, name: v.name });
+                else next.delete(v.responseId);
             });
             return next;
         });
@@ -587,6 +634,7 @@ const RecentLeadsContent = () => {
                 lead_tier: tierFilters.length > 0 ? tierFilters.join(',') : undefined,
                 lead_status_id: leadStatusId,
                 conversion_status_filter: conversionFilter,
+                audience_status_filter: audienceStatusFilter,
                 sla_filter:
                     slaFilters.length > 0 ? (slaFilters.join(',') as SlaFilter) : undefined,
                 assigned_counselor_id:
@@ -601,12 +649,15 @@ const RecentLeadsContent = () => {
                 page: 0,
                 size: totalElements,
             });
-            const map = new Map<string, { userId: string; name: string }>();
+            const map = new Map<string, { userId: string; responseId: string; name: string }>();
             (res.content ?? []).forEach((lead) => {
                 const uid = lead.user?.id || lead.user_id;
-                if (!uid) return;
-                map.set(uid, {
+                // Keyed by response id to match the per-row selection — a person with several
+                // responses is several selected rows, not one.
+                if (!uid || !lead.response_id) return;
+                map.set(lead.response_id, {
                     userId: uid,
+                    responseId: lead.response_id,
                     name: lead.user?.full_name || lead.parent_name || uid,
                 });
             });
@@ -864,6 +915,7 @@ const RecentLeadsContent = () => {
                     lead_tier: tierFilters.length > 0 ? tierFilters.join(',') : undefined,
                     lead_status_id: leadStatusId,
                     conversion_status_filter: conversionFilter,
+                    audience_status_filter: audienceStatusFilter,
                     sla_filter:
                         slaFilters.length > 0 ? (slaFilters.join(',') as SlaFilter) : undefined,
                     assigned_counselor_id:
@@ -1114,6 +1166,25 @@ const RecentLeadsContent = () => {
                 </div>
 
                 <div className="flex shrink-0 items-center gap-2">
+                    {/* Deleted leads are hidden from every view by default; this is the only
+                        place they surface, and the only route back for one (Restore). Admin-only,
+                        matching the delete/restore endpoints' own check. */}
+                    {canDeleteLeads && (
+                        <Button
+                            variant={showDeleted ? 'default' : 'outline'}
+                            size="sm"
+                            className={cn('h-10', showDeleted && 'bg-danger-600 hover:bg-danger-700')}
+                            onClick={() => {
+                                setShowDeleted((v) => !v);
+                                setPage(0);
+                                setSelectedLeads(new Map());
+                            }}
+                            title={showDeleted ? 'Back to active leads' : 'Show deleted leads'}
+                        >
+                            <Trash className="mr-1.5 size-4" />
+                            {showDeleted ? 'Viewing deleted' : 'Deleted leads'}
+                        </Button>
+                    )}
                     <Popover>
                         <PopoverTrigger asChild>
                             <Button variant="outline" size="sm" className="h-10">
@@ -1271,8 +1342,38 @@ const RecentLeadsContent = () => {
                                             value: 'unassign',
                                             icon: <UserMinus className="size-4" />,
                                         },
+                                        // Delete/restore are admin-only, matching the endpoints'
+                                        // own check. In the deleted-leads view the only sensible
+                                        // action is putting them back.
+                                        ...(canDeleteLeads
+                                            ? [
+                                                  showDeleted
+                                                      ? {
+                                                            label: 'Restore leads',
+                                                            value: 'restore',
+                                                            icon: (
+                                                                <ArrowCounterClockwise className="size-4 text-primary-600" />
+                                                            ),
+                                                        }
+                                                      : {
+                                                            label: 'Delete leads',
+                                                            value: 'delete',
+                                                            icon: (
+                                                                <Trash className="size-4 text-danger-600" />
+                                                            ),
+                                                        },
+                                              ]
+                                            : []),
                                     ]}
                                     onSelect={(value) => {
+                                        if (value === 'delete') {
+                                            setBulkDeleteOpen(true);
+                                            return;
+                                        }
+                                        if (value === 'restore') {
+                                            restoreMutation.mutate();
+                                            return;
+                                        }
                                         setBulkActionMode(
                                             value === 'unassign' ? 'REMOVE' : 'ROUND_ROBIN'
                                         );
@@ -1331,6 +1432,17 @@ const RecentLeadsContent = () => {
                     counsellorOptions={assignableCounsellorOptions}
                     initialMode={bulkActionMode}
                     onSuccess={handleBulkAssignSuccess}
+                />
+
+                <DeleteLeadsDialog
+                    open={bulkDeleteOpen}
+                    onOpenChange={setBulkDeleteOpen}
+                    instituteId={instituteId ?? ''}
+                    responseIds={Array.from(selectedLeads.keys())}
+                    onSuccess={() => {
+                        setSelectedLeads(new Map());
+                        handleStatusUpdated();
+                    }}
                 />
 
                 {noteTarget && (


### PR DESCRIPTION
## Summary of Changes

Follow-up to #2200 (lead soft delete), which shipped the backend for all of this. This is the UI layer: **bulk delete**, a **deleted-leads view**, and **restore**.

The enabling change is a refactor with real blast radius, so it's worth reading first. **Lead selection is now keyed by `response_id` instead of `user_id`.** A row in the leads list is one campaign *response*, but the selection Map was keyed by *person* — and 283 people in production hold multiple leads (one holds **17 in a single campaign**). So ticking one of their rows silently ticked all of them, and a bulk delete built on that would have deleted all 17 from one click.

That re-key has a consequence: assignment is per *person* (`user_lead_profile`, one row per user), so the same person can now appear in a selection twice. `bulk-assign-counsellor-dialog` therefore collapses the selection by `userId` before building its payload. This isn't cosmetic de-duplication — round-robin picks targets via an index-based `targetFor(lead, index)`, so a duplicated person would have been assigned to **two different counsellors**, with last-write-wins deciding. The dedupe lives inside the dialog rather than at each call site so any future caller inherits it.

**Frontend:**
- `lead-table`: selection keyed on `vm.responseId`. The selectable set is deliberately unchanged — rows still require a `userId` (assign targets a person), with `responseId` as a guard rather than a narrowing, since it's the `audience_response` primary key and always present.
- Both lead surfaces re-keyed, including the **"Select all N results"** path, which builds its Map from a full fetch and is easy to miss.
- **Bulk delete** in the "Bulk actions" menu on Recent Leads and campaign lead lists. Admin-only. Reuses the existing confirm dialog's bulk branch ("Delete N leads?", red warning). A batch containing a converted lead fails whole — the backend is all-or-nothing.
- **Deleted-leads view** — a toggle beside "Manage Column" on Recent Leads, flipping `audience_status_filter` to `ONLY_DELETED`. Admin-only.
- **Restore** — in that view the bulk menu's delete option becomes "Restore leads". No confirm dialog: restore is additive, and the rows sit in a view you had to opt into.

**Deliberate asymmetry:** the campaign lead list has bulk delete but no deleted-view/restore. Recent Leads is institute-wide and already covers every campaign's leads, so there's one canonical deleted view rather than one per surface.

## Related Issue

Follows #2200.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — ticking one row of a multi-lead person no longer selects all of their rows
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

An independent session tested this against a written brief and appended its findings to `.samar/docs/lead-soft-delete-test-report.md`. The brief made bulk-assign survival the priority, since that's what the re-key put at risk.

**Bulk assign survived** — verified with live network-payload evidence across round-robin, single-target, manual and unassign modes, plus select-all-across-pages. In every case 3 selected rows (2 belonging to the same person) deduped to exactly **2 distinct `user_ids`** with no duplicates, and each person landed with exactly one counsellor in the DB. Ticking one of a multi-lead person's rows now selects only that row — confirmed live.

- **Bulk delete** works on both surfaces: exactly the selected N go INACTIVE and nothing else; the selection clears and the list refreshes without a hard reload.
- **All-or-nothing** on a batch containing a converted lead — nothing deleted, message surfaced.
- **Deleted view + restore** work, restore is idempotent, and CSV export is correctly scoped to the deleted view.
- No regressions found. `tsc --noEmit` 0 errors; `design-lint` 0 errors (2 pre-existing inline-style warnings, none added here).

**Known UX sharp edge, not a defect:** the deleted-leads view inherits the default **"Last 30 days"** filter, which is on *submission* date — so a lead deleted today but submitted months ago won't appear until the range is widened. Called out in the brief and confirmed by the tester; left as-is rather than changed after a clean verdict.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
