### PR TITLE
fix(onboarding): actually throw InvalidRequestException in skip-guard…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepInstanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepInstanceService.java
@@ -123,7 +123,9 @@ public class OnboardingStepInstanceService {
         OnboardingStep step = onboardingStepRepository.findById(stepInstance.getStepId())
                 .orElseThrow(() -> new ResourceNotFoundException("Onboarding step not found: " + stepInstance.getStepId()));
         if (!Boolean.TRUE.equals(step.getIsOptional())) {
-            throw new IllegalStateException("Step is not optional and cannot be skipped: " + step.getId());
+            // InvalidRequestException -> 400 via GlobalExceptionHandler; see FormStepTypeHandler
+            // for the same fix on the mandatory-field-validation path.
+            throw new InvalidRequestException("Step is not optional and cannot be skipped: " + step.getId());
         }
         OnboardingInstance instance = onboardingInstanceRepository.findById(stepInstance.getOnboardingInstanceId())
                 .orElseThrow(() -> new ResourceNotFoundException("Onboarding instance not found: " + stepInstance.getOnboardingInstanceId()));


### PR DESCRIPTION
… (previous commit only added the unused import)

Live testing against backend-stage caught that the prior commit added the InvalidRequestException import but left the throw statement itself as IllegalStateException, so the skip-non-optional-step guard still returned 511 instead of 400.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
