### PR TITLE
fix(suborg): learner portal access uses the sub-org's own portal

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
@@ -470,4 +470,28 @@ public interface StudentSessionInstituteGroupMappingRepository
       """, nativeQuery = true)
   List<Object[]> findActiveSubOrgRoster(@Param("subOrgId") String subOrgId);
 
+  /**
+   * Sub-org ids a user belongs to within an institute, newest enrollment first.
+   *
+   * Membership mirrors {@link #findActiveSubOrgRoster(String)}: the mapping's own stamp
+   * (add-member / auto-link path) OR the sub-org invite the user_plan was created from.
+   * The second arm is essential because SUBORG_LEARNER self-enrollment does NOT stamp
+   * ssigm.sub_org_id.
+   */
+  @Query(value = """
+      SELECT COALESCE(ssigm.sub_org_id, ei.sub_org_id) AS sub_org_id
+      FROM student_session_institute_group_mapping ssigm
+      LEFT JOIN user_plan up ON up.id = ssigm.user_plan_id
+      LEFT JOIN enroll_invite ei ON ei.id = up.enroll_invite_id
+      WHERE ssigm.user_id = :userId
+        AND ssigm.institute_id = :instituteId
+        AND ssigm.status = 'ACTIVE'
+        AND COALESCE(ssigm.sub_org_id, ei.sub_org_id) IS NOT NULL
+      GROUP BY COALESCE(ssigm.sub_org_id, ei.sub_org_id)
+      ORDER BY MAX(ssigm.enrolled_date) DESC NULLS LAST
+      """, nativeQuery = true)
+  List<String> findActiveSubOrgIdsForUserInInstitute(
+      @Param("userId") String userId,
+      @Param("instituteId") String instituteId);
+
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerPortalAccessService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerPortalAccessService.java
@@ -8,10 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
-import vacademy.io.admin_core_service.features.domain_routing.entity.InstituteDomainRouting;
-import vacademy.io.admin_core_service.features.domain_routing.repository.InstituteDomainRoutingRepository;
 import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
 import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.learner.dto.LearnerPortalAccessResponse;
 import vacademy.io.admin_core_service.features.learner.enums.LmsSourcesEnum;
 import vacademy.io.admin_core_service.features.workflow.entity.WorkflowTrigger;
@@ -32,12 +31,15 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LearnerPortalAccessService {
 
+    /** The learner_portal_base_url column default — a stamped value nobody deliberately chose. */
+    private static final String DEFAULT_PORTAL_HOST = "learner.vacademy.io";
+
     private final InstituteRepository instituteRepository;
     private final InstituteSettingService instituteSettingService;
-    private final InstituteDomainRoutingRepository domainRoutingRepository;
     private final InternalClientUtils internalClientUtils;
     private final WorkflowTriggerService workflowTriggerService;
     private final AuthService authService;
+    private final StudentSessionInstituteGroupMappingRepository mappingRepository;
 
     @Value("${default.learner.portal.url}")
     private String defaultLearnerPortalUrl;
@@ -60,7 +62,7 @@ public class LearnerPortalAccessService {
        }
         Institute institute = instituteRepository.findById(instituteId)
                 .orElseThrow(() -> new VacademyException("Institute not found"));
-        String redirectUrl = buildRedirectUrl(institute, userWithJwtDTO);
+        String redirectUrl = buildRedirectUrl(institute, userWithJwtDTO, resolveSubOrgPortalBaseUrl(instituteId, userId));
 
         return LearnerPortalAccessResponse.builder()
                 .redirectUrl(redirectUrl)
@@ -89,13 +91,60 @@ public class LearnerPortalAccessService {
         }
     }
 
-    private String buildRedirectUrl(Institute institute, UserWithJwtDTO userWithJwtDTO) {
-        Optional<InstituteDomainRouting> domainRouting = domainRoutingRepository
-                .findByInstituteIdAndRole(institute.getId(), "LEARNER");
+    /**
+     * A sub-org is itself an institute row, so it can carry its own learner_portal_base_url.
+     * When the learner belongs to a sub-org that has one configured, the portal link must point
+     * at the sub-org's branded portal instead of the parent institute's.
+     *
+     * Returns null when the learner has no sub-org, or no sub-org of theirs has a portal of its
+     * own — the caller then falls back to the parent institute's configuration exactly as before.
+     * Best-effort: a lookup failure must never block portal access.
+     */
+    private String resolveSubOrgPortalBaseUrl(String instituteId, String userId) {
+        try {
+            List<String> subOrgIds = mappingRepository.findActiveSubOrgIdsForUserInInstitute(userId, instituteId);
+            for (String subOrgId : subOrgIds) {
+                if (!StringUtils.hasText(subOrgId)) {
+                    continue;
+                }
+                String subOrgBaseUrl = instituteRepository.findById(subOrgId)
+                        .map(Institute::getLearnerPortalBaseUrl)
+                        .orElse(null);
+                if (isConfiguredPortal(subOrgBaseUrl)) {
+                    return subOrgBaseUrl;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Error resolving sub-org learner portal url for user {} in institute {}: {}",
+                    userId, instituteId, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * A sub-org counts as having its own portal only if the value is a real, branded host.
+     * Blank means never configured; the platform-wide default host means "not configured either" —
+     * it's the learner_portal_base_url column default, so it can be stamped without anyone choosing
+     * it. Both cases must fall through to the parent institute's configuration.
+     */
+    private boolean isConfiguredPortal(String baseUrl) {
+        if (!StringUtils.hasText(baseUrl)) {
+            return false;
+        }
+        String host = withScheme(baseUrl).replaceFirst("^https?://", "");
+        return !DEFAULT_PORTAL_HOST.equalsIgnoreCase(host);
+    }
+
+    private String buildRedirectUrl(Institute institute, UserWithJwtDTO userWithJwtDTO, String subOrgPortalBaseUrl) {
+        // Sub-org portal (when configured) wins over the parent institute's, which wins over the
+        // global default. The instituteId stays the parent's — the tokens are minted against it.
+        String portalHost = StringUtils.hasText(subOrgPortalBaseUrl)
+                ? subOrgPortalBaseUrl
+                : institute.getLearnerPortalBaseUrl();
 
         String baseUrl;
-        if (StringUtils.hasText(institute.getLearnerPortalBaseUrl())) {
-            baseUrl = "https://" + institute.getLearnerPortalBaseUrl();
+        if (StringUtils.hasText(portalHost)) {
+            baseUrl = withScheme(portalHost);
         } else {
             baseUrl = defaultLearnerPortalUrl;
         }
@@ -107,12 +156,20 @@ public class LearnerPortalAccessService {
                 institute.getId());
     }
 
-    private String buildBaseUrl(String domain, String subdomain) {
-        if ("*".equals(subdomain)) {
-            return "https://" + domain;
-        } else {
-            return "https://" + subdomain + "." + domain;
+    /**
+     * Portal base urls are stored as bare domains ("bls.enarkuplift.in"), but real rows also carry
+     * a scheme ("https://training.enarkuplift.in") or a trailing slash ("example.com/") — normalize
+     * both so the caller can append "/login" without producing "//login".
+     */
+    private String withScheme(String host) {
+        String trimmed = host.trim();
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            return trimmed;
+        }
+        return "https://" + trimmed;
     }
 
     public Boolean sendCredForLMS(String instituteId,String packageId, String userId) {


### PR DESCRIPTION
"Access Learner Portal" always sent learners to the parent institute's portal, even when their sub-org has its own branded one. A sub-org is itself an institute row, so it can carry a learner_portal_base_url.

Resolution order is now sub-org portal -> parent institute -> global default. Learners with no sub-org are unaffected. instituteId stays the parent's, since the JWTs are minted against it.

A sub-org value of learner.vacademy.io is treated as unset and falls through to the parent: it is the column default, so it can be stamped without anyone choosing it.

Membership unions ssigm.sub_org_id with enroll_invite.sub_org_id, mirroring findActiveSubOrgRoster -- SUBORG_LEARNER self-enrollment does not stamp the mapping, so the stamp alone misses those learners.

Base urls are stored inconsistently in prod (bare host, https:// prefix, trailing slash), so normalize before appending /login.

Also drops a dead private buildBaseUrl; the live copy lives in LearnerInvitationLinkService.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
