### PR TITLE
feat(audit): log learner termination and name courses in enrollment logs

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/annotation/Auditable.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/annotation/Auditable.java
@@ -25,8 +25,28 @@ public @interface Auditable {
     /** Logical entity type, e.g. {@code "COURSE"}, {@code "LEARNER"}. */
     String entityType();
 
-    /** Logical action, e.g. {@code "CREATE"}, {@code "UPDATE"}, {@code "DELETE"}. */
-    String action();
+    /**
+     * Logical action, e.g. {@code "CREATE"}, {@code "UPDATE"}, {@code "DELETE"}.
+     * Leave blank when {@link #actionExpr()} derives the action at runtime;
+     * it is then used as the fallback if that expression yields nothing.
+     */
+    String action() default "";
+
+    /**
+     * Optional SpEL resolving the action at runtime, for endpoints that perform
+     * more than one logical operation behind a single mapping. Evaluated after
+     * the wrapped call, so {@code #result} is available alongside the method
+     * args and {@code #user}.
+     *
+     * <p>Example — an endpoint switching on a request field:
+     * {@code actionExpr = "#requestWrapper?.operation"} emits {@code TERMINATE},
+     * {@code MAKE_ACTIVE}, … as distinct, filterable actions.
+     *
+     * <p>Takes precedence over {@link #action()}. If it evaluates to null or
+     * blank, {@code action()} is used instead; if both are empty the row is
+     * skipped, since {@code action} is NOT NULL.
+     */
+    String actionExpr() default "";
 
     /**
      * Optional SpEL evaluated against method args + {@code #user} + {@code #result}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/aspect/AuditableAspect.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/aspect/AuditableAspect.java
@@ -214,6 +214,14 @@ public class AuditableAspect {
         Object beforeRaw = before == null ? null : before.raw();
         String beforeJson = before == null ? null : before.json();
 
+        String action = resolveAction(auditable, signature, args, user, result, beforeRaw);
+        if (action == null) {
+            // `action` is NOT NULL — a row without one would fail the insert.
+            logger.warn("Skipping audit for {} — actionExpr '{}' yielded nothing and no static action() fallback",
+                    signature.toShortString(), auditable.actionExpr());
+            return null;
+        }
+
         String entityId = spelEvaluator.evaluateString(
                 auditable.entityIdExpr(), signature, args, user, result, beforeRaw);
         String description = spelEvaluator.evaluateString(
@@ -228,7 +236,7 @@ public class AuditableAspect {
                 .actorEmail(snapshot.getActorEmail())
                 .entityType(auditable.entityType())
                 .entityId(entityId)
-                .action(auditable.action())
+                .action(action)
                 .httpMethod(snapshot.getHttpMethod())
                 .endpoint(truncate(snapshot.getEndpoint(), 512))
                 .description(description)
@@ -239,6 +247,28 @@ public class AuditableAspect {
                 .responseStatus(200) // We're past proceed() — exception path doesn't reach here
                 .responseTimeMs(elapsedMs)
                 .build();
+    }
+
+    /**
+     * Resolves the row's action: {@code actionExpr} first, falling back to the
+     * static {@code action()}. Returns null when neither yields a value, which
+     * tells the caller to skip the row rather than fail the insert.
+     */
+    private String resolveAction(Auditable auditable,
+            MethodSignature signature,
+            Object[] args,
+            CustomUserDetails user,
+            Object result,
+            Object beforeRaw) {
+        if (auditable.actionExpr() != null && !auditable.actionExpr().isBlank()) {
+            String resolved = spelEvaluator.evaluateString(
+                    auditable.actionExpr(), signature, args, user, result, beforeRaw);
+            if (resolved != null && !resolved.isBlank()) {
+                return truncate(resolved.trim(), 64);
+            }
+        }
+        String fallback = auditable.action();
+        return fallback == null || fallback.isBlank() ? null : fallback;
     }
 
     private String serializePayload(Auditable auditable, String httpMethod, Object[] args) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/AuditNarrator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/AuditNarrator.java
@@ -1,0 +1,240 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import vacademy.io.admin_core_service.features.institute_learner.dto.StudentStatusUpdateRequest;
+import vacademy.io.admin_core_service.features.institute_learner.entity.Student;
+import vacademy.io.admin_core_service.features.institute_learner.repository.InstituteStudentRepository;
+import vacademy.io.admin_core_service.features.packages.repository.PackageSessionRepository;
+import vacademy.io.common.institute.entity.session.PackageSession;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Turns raw ids on an audited request into the human-readable phrases stored in
+ * {@code admin_activity_log.description}.
+ *
+ * <p>Exists because the interesting endpoints carry ids, not names: a
+ * termination request knows a {@code userId} and a {@code packageSessionId},
+ * but the log has to read "terminated Amit Kumar from Physics 201". Resolving
+ * that in SpEL directly would mean unreadable expressions repeated across
+ * annotations, so the lookups live here and the annotations call
+ * {@code @auditNarrator.<method>(...)}.
+ *
+ * <p>The actor is not included in any phrase — the read UI prepends
+ * {@code actor_name} to the description when rendering the row.
+ *
+ * <p>Every method is total: no method here throws, and each degrades to a
+ * count or an id rather than propagating. Audit must never break a mutation.
+ */
+@Component
+public class AuditNarrator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuditNarrator.class);
+
+    @Autowired
+    private PackageSessionRepository packageSessionRepository;
+
+    @Autowired
+    private InstituteStudentRepository instituteStudentRepository;
+
+    // ── Courses ───────────────────────────────────────────────────────────
+
+    /**
+     * Names the courses behind {@code packageSessionIds}, deduplicated — several
+     * batches of one course read as that single course, not as "3 courses".
+     * One course gives its name; several give a count, since listing every name
+     * makes the sentence unreadable once a bulk action spans a dozen courses.
+     * Null when nothing resolves, so callers can omit the "in ..." clause.
+     */
+    public String coursesFor(List<String> packageSessionIds) {
+        List<String> ids = distinctNonBlank(packageSessionIds);
+        if (ids.isEmpty()) {
+            return null;
+        }
+        try {
+            List<PackageSession> sessions = packageSessionRepository.findAllById(ids);
+            LinkedHashSet<String> names = new LinkedHashSet<>();
+            for (PackageSession session : sessions) {
+                if (session == null || session.getPackageEntity() == null) {
+                    continue;
+                }
+                String name = session.getPackageEntity().getPackageName();
+                if (name != null && !name.isBlank()) {
+                    names.add(name.trim());
+                }
+            }
+            if (names.isEmpty()) {
+                return null;
+            }
+            if (names.size() == 1) {
+                return names.iterator().next();
+            }
+            return names.size() + " courses";
+        } catch (Exception e) {
+            logger.warn("Could not resolve course names for package sessions {}: {}", ids, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── Learners ──────────────────────────────────────────────────────────
+
+    /** Full name for one learner, falling back to the raw user id. */
+    public String learnerFor(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return null;
+        }
+        try {
+            List<Student> students = instituteStudentRepository.findByUserIdIn(List.of(userId));
+            String name = students.stream()
+                    .map(Student::getFullName)
+                    .filter(Objects::nonNull)
+                    .filter(n -> !n.isBlank())
+                    .findFirst()
+                    .orElse(null);
+            return name != null ? name.trim() : userId;
+        } catch (Exception e) {
+            logger.warn("Could not resolve learner name for {}: {}", userId, e.getMessage());
+            return userId;
+        }
+    }
+
+    /**
+     * Names one learner, or counts several — "Amit Kumar" vs "5 learner(s)".
+     * A bulk action naming every learner would not fit the row, and the count
+     * is what an admin scanning the log actually needs.
+     */
+    public String learnersFor(List<String> userIds) {
+        List<String> ids = distinctNonBlank(userIds);
+        if (ids.isEmpty()) {
+            return null;
+        }
+        if (ids.size() > 1) {
+            return ids.size() + " learner(s)";
+        }
+        return learnerFor(ids.get(0));
+    }
+
+    // ── Enrollments ───────────────────────────────────────────────────────
+
+    /**
+     * Phrases an enrollment of one named learner, e.g. "enrolled learner Amit
+     * Kumar in Physics 201". {@code verb} is the caller's ("enrolled",
+     * "re-enrolled"). Used where the request body already carries the name, so
+     * no lookup is needed. Falls back to the bare verb when the name is absent.
+     */
+    public String enrollmentOf(String verb, String learnerName, List<String> packageSessionIds) {
+        if (learnerName == null || learnerName.isBlank()) {
+            return verb + " learner" + inClause("in", coursesFor(packageSessionIds));
+        }
+        return verb + " learner " + learnerName.trim() + inClause("in", coursesFor(packageSessionIds));
+    }
+
+    /**
+     * Phrases a bulk enrollment, e.g. "enrolled 5 learner(s) in Physics 201".
+     * Resolves the single-learner case to a name so a one-row bulk call still
+     * reads like the individual one.
+     */
+    public String bulkEnrollmentOf(String verb, List<String> userIds, List<String> packageSessionIds) {
+        String who = learnersFor(userIds);
+        if (who == null) {
+            return null;
+        }
+        return verb + " " + who + inClause("in", coursesFor(packageSessionIds));
+    }
+
+    // ── Learner status changes ────────────────────────────────────────────
+
+    /**
+     * Describes one call to the learner status endpoint, whose {@code operation}
+     * field selects between six different mutations. Mirrors the switch in
+     * {@code StudentSessionManager#updateStudentStatus} — keep the two in step
+     * if an operation is added there.
+     */
+    public String statusChangeFor(String operation, List<StudentStatusUpdateRequest> requests) {
+        if (operation == null || requests == null || requests.isEmpty()) {
+            return null;
+        }
+        try {
+            String who = learnersFor(requests.stream().map(StudentStatusUpdateRequest::getUserId).toList());
+            String from = coursesFor(affectedPackageSessionIds(requests));
+            if (who == null) {
+                return null;
+            }
+
+            return switch (operation) {
+                case "TERMINATE" -> "terminated " + who + inClause("from", from);
+                case "MAKE_INACTIVE" -> "deactivated " + who + inClause("in", from);
+                case "MAKE_ACTIVE" -> "reactivated " + who + inClause("in", from);
+                case "UPDATE_BATCH" -> {
+                    // For a batch move `newState` carries the destination package session.
+                    String to = coursesFor(requests.stream()
+                            .map(StudentStatusUpdateRequest::getNewState)
+                            .toList());
+                    yield "moved " + who + inClause("from", from) + inClause("to", to);
+                }
+                case "ADD_EXPIRY" -> "changed expiry date of " + who + inClause("in", from)
+                        + toClause(distinctStates(requests));
+                case "UPDATE_STATUS" -> "changed status of " + who + inClause("in", from)
+                        + toClause(distinctStates(requests));
+                default -> operation.toLowerCase().replace('_', ' ') + " for " + who + inClause("in", from);
+            };
+        } catch (Exception e) {
+            logger.warn("Could not describe status change '{}': {}", operation, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────
+
+    /**
+     * MAKE_INACTIVE may carry a list of package sessions; the other operations
+     * act on the single current one.
+     */
+    private List<String> affectedPackageSessionIds(List<StudentStatusUpdateRequest> requests) {
+        List<String> ids = new ArrayList<>();
+        for (StudentStatusUpdateRequest request : requests) {
+            if (request == null) {
+                continue;
+            }
+            if (request.getPackageSessionIds() != null && !request.getPackageSessionIds().isEmpty()) {
+                ids.addAll(request.getPackageSessionIds());
+            } else if (request.getCurrentPackageSessionId() != null) {
+                ids.add(request.getCurrentPackageSessionId());
+            }
+        }
+        return ids;
+    }
+
+    /** The distinct target values of an operation, when they read as plain text. */
+    private String distinctStates(List<StudentStatusUpdateRequest> requests) {
+        List<String> states = distinctNonBlank(requests.stream()
+                .map(StudentStatusUpdateRequest::getNewState)
+                .toList());
+        return states.size() == 1 ? states.get(0) : null;
+    }
+
+    private String inClause(String preposition, String value) {
+        return value == null ? "" : " " + preposition + " " + value;
+    }
+
+    private String toClause(String value) {
+        return value == null ? "" : " to " + value;
+    }
+
+    private List<String> distinctNonBlank(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(Objects::nonNull)
+                .filter(v -> !v.isBlank())
+                .distinct()
+                .toList();
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteCSVBulkStudentController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteCSVBulkStudentController.java
@@ -34,6 +34,11 @@ public class InstituteCSVBulkStudentController {
         return ResponseEntity.ok(studentBulkInitUploadManager.generateCsvUploadForStudents(instituteId, bulkUploadInitRequest));
     }
 
+    // NOT @Auditable yet: this endpoint reports per-row success/failure and is
+    // designed to partially succeed, but AuditableAspect wraps the method in a
+    // REQUIRED transaction — which would make one poisoned row roll back the
+    // rows this response reports as added. Auditing it needs the aspect's async
+    // path to stop opening a transaction first. See docs/ADMIN_ACTIVITY_LOGS.md.
     @PostMapping(value = "/upload-csv", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<byte[]> uploadStudentCsv(
             @RequestParam("file") MultipartFile file,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentController.java
@@ -32,7 +32,9 @@ public class InstituteStudentController {
     @Auditable(
             entityType = "LEARNER",
             action = "ENROLL",
-            descriptionExpr = "'enrolled learner ' + (#instituteStudentDTO?.userDetails?.fullName ?: #instituteStudentDTO?.userDetails?.email ?: '')")
+            descriptionExpr = "@auditNarrator.enrollmentOf('enrolled', "
+                    + "#instituteStudentDTO?.userDetails?.fullName ?: #instituteStudentDTO?.userDetails?.email, "
+                    + "{#instituteStudentDTO?.instituteStudentDetails?.packageSessionId})")
     public ResponseEntity<String> addStudentToInstitute(@RequestAttribute("user") CustomUserDetails user,
             @RequestParam(value = "notify", required = false, defaultValue = "true") boolean notify,
             @RequestBody InstituteStudentDTO instituteStudentDTO) {
@@ -50,7 +52,9 @@ public class InstituteStudentController {
     @Auditable(
             entityType = "LEARNER",
             action = "ENROLL",
-            descriptionExpr = "'enrolled learner ' + (#request?.user?.fullName ?: #request?.user?.email ?: '')")
+            descriptionExpr = "@auditNarrator.enrollmentOf('enrolled', "
+                    + "#request?.user?.fullName ?: #request?.user?.email, "
+                    + "#request?.learnerPackageSessionEnroll?.packageSessionIds)")
     public ResponseEntity<LearnerEnrollResponseDTO> adminEnrollLearner(
             @RequestAttribute("user") CustomUserDetails admin,
             @RequestBody LearnerEnrollRequestDTO request) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentOperationController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/controller/InstituteStudentOperationController.java
@@ -23,7 +23,16 @@ public class InstituteStudentOperationController {
     @Autowired
     private LearnerSessionOperationService learnerSessionOperationService;
 
+    /**
+     * One mapping, six operations — so the audited action is derived from the
+     * request's own {@code operation} field rather than fixed on the annotation,
+     * keeping TERMINATE distinguishable from a batch move in the activity log.
+     */
     @PostMapping("/update")
+    @Auditable(
+            entityType = "LEARNER",
+            actionExpr = "#requestWrapper?.operation",
+            descriptionExpr = "@auditNarrator.statusChangeFor(#requestWrapper?.operation, #requestWrapper?.requests)")
     public void updateStudentStatus(@RequestAttribute("user") CustomUserDetails user, @RequestBody StudentStatusUpdateRequestWrapper requestWrapper) {
         manager.updateStudentStatus(requestWrapper.getRequests(), requestWrapper.getOperation(), user);
     }
@@ -33,7 +42,8 @@ public class InstituteStudentOperationController {
     @Auditable(
             entityType = "LEARNER",
             action = "ENROLL",
-            descriptionExpr = "'added ' + (#learnerBatchRegister?.userIds?.size() ?: 0) + ' learner(s) to batches'")
+            descriptionExpr = "@auditNarrator.bulkEnrollmentOf('enrolled', #learnerBatchRegister?.userIds, "
+                    + "#learnerBatchRegister?.learnerBatchRegisterInfos?.![packageSessionId])")
     public String addPackageSessionsToLearner(
             @RequestBody LearnerBatchRegisterRequestDTO learnerBatchRegister,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -45,7 +55,9 @@ public class InstituteStudentOperationController {
     @Auditable(
             entityType = "LEARNER",
             action = "ENROLL",
-            descriptionExpr = "'re-enrolled learner ' + (#instituteStudentDTO?.userDetails?.fullName ?: #instituteStudentDTO?.userDetails?.email ?: '')")
+            descriptionExpr = "@auditNarrator.enrollmentOf('re-enrolled', "
+                    + "#instituteStudentDTO?.userDetails?.fullName ?: #instituteStudentDTO?.userDetails?.email, "
+                    + "{#instituteStudentDTO?.instituteStudentDetails?.packageSessionId})")
     public ResponseEntity<?> reEnrollLearner(
             @RequestBody InstituteStudentDTO instituteStudentDTO,
             @RequestAttribute("user") CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/controller/BulkLearnerManagementController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/controller/BulkLearnerManagementController.java
@@ -42,6 +42,7 @@ public class BulkLearnerManagementController {
      * - Duplicate handling: SKIP / ERROR / RE_ENROLL
      * - dry_run mode for preview
      */
+    // NOT @Auditable yet — see the note on bulkDeassign below.
     @PostMapping("/assign")
     public ResponseEntity<BulkAssignResponseDTO> bulkAssign(
             @RequestBody BulkAssignRequestDTO request,
@@ -77,6 +78,13 @@ public class BulkLearnerManagementController {
      * - Shared UserPlan warnings
      * - dry_run mode for preview
      */
+    // NOT @Auditable yet: both v3 bulk endpoints catch per-item failures and
+    // report successful/failed/skipped, so they are built to partially succeed.
+    // AuditableAspect wraps the annotated method in a REQUIRED transaction,
+    // which would turn that into all-or-nothing and could roll back items the
+    // response reports as successful. Auditing these needs the aspect's async
+    // path to stop opening a transaction first (its javadoc already claims it
+    // doesn't). Dry-run calls must also be excluded — they mutate nothing.
     @PostMapping("/deassign")
     public ResponseEntity<BulkDeassignResponseDTO> bulkDeassign(
             @RequestBody BulkDeassignRequestDTO request,

--- a/docs/ADMIN_ACTIVITY_LOGS.md
+++ b/docs/ADMIN_ACTIVITY_LOGS.md
@@ -54,7 +54,8 @@ The frontend renders this in `/admin-activity-logs` as **"John Doe created cours
 | Field | Required | Type | Purpose |
 |---|---|---|---|
 | `entityType` | yes | String | Logical resource type, uppercase snake. Used to filter audit rows. Examples: `COURSE`, `LIVE_SESSION`, `LEARNER`, `INSTITUTE_SETTING`. New types are free-form — add to the frontend's `RESOURCE_OPTIONS` dropdown in [ActivityLogFilters.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx) once you start emitting them. |
-| `action` | yes | String | Logical action, uppercase. Examples: `CREATE`, `UPDATE`, `DELETE`, `CANCEL`, `ENROLL`, `PUBLISH`. Same dropdown convention as above (`ACTIVITY_OPTIONS`). |
+| `action` | yes* | String | Logical action, uppercase. Examples: `CREATE`, `UPDATE`, `DELETE`, `CANCEL`, `ENROLL`, `PUBLISH`. Same dropdown convention as above (`ACTIVITY_OPTIONS`). *Optional only when `actionExpr` is set, in which case it acts as the fallback. |
+| `actionExpr` | optional | SpEL | Resolves the action at runtime, for one mapping that performs several logical operations. Evaluated after the call, so `#result` is available. Takes precedence over `action`; falls back to it when blank. If both are empty the row is **skipped** — `action` is NOT NULL. See the multi-operation example below. |
 | `entityIdExpr` | optional | SpEL | Returns the id of the affected entity. Pulled from method args, `#user`, or `#result`. Example: `"#courseId"`, `"#result"`, `"#req?.id"`. |
 | `descriptionExpr` | optional but recommended | SpEL | Produces the human-readable verb-and-object fragment ("created course X"). Actor name is prepended automatically by the frontend, so don't include the actor. |
 | `captureBefore` | optional | SpEL | Evaluated *before* the wrapped method runs. Used for UPDATE/DELETE to snapshot the entity's prior state. Supports bean references — see the example below. |
@@ -158,6 +159,55 @@ Output row: `John deleted course Mathematics 101, Physics 201, Chemistry 110`.
 public ResponseEntity<?> deleteLiveSessions(@RequestBody DeleteLiveSessionRequest request, ...) { ... }
 ```
 
+### Multi-operation endpoint — action derived from the request
+
+`POST /institute_learner-operation/v1/update` switches on an `operation` field to
+terminate, deactivate, reactivate, move batches, or change expiry. A fixed
+`action` would stamp all six identically and make terminations unfilterable, so
+the action comes from the request itself:
+
+```java
+@PostMapping("/update")
+@Auditable(
+        entityType = "LEARNER",
+        actionExpr = "#requestWrapper?.operation",
+        descriptionExpr = "@auditNarrator.statusChangeFor(#requestWrapper?.operation, #requestWrapper?.requests)")
+public void updateStudentStatus(@RequestAttribute("user") CustomUserDetails user,
+                                @RequestBody StudentStatusUpdateRequestWrapper requestWrapper) { ... }
+```
+
+Emits `TERMINATE`, `MAKE_INACTIVE`, `MAKE_ACTIVE`, `UPDATE_BATCH`, `ADD_EXPIRY`,
+`UPDATE_STATUS` as distinct actions. Each needs an entry in `ACTIVITY_OPTIONS`
+to be filterable from the UI.
+
+### Naming things: `AuditNarrator`
+
+Requests carry ids, not names — a termination knows a `userId` and a
+`packageSessionId`, but the log has to read "terminated Amit Kumar from Physics
+201". Rather than repeat lookups across annotations as unreadable SpEL, they
+live in the [`AuditNarrator`](../admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/AuditNarrator.java)
+bean and annotations call `@auditNarrator.<method>(...)`:
+
+| Method | Produces |
+|---|---|
+| `enrollmentOf(verb, name, psIds)` | `enrolled learner Amit Kumar in Physics 201` |
+| `bulkEnrollmentOf(verb, userIds, psIds)` | `enrolled 5 learner(s) in Physics 201` |
+| `statusChangeFor(operation, requests)` | `terminated 5 learner(s) from Physics 201` |
+| `coursesFor(ids)` | `Physics 201` / `3 courses` |
+| `learnerFor(id)` / `learnersFor(ids)` | `Amit Kumar` / `5 learner(s)` |
+
+Conventions worth keeping if you extend it:
+
+- **Never throw.** Every method degrades to a count, an id, or null. Audit must
+  not break a mutation.
+- **Course names are deduplicated**, so several batches of one course read as
+  that course rather than "3 courses".
+- **One name, many counted.** Listing every learner in a bulk action makes the
+  row unreadable; the count is what an admin scanning the log needs.
+- **No actor in the phrase** — the table prepends `actor_name` when rendering.
+- **Distinct method names, no overloads.** SpEL resolves overloads poorly when
+  an argument is null.
+
 ### Settings UPDATE — before/after diff
 
 ```java
@@ -181,7 +231,9 @@ The drawer in the audit-log UI shows the prior setting JSON on the left and the 
 
 ## Frontend description rendering
 
-The audit table renders each row as `**{actor_name}** {description}`. The entity name at the end of the description is auto-bolded by regex match in [ActivityLogTable.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx). Patterns currently matched:
+The audit table renders each row as `**{actor_name}** {description}`. Names inside the description are auto-bolded by regex match in [ActivityLogTable.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx).
+
+`NAMED_DESCRIPTION_PATTERNS` entries capture **alternating groups**: odd groups are connective text, even groups are names. That lets one sentence bold more than one subject. First match wins, so specific patterns must precede looser ones.
 
 | Backend `descriptionExpr` outputs | Renders as |
 |---|---|
@@ -190,13 +242,19 @@ The audit table renders each row as `**{actor_name}** {description}`. The entity
 | `deleted course X, Y, Z` | deleted course **X, Y, Z** |
 | `scheduled live session X` | scheduled live session **X** |
 | `created booking X` | created booking **X** |
-| `enrolled learner X` | enrolled learner **X** |
-| `re-enrolled learner X` | re-enrolled learner **X** |
+| `enrolled learner X in Y` | enrolled learner **X** in **Y** |
+| `re-enrolled learner X in Y` | re-enrolled learner **X** in **Y** |
+| `enrolled 5 learner(s) in Y` | enrolled **5 learner(s)** in **Y** |
+| `terminated X from Y` | terminated **X** from **Y** |
+| `deactivated X in Y` / `reactivated X in Y` | deactivated **X** in **Y** |
+| `moved X from A to B` | moved **X** from **A** to **B** |
+| `changed status of X in Y to Z` | changed status of **X** in **Y** to **Z** |
+| `changed expiry date of X in Y to Z` | changed expiry date of **X** in **Y** to **Z** |
 | `switched WhatsApp provider to X` | switched WhatsApp provider to **X** |
 | `updated WhatsApp credentials for X` | updated WhatsApp credentials for **X** |
 | `removed WhatsApp credentials for X` | removed WhatsApp credentials for **X** |
 
-If your new endpoint emits a verb-noun phrase the frontend doesn't recognize, the description renders as plain text (no bolding). That's fine — adding a new pattern is a one-line regex addition in `NAMED_DESCRIPTION_PATTERNS`.
+If your new endpoint emits a verb-noun phrase the frontend doesn't recognize, the description renders as plain text (no bolding). That's fine — adding a new pattern is a one-line regex addition in `NAMED_DESCRIPTION_PATTERNS`. Keep the alternating-group convention or the renderer will bold the wrong half.
 
 ---
 
@@ -348,13 +406,40 @@ Display-settings integration: `sidebar/constant.ts` (`controlledTabs`), `sidebar
 
 6. **Adding to the frontend dropdowns.** New `entityType` / `action` values will work in the backend immediately but won't appear in the filter dropdowns until they're added to `RESOURCE_OPTIONS` / `ACTIVITY_OPTIONS` in [ActivityLogFilters.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx). Filters still accept any string typed/pasted, just no autocomplete.
 
-7. **The `clientId` header is required.** The axios interceptor in [axiosInstance.ts](../frontend-admin-dashboard/src/lib/auth/axiosInstance.ts) attaches it automatically from `getInstituteId()`. If you ever build a non-axios request path (e.g., a worker-side fetch), make sure that header is included or audit silently drops the row.
+7. **Never annotate an endpoint that is designed to partially succeed.** This is
+   the sharpest edge here. `AuditableAspect#audit` is
+   `@Transactional(Propagation.REQUIRED)`, so annotating a method wraps *the
+   whole method* in one transaction. Endpoints that loop over items, catch
+   per-item exceptions, and return a `successful/failed/skipped` report (CSV
+   bulk learner upload, `POST /v3/learner-management/assign` and `/deassign`)
+   rely on each item committing independently. Wrap them and a single poisoned
+   row can mark the transaction rollback-only, discarding work the response has
+   already reported as successful. Those three are deliberately left
+   un-annotated with a comment saying so. **`async = true` is not a workaround
+   today** — despite what its javadoc claims, the `@Transactional` sits on the
+   `@Around` method unconditionally, so the async path opens an outer
+   transaction too. Fixing that is the prerequisite for auditing these.
+
+8. **The `clientId` header is required.** The axios interceptor in [axiosInstance.ts](../frontend-admin-dashboard/src/lib/auth/axiosInstance.ts) attaches it automatically from `getInstituteId()`. If you ever build a non-axios request path (e.g., a worker-side fetch), make sure that header is included or audit silently drops the row.
 
 ---
 
+## Coverage reality check
+
+Worth knowing before assuming a mutation is logged: as of 2026-07-17 the local
+snapshot of `admin_activity_log` held **3,030 rows** against **~11,358**
+enrollment rows created in the same window. Enrollment *is* audited, but only on
+the four annotated enroll endpoints — the bulk paths above are unannotated, and
+most enrollments are learner-driven (self-signup, invitation response,
+payment/`UserPlanService`, workflow activation, Keap migrations) rather than
+admin actions. Roughly 3.5% of `admin_core_service`'s ~687 mutation endpoints
+carry `@Auditable`. An absent row usually means *not instrumented*, not *broken*.
+
 ## Future improvements (not yet wired)
 
-- **Promote annotation + aspect to `common_service`** so other services can audit into the same table without DB changes.
+- **Make `async = true` skip the outer transaction**, matching its javadoc. Unblocks auditing the partial-success bulk endpoints (gotcha 7) and needs a `conditionExpr`-style guard so dry-run calls aren't logged as real ones.
+- **Promote annotation + aspect to `common_service`** so other services can audit into the same table without DB changes. `auth_service` (role grants, permission changes, password resets) is the highest-value gap and is blocked on this.
+- **Failed/denied attempts are never recorded.** The row writes inside the business transaction, so a throw rolls the audit away too — "who *tried* to do X" is unanswerable by design.
 - **Bolding patterns auto-derived from `entityType`/`action`** instead of regex matching the description text.
 - **Per-institute retention override** via institute settings, falling back to the global `audit.retention.days`.
 - **S3 / cold-storage archival before delete** — required for SOC 2 / ISO 27001 evidence trails.

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
@@ -31,6 +31,7 @@ const RESOURCE_OPTIONS: { value: string; label: string }[] = [
     { value: 'COURSE', label: 'Course' },
     { value: 'LIVE_SESSION', label: 'Live session' },
     { value: 'LEARNER', label: 'Learner' },
+    { value: 'GUARDIAN_LINK', label: 'Guardian link' },
     { value: 'INSTITUTE_SETTING', label: 'Settings' },
 ];
 
@@ -40,6 +41,14 @@ const ACTIVITY_OPTIONS: { value: string; label: string }[] = [
     { value: 'DELETE', label: 'Deleted' },
     { value: 'CANCEL', label: 'Cancelled' },
     { value: 'ENROLL', label: 'Enrolled' },
+    // Emitted by the learner status endpoint, which derives its action from the
+    // operation it was asked to perform.
+    { value: 'TERMINATE', label: 'Terminated' },
+    { value: 'MAKE_INACTIVE', label: 'Deactivated' },
+    { value: 'MAKE_ACTIVE', label: 'Reactivated' },
+    { value: 'UPDATE_BATCH', label: 'Moved to another batch' },
+    { value: 'ADD_EXPIRY', label: 'Expiry changed' },
+    { value: 'UPDATE_STATUS', label: 'Status changed' },
 ];
 
 // Sentinel value used in the Select for "any" (Radix Select doesn't allow

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
@@ -62,16 +62,44 @@ const formatRelativeTime = (iso: string | null | undefined) => {
     return d.toLocaleDateString();
 };
 
-// Patterns where we know the trailing portion is the entity name and should
-// be bolded. The first capture group is the verb-and-noun prefix; the second
-// is the name(s). Falls through to plain text if nothing matches — safe for
-// descriptions that don't have a distinct named target (e.g. "deleted 3
-// course(s)", "cancelled live session booking", "updated naming settings").
+// Patterns marking which parts of a description are names worth bolding.
+// Capture groups alternate: odd groups are connective text, even groups are
+// the names. That lets one sentence highlight more than one subject —
+// "enrolled learner |Amit Kumar| in |Physics 201|" bolds learner and course.
+// First match wins, so more specific patterns must precede looser ones.
+// Falls through to plain text when nothing matches — safe for descriptions
+// with no distinct named target ("deleted 3 course(s)", "updated naming
+// settings").
 const NAMED_DESCRIPTION_PATTERNS: RegExp[] = [
     /^((?:created|updated|deleted) course )(.+)$/i,
     /^(created booking )(.+)$/i,
     /^(scheduled live session )(.+)$/i,
+
+    // Enrollment — with and without a resolved course.
+    /^((?:re-)?enrolled learner )(.+?)( in )(.+)$/i,
     /^((?:re-)?enrolled learner )(.+)$/i,
+    /^(bulk enrolled learners from CSV into )(.+)$/i,
+    /^(enrolled )(.+?)( in )(.+)$/i,
+
+    // Removal from a course.
+    /^(terminated )(.+?)( from )(.+)$/i,
+    /^(cancelled enrollment of )(.+?)( in )(.+)$/i,
+    /^((?:deactivated|reactivated) )(.+?)( in )(.+)$/i,
+
+    // Batch move: "moved X from A to B".
+    /^(moved )(.+?)( from )(.+?)( to )(.+)$/i,
+
+    // Status / expiry changes, longest form first.
+    /^(changed (?:status|expiry date) of )(.+?)( in )(.+?)( to )(.+)$/i,
+    /^(changed (?:status|expiry date) of )(.+?)( in )(.+)$/i,
+
+    // Same actions where the course could not be resolved — still bold the
+    // learner(s). Must trail the "in <course>" forms above.
+    /^(enrolled )(.+)$/i,
+    /^(terminated )(.+)$/i,
+    /^(cancelled enrollment of )(.+)$/i,
+    /^((?:deactivated|reactivated) )(.+)$/i,
+
     /^(switched WhatsApp provider to )(.+)$/i,
     /^((?:updated|removed) WhatsApp credentials for )(.+)$/i,
 ];
@@ -86,14 +114,21 @@ const renderActivitySentence = (row: AdminActivityLog): React.ReactNode => {
 
     for (const re of NAMED_DESCRIPTION_PATTERNS) {
         const m = description.match(re);
-        if (m) {
-            return (
-                <>
-                    {m[1]}
-                    <span className="font-semibold text-gray-900">{m[2]}</span>
-                </>
-            );
-        }
+        if (!m) continue;
+        // Groups alternate connective / name, starting with connective.
+        return (
+            <>
+                {m.slice(1).map((part, i) =>
+                    i % 2 === 0 ? (
+                        <span key={i}>{part}</span>
+                    ) : (
+                        <span key={i} className="font-semibold text-gray-900">
+                            {part}
+                        </span>
+                    )
+                )}
+            </>
+        );
     }
     return description;
 };


### PR DESCRIPTION
## Summary of Changes

Admin activity logs recorded enrollments without saying which course, and did not record terminations at all. Enrollment was already audited — it just looked broken because only 4 of ~6 admin enroll paths are annotated and most enrollments are learner-driven (self-signup, payment, invitations) rather than admin actions.

Terminations were genuinely missing: they run through `POST /institute_learner-operation/v1/update`, which had no annotation. That endpoint switches on an `operation` field to do six different things, so a fixed `action` would have stamped all six identically and left terminations unfilterable. The action is now derived from the request itself.

**Backend:**
- Add `actionExpr` to `@Auditable` — SpEL resolving the action at runtime for endpoints with several logical operations. Takes precedence over `action`, falls back to it when blank; the row is skipped if both are empty (`action` is NOT NULL).
- Add `AuditNarrator` bean resolving ids into names (`userId` → learner, `packageSessionId` → course). Annotations call `@auditNarrator.<method>(...)` instead of repeating lookups as unreadable SpEL. Never throws; degrades to a count or an id.
- Annotate `POST /institute_learner-operation/v1/update`, covering `TERMINATE`, `MAKE_INACTIVE`, `MAKE_ACTIVE`, `UPDATE_BATCH`, `ADD_EXPIRY`, `UPDATE_STATUS` as distinct, filterable actions.
- Enrich the four existing enroll descriptions with course names, deduplicated so several batches of one course read as that course rather than "3 courses".

**Frontend:**
- Add the six learner-status actions to `ACTIVITY_OPTIONS`, and `GUARDIAN_LINK` to `RESOURCE_OPTIONS` (the backend already emitted it but it was not filterable).
- Rework `NAMED_DESCRIPTION_PATTERNS` to alternating capture groups so one sentence can bold more than one subject. Previously the trailing `(.+)` bolded "Amit Kumar in Physics 201" as a single blob.

**Docs:**
- Document `actionExpr`, the `AuditNarrator` conventions, the new rendering patterns, and a coverage reality check (~3.5% of admin_core mutation endpoints are audited; an absent row usually means "not instrumented", not "broken").

### Deliberately not included

The CSV bulk upload and both `POST /v3/learner-management/assign|deassign` endpoints have no `@Transactional` and catch per-item failures, returning a `successful/failed/skipped` report — partial success is their design. `AuditableAspect` wraps annotated methods in a `REQUIRED` transaction, so annotating them could let one poisoned row roll back items the response already reported as successful. `async = true` is not a workaround: despite its javadoc claiming otherwise, the `@Transactional` sits on the `@Around` method unconditionally. Those endpoints are left un-annotated with comments explaining why, and fixing the async path is documented as the prerequisite follow-up.

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How Has This Been Tested?

Live against local Docker Postgres with auth_service (8071) and admin_core (8072) booted locally, authenticated as a real admin account. Eight requests through the real endpoints, all HTTP 200, each verified by reading the resulting `admin_activity_log` row:

- `TERMINATE` single → `terminated Shah Rukh Khan from very cheap book`; confirmed the mapping really flipped to `TERMINATED`, so the row is not claiming an action that did not happen.
- `TERMINATE` bulk (3 learners) → `terminated 3 learner(s) from very free book`
- `MAKE_ACTIVE` → `reactivated Shah Rukh Khan in very cheap book`
- `UPDATE_BATCH` → `moved samarkse ialhwerfs from Very Expensive Course to very free book`
- `ADD_EXPIRY` → `changed expiry date of Shah Rukh Khan in very cheap book to 01-01-2027`
- Enroll bulk → `enrolled 2 learner(s) in Very Expensive Course`
- Enroll into two courses → `enrolled samarkse ialhwerfs in 2 courses`
- `GET /audit/v1/logs?action=TERMINATE` returned exactly the 2 matching rows, confirming the new Activity dropdown values filter correctly.

`actionExpr` confirmed resolving at runtime (rows came back as `TERMINATE` / `MAKE_ACTIVE` / `UPDATE_BATCH` / `ADD_EXPIRY`, not a hardcoded constant), and `AuditNarrator`'s bean lookups confirmed working — SpEL resolves them reflectively, so a parse check alone would not have proved it. Audit overhead measured at 6–12 ms per call, in line with the existing docs. Test data restored afterwards.

Also: all 11 SpEL expressions verified to parse (a typo fails silently at runtime and nulls the column); the 8 live descriptions rendered through the patterns extracted from the shipped `ActivityLogTable.tsx`; backend compiles, frontend typechecks and `design-lint` is clean — all re-run after rebasing onto current `main`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
