### PR TITLE
fix(parent-portal): enrolment check accepts real statuses; /children …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/core/security/GuardianAccessGuard.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/core/security/GuardianAccessGuard.java
@@ -38,7 +38,6 @@ import java.util.List;
 public class GuardianAccessGuard {
 
     private static final String PARENT_ROLE = "PARENT";
-    private static final List<String> ACTIVE_STATUSES = List.of("ACTIVE");
 
     private final GuardianLinkCacheService guardianLinkCacheService;
     private final InstituteAccessValidator instituteAccessValidator;
@@ -175,7 +174,7 @@ public class GuardianAccessGuard {
 
     private GuardedChild buildContext(String childUserId, String instituteId, String fullName) {
         List<String> packageSessionIds = ssigmRepository
-                .findPackageSessionIdsByUserIdAndInstituteAndStatusIn(childUserId, instituteId, ACTIVE_STATUSES);
+                .findEnrolledPackageSessionIds(childUserId, instituteId);
         if (packageSessionIds == null || packageSessionIds.isEmpty()) {
             throw new ForbiddenException("Child is not enrolled in this institute");
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
@@ -108,6 +108,24 @@ public interface StudentSessionInstituteGroupMappingRepository
       @Param("instituteId") String instituteId,
       @Param("statuses") List<String> statuses);
 
+  /**
+   * Package sessions a learner is enrolled in within one institute, excluding only
+   * TERMINAL states. Used by the parent-portal guard's enrolment leg. Deliberately an
+   * EXCLUDE-list, case-insensitive: the status column is dirty in prod ('ACTIVE' vs
+   * 'Active', plus INVITED/PENDING/INACTIVE/null), so an ACTIVE-only allow-list wrongly
+   * 403s genuinely-enrolled children. Empty result = the child is not in this institute.
+   */
+  @Query(value = """
+      SELECT DISTINCT package_session_id FROM student_session_institute_group_mapping
+      WHERE user_id = :userId
+        AND institute_id = :instituteId
+        AND package_session_id IS NOT NULL
+        AND (status IS NULL OR UPPER(status) NOT IN ('DELETED', 'DELETED1', 'TERMINATED', 'EXPIRED'))
+      """, nativeQuery = true)
+  List<String> findEnrolledPackageSessionIds(
+      @Param("userId") String userId,
+      @Param("instituteId") String instituteId);
+
   @Query(value = """
       SELECT * FROM student_session_institute_group_mapping
       WHERE user_id = :userId

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentPortalChildrenService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentPortalChildrenService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.core.security.GuardianAccessGuard;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.learner.dto.StudentInstituteInfoDTO;
 import vacademy.io.admin_core_service.features.learner.manager.LearnerInstituteManager;
 import vacademy.io.admin_core_service.features.parent_portal.dto.ParentChildSummaryDTO;
@@ -13,7 +14,9 @@ import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.institute.dto.PackageSessionDTO;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The {@code /children} listing — the child-picker backend.
@@ -32,6 +35,7 @@ public class ParentPortalChildrenService {
     private final GuardianAccessGuard guard;
     private final LearnerInstituteManager learnerInstituteManager;
     private final ParentPortalSettingService settingService;
+    private final StudentSessionInstituteGroupMappingRepository ssigmRepository;
 
     public List<ParentChildSummaryDTO> listChildren(CustomUserDetails caller, String instituteId) {
         settingService.requireEnabled(instituteId);
@@ -42,13 +46,39 @@ public class ParentPortalChildrenService {
             if (child == null || !StringUtils.hasText(child.getId())) {
                 continue;
             }
+            // Inclusion gate: the CHILD's own non-terminal enrolment in THIS institute —
+            // NOT the institute's batch pool (getInstituteDetails.batchesForSessions is
+            // institute-wide and would over-list). Same source the guard uses, so the
+            // picker and the per-child endpoints agree.
+            List<String> childPackageSessionIds =
+                    ssigmRepository.findEnrolledPackageSessionIds(child.getId(), instituteId);
+            if (childPackageSessionIds.isEmpty()) {
+                continue; // not enrolled here — don't surface
+            }
             try {
                 StudentInstituteInfoDTO info =
                         learnerInstituteManager.getInstituteDetails(instituteId, child.getId(), true);
-                List<PackageSessionDTO> batches = info == null ? null : info.getBatchesForSessions();
-                if (batches == null || batches.isEmpty()) {
-                    continue; // not enrolled in this institute — don't surface
+                String instituteName = info != null ? info.getInstituteName() : null;
+
+                // Real batch labels for the child's OWN sessions: intersect the institute's
+                // batch pool with the child's package session ids.
+                Set<String> childPs = new HashSet<>(childPackageSessionIds);
+                List<PackageSessionDTO> pool = (info != null && info.getBatchesForSessions() != null)
+                        ? info.getBatchesForSessions()
+                        : List.of();
+                List<ParentChildSummaryDTO.EnrollmentSummary> enrollments = pool.stream()
+                        .filter(ps -> ps.getId() != null && childPs.contains(ps.getId()))
+                        .map(this::toEnrollment)
+                        .toList();
+                // Fallback: a child session not present in the institute's active pool still
+                // counts as an enrolment — emit id-only so the child isn't dropped.
+                if (enrollments.isEmpty()) {
+                    enrollments = childPackageSessionIds.stream()
+                            .map(id -> ParentChildSummaryDTO.EnrollmentSummary.builder()
+                                    .packageSessionId(id).batchName("").build())
+                            .toList();
                 }
+
                 result.add(ParentChildSummaryDTO.builder()
                         .childUserId(child.getId())
                         .fullName(child.getFullName())
@@ -56,8 +86,8 @@ public class ParentPortalChildrenService {
                         .mobileNumber(child.getMobileNumber())
                         .profilePicFileId(child.getProfilePicFileId())
                         .instituteId(instituteId)
-                        .instituteName(info.getInstituteName())
-                        .enrollments(batches.stream().map(this::toEnrollment).toList())
+                        .instituteName(instituteName)
+                        .enrollments(enrollments)
                         .build());
             } catch (Exception e) {
                 // one child's enrichment failure must not drop the whole list


### PR DESCRIPTION
…gated on child's own enrolment

Two fixes for a 403 "Child is not enrolled in this institute" on a genuinely enrolled child:

- The guard's enrolment leg required status = 'ACTIVE' exactly. The status column is dirty in prod ('ACTIVE' vs 'Active', plus INVITED/PENDING/INACTIVE/null), so enrolled children with any other status were wrongly 403'd. New repository finder findEnrolledPackageSessionIds is a case-insensitive EXCLUDE-list (rejects only DELETED/DELETED1/TERMINATED/EXPIRED). Guard uses it.
- ParentPortalChildrenService listed a child based on the INSTITUTE's batch pool (getInstituteDetails.batchesForSessions is institute-wide), which over-listed children not actually enrolled. It now gates inclusion on the child's own non-terminal enrolment (same source as the guard) and builds enrolments from the child's real sessions, so the picker and per-child endpoints agree.

Additive/safe; no schema change.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
