### PR TITLE
fix(slides): refuse writes when the editor value collapses, and stop rename carrying content

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -47,7 +47,11 @@ import { handlePublishSlide } from './slide-operations/handlePublishSlide';
 import { handleUnpublishSlide } from './slide-operations/handleUnpublishSlide';
 import { updateHeading } from './slide-operations/updateSlideHeading';
 import { formatHTMLString, stripAwsQueryParamsFromUrls } from './slide-operations/formatHtmlString';
-import { flattenSemanticWrappers, detectDeserializeLoss } from './slide-operations/doc-slide-integrity/reload';
+import {
+    flattenSemanticWrappers,
+    detectDeserializeLoss,
+    countSerializedBlocks,
+} from './slide-operations/doc-slide-integrity/reload';
 import { handleConvertAndUpload } from './slide-operations/handleConvertUpload';
 import { HtmlDocAiAuthor } from './html-doc/html-doc-ai-author';
 import { HTML_DOC_TYPE, isHtmlDocEmpty } from './html-doc/html-doc-utils';
@@ -416,16 +420,56 @@ export const SlideMaterial = ({
     // auto-save reads this to refuse a destructive overwrite. Reset on every
     // serialize; only the LAST serialize before a save matters.
     const lastSerializeDegradedRef = useRef(false);
+    // Timestamp of the last real user input inside the editor (keystroke, paste, cut,
+    // drag). Used to tell an intentional deletion from a programmatic collapse: only a
+    // deletion is preceded by input, so only a deletion may lower the content baseline.
+    const lastUserInputAtRef = useRef(0);
     // Layer-2 load integrity: set when the last DOC deserialize dropped blocks vs the
     // stored HTML (a lossy round-trip for some block type). Tagged with the slide it
     // was computed for. While set for the active slide, the DOC save path REFUSES to
     // overwrite `data` — otherwise the reduced editor state would be persisted and the
     // dropped content lost permanently. Recomputed on every content-apply.
-    const docLoadIntegrityRef = useRef<{ slideId: string | null; lossy: boolean; lost: string[] }>({
+    const docLoadIntegrityRef = useRef<{
+        slideId: string | null;
+        lossy: boolean;
+        lost: string[];
+        imagesInsideTables: number;
+    }>({
         slideId: null,
         lossy: false,
         lost: [],
+        imagesInsideTables: 0,
     });
+    /**
+     * The message shown when a slide loaded incompletely and we are refusing to save it.
+     *
+     * Two very different situations reach here, and telling them apart matters:
+     *  - Images inside a table cell: Yoopta has no representation for one, so it is
+     *    dropped on EVERY load. This is permanent — "reload and try again" loops the
+     *    author forever, because the loss happens DURING the load. Say what's wrong and
+     *    what would make the slide editable again.
+     *  - Anything else: treat as transient; a reload may genuinely fix it.
+     */
+    const describeLoadIntegrityFailure = (
+        integrity: { lost: string[]; imagesInsideTables: number },
+        action: 'saved' | 'published'
+    ): string => {
+        if (integrity.imagesInsideTables > 0) {
+            const n = integrity.imagesInsideTables;
+            return (
+                `This slide has ${n} image${n > 1 ? 's' : ''} inside a table, which the editor ` +
+                `cannot open or keep. It was NOT ${action}, so nothing is lost — your slide is ` +
+                `safe as-is. To edit it, the image${n > 1 ? 's' : ''} must be moved out of the ` +
+                'table first; please contact support.'
+            );
+        }
+        return (
+            'This slide did not load completely (' +
+            integrity.lost.join(', ') +
+            ` missing). To protect your content it was NOT ${action}. Please reload the page and try again.`
+        );
+    };
+
     // Dedup guard to prevent double-save on add + switch happening together
     const lastHandledPrevSlideIdRef = useRef<string | null>(null);
     // activeItem.id from the previous loadContent() run. Lets the DOC branch tell
@@ -690,7 +734,19 @@ export const SlideMaterial = ({
         };
 
         return (
-            <div className="relative w-full">
+            // Capture real user input so we can tell an intentional deletion from a
+            // programmatic collapse. Both look identical in the editor value; the only
+            // honest difference is that a deletion follows a keystroke/paste and a
+            // load-time reset does not. Capture phase so we see it even when a nested
+            // custom-block field stops propagation.
+            <div
+                className="relative w-full"
+                onKeyDownCapture={() => (lastUserInputAtRef.current = Date.now())}
+                onBeforeInputCapture={() => (lastUserInputAtRef.current = Date.now())}
+                onPasteCapture={() => (lastUserInputAtRef.current = Date.now())}
+                onCutCapture={() => (lastUserInputAtRef.current = Date.now())}
+                onDragEndCapture={() => (lastUserInputAtRef.current = Date.now())}
+            >
                 {showPlaceholder && (
                     <div
                         className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center text-gray-400"
@@ -728,6 +784,36 @@ export const SlideMaterial = ({
                                     const serializedHtml = formatHTMLString(currentContent || '');
                                     const targetSlideId =
                                         prevDocSlideRef.current?.id ?? activeItem?.id ?? null;
+                                    // Guard the BASELINE. setEditorValue also fires onChange,
+                                    // so a load-time reset / mid-reload collapse would other-
+                                    // wise overwrite currentDocHtmlRef with the collapsed HTML
+                                    // within 500ms — destroying the very reference the save
+                                    // path needs to notice the collapse (and re-poisoning the
+                                    // serialize-failure fallback). Only let the baseline drop
+                                    // sharply when a real keystroke/paste preceded it: an
+                                    // intentional deletion always follows user input, a
+                                    // programmatic collapse never does.
+                                    const prevBaseline =
+                                        currentDocHtmlRef.current.slideId === targetSlideId
+                                            ? currentDocHtmlRef.current.html
+                                            : null;
+                                    const prevBaselineBlocks = prevBaseline
+                                        ? countSerializedBlocks(prevBaseline)
+                                        : 0;
+                                    const nowBlocks = countSerializedBlocks(serializedHtml);
+                                    const userTypedRecently =
+                                        Date.now() - lastUserInputAtRef.current < 3000;
+                                    const unexplainedCollapse =
+                                        prevBaselineBlocks >= 3 &&
+                                        nowBlocks < prevBaselineBlocks * 0.5 &&
+                                        !userTypedRecently;
+                                    if (unexplainedCollapse) {
+                                        console.error(
+                                            `[Editor] value collapsed ${prevBaselineBlocks} -> ${nowBlocks} block(s) ` +
+                                                'with no user input — keeping the previous baseline and not stashing.'
+                                        );
+                                        return;
+                                    }
                                     currentDocHtmlRef.current = {
                                         slideId: targetSlideId,
                                         html: serializedHtml,
@@ -744,11 +830,24 @@ export const SlideMaterial = ({
                                     const isRealEdit =
                                         initialForThisSlide !== null &&
                                         serializedHtml !== initialForThisSlide;
+                                    // Never stash a serialization that lost blocks relative to
+                                    // the editor value. The stashed draft OUTRANKS server
+                                    // content on reopen, so laundering a collapsed serialize
+                                    // through localStorage makes the loss authoritative — and
+                                    // the load-integrity gate can't see it, because it then
+                                    // compares that partial draft against itself.
+                                    const editorBlocks = Object.keys(editor.children || {}).length;
+                                    const stashBlocks = countSerializedBlocks(serializedHtml);
+                                    const stashLostBlocks =
+                                        editorBlocks >= 3 &&
+                                        stashBlocks > 0 &&
+                                        stashBlocks < editorBlocks * 0.5;
                                     if (
                                         targetSlideId &&
                                         serializedHtml &&
                                         !checkIsHtmlEmpty(serializedHtml) &&
-                                        isRealEdit
+                                        isRealEdit &&
+                                        !stashLostBlocks
                                     ) {
                                         // guardShrink=false: continuous stash reflects the user's real
                                         // current content and must always win over an older draft.
@@ -1073,6 +1172,7 @@ export const SlideMaterial = ({
                 slideId: activeItem?.id ?? null,
                 lossy: loss.lossy,
                 lost: loss.lost,
+                imagesInsideTables: loss.imagesInsideTables,
             };
             if (loss.lossy) {
                 console.error(
@@ -1083,7 +1183,12 @@ export const SlideMaterial = ({
                 );
             }
         } catch {
-            docLoadIntegrityRef.current = { slideId: activeItem?.id ?? null, lossy: false, lost: [] };
+            docLoadIntegrityRef.current = {
+                slideId: activeItem?.id ?? null,
+                lossy: false,
+                lost: [],
+                imagesInsideTables: 0,
+            };
         }
 
         const processNode = (node: any): any => {
@@ -1376,47 +1481,95 @@ export const SlideMaterial = ({
                     .join('');
             }
             const formatted = formatHTMLString(htmlString);
+
+            // ---- Save-side integrity: two independent checks ----
+            // Both compare the HTML we are about to persist against a baseline that a
+            // REAL user deletion would have already moved. Neither can fire on intent.
+            const inBlockCount = Object.keys((data || {}) as Record<string, unknown>).length;
+            const outBlockCount = countSerializedBlocks(formatted);
+
+            // (1) Serializer dropped blocks: the editor value holds them, the HTML
+            // doesn't. Catches silent drops that never throw (the per-block fallback
+            // above only sees blocks whose serializer raised).
+            if (inBlockCount >= 3 && outBlockCount > 0 && outBlockCount < inBlockCount * 0.5) {
+                lastSerializeDegradedRef.current = true;
+                console.error(
+                    `[Save] serialize emitted ${outBlockCount} block(s) from an editor holding ` +
+                        `${inBlockCount} — treating as degraded; refusing to overwrite stored content.`
+                );
+            }
+
+            // (2) The editor VALUE itself collapsed — the case (1) is blind to, because
+            // a collapsed value serializes faithfully (0 in -> 0 out, 1 in -> 1 out).
+            // Seen live: a rename/slide-switch reload leaves the editor empty or
+            // holding only the focused block for a window, while the screen still shows
+            // the full slide. Saving in that window is what wiped published lessons
+            // (58KB -> a single 3KB quiz block). Compare against the last GOOD serialize
+            // of THIS slide: a real deletion lands there first via the onChange stash,
+            // so this only fires when content vanished without the user touching it.
+            const baselineSlideId = prevDocSlideRef.current?.id ?? activeItem?.id ?? null;
+            const prevGoodHtml =
+                currentDocHtmlRef.current.slideId === baselineSlideId
+                    ? currentDocHtmlRef.current.html
+                    : null;
+            const prevGoodBlocks = prevGoodHtml ? countSerializedBlocks(prevGoodHtml) : 0;
+            const collapsedVsBaseline =
+                prevGoodBlocks >= 3 && outBlockCount < prevGoodBlocks * 0.5;
+            if (collapsedVsBaseline) {
+                lastSerializeDegradedRef.current = true;
+                console.error(
+                    `[Save] editor collapsed: about to write ${outBlockCount} block(s) where this ` +
+                        `slide last held ${prevGoodBlocks}. Refusing — the editor is mid-reload, ` +
+                        'not edited down. (rename / slide-switch race)'
+                );
+            }
+
             // Keep the last-known-good snapshot in sync so future serialize
             // failures (e.g. the Yoopta accordion "Cannot find descendant
             // at path" Slate bug) have something to fall back to. Only cache a
-            // NON-empty result: a transient empty/degenerate serialize (e.g.
-            // mid slide-switch) must not poison the fallback, or the catch
-            // block below would itself recover empty content and lose work.
-            if (!checkIsHtmlEmpty(formatted)) {
+            // NON-empty, NON-collapsed result: a transient empty/degenerate
+            // serialize (e.g. mid slide-switch) must not poison the fallback, or
+            // the catch block below would itself recover reduced content.
+            if (!checkIsHtmlEmpty(formatted) && !collapsedVsBaseline) {
                 currentDocHtmlRef.current = {
-                    slideId: prevDocSlideRef.current?.id ?? activeItem?.id ?? null,
+                    slideId: baselineSlideId,
                     html: formatted,
                 };
             }
             return formatted;
         } catch (error) {
-            console.error('Error serializing content in getCurrentEditorHTMLContent:', error);
-            // Serialize blew up (typically Yoopta/Slate throwing on a
-            // partially-normalized accordion/custom-block state). The value we
-            // return here is a FALLBACK, not a faithful serialization of the
-            // live editor — mark it degraded so the silent auto-save won't treat
-            // it as an authoritative new version to overwrite stored data with.
-            lastSerializeDegradedRef.current = true;
-            // Fall back to the most recent successfully-serialized HTML
-            // (captured on every onChange), then to the slide's stored
-            // data. Returning '' used to land in SaveDraft's empty-guard
-            // and surface "Could not read editor content" — we'd rather
-            // preserve prior content than lose work.
-            // Only reuse the cached HTML if it belongs to the slide currently in
-            // the editor — otherwise it's a DIFFERENT slide's content, and handing
-            // it back here is exactly how one slide's data bleeds into another.
-            if (
-                currentDocHtmlRef.current.html &&
-                currentDocHtmlRef.current.slideId ===
-                    (prevDocSlideRef.current?.id ?? activeItem?.id)
-            ) {
-                return currentDocHtmlRef.current.html;
-            }
-            if (activeItem?.document_slide?.data) {
-                return activeItem.document_slide.data;
-            }
-            return '';
+            return getCurrentEditorHTMLContentFallback(error);
         }
+    };
+
+    // The serialize-threw path, extracted so the happy path can return early.
+    // Behaviour unchanged from the original catch block.
+    const getCurrentEditorHTMLContentFallback = (error: unknown): string => {
+        console.error('Error serializing content in getCurrentEditorHTMLContent:', error);
+        // Serialize blew up (typically Yoopta/Slate throwing on a
+        // partially-normalized accordion/custom-block state). The value we
+        // return here is a FALLBACK, not a faithful serialization of the
+        // live editor — mark it degraded so no write path treats it as an
+        // authoritative new version to overwrite stored data with.
+        lastSerializeDegradedRef.current = true;
+        // Fall back to the most recent successfully-serialized HTML
+        // (captured on every onChange), then to the slide's stored
+        // data. Returning '' used to land in SaveDraft's empty-guard
+        // and surface "Could not read editor content" — we'd rather
+        // preserve prior content than lose work.
+        // Only reuse the cached HTML if it belongs to the slide currently in
+        // the editor — otherwise it's a DIFFERENT slide's content, and handing
+        // it back here is exactly how one slide's data bleeds into another.
+        if (
+            currentDocHtmlRef.current.html &&
+            currentDocHtmlRef.current.slideId === (prevDocSlideRef.current?.id ?? activeItem?.id)
+        ) {
+            return currentDocHtmlRef.current.html;
+        }
+        if (activeItem?.document_slide?.data) {
+            return activeItem.document_slide.data;
+        }
+        return '';
     };
 
     // Unified handler to check and handle unsaved DOC changes for the previous slide
@@ -3140,24 +3293,24 @@ export const SlideMaterial = ({
                 docLoadIntegrityRef.current.lossy &&
                 docLoadIntegrityRef.current.slideId === slide?.id
             ) {
-                toast.error(
-                    'This slide did not load completely (' +
-                        docLoadIntegrityRef.current.lost.join(', ') +
-                        ' missing). To protect your content it was NOT saved. Please reload the page and try again.'
-                );
+                toast.error(describeLoadIntegrityFailure(docLoadIntegrityRef.current, 'saved'));
                 return;
             }
 
             const currentHtml = getCurrentEditorHTMLContent();
 
-            // Explicit Save proceeds on user intent, but if a block's serializer
-            // threw it was dropped from currentHtml — tell the user so the loss
-            // isn't silent (the silent auto-save-on-switch already refuses this).
+            // A degraded serialize is NOT user intent — the editor still holds the
+            // blocks; only the HTML we just produced is missing them. Persisting it
+            // writes that loss into `data`, which is what an UNSYNC slide reopens
+            // from, so the blocks are gone on the next load. Refuse, like the
+            // auto-save and publish paths do. (This used to warn and save anyway.)
             if (lastSerializeDegradedRef.current) {
-                toast.warning(
-                    'A block on this slide could not be saved and was left out. ' +
-                        'Please check the slide — you may need to re-create that block.'
+                toast.error(
+                    'This slide could not be read correctly, so it was NOT saved. ' +
+                        'Your saved content is safe — reload the page to get it back, then redo ' +
+                        'any recent edits.'
                 );
+                return;
             }
 
             // Process images in HTML content before saving
@@ -3865,16 +4018,35 @@ export const SlideMaterial = ({
                                                             activeItem?.id
                                                     ) {
                                                         toast.error(
-                                                            'This slide did not load completely (' +
-                                                                docLoadIntegrityRef.current.lost.join(
-                                                                    ', '
-                                                                ) +
-                                                                ' missing). Publish blocked to protect your content. Please reload the page.'
+                                                            describeLoadIntegrityFailure(
+                                                                docLoadIntegrityRef.current,
+                                                                'published'
+                                                            )
                                                         );
                                                         setIsPublishDialogOpen(false);
                                                         return;
                                                     }
                                                     let currentHtml = getCurrentEditorHTMLContent();
+                                                    // A degraded serialize means blocks were
+                                                    // DROPPED from currentHtml — the editor holds
+                                                    // more than this HTML represents. The
+                                                    // switch-time auto-save already refuses to
+                                                    // persist that; publish MUST too. Publish is
+                                                    // the only writer of published_data, so an
+                                                    // unguarded write here replaces the live slide
+                                                    // with the fragment that survived
+                                                    // serialization. The author only ever sees the
+                                                    // server's "this will remove N blocks"
+                                                    // confirm, which reads as a false alarm after
+                                                    // they've merely ADDED content — they click OK
+                                                    // and the lesson is gone.
+                                                    if (lastSerializeDegradedRef.current) {
+                                                        toast.error(
+                                                            'Some blocks on this slide could not be read, so publishing was stopped to protect your content. Please reload the page and try again.'
+                                                        );
+                                                        setIsPublishDialogOpen(false);
+                                                        return;
+                                                    }
                                                     if (containsBase64Images(currentHtml)) {
                                                         const { processedHtml } =
                                                             await processHtmlImages(currentHtml);

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
@@ -60,6 +60,15 @@ export interface DeserializeLossReport {
     lossy: boolean;
     /** Human-readable list of what was dropped, e.g. ["1 table", "2 heading(s)"]. */
     lost: string[];
+    /**
+     * Images sitting INSIDE a table cell. Yoopta's table has no representation for an
+     * image, so these are dropped on every single load — the editor cannot even create
+     * this shape (it arrives via AI-generated HTML or a paste). This is therefore a
+     * PERMANENT condition, not a transient glitch: telling the author to "reload and try
+     * again" loops them forever, because the loss happens DURING the load. Surfaced
+     * separately so the save gate can explain the real reason instead.
+     */
+    imagesInsideTables: number;
 }
 
 /**
@@ -82,8 +91,13 @@ export function detectDeserializeLoss(
     deserializedValue: Record<string, any>
 ): DeserializeLossReport {
     const lost: string[] = [];
+    let imagesInsideTables = 0;
     try {
         const doc = new DOMParser().parseFromString(sourceHtml || '', 'text/html');
+
+        // Count images inside tables BEFORE any stripping — these are unrepresentable
+        // in a Yoopta table and are dropped on every load (see the interface docs).
+        imagesInsideTables = doc.body.querySelectorAll('table img').length;
 
         // Source custom blocks (by data-yoopta-type), counted BEFORE stripping.
         const srcCustom: Record<string, number> = {};
@@ -121,9 +135,41 @@ export function detectDeserializeLoss(
         if (srcHeading > edHeading) lost.push(`${srcHeading - edHeading} heading(s)`);
     } catch {
         // Detection must never throw or block a load — treat as non-lossy on failure.
-        return { lossy: false, lost: [] };
+        return { lossy: false, lost: [], imagesInsideTables: 0 };
     }
-    return { lossy: lost.length > 0, lost };
+    return { lossy: lost.length > 0, lost, imagesInsideTables };
+}
+
+/**
+ * Count the top-level blocks in HTML produced by html.serialize + formatHTMLString.
+ * Yoopta emits one element per block; formatHTMLString then wraps the lot in plain
+ * <div>s, so we descend through those wrappers before counting. Used by the save-side
+ * integrity check to compare serialize INPUT (the editor value) against OUTPUT.
+ */
+export function countSerializedBlocks(serializedHtml: string): number {
+    if (!serializedHtml) return 0;
+    try {
+        const doc = new DOMParser().parseFromString(serializedHtml, 'text/html');
+        let root: Element = doc.body;
+        // Descend only through plain wrapper divs — never into a real block (a custom
+        // block root, or a div that IS the block, e.g. the mermaid/image wrapper).
+        while (root.children.length === 1) {
+            const only = root.children[0];
+            if (
+                !only ||
+                only.tagName !== 'DIV' ||
+                only.hasAttribute('data-yoopta-type') ||
+                only.classList.contains('mermaid')
+            ) {
+                break;
+            }
+            root = only;
+        }
+        return root.children.length;
+    } catch {
+        // Never let the check itself break a save; 0 disables the comparison.
+        return 0;
+    }
 }
 
 export function appReloadPreprocess(storedHtml: string): string {

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
@@ -18,7 +18,7 @@ import { createYooptaEditor } from '@yoopta/editor';
 import { html } from '@yoopta/exports';
 import { plugins } from '@/constants/study-library/yoopta-editor-plugins-tools';
 import { formatHTMLString, stripAwsQueryParamsFromUrls } from '../formatHtmlString';
-import { appReloadPreprocess, detectDeserializeLoss } from './reload';
+import { appReloadPreprocess, detectDeserializeLoss, countSerializedBlocks } from './reload';
 
 // Register the app's real plugins onto a bare editor, mirroring
 // slide-material.tsx applyDocContentToEditor() so serialize/deserialize
@@ -571,5 +571,93 @@ describe('DOC slide: load-integrity detector flags a lossy deserialize (Layer 2)
         const r = detectDeserializeLoss(src, value as any);
         expect(r.lossy).toBe(true);
         expect(r.lost.join(' ')).toMatch(/flashcard/);
+    });
+});
+
+/**
+ * Save-side integrity (the "publish wiped my lesson" incident, 2026-07-17).
+ *
+ * Prod forensics: a slide's published_data went 47864B -> 3267B, where 3267B was
+ * exactly ONE block (the quizBlock the author had been editing). The serializer had
+ * dropped every other block; publish had no degraded-guard, so it shipped the
+ * fragment, and the server's "this will remove N blocks" confirm read as a false
+ * alarm to an author who had only ADDED content. They clicked OK; the lesson was gone.
+ *
+ * The invariant: the editor VALUE is the source of truth for author intent — a real
+ * deletion is already reflected there. So serialize emitting materially fewer blocks
+ * than the value holds is ALWAYS a bug, never a deletion.
+ */
+/**
+ * Images inside table cells (prod slide 4f31649f "Lesson 5", 2026-07-17).
+ * Yoopta's table cannot hold an image, so html.deserialize drops it on EVERY load —
+ * the editor cannot even create this shape (it arrives via AI-generated HTML or a
+ * paste). The load gate then refuses to save, which is correct but must be explained
+ * honestly: this is permanent, so "reload and try again" would loop the author forever.
+ */
+describe('detectDeserializeLoss — images inside table cells', () => {
+    it('reports images nested in a table cell', () => {
+        const src =
+            '<table><tbody><tr><td><div><img src="a.jpg"/></div></td><td><img src="b.jpg"/></td></tr></tbody></table>';
+        // The table survived as a block; its images did not.
+        const value = { t: blk(0, 'Table', 'table', '') };
+        const r = detectDeserializeLoss(src, value as any);
+        expect(r.imagesInsideTables).toBe(2);
+        expect(r.lossy).toBe(true);
+        expect(r.lost.join(' ')).toMatch(/image/);
+    });
+
+    it('does NOT count standalone images as in-table', () => {
+        const src = '<p>x</p><img src="a.jpg"/>';
+        const value = { i: blk(0, 'Image', 'image', '') };
+        expect(detectDeserializeLoss(src, value as any).imagesInsideTables).toBe(0);
+    });
+
+    it('reports zero when detection fails rather than blocking a load', () => {
+        const r = detectDeserializeLoss('', {} as any);
+        expect(r.imagesInsideTables).toBe(0);
+        expect(r.lossy).toBe(false);
+    });
+});
+
+describe('countSerializedBlocks — save-side block accounting', () => {
+    // Mirrors the guard predicate in slide-material.tsx getCurrentEditorHTMLContent().
+    const isDegraded = (inBlocks: number, outBlocks: number) =>
+        inBlocks >= 3 && outBlocks > 0 && outBlocks < inBlocks * 0.5;
+
+    const wrap = (inner: string) => `<html><head></head><body><div>${inner}</div></body></html>`;
+
+    it('counts each top-level block, seeing through formatHTMLString wrappers', () => {
+        const h = wrap('<h2>a</h2><p>b</p><table><tr><td>c</td></tr></table>');
+        expect(countSerializedBlocks(h)).toBe(3);
+    });
+
+    it('counts a lone custom block as 1 and does not descend into it', () => {
+        // The exact shape of the 3267B payload that wiped the live slide.
+        const h = wrap('<div data-yoopta-type="quizBlock" data-quiz="eyJ4IjoxfQ=="><p>q</p></div>');
+        expect(countSerializedBlocks(h)).toBe(1);
+    });
+
+    it('FIRES when serialization collapses a full slide to the focused block', () => {
+        // Editor holds 119 blocks; serialize emitted 1. This is the incident.
+        expect(isDegraded(119, 1)).toBe(true);
+    });
+
+    it('does NOT fire on a healthy serialize', () => {
+        expect(isDegraded(119, 119)).toBe(false);
+    });
+
+    it('does NOT fire when the author genuinely deletes almost everything', () => {
+        // The deletion is reflected in the VALUE, so in and out shrink together.
+        expect(isDegraded(1, 1)).toBe(false);
+        expect(isDegraded(2, 2)).toBe(false);
+    });
+
+    it('does NOT fire on a small slide, where ratios are noisy', () => {
+        expect(isDegraded(2, 1)).toBe(false);
+    });
+
+    it('stays silent when counting fails rather than blocking a save', () => {
+        expect(countSerializedBlocks('')).toBe(0);
+        expect(isDegraded(119, 0)).toBe(false); // out=0 disables the comparison
     });
 });

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/updateSlideHeading.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/updateSlideHeading.tsx
@@ -118,10 +118,16 @@ export const updateHeading = async (
                 document_slide: {
                     id: activeItem?.document_slide?.id || '',
                     type: activeItem?.document_slide?.type || '',
-                    data:
-                        activeItem.status == 'PUBLISHED'
-                            ? activeItem.document_slide?.published_data || null
-                            : activeItem.document_slide?.data || null,
+                    // A rename must NOT carry content. This used to send the STORE's copy
+                    // of the slide (never the live editor's), which meant renaming while
+                    // you had unsaved edits silently reverted them — and made the rename
+                    // one more writer that could persist a stale/collapsed document.
+                    // null is safe: handleDraft/handleUnsyncDocumentSlide only write
+                    // `data` when it is non-null (SlideService.java), while the title is
+                    // applied from the DTO regardless. Status stays UNSYNC/DRAFT as
+                    // before, so this never reaches handlePublishedDocumentSlide (which
+                    // WOULD republish `data` when published_data is null).
+                    data: null,
                     title: heading,
                     cover_file_id: activeItem.document_slide?.cover_file_id || '',
                     total_pages: activeItem?.document_slide?.total_pages || 0,


### PR DESCRIPTION
## Summary of Changes

A published lesson could be silently replaced by a single block. Prod forensics (`slide_content_history`) show one slide going `published_data` 47,864B -> 3,267B, 86,524B -> 1,663B and 80,933B -> 526B in a single morning — each tiny payload being exactly ONE block (the quizBlock / table / image the author had just been editing).

**Root cause:** after a rename (and on slide-switch reloads) the editor's value is briefly **empty or partially applied** while the screen still shows the full slide. `getEditorValue()` then returns that collapsed value, it serializes faithfully (no throw, no error), and the save path persists it. The author only ever saw the server's "This will remove N blocks" confirm — which reads as a false alarm to someone who has only ADDED content — clicked OK, and the lesson was gone.

Reproduced locally: renaming a slide, then saving, logged `editor returned empty content` while the slide was visibly full.

**Frontend:**
- `getCurrentEditorHTMLContent`: refuse a write when the content collapsed. Two checks — (1) serializer dropped blocks the editor value still holds; (2) **the editor value itself collapsed**, compared against the last known-good serialize of this slide. (2) is the one that matters: a collapsed value serializes faithfully (0 in -> 0 out, 1 in -> 1 out), so a self-comparison is blind to it.
- `onChange`: stop overwriting the content baseline (and the localStorage stash) with a collapsed value. `setEditorValue` also fires `onChange`, so the collapse would otherwise become the baseline within 500ms and blind every downstream guard.
- Distinguish an intentional deletion from a programmatic collapse by tracking real user input (keydown/beforeinput/paste/cut) in the editor. **A deletion always follows a keystroke; a load-time collapse never does.** The two are indistinguishable in a single snapshot — only over time. This is what keeps the guards from firing on genuine edits.
- Publish now honours the degraded-serialize flag. It was the ONLY writer of `published_data` without that check, while auto-save and Save Draft both had it — which is exactly why every observed wipe was publish-shaped and none came from a slide switch.
- Rename (`updateSlideHeading`) no longer carries content: it sent the STORE's copy of the slide (never the live editor's), so renaming with unsaved edits silently reverted them. Now sends `data: null` — `handleDraft/handleUnsyncDocumentSlide` skip a null `data`, and the title still applies.
- Images inside table cells: Yoopta cannot represent one, so they are dropped on every load and the gate blocks the save. Previously the message said "reload and try again", which can never work (the loss happens DURING the load) — it now explains the real, permanent reason instead of looping the author. Affects 1 slide in prod.

## Related Issue

Reported by Edustream: "seeing data-loss prompts even though I only added content to the slide."

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- **Collapse blocked (the real bug), live against a local backend + prod-dump DB:** loaded a real 87KB / 112-block copy of the affected slide, forced the value to 1 block, hit Save Draft. Both layers fired (`value collapsed 112 -> 1 with no user input`, `about to write 1 block(s) where this slide last held 112`), no request was sent, and the DB stayed at 87,472B / 23 blocks. Before this change that same sequence wrote the fragment over the lesson.
- **No false positive on a genuine deletion:** deleted a large chunk by keyboard, Save Draft. The FE guard stayed silent, the request went out, the backend's structural-loss confirm appeared (correctly — 2 fillBlanks + 6 quizBlocks really were removed), and force-override persisted 87,472B -> 62,327B. `published_data` untouched.
- **Rename:** verified live that the write now carries `data: NULL` / `published_data: NULL` while the title updates and content is untouched.
- **Round-trip is lossless on the real content** (5 real slides through the actual pipeline, `degraded=false`), confirming the fix targets the collapse and not a serializer bug.
- Unit tests: 31 pass (10 new) — block accounting, collapse-vs-deletion, images-in-table detection, and the no-false-positive cases.
- `tsc --noEmit`: 0 errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

## Follow-ups (not in this PR)

- **`applyDocContentToEditor` runs twice per load** — two deserializes racing on one editor, the likely source of the collapse window. This PR is the net under it; that is the cure.
- **Two slides are currently sitting wiped in prod** and are recoverable from `slide_content_history`: "Lesson 5" (748B live vs 59,640B in history) and "Proteins: Structure and Digestion Overview" (1,852B vs 9,139B).
- Backend `describeStructuralLoss` pluralisation prints "2 fillBlankss".
