### PR TITLE
fix: stop white-label tabs falling back to the Vacademy logo (tab icon caching)

### DIFF
--- a/frontend-learner-dashboard-app/src/utils/branding.ts
+++ b/frontend-learner-dashboard-app/src/utils/branding.ts
@@ -11,7 +11,29 @@ let currentFaviconUrl: string | null = null;
 let faviconMonitorInterval: NodeJS.Timeout | null = null;
 let lastFaviconRefreshMs = 0;
 const FAVICON_REFRESH_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
-const FALLBACK_FAVICON_URL = "/icons/icon-48.webp"; // Static fallback
+const FALLBACK_FAVICON_URL = "/icons/icon-48.webp"; // Static Vacademy fallback (Vacademy hosts only)
+
+// A 1x1 transparent SVG. Used as the favicon fallback on white-labelled
+// (non-Vacademy) hosts so a failed/absent institute icon never flashes the
+// Vacademy "V" in the tab. Mirrors the cold-cache behaviour of the inline
+// bootstrap script in index.html.
+const BLANK_FAVICON =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"></svg>'
+  );
+
+// Vacademy-owned hosts may legitimately show the Vacademy mark; every other
+// (white-labelled) host must not.
+const isVacademyHost = (): boolean => {
+  const h = typeof location !== "undefined" ? location.hostname : "";
+  return /(^|\.)vacademy\.io$/.test(h) || h === "localhost" || h === "127.0.0.1";
+};
+
+// The favicon to show when no institute icon is available: the Vacademy mark on
+// Vacademy hosts, a blank icon everywhere else.
+const getFallbackFavicon = (): string =>
+  isVacademyHost() ? FALLBACK_FAVICON_URL : BLANK_FAVICON;
 
 // Helper: create favicon link elements
 const createFaviconLink = (href: string, rel: string, sizes?: string, type?: string) => {
@@ -33,11 +55,14 @@ const removeAllFaviconLinks = () => {
 
 // Helper: apply favicon links for a given URL (creates common sizes and apple touch)
 const applyFaviconLinks = (iconUrl: string) => {
-  // Do NOT cache-bust signed URLs (e.g., S3 pre-signed) or the signature will break
-  const isSignedUrl = /[?&]X-Amz-/.test(iconUrl) || /[?&]Signature=/.test(iconUrl);
-  const hrefToUse = isSignedUrl
-    ? iconUrl
-    : (iconUrl.includes('?') ? `${iconUrl}&v=${Date.now()}` : `${iconUrl}?v=${Date.now()}`);
+  // Use the URL as-is — do NOT append a `?v=Date.now()` cache-buster. The icon
+  // is a stable asset (a public S3 object, the local fallback, or a signed URL
+  // whose signature must be preserved). A per-load cache-buster gives the
+  // browser a brand-new URL every load, defeating its cache and forcing a
+  // network re-fetch each time; whenever that fetch is slow or fails the
+  // browser falls back to /favicon.ico (the Vacademy mark) until the next
+  // refresh. Keeping the URL stable lets the browser reuse the cached icon.
+  const hrefToUse = iconUrl;
 
   removeAllFaviconLinks();
   createFaviconLink(hrefToUse, 'icon', '16x16');
@@ -45,17 +70,6 @@ const applyFaviconLinks = (iconUrl: string) => {
   createFaviconLink(hrefToUse, 'icon');
   createFaviconLink(hrefToUse, 'shortcut icon');
   createFaviconLink(hrefToUse, 'apple-touch-icon', '180x180');
-  // Nudge browsers to refresh the favicon
-  setTimeout(() => {
-    const links = document.querySelectorAll<HTMLLinkElement>('link[rel*="icon"]');
-    links.forEach((link) => {
-      const originalHref = link.href;
-      link.href = '';
-      setTimeout(() => {
-        link.href = originalHref;
-      }, 1);
-    });
-  }, 100);
 };
 
 // Apply tab title and favicon from stored Preferences. Optional fallbackTitle used if no tabText stored.
@@ -114,9 +128,11 @@ export const applyTabBranding = async (
       // Ignore font family errors
     }
 
-    // Ensure we always have some icon to show
+    // Ensure we always have some icon to show. On a white-labelled host fall
+    // back to a blank icon rather than the Vacademy mark, so a missing/failed
+    // institute icon never flashes a competitor's "V".
     if (!iconUrl) {
-      iconUrl = FALLBACK_FAVICON_URL;
+      iconUrl = getFallbackFavicon();
     }
 
     // Update favicon via DOM - but only if it's different from current
@@ -180,7 +196,7 @@ const startFaviconMonitoring = () => {
         allFaviconLinks.forEach(link => link.remove());
         
         // Reapply favicon using the last known URL or fallback
-        applyFaviconLinks(currentFaviconUrl || FALLBACK_FAVICON_URL);
+        applyFaviconLinks(currentFaviconUrl || getFallbackFavicon());
         lastFaviconRefreshMs = Date.now();
       } else if (isTimeToRefresh) {
         console.log('[Branding] Periodic favicon refresh');
@@ -200,20 +216,20 @@ const startFaviconMonitoring = () => {
             }
           }
           if (!nextUrl) {
-            nextUrl = FALLBACK_FAVICON_URL;
+            nextUrl = getFallbackFavicon();
           }
+          // Only touch the DOM when the URL actually changed (e.g. a rotated
+          // signed URL). Reapplying an identical, stable URL would needlessly
+          // re-request the icon — the very churn this fix removes.
           if (nextUrl !== currentFaviconUrl) {
             currentFaviconUrl = nextUrl;
-            applyFaviconLinks(nextUrl);
-          } else {
-            // Even if unchanged, reapply to bust cache in case URL has expired server-side
             applyFaviconLinks(nextUrl);
           }
         } catch (e) {
           console.warn('[Branding] Error refreshing favicon URL:', e);
           // Apply fallback on error
-          currentFaviconUrl = FALLBACK_FAVICON_URL;
-          applyFaviconLinks(FALLBACK_FAVICON_URL);
+          currentFaviconUrl = getFallbackFavicon();
+          applyFaviconLinks(currentFaviconUrl);
         }
         lastFaviconRefreshMs = Date.now();
       }

--- a/media_service/src/main/java/vacademy/io/media_service/service/FileServiceImpl.java
+++ b/media_service/src/main/java/vacademy/io/media_service/service/FileServiceImpl.java
@@ -54,6 +54,16 @@ public class FileServiceImpl implements FileService {
     @Value("${aws.s3.public-bucket}")
     private String publicBucket;
 
+    /**
+     * Cache-Control stamped on objects copied into the public bucket.
+     * <p>
+     * Every key from {@link #generateFileKey} embeds a fresh UUID, so a public
+     * object's bytes never change once written — a re-upload is always a new key.
+     * That makes these assets safely immutable, so browsers can reuse them without
+     * revalidating rather than re-fetching on every page load.
+     */
+    private static final String PUBLIC_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
     @Autowired
     private FileMetadataRepository fileMetadataRepository;
 
@@ -526,8 +536,18 @@ public class FileServiceImpl implements FileService {
     }
 
     public void copyFileToPublicBucket(String objectKey) {
-        CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, objectKey.trim(), publicBucket,
-                objectKey.trim());
+        String key = objectKey.trim();
+
+        // Supplying newObjectMetadata switches S3 to the REPLACE metadata directive,
+        // which drops every header we do not re-set (Content-Type, SSE, …). So start
+        // from the source object's own metadata and add Cache-Control on top of it —
+        // never build a fresh ObjectMetadata here, or the copy would silently lose
+        // the object's content type and encryption settings.
+        ObjectMetadata metadata = s3Client.getObjectMetadata(bucketName, key);
+        metadata.setCacheControl(PUBLIC_ASSET_CACHE_CONTROL);
+
+        CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, key, publicBucket, key)
+                .withNewObjectMetadata(metadata);
         s3Client.copyObject(copyRequest);
     }
 


### PR DESCRIPTION
## Summary of Changes

On EduStream's white-labelled learner portal (`student.edustream.ae`), the browser tab intermittently showed the **Vacademy logo** instead of EduStream's, and it stayed wrong until a manual refresh.

**Root cause:** `applyFaviconLinks` appended `?v=${Date.now()}` to the tab icon's S3 URL on every apply. A fresh timestamp each load means a brand-new URL to the browser, so the cached icon could never be reused — forcing a full ~230 KB re-download on **every page load**. Whenever that download was slow or failed, the browser fell back to the static `/favicon.ico` (the Vacademy mark), and it stuck until refresh.

The cache-buster's intent was legitimate (browsers cache favicons aggressively, so force pickup of a changed icon), but `Date.now()` changes on every call — not just when the icon changes. So "bust the cache when the icon changes" effectively became "never cache this."

**Backend:**
- `copyFileToPublicBucket` now stamps `Cache-Control: public, max-age=31536000, immutable` on objects copied into the public bucket. Safe because `generateFileKey` embeds a fresh UUID per upload, so public objects are immutable — a re-upload is always a new key.
- Reads the source object's existing metadata via `getObjectMetadata` and *adds* Cache-Control on top, rather than building fresh metadata. Supplying `newObjectMetadata` switches S3 to the `REPLACE` directive, which drops any header not re-set — building fresh metadata would have silently wiped **Content-Type and SSE encryption**.
- Content-Type is deliberately left untouched (see "not included" below).

**Frontend:**
- Removed the `?v=${Date.now()}` cache-buster so the icon URL is stable and the browser can cache it.
- Removed the `href=''` "nudge", which forced a redundant *second* fetch of the same 230 KB PNG ~100 ms after the first.
- White-label-aware fallback: added `isVacademyHost()` / `getFallbackFavicon()` so non-Vacademy hosts fall back to a **blank** icon instead of the Vacademy mark. Applied in both `applyTabBranding` and the 5-second `startFaviconMonitoring` loop — otherwise the monitor re-applied the Vacademy icon moments later.
- Dropped the monitor's "reapply identical URL to bust cache" branch, which became pure churn once cache-busting was removed.

### Deliberately not included

- **Setting Content-Type from the DB's `fileType`** — `fileType` is unreliable: `UploadFileInS3V2` hardcodes the literal `'json'` as both filename and filetype for any file, and `FileServiceImpl` can store `"unknown"`. Stamping `Content-Type: json` would be *worse* than today's bogus `application/x-www-form-urlencoded`, which browsers currently sniff past successfully.
- **Bucket-wide metadata backfill** — mass mutation of production objects using that same unreliable data; also rewrites every ETag (one-time re-download for all clients) and risks dropping SSE.

### Follow-ups identified (not in this PR)

- `UploadFileInS3V2` sends `'json','json'` and sets no `Content-Type` on the PUT, so it still writes wrong-typed objects to S3. `UploadFileInS3` (v1) was already fixed in `da2a2dfde` (2026-06-24). Worth confirming V2 isn't intentionally JSON-only before changing it.
- EduStream's existing icon (`Last-Modified: 2026-01-06`) predates the v1 fix, so its wrong Content-Type is a legacy artifact rather than an ongoing bug.
- The tab icon is a 512×512 / 230 KB PNG serving a 16×16 slot — should be resized at upload.
- The admin app (`admin.edustream.ae`) has separate favicon logic (`current_domain_branding`, `useTitleStore`) plus a static Vacademy `/favicon.ico`, and has not been audited for the same class of bug.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- **Reproduced the bug deliberately:** DevTools → Network → "Block URL" on the icon's S3 request on `student.edustream.ae`. The tab immediately flipped to the Vacademy logo and stayed there until refresh, confirming the fallback chain.
- **Confirmed the mechanism from the live request:** the Network panel showed the icon fetched as `…removebg-preview.png?v=178426331556` while the cached `TabBranding` value held the same URL *without* `?v=` — proving the cache-buster was appended at apply time and that a full 230 KB download (`Content-Length: 229685`) happened per load.
- **Backend compiles clean:** `./mvnw -o compile -DskipTests` on `media_service` (exit 0).
- **Verified fix preconditions before implementing:** keys are UUID-unique (`generateFileKey`, so `immutable` is safe), and `copyFileToPublicBucket` has exactly one caller (narrow blast radius).

**Not yet verified (needs a deploy):**
- Backend change is forward-looking: it only affects files uploaded *after* deploy. Existing objects (including EduStream's current icon) still have no `Cache-Control`. After deploy, confirm with `curl -sI "<new public S3 URL>"` that `Cache-Control: public, max-age=31536000, immutable` is present and `Content-Type` is unchanged.
- The frontend change is what actually resolves the reported bug; the backend change is hardening that removes the remaining revalidation round-trip.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
