### PR TITLE
Fix severe slowdown when applying custom-field filters on Manage Stud…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/InstituteStudentRepositoryImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/InstituteStudentRepositoryImpl.java
@@ -85,9 +85,23 @@ public class InstituteStudentRepositoryImpl implements InstituteStudentRepositor
             FROM student s
             JOIN student_session_institute_group_mapping ssigm
                 ON s.user_id = ssigm.user_id
-            LEFT JOIN institute_custom_fields icf
+            LEFT JOIN (
+                -- institute_custom_fields can carry multiple duplicate mapping
+                -- rows for the same (institute_id, custom_field_id) — some
+                -- institutes have 80+ duplicates for a single field. Joining
+                -- the raw table multiplies every learner row by every
+                -- duplicate (turning e.g. 465 learners into 470k+ intermediate
+                -- rows before the GROUP BY collapses them back down), which is
+                -- what made any filter that routes through this query (custom
+                -- field filters in particular) painfully slow. Dedup to one
+                -- row per (institute_id, custom_field_id) — the most recent —
+                -- before joining.
+                SELECT DISTINCT ON (institute_id, custom_field_id) *
+                FROM institute_custom_fields
+                WHERE (:customFieldStatus IS NULL OR status IN :customFieldStatus)
+                ORDER BY institute_id, custom_field_id, created_at DESC
+            ) icf
                 ON icf.institute_id = ssigm.institute_id
-                AND (:customFieldStatus IS NULL OR icf.status IN :customFieldStatus)
             LEFT JOIN custom_fields cf
                 ON cf.id = icf.custom_field_id
             LEFT JOIN custom_field_values cfv


### PR DESCRIPTION
…ents

Custom-field filters (Job Title, Practice Name, Corporate Group, ...) route through InstituteStudentRepositoryImpl's heavy JOIN query, which left-joins institute_custom_fields per learner to build the customFieldsJson column. That table can carry many duplicate mapping rows for the same (institute_id, custom_field_id) — verified one real institute has 83 duplicate ACTIVE rows for a single field (1,006 active mappings total vs. ~18 real fields). Joining the raw table multiplied every learner row by every duplicate: 465 learners became 470,808 intermediate rows before the GROUP BY collapsed them back down, which is what made Apply Filters unusably slow whenever a custom-field filter was selected.

Dedup institute_custom_fields to one row per (institute_id, custom_field_id) before joining. Verified directly against a read replica: the same join drops from 470,808 to 8,424 rows, and the full end-to-end query (GROUP BY + json_agg, with a real custom-field filter applied) now returns in ~0.3s.

The underlying duplicate-mapping rows are a separate data-quality issue (not touched here — this fix is a query-level defense that doesn't depend on the data being clean).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
