### PR TITLE
feat(live-session): send WhatsApp on live-session form submission (webinar seat confirmation)

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LiveSessionWorkflowAsyncHelper.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LiveSessionWorkflowAsyncHelper.java
@@ -51,4 +51,32 @@ public class LiveSessionWorkflowAsyncHelper {
                     session.getId(), e.getMessage(), e);
         }
     }
+
+    /**
+     * Fires {@code LIVE_SESSION_FORM_SUBMISSION} after a guest submits a session's
+     * public registration form. Scoped by session id, so a trigger can be configured
+     * for one webinar without firing for every public session in the institute.
+     *
+     * <p>Async because the caller is an unauthenticated public form POST: the guest
+     * should not wait on a WhatsApp/email round-trip, and a notification failure must
+     * never fail a registration that is already committed. Pinned to the bounded
+     * {@code workflowTaskExecutor} (not the default unbounded SimpleAsyncTaskExecutor)
+     * so a burst of registrations for a popular webinar cannot spawn unbounded threads.
+     */
+    @Async("workflowTaskExecutor")
+    public void fireLiveSessionFormSubmissionWorkflow(String sessionId,
+                                                      String instituteId,
+                                                      Map<String, Object> contextData) {
+        if (sessionId == null || instituteId == null) return;
+        try {
+            workflowTriggerService.handleTriggerEvents(
+                    WorkflowTriggerEvent.LIVE_SESSION_FORM_SUBMISSION.name(),
+                    sessionId,
+                    instituteId,
+                    contextData);
+        } catch (Exception e) {
+            log.warn("Async LIVE_SESSION_FORM_SUBMISSION workflow failed for sessionId={}: {}",
+                    sessionId, e.getMessage(), e);
+        }
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/RegistrationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/RegistrationService.java
@@ -1,24 +1,50 @@
 package vacademy.io.admin_core_service.features.live_session.service;
 
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import vacademy.io.admin_core_service.features.live_session.dto.GuestRegistrationRequestDTO;
-import vacademy.io.admin_core_service.features.common.entity.CustomFieldValues;
+import vacademy.io.admin_core_service.features.common.entity.CustomFields;
+import vacademy.io.admin_core_service.features.common.repository.CustomFieldRepository;
+import vacademy.io.admin_core_service.features.live_session.entity.LiveSession;
 import vacademy.io.admin_core_service.features.live_session.entity.SessionGuestRegistration;
+import vacademy.io.admin_core_service.features.common.entity.CustomFieldValues;
 import vacademy.io.admin_core_service.features.common.repository.CustomFieldValuesRepository;
+import vacademy.io.admin_core_service.features.live_session.repository.LiveSessionRepository;
 import vacademy.io.admin_core_service.features.live_session.repository.SessionGuestRegistrationRepository;
+import vacademy.io.admin_core_service.features.live_session.util.GuestFormFieldResolver;
+import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
+import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 public class RegistrationService {
 
     @Autowired
     SessionGuestRegistrationRepository sessionGuestRegistration;
     @Autowired
     CustomFieldValuesRepository customFieldValuesRepository;
+    @Autowired
+    CustomFieldRepository customFieldRepository;
+    @Autowired
+    LiveSessionRepository liveSessionRepository;
+    @Autowired
+    LiveSessionWorkflowAsyncHelper liveSessionWorkflowAsyncHelper;
+    @Autowired
+    WorkflowTriggerService workflowTriggerService;
 
 
     public String registerGuest(String email, String sessionId) {
@@ -57,6 +83,182 @@ public class RegistrationService {
 
             customFieldValuesRepository.save(value);
         }
+
+        scheduleFormSubmissionWorkflow(requestDto, guestUserId);
         return guestUserId;
+    }
+
+    /**
+     * Schedules the {@code LIVE_SESSION_FORM_SUBMISSION} emit to run strictly AFTER the
+     * registration commits.
+     *
+     * <p>Nothing in the emit — not even the trigger-existence lookup — runs inside the
+     * registration transaction. That matters: a JPQL read here would force Hibernate to
+     * flush the just-inserted guest rows early, so a genuine constraint failure (dangling
+     * custom_field_id, the unique (session_id, email) race, a session deleted mid-submit)
+     * would surface at our query and be swallowed instead of surfacing cleanly at commit.
+     * Running post-commit keeps the registration's own success/failure path byte-for-byte
+     * unchanged, and {@code afterCommit} only fires when the commit actually succeeded, so
+     * a rolled-back registration never emits.
+     */
+    private void scheduleFormSubmissionWorkflow(GuestRegistrationRequestDTO requestDto, String guestUserId) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    emitFormSubmissionWorkflow(requestDto, guestUserId);
+                }
+            });
+        } else {
+            // No active transaction (defensive): the writes above auto-committed, emit now.
+            emitFormSubmissionWorkflow(requestDto, guestUserId);
+        }
+    }
+
+    /**
+     * Emits {@code LIVE_SESSION_FORM_SUBMISSION} so admins can hang a workflow (e.g. a
+     * WhatsApp seat-confirmation) off a public registration form. Runs after commit.
+     *
+     * <p>Never throws — a notification problem must not fail or disturb the registration,
+     * which has already committed by the time this runs.
+     *
+     * <p>Gated on an existing trigger so this is inert for every institute/session that
+     * hasn't configured one: the only cost on that (overwhelmingly common) path is a
+     * session lookup plus one indexed trigger lookup — no context is built and no async
+     * thread is spawned.
+     */
+    private void emitFormSubmissionWorkflow(GuestRegistrationRequestDTO requestDto, String guestUserId) {
+        try {
+            Optional<LiveSession> sessionOpt = liveSessionRepository.findById(requestDto.getSessionId());
+            if (sessionOpt.isEmpty()) {
+                log.warn("Skipping LIVE_SESSION_FORM_SUBMISSION: no live session for id={}", requestDto.getSessionId());
+                return;
+            }
+            LiveSession session = sessionOpt.get();
+            String instituteId = session.getInstituteId();
+            if (instituteId == null || instituteId.isBlank()) {
+                log.warn("Skipping LIVE_SESSION_FORM_SUBMISSION: session {} has no instituteId", session.getId());
+                return;
+            }
+
+            boolean triggerConfigured = workflowTriggerService
+                    .findByInstituteIdEventNameAndEventId(
+                            instituteId,
+                            WorkflowTriggerEvent.LIVE_SESSION_FORM_SUBMISSION.name(),
+                            session.getId())
+                    .isPresent();
+            if (!triggerConfigured) {
+                return;
+            }
+
+            Map<String, Object> contextData = buildContext(requestDto, guestUserId, session, instituteId);
+            dispatchFormSubmissionWorkflow(session.getId(), instituteId, contextData);
+        } catch (Exception e) {
+            log.warn("Failed to emit LIVE_SESSION_FORM_SUBMISSION for sessionId={}: {}",
+                    requestDto.getSessionId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Hands the trigger to the async helper, swallowing any dispatch-time failure
+     * (e.g. executor rejection). The async work itself is fire-and-forget; the guest's
+     * registration has already committed and must not be affected either way.
+     */
+    private void dispatchFormSubmissionWorkflow(String sessionId, String instituteId,
+                                                Map<String, Object> contextData) {
+        try {
+            liveSessionWorkflowAsyncHelper.fireLiveSessionFormSubmissionWorkflow(
+                    sessionId, instituteId, contextData);
+        } catch (Exception e) {
+            log.warn("Failed to dispatch LIVE_SESSION_FORM_SUBMISSION workflow for sessionId={}: {}",
+                    sessionId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Builds the workflow context for one guest submission.
+     *
+     * <p>The form is entirely admin-defined custom fields, so the guest's name and phone
+     * are resolved via {@link GuestFormFieldResolver} rather than read from fixed columns.
+     * Answers are exposed under both their field key and their (lowercased) label so a
+     * workflow can reference whichever is stable for that institute, and {@code guests}
+     * is a single-element list so a SEND_WHATSAPP node can iterate it the same way it
+     * iterates a QUERY result.
+     */
+    private Map<String, Object> buildContext(GuestRegistrationRequestDTO requestDto,
+                                             String guestUserId,
+                                             LiveSession session,
+                                             String instituteId) {
+        List<GuestRegistrationRequestDTO.CustomFieldValueDTO> submitted =
+                requestDto.getCustomFields() == null ? List.of() : requestDto.getCustomFields();
+
+        List<String> fieldIds = submitted.stream()
+                .map(GuestRegistrationRequestDTO.CustomFieldValueDTO::getCustomFieldId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toList());
+
+        Map<String, CustomFields> fieldsById = new HashMap<>();
+        if (!fieldIds.isEmpty()) {
+            for (CustomFields field : customFieldRepository.findAllById(fieldIds)) {
+                fieldsById.put(field.getId(), field);
+            }
+        }
+
+        Map<String, Object> byKey = new LinkedHashMap<>();
+        Map<String, Object> byName = new LinkedHashMap<>();
+        String fullName = null;
+        String mobileNumber = null;
+        String email = requestDto.getEmail();
+
+        for (GuestRegistrationRequestDTO.CustomFieldValueDTO answer : submitted) {
+            CustomFields field = fieldsById.get(answer.getCustomFieldId());
+            if (field == null) continue;
+
+            String value = answer.getValue();
+            if (field.getFieldKey() != null) byKey.put(field.getFieldKey(), value);
+            if (field.getFieldName() != null) byName.put(field.getFieldName().toLowerCase().trim(), value);
+
+            if (value == null || value.isBlank()) continue;
+            switch (GuestFormFieldResolver.classify(field.getFieldKey(), field.getFieldName())) {
+                case NAME -> {
+                    if (fullName == null) fullName = value.trim();
+                }
+                case PHONE -> {
+                    if (mobileNumber == null) mobileNumber = value.trim();
+                }
+                case EMAIL -> {
+                    if (email == null || email.isBlank()) email = value.trim();
+                }
+                default -> {
+                }
+            }
+        }
+
+        Map<String, Object> guest = new LinkedHashMap<>();
+        guest.put("guestRegistrationId", guestUserId);
+        guest.put("fullName", fullName);
+        guest.put("mobileNumber", mobileNumber);
+        guest.put("email", email);
+        guest.put("sessionId", session.getId());
+        guest.put("sessionTitle", session.getTitle());
+        guest.putAll(byName);
+
+        List<Map<String, Object>> guests = new ArrayList<>();
+        guests.add(guest);
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("instituteId", instituteId);
+        contextData.put("instituteIdForWhatsapp", instituteId);
+        contextData.put("sessionId", session.getId());
+        contextData.put("sessionTitle", session.getTitle());
+        contextData.put("guestRegistrationId", guestUserId);
+        contextData.put("fullName", fullName);
+        contextData.put("mobileNumber", mobileNumber);
+        contextData.put("email", email);
+        contextData.put("customFields", byKey);
+        contextData.put("customFieldsByName", byName);
+        contextData.put("liveSession", session);
+        contextData.put("guests", guests);
+        return contextData;
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/util/GuestFormFieldResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/util/GuestFormFieldResolver.java
@@ -1,0 +1,60 @@
+package vacademy.io.admin_core_service.features.live_session.util;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Identifies the "who is this person" fields (name / email / phone) inside a live
+ * session's public registration form.
+ *
+ * <p>A session's form is built entirely from admin-defined custom fields, so there is
+ * no fixed column to read a phone number from. Field keys are additionally suffixed
+ * per institute by {@code CustomFieldKeyGenerator} (e.g. {@code phone_number_inst_<uuid>},
+ * and {@code _1}/{@code _2} on collision), which rules out an exact-key match.
+ *
+ * <p>The substring rule here mirrors {@code getFieldRenderType} in the learner app's
+ * {@code custom-field-helpers.ts} — the same rule that decides a field renders as a
+ * phone input on the form. Keeping both ends on one rule is what stops a field that
+ * renders as a phone box from being invisible to notifications.
+ *
+ * <p>Matching runs email → name → phone so that a field like {@code contact_name}
+ * resolves to NAME rather than being claimed by the phone keyword {@code contact}.
+ * Institute-id suffixes are hex UUIDs and cannot contain these keywords.
+ */
+public final class GuestFormFieldResolver {
+
+    /** Field roles a registration form field can map to. */
+    public enum Role {
+        EMAIL, NAME, PHONE, OTHER
+    }
+
+    private static final List<String> EMAIL_KEYWORDS = List.of("email", "e-mail", "mail");
+    private static final List<String> NAME_KEYWORDS = List.of("name");
+    private static final List<String> PHONE_KEYWORDS = List.of("phone", "mobile", "contact", "telephone", "cell");
+
+    private GuestFormFieldResolver() {
+    }
+
+    /**
+     * Classifies a form field by its key and label. Either argument may be null —
+     * whichever is present is checked, key first.
+     */
+    public static Role classify(String fieldKey, String fieldName) {
+        String key = normalize(fieldKey);
+        String name = normalize(fieldName);
+
+        if (matches(key, EMAIL_KEYWORDS) || matches(name, EMAIL_KEYWORDS)) return Role.EMAIL;
+        if (matches(key, NAME_KEYWORDS) || matches(name, NAME_KEYWORDS)) return Role.NAME;
+        if (matches(key, PHONE_KEYWORDS) || matches(name, PHONE_KEYWORDS)) return Role.PHONE;
+        return Role.OTHER;
+    }
+
+    private static boolean matches(String value, List<String> keywords) {
+        if (value.isEmpty()) return false;
+        return keywords.stream().anyMatch(value::contains);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).trim();
+    }
+}

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/live_session/util/GuestFormFieldResolverTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/live_session/util/GuestFormFieldResolverTest.java
@@ -1,0 +1,68 @@
+package vacademy.io.admin_core_service.features.live_session.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static vacademy.io.admin_core_service.features.live_session.util.GuestFormFieldResolver.Role;
+import static vacademy.io.admin_core_service.features.live_session.util.GuestFormFieldResolver.classify;
+
+class GuestFormFieldResolverTest {
+
+    /** The institute-suffixed keys a real live session registration form submits. */
+    private static final String INST = "_inst_f5989aa0-eb6a-44b7-a43e-0e1d0271d014";
+
+    @Test
+    @DisplayName("resolves the real institute-suffixed keys of a live session form")
+    void resolvesInstituteSuffixedKeys() {
+        assertEquals(Role.NAME, classify("full_name" + INST, "Full Name"));
+        assertEquals(Role.EMAIL, classify("email" + INST, "Email"));
+        assertEquals(Role.PHONE, classify("phone_number" + INST, "Phone Number"));
+        assertEquals(Role.OTHER, classify("cuet_marks_out_of_1000" + INST, "CUET Marks out of 1000"));
+    }
+
+    @Test
+    @DisplayName("a hex institute-id suffix never swallows a keyword")
+    void suffixDoesNotCreateFalsePositives() {
+        // UUID suffixes are hex + dashes, so they cannot contain name/mail/phone.
+        assertEquals(Role.OTHER, classify("city" + INST, "City"));
+        assertEquals(Role.OTHER, classify("grade" + INST, "Grade"));
+    }
+
+    @Test
+    @DisplayName("matches the seeded institute defaults, which are not suffixed")
+    void resolvesUnsuffixedSeededDefaults() {
+        assertEquals(Role.NAME, classify("full_name", "Full Name"));
+        assertEquals(Role.EMAIL, classify("email", "Email"));
+        assertEquals(Role.PHONE, classify("phone_number", "Phone Number"));
+    }
+
+    @Test
+    @DisplayName("phone is found regardless of the label an admin picks")
+    void resolvesPhoneVariants() {
+        assertEquals(Role.PHONE, classify("mobile_number" + INST, "Mobile Number"));
+        assertEquals(Role.PHONE, classify("contact_number", "Contact Number"));
+        assertEquals(Role.PHONE, classify("telephone", "Telephone"));
+        assertEquals(Role.PHONE, classify("cell", "Cell"));
+        assertEquals(Role.PHONE, classify("whatsapp_no", "Phone"));
+    }
+
+    @Test
+    @DisplayName("email wins over name, and name wins over the 'contact' phone keyword")
+    void ordersOverlappingKeywords() {
+        // "contact_name" contains both a name and a phone keyword; a person's name is
+        // the correct read, and claiming it as a phone would send messages nowhere.
+        assertEquals(Role.NAME, classify("contact_name", "Contact Name"));
+        // "email" contains "mail"; it must not be read as anything else.
+        assertEquals(Role.EMAIL, classify("email_address", "Email Address"));
+    }
+
+    @Test
+    @DisplayName("classification survives casing, padding and missing arguments")
+    void handlesNullAndCasing() {
+        assertEquals(Role.PHONE, classify(null, "  Phone Number  "));
+        assertEquals(Role.NAME, classify("FULL_NAME", null));
+        assertEquals(Role.OTHER, classify(null, null));
+        assertEquals(Role.OTHER, classify("", ""));
+    }
+}


### PR DESCRIPTION
## What

Wires the `LIVE_SESSION_FORM_SUBMISSION` workflow trigger so a guest submitting a live-session public registration form can fire a workflow (e.g. a WhatsApp seat confirmation).

The trigger event was already declared in `WorkflowTriggerEvent` and shown in the admin trigger dropdown, but **no code ever raised it** — selecting it did nothing. This makes it real.

First user: Elevate Education (`f5989aa0-…`), CUET/IPMAT webinar session `c5095124-…`, template `webinarseatconfirm`.

## How

`RegistrationService.saveGuestUserDetails` now emits the event after a guest registers, scoped by session id (so a workflow targets one webinar), off the request thread via `LiveSessionWorkflowAsyncHelper`.

The public form is built entirely from admin-defined custom fields whose keys are institute-suffixed, so name/phone/email are resolved by a new `GuestFormFieldResolver` that mirrors the learner app's `getFieldRenderType` substring rule (unit-tested against the real production field keys). The workflow context exposes a single-element `guests` list (`mobileNumber`/`fullName`/`email`) plus the raw answers by key and by label, so a `SEND_WHATSAPP` node iterates it the same way it iterates a `QUERY` result.

## Registration behaviour is left untouched

- The **entire** emit — including the trigger-existence gate — runs in an `afterCommit` synchronization, **not** inside the registration transaction. A JPQL read inside the tx would force an early Hibernate flush of the guest inserts, so a real constraint failure (dangling `custom_field_id`, the unique `(session_id, email)` race, a session deleted mid-submit) would surface at our query and be swallowed instead of surfacing cleanly at commit. Post-commit, the registration's own success/failure path is byte-for-byte unchanged, and a rolled-back registration never emits.
- The emit is **gated** on `findByInstituteIdEventNameAndEventId`, so for every institute/session without a configured trigger (all of them today) it does a session lookup plus one indexed trigger lookup and stops — no context built, no thread spawned.
- The async fire is pinned to the bounded `workflowTaskExecutor` (not the default unbounded `SimpleAsyncTaskExecutor`), and both the dispatch and the whole emit swallow their exceptions — nothing here can 500 a committed registration.

## Verification

- `admin_core_service` compiles clean; `GuestFormFieldResolverTest` (6 cases) passes against the real production field keys.
- The WhatsApp send path was exercised end-to-end on prod for this institute (first WhatsApp it has ever sent): `webinarseatconfirm` went `SENT` → `DELIVERED` via Meta with the exact positional param the workflow produces.

## Deploy / rollout notes

- The workflow + trigger rows for the Elevate CUET session are **already seeded in prod** (session-specific, ephemeral data — deliberately not a Flyway migration). They are inert until this code deploys, since nothing emits the event yet.
- **After this deploys**, a guest registering on session `c5095124` gets the `webinarseatconfirm` WhatsApp automatically. No config change needed.
- Reminder messaging is out of scope here: `reminder_tomorrow` is a MARKETING template and is dropped by Meta's per-recipient cap (error 131049); a reliable reminder needs a UTILITY template (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)