### PR TITLE
Fix payment plan edit silently nulling name/status on partial update

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
@@ -60,15 +60,17 @@ public class PaymentPlanService {
         }
         return toSave;
     }
+    // Callers (e.g. the Edit Payment Option dialog) may send only a subset of fields;
+    // a missing field deserializes as null and must not overwrite the existing value.
     private void updatePaymentPlan(PaymentPlan paymentPlan, PaymentPlanDTO paymentPlanDTO) {
-        paymentPlan.setName(paymentPlanDTO.getName());
-        paymentPlan.setStatus(paymentPlanDTO.getStatus());
-        paymentPlan.setValidityInDays(paymentPlanDTO.getValidityInDays());
+        if (paymentPlanDTO.getName() != null) paymentPlan.setName(paymentPlanDTO.getName());
+        if (paymentPlanDTO.getStatus() != null) paymentPlan.setStatus(paymentPlanDTO.getStatus());
+        if (paymentPlanDTO.getValidityInDays() != null) paymentPlan.setValidityInDays(paymentPlanDTO.getValidityInDays());
         paymentPlan.setActualPrice(paymentPlanDTO.getActualPrice());
         paymentPlan.setElevatedPrice(paymentPlanDTO.getElevatedPrice());
-        paymentPlan.setCurrency(paymentPlanDTO.getCurrency());
-        paymentPlan.setDescription(paymentPlanDTO.getDescription());
-        paymentPlan.setTag(paymentPlanDTO.getTag());
-        paymentPlan.setFeatureJson(paymentPlanDTO.getFeatureJson());
+        if (paymentPlanDTO.getCurrency() != null) paymentPlan.setCurrency(paymentPlanDTO.getCurrency());
+        if (paymentPlanDTO.getDescription() != null) paymentPlan.setDescription(paymentPlanDTO.getDescription());
+        if (paymentPlanDTO.getTag() != null) paymentPlan.setTag(paymentPlanDTO.getTag());
+        if (paymentPlanDTO.getFeatureJson() != null) paymentPlan.setFeatureJson(paymentPlanDTO.getFeatureJson());
     }
 }


### PR DESCRIPTION
## Summary of Changes

The Edit Payment Option dialog only sends `actual_price`, `elevated_price`, `currency`, and `validity_in_days` when saving a payment plan. The backend's update path treated every field on the incoming DTO as authoritative, including fields the client never sent — so `name` and `status` (and `description`/`tag`/`feature_json`) were unconditionally overwritten with `null` on every save, even though the dialog never intended to touch them.

This silently corrupted plan rows in prod (discovered via ReadOnRent's rent-book pricing plans) and had a second-order effect: the query that lists payment options only includes an option if it has a plan with `status = 'ACTIVE'`. Once a plan's `status` went `null`, the entire payment option disappeared from both the summary view and the edit dialog itself, with no way back in through the UI.

**Backend:**
- `PaymentPlanService.updatePaymentPlan(...)`: guard `name`, `status`, `validity_in_days`, `currency`, `description`, `tag`, `feature_json` so they're only overwritten when the incoming DTO actually sends a non-null value, instead of unconditionally.
- `actual_price`/`elevated_price` are left unconditional (primitive `double` on the DTO, can't distinguish "not sent" from "0"); the dialog always sends both today so this isn't implicated in the bug.

## Related Issue

(discovered live via a ReadOnRent support request — no tracked issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Root-caused via direct code trace (`PaymentOptionController` → `PaymentOptionService` → `PaymentPlanService.editPaymentPlans` → `updatePaymentPlan`) and confirmed against real prod PUT/response pairs.
- Ran `admin_core_service` locally against a fresh local Docker Postgres dump (write-enabled) with the fix compiled in; replayed the exact partial-field PUT payload the dialog sends against a live local plan — confirmed `name`/`status` now survive, price still updates correctly.
- Full browser test via Playwright against the real production frontend (`dash.vacademy.io`), with only `admin-core-service` traffic transparently proxied to the local fixed backend (all other services — auth/community/notification — hit the real backend normally; no writes ever reached real prod data). Clicked through the actual flow: Manage Books → book → Sessions → invite → Edit Option → changed price → Save Payment → reloaded the page fresh → re-verified the plan is still visible with name/status intact.
- Confirmed via direct DB read after each step.
- Manually audited and repaired the 4 corrupted prod rows for the ReadOnRent institute that predated this fix (read-only queries via SSH tunnel, repair via targeted `UPDATE` statements run by the user).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly