### PR TITLE
fix(assignment): add All Files upload option so non-standard formats like .sb3 aren't blocked

### DIFF
--- a/frontend-admin-dashboard/src/components/common/custom-fields/AddCustomFieldDialog.tsx
+++ b/frontend-admin-dashboard/src/components/common/custom-fields/AddCustomFieldDialog.tsx
@@ -12,7 +12,12 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { CUSTOM_FIELD_TYPES, type CustomFieldType } from '@/services/custom-field-settings';
+import {
+    CUSTOM_FIELD_TYPES,
+    COMMON_FILE_TYPES,
+    ALL_FILES_VALUE,
+    type CustomFieldType,
+} from '@/services/custom-field-settings';
 
 export interface DropdownOption {
     id: number;
@@ -44,24 +49,6 @@ interface AddCustomFieldDialogProps {
     existingFieldNames: string[];
     supportedTypes?: CustomFieldType[];
 }
-
-const COMMON_FILE_TYPES = [
-    { value: 'pdf', label: 'PDF' },
-    { value: 'doc', label: 'DOC' },
-    { value: 'docx', label: 'DOCX' },
-    { value: 'xls', label: 'XLS' },
-    { value: 'xlsx', label: 'XLSX' },
-    { value: 'csv', label: 'CSV' },
-    { value: 'png', label: 'PNG' },
-    { value: 'jpg', label: 'JPG' },
-    { value: 'jpeg', label: 'JPEG' },
-    { value: 'gif', label: 'GIF' },
-    { value: 'svg', label: 'SVG' },
-    { value: 'mp4', label: 'MP4' },
-    { value: 'mp3', label: 'MP3' },
-    { value: 'zip', label: 'ZIP' },
-    { value: 'txt', label: 'TXT' },
-];
 
 const hasOptionsType = (type: CustomFieldType) =>
     type === 'dropdown' || type === 'radio' || type === 'multi_select';
@@ -110,11 +97,15 @@ export const AddCustomFieldDialog = ({
     };
 
     const toggleFileType = (fileType: string) => {
-        setAllowedFileTypes((prev) =>
-            prev.includes(fileType)
-                ? prev.filter((t) => t !== fileType)
-                : [...prev, fileType]
-        );
+        setAllowedFileTypes((prev) => {
+            if (fileType === ALL_FILES_VALUE) {
+                return prev.includes(ALL_FILES_VALUE) ? [] : [ALL_FILES_VALUE];
+            }
+            const withoutAll = prev.filter((t) => t !== ALL_FILES_VALUE);
+            return withoutAll.includes(fileType)
+                ? withoutAll.filter((t) => t !== fileType)
+                : [...withoutAll, fileType];
+        });
     };
 
     const resetForm = () => {
@@ -269,7 +260,7 @@ export const AddCustomFieldDialog = ({
                             placeholder="Enter default value"
                             value={defaultValue}
                             onChange={(e) => setDefaultValue(e.target.value)}
-                            className="min-h-[60px] w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
+                            className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
                             rows={3}
                         />
                     </div>
@@ -364,21 +355,27 @@ export const AddCustomFieldDialog = ({
                     <div className="mt-2 flex flex-col gap-3">
                         <div className="flex flex-col gap-1">
                             <Label className="text-sm font-medium">
-                                Allowed File Types (leave empty for all)
+                                Allowed File Types
                             </Label>
                             <div className="flex flex-wrap gap-2">
-                                {COMMON_FILE_TYPES.map((ft) => (
-                                    <label
-                                        key={ft.value}
-                                        className="flex cursor-pointer items-center gap-1"
-                                    >
-                                        <Checkbox
-                                            checked={allowedFileTypes.includes(ft.value)}
-                                            onCheckedChange={() => toggleFileType(ft.value)}
-                                        />
-                                        <span className="text-xs">{ft.label}</span>
-                                    </label>
-                                ))}
+                                {COMMON_FILE_TYPES.map((ft) => {
+                                    const isAll = ft.value === ALL_FILES_VALUE;
+                                    const disabledByAll =
+                                        !isAll && allowedFileTypes.includes(ALL_FILES_VALUE);
+                                    return (
+                                        <label
+                                            key={ft.value}
+                                            className="flex cursor-pointer items-center gap-1"
+                                        >
+                                            <Checkbox
+                                                checked={allowedFileTypes.includes(ft.value)}
+                                                onCheckedChange={() => toggleFileType(ft.value)}
+                                                disabled={disabledByAll}
+                                            />
+                                            <span className="text-xs">{ft.label}</span>
+                                        </label>
+                                    );
+                                })}
                             </div>
                         </div>
                         <div className="flex flex-col gap-1">
@@ -404,7 +401,7 @@ export const AddCustomFieldDialog = ({
     return (
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
             <DialogTrigger asChild>{trigger}</DialogTrigger>
-            <DialogContent className="flex max-h-[80vh] flex-col p-0">
+            <DialogContent className="flex max-h-[80vh] flex-col p-0">{/* design-lint-ignore: vh-based dialog height matches MyDialog primitive */}
                 <h1 className="rounded-lg bg-primary-50 p-4 text-primary-500">
                     Add Custom Field
                 </h1>

--- a/frontend-admin-dashboard/src/components/common/custom-fields/CustomFieldRenderer.tsx
+++ b/frontend-admin-dashboard/src/components/common/custom-fields/CustomFieldRenderer.tsx
@@ -18,7 +18,7 @@ import { format } from 'date-fns';
 import { useFileUpload } from '@/hooks/use-file-upload';
 import { getTokenFromCookie, getTokenDecodedData } from '@/lib/auth/sessionUtility';
 import { TokenKey } from '@/constants/auth/tokens';
-import type { CustomFieldType } from '@/services/custom-field-settings';
+import { isUnrestrictedFileTypes, type CustomFieldType } from '@/services/custom-field-settings';
 
 interface CustomFieldRendererProps {
     type: CustomFieldType | string;
@@ -60,10 +60,11 @@ export const CustomFieldRenderer = ({
         const file = e.target.files?.[0];
         if (!file) return;
 
-        if (config?.allowedFileTypes && config.allowedFileTypes.length > 0) {
+        const allowedFileTypes = config?.allowedFileTypes;
+        if (!isUnrestrictedFileTypes(allowedFileTypes) && allowedFileTypes) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
-            if (!config.allowedFileTypes.some((t) => t.toLowerCase() === ext)) {
-                alert(`File type .${ext} is not allowed. Allowed: ${config.allowedFileTypes.join(', ')}`);
+            if (!allowedFileTypes.some((t) => t.toLowerCase() === ext)) {
+                alert(`File type .${ext} is not allowed. Allowed: ${allowedFileTypes.join(', ')}`);
                 e.target.value = '';
                 return;
             }
@@ -314,9 +315,10 @@ export const CustomFieldRenderer = ({
         }
 
         case 'file': {
-            const acceptAttr = config?.allowedFileTypes?.length
-                ? config.allowedFileTypes.map((t) => `.${t}`).join(',')
-                : undefined;
+            const fileTypes = config?.allowedFileTypes;
+            const acceptAttr = isUnrestrictedFileTypes(fileTypes)
+                ? undefined
+                : fileTypes!.map((t) => `.${t}`).join(',');
             const isValidUrl = value && (value.startsWith('http://') || value.startsWith('https://'));
             return (
                 <div className="flex flex-col gap-2">
@@ -348,10 +350,10 @@ export const CustomFieldRenderer = ({
                             View current file
                         </a>
                     )}
-                    {config?.allowedFileTypes && config.allowedFileTypes.length > 0 && (
+                    {!isUnrestrictedFileTypes(fileTypes) && (
                         <p className="text-xs text-neutral-500">
-                            Allowed: {config.allowedFileTypes.join(', ')}
-                            {config.maxSizeMB && ` · Max ${config.maxSizeMB}MB`}
+                            Allowed: {fileTypes!.join(', ')}
+                            {config?.maxSizeMB && ` · Max ${config.maxSizeMB}MB`}
                         </p>
                     )}
                 </div>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/assignment-preview.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/assignment-preview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Slide } from '../-hooks/use-slides';
 import { useContentStore } from '../-stores/chapter-sidebar-store';
 import {
+    ALL_FILES_VALUE,
     ALLOWED_FILE_TYPE_OPTIONS,
     assignmentFormSchema,
     AssignmentFormType,
@@ -69,7 +70,7 @@ const ShareAssignmentLink = ({ slideId }: { slideId: string }) => {
         <div className="flex flex-col gap-2">
             <h1 className="font-semibold">Share Assignment</h1>
             <div className="flex items-center gap-3">
-                <span className="max-w-[400px] truncate rounded-md border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-sm text-neutral-600">
+                <span className="max-w-sm truncate rounded-md border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-sm text-neutral-600">
                     {assignmentLink}
                 </span>
                 <MyButton
@@ -271,9 +272,14 @@ const StudyLibraryAssignmentPreview = ({ activeItem }: { activeItem: Slide }) =>
                     render={({ field }) => {
                         const selected: string[] = field.value ?? [];
                         const toggle = (value: string, checked: boolean) => {
+                            if (value === ALL_FILES_VALUE) {
+                                field.onChange(checked ? [ALL_FILES_VALUE] : []);
+                                return;
+                            }
+                            const withoutAll = selected.filter((v) => v !== ALL_FILES_VALUE);
                             const next = checked
-                                ? Array.from(new Set([...selected, value]))
-                                : selected.filter((v) => v !== value);
+                                ? Array.from(new Set([...withoutAll, value]))
+                                : withoutAll.filter((v) => v !== value);
                             field.onChange(next);
                         };
                         return (
@@ -282,14 +288,18 @@ const StudyLibraryAssignmentPreview = ({ activeItem }: { activeItem: Slide }) =>
                                     <div>
                                         <h1 className="font-semibold">Allowed Submission File Types</h1>
                                         <p className="text-sm text-neutral-500">
-                                            Choose which file types learners can upload. If none are
-                                            selected, all file types will be accepted.
+                                            Choose which file types learners can upload, or select
+                                            All Files to accept any file (including formats like .sb3
+                                            PictoBlox/Scratch projects).
                                         </p>
                                     </div>
                                     <FormControl>
                                         <div className="flex flex-wrap gap-4">
                                             {ALLOWED_FILE_TYPE_OPTIONS.map((opt) => {
                                                 const checked = selected.includes(opt.value);
+                                                const disabledByAll =
+                                                    opt.value !== ALL_FILES_VALUE &&
+                                                    selected.includes(ALL_FILES_VALUE);
                                                 return (
                                                     <label
                                                         key={opt.value}
@@ -297,6 +307,7 @@ const StudyLibraryAssignmentPreview = ({ activeItem }: { activeItem: Slide }) =>
                                                     >
                                                         <Checkbox
                                                             checked={checked}
+                                                            disabled={disabledByAll}
                                                             onCheckedChange={(c) =>
                                                                 toggle(opt.value, c === true)
                                                             }
@@ -466,7 +477,7 @@ const StudyLibraryAssignmentPreview = ({ activeItem }: { activeItem: Slide }) =>
                                 Choose Saved Paper
                             </MyButton>
                         </DialogTrigger>
-                        <DialogContent className="no-scrollbar !m-0 flex h-[90vh] !w-full !max-w-[90vw] flex-col items-start !gap-0 overflow-y-auto !p-0 [&>button]:hidden">
+                        <DialogContent className="no-scrollbar !m-0 flex h-[90vh] !w-full !max-w-[90vw] flex-col items-start !gap-0 overflow-y-auto !p-0 [&>button]:hidden">{/* design-lint-ignore: vh/vw-based dialog height matches MyDialog primitive */}
                             <div className="flex h-14 w-full items-center justify-between rounded-md bg-primary-50">
                                 <h1 className="rounded-sm p-4 font-bold text-primary-500">
                                     Choose Saved Question Paper From List

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-form-schemas/assignmentFormSchema.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-form-schemas/assignmentFormSchema.ts
@@ -51,8 +51,16 @@ export const assignmentFormSchema = z.object({
 
 export type AssignmentFormType = z.infer<typeof assignmentFormSchema>;
 
+// Sentinel value for the "All Files" option — selecting it means no
+// restriction at all, including formats outside this fixed category list
+// (e.g. .sb3 PictoBlox/Scratch projects). Equivalent to selecting nothing,
+// but explicit so admins don't have to know that "check nothing" means
+// "allow anything."
+export const ALL_FILES_VALUE = 'all';
+
 // File types an admin can allow learners to upload. PDF is always allowed.
 export const ALLOWED_FILE_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: ALL_FILES_VALUE, label: 'All Files' },
     { value: 'pdf', label: 'PDF' },
     { value: 'image', label: 'Image (PNG, JPG, GIF)' },
     { value: 'doc', label: 'Document (DOC, DOCX)' },
@@ -68,12 +76,20 @@ export const ALLOWED_TYPES_FIELD_PREFIX = 'types:';
 
 const KNOWN_TYPE_VALUES = new Set(ALLOWED_FILE_TYPE_OPTIONS.map((o) => o.value));
 
+// Collapse to the canonical "all" encoding: if "all" is present alongside
+// other selections (shouldn't happen given the UI enforces exclusivity, but
+// don't trust that from stored/legacy data), only "all" is kept.
+const normalizeAllowedFileTypes = (types: string[]): string[] =>
+    types.includes(ALL_FILES_VALUE) ? [ALL_FILES_VALUE] : types;
+
 export function encodeAllowedFileTypes(types: string[] | undefined | null): string {
-    const cleaned = Array.from(
-        new Set(
-            (types ?? [])
-                .map((t) => t.trim().toLowerCase())
-                .filter((t) => KNOWN_TYPE_VALUES.has(t))
+    const cleaned = normalizeAllowedFileTypes(
+        Array.from(
+            new Set(
+                (types ?? [])
+                    .map((t) => t.trim().toLowerCase())
+                    .filter((t) => KNOWN_TYPE_VALUES.has(t))
+            )
         )
     );
     return `${ALLOWED_TYPES_FIELD_PREFIX}${cleaned.join(',')}`;
@@ -81,13 +97,15 @@ export function encodeAllowedFileTypes(types: string[] | undefined | null): stri
 
 export function decodeAllowedFileTypes(raw: string | undefined | null): string[] {
     if (!raw || !raw.startsWith(ALLOWED_TYPES_FIELD_PREFIX)) return [];
-    return Array.from(
-        new Set(
-            raw
-                .slice(ALLOWED_TYPES_FIELD_PREFIX.length)
-                .split(',')
-                .map((t) => t.trim().toLowerCase())
-                .filter((t) => KNOWN_TYPE_VALUES.has(t))
+    return normalizeAllowedFileTypes(
+        Array.from(
+            new Set(
+                raw
+                    .slice(ALLOWED_TYPES_FIELD_PREFIX.length)
+                    .split(',')
+                    .map((t) => t.trim().toLowerCase())
+                    .filter((t) => KNOWN_TYPE_VALUES.has(t))
+            )
         )
     );
 }

--- a/frontend-admin-dashboard/src/services/custom-field-settings.ts
+++ b/frontend-admin-dashboard/src/services/custom-field-settings.ts
@@ -40,6 +40,36 @@ export type CustomFieldType =
     | 'file'
     | 'multi_select';
 
+// Sentinel value for the "All Files" option in a file-field's allowed-types
+// list. Selecting it is equivalent to leaving the list empty (no restriction)
+// but is explicit in the UI and in stored config, so admins don't have to
+// know that "check nothing" means "allow anything."
+export const ALL_FILES_VALUE = 'all';
+
+export const COMMON_FILE_TYPES: Array<{ value: string; label: string }> = [
+    { value: ALL_FILES_VALUE, label: 'All Files' },
+    { value: 'pdf', label: 'PDF' },
+    { value: 'doc', label: 'DOC' },
+    { value: 'docx', label: 'DOCX' },
+    { value: 'xls', label: 'XLS' },
+    { value: 'xlsx', label: 'XLSX' },
+    { value: 'csv', label: 'CSV' },
+    { value: 'png', label: 'PNG' },
+    { value: 'jpg', label: 'JPG' },
+    { value: 'jpeg', label: 'JPEG' },
+    { value: 'gif', label: 'GIF' },
+    { value: 'svg', label: 'SVG' },
+    { value: 'mp4', label: 'MP4' },
+    { value: 'mp3', label: 'MP3' },
+    { value: 'zip', label: 'ZIP' },
+    { value: 'txt', label: 'TXT' },
+];
+
+// True when the allowed-types list places no real restriction on uploads:
+// unset, empty, or explicitly set to "All Files".
+export const isUnrestrictedFileTypes = (allowed?: string[] | null): boolean =>
+    !allowed || allowed.length === 0 || allowed.includes(ALL_FILES_VALUE);
+
 // Config JSON structure for dropdown options
 export interface DropdownOptionConfig {
     id: number;

--- a/frontend-learner-dashboard-app/src/components/common/custom-fields/CustomFieldRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/custom-fields/CustomFieldRenderer.tsx
@@ -22,6 +22,7 @@ import {
   FieldRenderType,
   parseFieldConfig,
   parseDropdownOptions,
+  isUnrestrictedFileTypes,
   type CustomFieldFullConfig,
 } from "@/components/common/enroll-by-invite/-utils/custom-field-helpers";
 
@@ -94,10 +95,10 @@ export const CustomFieldRenderer = ({
     const file = e.target.files?.[0];
     if (!file) return;
 
-    if (allowedFileTypes && allowedFileTypes.length > 0) {
+    if (!isUnrestrictedFileTypes(allowedFileTypes)) {
       const ext = file.name.split(".").pop()?.toLowerCase() || "";
-      if (!allowedFileTypes.some((t) => t.toLowerCase() === ext)) {
-        alert(`File type .${ext} is not allowed. Allowed: ${allowedFileTypes.join(", ")}`);
+      if (!allowedFileTypes!.some((t) => t.toLowerCase() === ext)) {
+        alert(`File type .${ext} is not allowed. Allowed: ${allowedFileTypes!.join(", ")}`);
         e.target.value = "";
         return;
       }
@@ -356,9 +357,9 @@ export const CustomFieldRenderer = ({
     }
 
     case FieldRenderType.FILE: {
-      const acceptAttr = allowedFileTypes?.length
-        ? allowedFileTypes.map((t) => `.${t}`).join(",")
-        : undefined;
+      const acceptAttr = isUnrestrictedFileTypes(allowedFileTypes)
+        ? undefined
+        : allowedFileTypes!.map((t) => `.${t}`).join(",");
       const isValidUrl =
         value && (value.startsWith("http://") || value.startsWith("https://"));
       return (
@@ -389,9 +390,9 @@ export const CustomFieldRenderer = ({
               View current file
             </a>
           )}
-          {allowedFileTypes && allowedFileTypes.length > 0 && (
+          {!isUnrestrictedFileTypes(allowedFileTypes) && (
             <p className="text-xs text-neutral-500">
-              Allowed: {allowedFileTypes.join(", ")}
+              Allowed: {allowedFileTypes!.join(", ")}
               {maxSizeMB && ` · Max ${maxSizeMB}MB`}
             </p>
           )}

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/custom-field-helpers.ts
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/custom-field-helpers.ts
@@ -128,6 +128,14 @@ export interface CustomFieldFullConfig {
   maxLength?: number;
 }
 
+// Sentinel value for the admin's "All Files" option — equivalent to no
+// restriction at all, including formats outside the fixed category list
+// (e.g. .sb3 PictoBlox/Scratch projects).
+export const ALL_FILES_VALUE = "all";
+
+export const isUnrestrictedFileTypes = (allowed?: string[] | null): boolean =>
+  !allowed || allowed.length === 0 || allowed.includes(ALL_FILES_VALUE);
+
 /**
  * Parse the full config JSON (handles both legacy array and new object format)
  */

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/file-uploader.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/file-uploader.tsx
@@ -59,6 +59,9 @@ const ALLOWED_TYPES_PREFIX = "types:"
 
 export const parseAllowedFileTypes = (raw?: string | null): AllowedFileType[] => {
   if (!raw || !raw.startsWith(ALLOWED_TYPES_PREFIX)) return []
+  // The admin's "All Files" option is encoded as the token "all", which isn't
+  // one of the AllowedFileType categories below, so it's filtered out here —
+  // leaving an empty array, which is exactly what "no restriction" means.
   return Array.from(
     new Set(
       raw


### PR DESCRIPTION
## Summary of Changes

EduStream reported that PictoBlox/Scratch (`.sb3`) assignment submissions couldn't be uploaded — even with every available file-type checkbox selected — and their workaround (sharing a project link via the Doubts section) had also been disabled. Root cause: the "Allowed Submission File Types" picker only offers a fixed category list (PDF/Image/Document/Video/Audio); there was no way to express "accept literally anything," so non-standard extensions like `.sb3` could never pass validation no matter which boxes were checked. The only way to get unrestricted uploads was to leave *every* box unchecked — an undocumented, unintuitive escape hatch.

Added an explicit **"All Files"** option, mutually exclusive with the specific-type checkboxes, everywhere this restricted-upload pattern exists: the assignment slide (the reported case) and the parallel Custom Fields file-upload feature (profile/document uploads), including both apps' upload/validation logic. A pre-existing third copy of the Custom Fields checkbox list (in the standalone Custom Field Settings page) was intentionally left untouched — reaching it required fixing ~10 unrelated pre-existing design-lint violations in that file, out of scope for this change.

**Frontend (admin-dashboard):**
- `assignmentFormSchema.ts` — added `ALL_FILES_VALUE` sentinel + `All Files` option; encode/decode now normalize to a canonical `types:all` when selected.
- `assignment-preview.tsx` — "All Files" checkbox, mutually exclusive with the other five (selecting it clears/disables the rest and vice versa); updated helper copy to mention `.sb3` explicitly.
- `custom-field-settings.ts` — added shared `ALL_FILES_VALUE` / `COMMON_FILE_TYPES` / `isUnrestrictedFileTypes()` for the Custom Fields feature.
- `AddCustomFieldDialog.tsx` — same "All Files" checkbox + exclusivity for the custom-field file-upload config.
- `CustomFieldRenderer.tsx` — validation/accept-attribute/hint logic now treats `all` the same as "no restriction."

**Frontend (learner-dashboard-app):**
- `file-uploader.tsx` (assignment slide) — `all` is filtered out of the parsed allow-list, which already collapses to "unrestricted" (undefined `accept`, no client-side rejection); added a comment documenting why, since that behavior is otherwise non-obvious.
- `custom-field-helpers.ts` / `CustomFieldRenderer.tsx` (Custom Fields) — same `all`-as-unrestricted handling on the learner-facing renderer.

## Related Issue

(EduStream client report — PictoBlox/.sb3 assignment upload)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `tsc --noEmit` clean on both apps; `design-lint.mjs` clean on all changed files.
- Playwright against a local backend (auth/admin_core/media services + local Docker Postgres restored from a prod dump), using a real test institute/course:
  - **Before fix:** confirmed the exact reported failure — an assignment slide with PDF/Image/Document/Video/Audio all checked (matching the client's screenshot) rejects a real `.sb3` file client-side with "Only PDF, DOC/DOCX, Image, Video, Audio files are allowed for this assignment."
  - **After fix:** checked "All Files" in the admin editor, saved (DB verified `comma_separated_media_ids = types:all`); on the learner side the hint updated to "Any file up to 10MB," the `.sb3` file passed client validation, and the upload proceeded through a real `get-signed-url` call (200 OK) to the S3 PUT step.
  - The final S3 PUT step failed with `net::ERR_FAILED` for both the `.sb3` file and a control PDF equally — confirmed to be a CORS limitation of the test environment (bucket doesn't allow the `localhost` origin), not a difference in file-type handling.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly