### PR TITLE
fix(slides): stop rename input clipping, add cancel, shrink header bu…

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
@@ -157,8 +157,9 @@ export const SlideHistoryDialog = ({
             <MyButton
                 buttonType="secondary"
                 scale="medium"
-                layoutVariant="default"
+                layoutVariant="icon"
                 title="View and restore previous versions"
+                aria-label="History"
                 onClick={() => {
                     setSelectedId(null);
                     setConfirmingRestore(false);
@@ -166,7 +167,6 @@ export const SlideHistoryDialog = ({
                 }}
             >
                 <ClockCounterClockwise size={18} />
-                <span className="hidden md:inline">History</span>
             </MyButton>
             <MyDialog
                 heading="Version history"

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -29,7 +29,7 @@ import {
     useSlidesMutations,
 } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides';
 import { toast } from 'sonner';
-import { Check, DownloadSimple, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning } from '@phosphor-icons/react';
+import { Check, DownloadSimple, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning, X } from '@phosphor-icons/react';
 import { AlertCircle } from 'lucide-react';
 import {
     converDataToAssignmentFormat,
@@ -3570,6 +3570,26 @@ export const SlideMaterial = ({
         (editableVideoSourceType === 'VIDEO' || editableVideoSourceType === 'VIMEO') &&
         !activeItem?.splitScreenMode;
 
+    const saveHeading = () => {
+        if (!activeItem) return;
+        updateHeading(
+            activeItem,
+            addUpdateVideoSlide,
+            SaveDraft,
+            heading,
+            setIsEditing,
+            addUpdateDocumentSlide,
+            addUpdateQuizSlide,
+            updateAssignmentOrder,
+            updateQuestionOrder
+        );
+    };
+
+    const cancelHeadingEdit = () => {
+        setHeading(activeItem?.title || '');
+        setIsEditing(false);
+    };
+
     return (
         <div
             // Bounded-height scroll container so the `sticky top-0` header below
@@ -3652,30 +3672,45 @@ export const SlideMaterial = ({
                     <div className="flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2">
                     <div className="w-full min-w-0 md:w-auto md:flex-1">
                         {isEditing ? (
-                            <div className="flex items-center justify-center gap-2 duration-200 animate-in fade-in">
+                            <div className="flex min-w-0 items-center gap-2 duration-200 animate-in fade-in">
                                 <input
                                     type="text"
                                     value={heading}
                                     onChange={handleHeadingChange}
-                                    className="w-fit border-b border-neutral-300 bg-transparent text-lg font-semibold text-neutral-700 transition-colors duration-200 focus:border-primary-500 focus:outline-none"
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            e.preventDefault();
+                                            saveHeading();
+                                        } else if (e.key === 'Escape') {
+                                            e.preventDefault();
+                                            cancelHeadingEdit();
+                                        }
+                                    }}
+                                    className="min-w-0 flex-1 border-b border-neutral-300 bg-transparent text-lg font-semibold text-neutral-700 transition-colors duration-200 focus:border-primary-500 focus:outline-none"
                                     autoFocus
                                 />
-                                <Check
-                                    onClick={() =>
-                                        updateHeading(
-                                            activeItem,
-                                            addUpdateVideoSlide,
-                                            SaveDraft,
-                                            heading,
-                                            setIsEditing,
-                                            addUpdateDocumentSlide,
-                                            addUpdateQuizSlide, // <-- pass this for QUIZ support
-                                            updateAssignmentOrder, // <-- pass for ASSIGNMENT
-                                            updateQuestionOrder // <-- pass for QUESTION
-                                        )
-                                    }
-                                    className="cursor-pointer hover:text-primary-500"
-                                />
+                                <MyButton
+                                    type="button"
+                                    buttonType="text"
+                                    layoutVariant="icon"
+                                    scale="small"
+                                    className="shrink-0"
+                                    aria-label="Save title"
+                                    onClick={saveHeading}
+                                >
+                                    <Check size={16} />
+                                </MyButton>
+                                <MyButton
+                                    type="button"
+                                    buttonType="text"
+                                    layoutVariant="icon"
+                                    scale="small"
+                                    className="shrink-0 text-neutral-500 hover:text-danger-500"
+                                    aria-label="Cancel rename"
+                                    onClick={cancelHeadingEdit}
+                                >
+                                    <X size={16} />
+                                </MyButton>
                             </div>
                         ) : (
                             <div className="flex min-w-0 items-center gap-1.5">
@@ -3743,6 +3778,7 @@ export const SlideMaterial = ({
                                         buttonType="secondary"
                                         scale="medium"
                                         layoutVariant="default"
+                                        className="sm:min-w-0"
                                         onClick={() => setIsEditLinkDialogOpen(true)}
                                     >
                                         <LinkSimple size={18} />
@@ -3773,7 +3809,10 @@ export const SlideMaterial = ({
                                         layoutVariant="default"
                                         onClick={handleSaveDraftClick}
                                         disabled={isSaving}
-                                        className={cn(isSaving && 'pointer-events-none')}
+                                        className={cn(
+                                            'sm:min-w-0',
+                                            isSaving && 'pointer-events-none'
+                                        )}
                                     >
                                         {isSaving ? (
                                             <>
@@ -3803,6 +3842,7 @@ export const SlideMaterial = ({
                                                 buttonType="secondary"
                                                 scale="medium"
                                                 layoutVariant="default"
+                                                className="sm:min-w-0"
                                                 onClick={() => setIsUnpublishDialogOpen(true)}
                                             >
                                                 <span className="hidden sm:inline">Unpublish</span>
@@ -3836,6 +3876,7 @@ export const SlideMaterial = ({
                                                 buttonType="primary"
                                                 scale="medium"
                                                 layoutVariant="default"
+                                                className="sm:min-w-0"
                                                 onClick={() => setIsPublishDialogOpen(true)}
                                             >
                                                 <span className="hidden sm:inline">Publish</span>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/stats-dialog/activity-sidebar.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/stats-dialog/activity-sidebar.tsx
@@ -169,11 +169,11 @@ export const ActivityStatsSidebar = () => {
                 <MyButton
                     buttonType="secondary"
                     scale="medium"
-                    layoutVariant="default"
+                    layoutVariant="icon"
                     title="Activity Stats"
+                    aria-label="Activity Stats"
                 >
-                    <ChartBar className="size-4 md:hidden" />
-                    <span className="hidden md:inline">Activity Stats</span>
+                    <ChartBar size={18} />
                 </MyButton>
             </DialogTrigger>
             <DialogContent className="flex h-[680px] max-h-[92vh] w-[760px] max-w-[95vw] flex-col gap-0 overflow-hidden p-0 font-normal">


### PR DESCRIPTION
## Summary of Changes

Renaming a slide from the study-library header was effectively unusable: the title
input overflowed its container and spilled off the left edge into a clipped region,
and the confirm tick rendered underneath the download button. There was also no way
to abandon a rename once started.

**Frontend:**
- Fix the rename input overflowing its container. It was `w-fit` with no `min-w-0`,
  so flexbox refused to shrink it below an `<input>`'s ~20-character min-content
  floor; now `min-w-0 flex-1`. Dropped `justify-center`, which was splitting the
  overflow to both sides and pushing text off the left edge, where the ancestor's
  `overflow-x-hidden` clipped it unreachably.
- Confirm/cancel are now `MyButton` with `shrink-0`, so they can't be collapsed to
  zero width or painted over by the later-in-DOM actions row. Adds a real 24px hit
  area, `type="button"`, and `aria-label` — the old bare `<Check>` icon had none.
- Add a cancel (X) button that reverts the title to the persisted value. Previously
  the only exit from edit mode was committing the change.
- Enter commits the rename, Escape cancels.
- Free ~330px of header width for the title: Activity Stats and History become
  icon-only (they already carried `title` tooltips), and Save Draft / Publish /
  Unpublish / Edit Link drop the `sm:min-w-36` 144px floor via `sm:min-w-0`, so
  they size to their text.

## Related Issue

<!-- leave blank -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `tsc --noEmit` passes clean across all three changed files.
- `scripts/design-lint.mjs` reports no findings in any changed region (pre-existing
  findings elsewhere in these files are untouched).
- Manual: renaming a document slide shows the full title, a visible tick and X, with
  no clipping at the left edge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
