### PR TITLE
fix(onboarding): attached-existing-field visibility bug + generalize …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepInstanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepInstanceService.java
@@ -60,6 +60,7 @@ public class OnboardingStepInstanceService {
     private final InstituteCustomFieldRepository instituteCustomFieldRepository;
     private final CustomFieldRepository customFieldRepository;
     private final CustomFieldValuesRepository customFieldValuesRepository;
+    private final OnboardingStudentCreationService onboardingStudentCreationService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -117,6 +118,23 @@ public class OnboardingStepInstanceService {
         // the learner endpoint always resolves the caller's real role before calling this.
         if (isCreateStudentConfigured(step) && !OnboardingRoleKey.ADMIN.name().equals(actorRoleKey)) {
             throw new ForbiddenException("This step assigns a course and must be completed by an admin.");
+        }
+
+        // Leads can be filled out by either the student or a parent on their behalf. Resolve
+        // that BEFORE any identity-touching side effect -- role grant, credentials, or course
+        // enrollment can each live on their own, independent step, so this can't be scoped to
+        // just the create_student step. Once resolved, instance.subjectUserId is reassigned to
+        // the real student for the rest of this completion AND every later step (same managed
+        // entity within this transaction, visible to applyCompletionSideEffects below and to
+        // FormStepTypeHandler's own instance lookup).
+        boolean touchesIdentity = Boolean.TRUE.equals(step.getGrantsStudentRole())
+                || Boolean.TRUE.equals(step.getSendsLoginCredentials())
+                || isCreateStudentConfigured(step);
+        if (touchesIdentity && payload != null && "true".equalsIgnoreCase(String.valueOf(payload.get("is_parent")))) {
+            onboardingStudentCreationService.resolveSubjectUserId(instance, true,
+                    readPayloadString(payload, "student_full_name"),
+                    readPayloadString(payload, "student_email"),
+                    readPayloadString(payload, "student_mobile_number"));
         }
 
         OnboardingStepTypeHandler handler = stepTypeHandlerRegistry.getHandler(step.getStepType());
@@ -277,6 +295,12 @@ public class OnboardingStepInstanceService {
                     .build());
         }
         return out;
+    }
+
+    private String readPayloadString(Map<String, Object> payload, String key) {
+        if (payload == null) return null;
+        Object raw = payload.get(key);
+        return raw == null ? null : String.valueOf(raw);
     }
 
     private boolean isCreateStudentConfigured(OnboardingStep step) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStepService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.common.dto.CustomFieldDTO;
-import vacademy.io.admin_core_service.features.common.entity.CustomFields;
 import vacademy.io.admin_core_service.features.common.entity.InstituteCustomField;
 import vacademy.io.admin_core_service.features.common.enums.CustomFieldTypeEnum;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
@@ -23,6 +22,7 @@ import vacademy.io.common.exceptions.ResourceNotFoundException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -121,26 +121,45 @@ public class OnboardingStepService {
         return resolved;
     }
 
-    /** Attaches an existing institute_custom_fields row, or creates a new custom field + mapping (type=ONBOARDING_STEP) inline. */
+    /**
+     * Attaches an existing institute_custom_fields row, or creates a new custom field, to this
+     * step -- either way, resolves to a mapping row SCOPED TO THIS STEP (type=ONBOARDING_STEP,
+     * typeId=stepId), never the picker's original row id. The "attach existing field" picker
+     * hands us an institute_custom_fields row from the institute's general catalog (e.g.
+     * DEFAULT_CUSTOM_FIELD) -- reusing that row's id directly would leave the field invisible
+     * to every ONBOARDING_STEP feature-fields lookup, since that row's own type/typeId still
+     * points wherever it was originally defined, not at this step. Idempotent: re-saving a step
+     * reuses the same per-step mapping instead of creating a duplicate each time.
+     */
     private String resolveInstituteCustomFieldId(String instituteId, String stepId, OnboardingStepFieldConfigDTO fieldDto) {
+        String customFieldId;
         if (StringUtils.hasText(fieldDto.getInstituteCustomFieldId())) {
-            return fieldDto.getInstituteCustomFieldId();
+            customFieldId = instituteCustomFieldRepository.findById(fieldDto.getInstituteCustomFieldId())
+                    .map(InstituteCustomField::getCustomFieldId)
+                    .orElse(null);
+            if (!StringUtils.hasText(customFieldId)) return null;
+        } else if (fieldDto.getNewField() != null && StringUtils.hasText(stepId)) {
+            CustomFieldDTO customFieldDTO = new CustomFieldDTO();
+            customFieldDTO.setFieldName(String.valueOf(fieldDto.getNewField().get("field_name")));
+            customFieldDTO.setFieldType(String.valueOf(fieldDto.getNewField().get("field_type")));
+            Object defaultValue = fieldDto.getNewField().get("default_value");
+            if (defaultValue != null) customFieldDTO.setDefaultValue(String.valueOf(defaultValue));
+            Object config = fieldDto.getNewField().get("config");
+            if (config != null) customFieldDTO.setConfig(String.valueOf(config));
+            customFieldId = instituteCustomFiledService.createOrFindCustomFieldByKey(customFieldDTO, instituteId).getId();
+        } else {
+            return null;
         }
-        if (fieldDto.getNewField() == null || !StringUtils.hasText(stepId)) return null;
 
-        CustomFieldDTO customFieldDTO = new CustomFieldDTO();
-        customFieldDTO.setFieldName(String.valueOf(fieldDto.getNewField().get("field_name")));
-        customFieldDTO.setFieldType(String.valueOf(fieldDto.getNewField().get("field_type")));
-        Object defaultValue = fieldDto.getNewField().get("default_value");
-        if (defaultValue != null) customFieldDTO.setDefaultValue(String.valueOf(defaultValue));
-        Object config = fieldDto.getNewField().get("config");
-        if (config != null) customFieldDTO.setConfig(String.valueOf(config));
-
-        CustomFields savedField = instituteCustomFiledService.createOrFindCustomFieldByKey(customFieldDTO, instituteId);
+        Optional<InstituteCustomField> existingMapping = instituteCustomFieldRepository
+                .findTopByInstituteIdAndCustomFieldIdAndTypeAndTypeIdAndStatusOrderByCreatedAtDesc(
+                        instituteId, customFieldId, CustomFieldTypeEnum.ONBOARDING_STEP.name(), stepId,
+                        StatusEnum.ACTIVE.name());
+        if (existingMapping.isPresent()) return existingMapping.get().getId();
 
         InstituteCustomField mapping = instituteCustomFieldRepository.save(InstituteCustomField.builder()
                 .instituteId(instituteId)
-                .customFieldId(savedField.getId())
+                .customFieldId(customFieldId)
                 .type(CustomFieldTypeEnum.ONBOARDING_STEP.name())
                 .typeId(stepId)
                 .status(StatusEnum.ACTIVE.name())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStudentCreationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/service/OnboardingStudentCreationService.java
@@ -48,16 +48,40 @@ public class OnboardingStudentCreationService {
     private final ParentLinkService parentLinkService;
 
     /**
-     * Leads can be filled out by either the student themselves or a parent on their behalf.
-     * When {@code isParent} is true, {@code instance.subjectUserId} (whoever the lead form was
-     * originally captured against) is NOT the person to enroll -- it's their parent. Resolves/
-     * creates the real student via the existing guardian-link mechanism (the same one the
-     * assign-learner dialog uses) and reassigns the instance to them, so every side effect from
-     * here on (role grant, credentials email, subsequent steps) targets the actual student.
+     * Leads can be filled out by either the student themselves or a parent on their behalf. When
+     * {@code isParent} is true, {@code instance.subjectUserId} (whoever the lead form was
+     * originally captured against) is NOT the person any onboarding side effect should target --
+     * it's their parent. Resolves/creates the real student via the existing guardian-link
+     * mechanism (the same one the assign-learner dialog uses) and reassigns the instance to them,
+     * so every side effect from here on (role grant, credentials email, course enrollment, later
+     * steps) targets the actual student. Called once per step-instance completion by
+     * {@link OnboardingStepInstanceService#completeStep}, before ANY identity-touching side
+     * effect runs -- not just the create_student one -- since "grant STUDENT role" and "send
+     * credentials" can each live on their own, earlier step.
      */
-    public void createStudentIfAbsent(OnboardingStepInstance stepInstance, String packageSessionId,
-                                       boolean isParent, String studentFullName, String studentEmail,
-                                       String studentMobileNumber) {
+    public void resolveSubjectUserId(OnboardingInstance instance, boolean isParent, String studentFullName,
+                                      String studentEmail, String studentMobileNumber) {
+        if (!isParent) return;
+        if (!StringUtils.hasText(studentFullName)
+                || (!StringUtils.hasText(studentEmail) && !StringUtils.hasText(studentMobileNumber))) {
+            throw new InvalidRequestException(
+                    "Student name and email or mobile number are required when filling on behalf of a parent.");
+        }
+        ParentLinkActionRequestDTO linkRequest = ParentLinkActionRequestDTO.builder()
+                .instituteId(instance.getInstituteId())
+                .direction("PARENT_ADDS_STUDENT")
+                .mode("CREATE_NEW")
+                .anchorUserId(instance.getSubjectUserId())
+                .newFullName(studentFullName)
+                .newEmail(studentEmail)
+                .newMobileNumber(studentMobileNumber)
+                .build();
+        ParentLinkActionResponseDTO linkResponse = parentLinkService.link(linkRequest);
+        instance.setSubjectUserId(linkResponse.getStudentUserId());
+        onboardingInstanceRepository.save(instance);
+    }
+
+    public void createStudentIfAbsent(OnboardingStepInstance stepInstance, String packageSessionId) {
         if (!StringUtils.hasText(packageSessionId)) {
             log.warn("onboarding step configured to create a student but no packageSessionId set (stepInstance {})",
                     stepInstance.getId());
@@ -73,27 +97,6 @@ public class OnboardingStudentCreationService {
         }
         OnboardingInstance instance = instanceOpt.get();
         String instituteId = instance.getInstituteId();
-
-        if (isParent) {
-            if (!StringUtils.hasText(studentFullName)
-                    || (!StringUtils.hasText(studentEmail) && !StringUtils.hasText(studentMobileNumber))) {
-                throw new InvalidRequestException(
-                        "Student name and email or mobile number are required when filling on behalf of a parent.");
-            }
-            ParentLinkActionRequestDTO linkRequest = ParentLinkActionRequestDTO.builder()
-                    .instituteId(instituteId)
-                    .direction("PARENT_ADDS_STUDENT")
-                    .mode("CREATE_NEW")
-                    .anchorUserId(instance.getSubjectUserId())
-                    .newFullName(studentFullName)
-                    .newEmail(studentEmail)
-                    .newMobileNumber(studentMobileNumber)
-                    .build();
-            ParentLinkActionResponseDTO linkResponse = parentLinkService.link(linkRequest);
-            instance.setSubjectUserId(linkResponse.getStudentUserId());
-            onboardingInstanceRepository.save(instance);
-        }
-
         String subjectUserId = instance.getSubjectUserId();
 
         authService.addRolesToUserInternal(subjectUserId, List.of("STUDENT"), instituteId);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/steptype/FormStepTypeHandler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/onboarding/steptype/FormStepTypeHandler.java
@@ -112,16 +112,11 @@ public class FormStepTypeHandler implements OnboardingStepTypeHandler {
         customFieldValueService.upsertCustomFieldValues(valuesToSave);
 
         if (isCreateStudentConfigured(step)) {
+            // Parent-vs-student resolution (is_parent + student_* fields) already ran centrally
+            // in OnboardingStepInstanceService.completeStep, before this handler was invoked --
+            // stepInstance's onboarding_instance already carries the correct subject by now.
             String selectedPackageSessionId = resolveSelectedPackageSessionId(step, payload);
-            // Leads can be filled out by either the student or a parent on their behalf --
-            // "is_parent" (+ the student_* fields) tells createStudentIfAbsent which one it is,
-            // so it enrolls the right person, not whoever the lead form happened to be under.
-            boolean isParent = payload != null && "true".equalsIgnoreCase(String.valueOf(payload.get("is_parent")));
-            String studentFullName = readPayloadString(payload, "student_full_name");
-            String studentEmail = readPayloadString(payload, "student_email");
-            String studentMobileNumber = readPayloadString(payload, "student_mobile_number");
-            onboardingStudentCreationService.createStudentIfAbsent(stepInstance, selectedPackageSessionId,
-                    isParent, studentFullName, studentEmail, studentMobileNumber);
+            onboardingStudentCreationService.createStudentIfAbsent(stepInstance, selectedPackageSessionId);
         }
 
         return OnboardingStepInstanceStatus.COMPLETED;
@@ -147,12 +142,6 @@ public class FormStepTypeHandler implements OnboardingStepTypeHandler {
             throw new InvalidRequestException("Selected course is not one of the allowed courses for this step");
         }
         return selected;
-    }
-
-    private String readPayloadString(Map<String, Object> payload, String key) {
-        if (payload == null) return null;
-        Object raw = payload.get(key);
-        return raw == null ? null : String.valueOf(raw);
     }
 
     private boolean isCreateStudentConfigured(OnboardingStep step) {

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-onboarding/student-onboarding-profile.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-onboarding/student-onboarding-profile.tsx
@@ -22,6 +22,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AsyncSearchableSelect } from '@/components/design-system/async-searchable-select';
+import PhoneNumberInput from '@/components/design-system/phone-number-input';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import {
     ProfileSectionCard,
@@ -462,8 +463,12 @@ function CompleteFormStepDialog({
 
     // Leads can be filled out by either the student or a parent on their behalf. When a
     // parent fills it, the person we have on file (the onboarding subject) isn't who should
-    // be enrolled — their child is. This resolves/creates the real student and redirects the
-    // rest of the flow to them (see OnboardingStudentCreationService).
+    // receive the role/credentials/enrollment — their child is. This resolves/creates the real
+    // student and redirects the rest of the flow to them (see OnboardingStudentCreationService).
+    // Relevant on ANY step that touches identity, not just the one that assigns a course — role
+    // grant and credentials can each live on their own, earlier step.
+    const touchesIdentity =
+        createsStudent || stepDef?.grants_student_role === true || stepDef?.sends_login_credentials === true;
     const [isParent, setIsParent] = useState(false);
     const [studentFullName, setStudentFullName] = useState('');
     const [studentEmail, setStudentEmail] = useState('');
@@ -471,7 +476,7 @@ function CompleteFormStepDialog({
 
     const missingCourseChoice = createsStudent && !packageSessionId;
     const missingStudentDetails =
-        createsStudent && isParent && (!studentFullName.trim() || (!studentEmail.trim() && !studentMobileNumber.trim()));
+        touchesIdentity && isParent && (!studentFullName.trim() || (!studentEmail.trim() && !studentMobileNumber.trim()));
 
     return (
         <MyDialog
@@ -489,22 +494,18 @@ function CompleteFormStepDialog({
                         scale="medium"
                         disable={submitting || fieldsQuery.isLoading || missingCourseChoice || missingStudentDetails}
                         onClick={() =>
-                            onSubmit(
-                                createsStudent
+                            onSubmit({
+                                ...values,
+                                ...(createsStudent ? { package_session_id: packageSessionId } : {}),
+                                ...(touchesIdentity ? { is_parent: isParent } : {}),
+                                ...(touchesIdentity && isParent
                                     ? {
-                                          ...values,
-                                          package_session_id: packageSessionId,
-                                          is_parent: isParent,
-                                          ...(isParent
-                                              ? {
-                                                    student_full_name: studentFullName,
-                                                    student_email: studentEmail,
-                                                    student_mobile_number: studentMobileNumber,
-                                                }
-                                              : {}),
+                                          student_full_name: studentFullName,
+                                          student_email: studentEmail,
+                                          student_mobile_number: studentMobileNumber,
                                       }
-                                    : values
-                            )
+                                    : {}),
+                            })
                         }
                     >
                         {submitting ? 'Completing…' : 'Complete Step'}
@@ -513,7 +514,7 @@ function CompleteFormStepDialog({
             }
         >
             <div className="flex flex-col gap-3 px-6 py-6">
-                {createsStudent && (
+                {touchesIdentity && (
                     <div className="flex items-center justify-between rounded-lg border border-neutral-200 px-3 py-2.5">
                         <Label htmlFor="complete-step-is-parent" className="cursor-pointer text-body">
                             This form was filled by a parent, on behalf of a student
@@ -521,7 +522,7 @@ function CompleteFormStepDialog({
                         <Switch id="complete-step-is-parent" checked={isParent} onCheckedChange={setIsParent} />
                     </div>
                 )}
-                {createsStudent && isParent && (
+                {touchesIdentity && isParent && (
                     <div className="flex flex-col gap-2 rounded-lg border border-neutral-200 p-3">
                         <p className="text-caption text-neutral-500">
                             Enter the student&apos;s own details — they&apos;ll be the one enrolled and
@@ -542,12 +543,13 @@ function CompleteFormStepDialog({
                             input={studentEmail}
                             onChangeFunction={(e) => setStudentEmail(e.target.value)}
                         />
-                        <MyInput
-                            inputType="text"
+                        <PhoneNumberInput
+                            name="student_mobile_number"
                             label="Student's mobile number"
-                            inputPlaceholder="Optional if email is provided"
-                            input={studentMobileNumber}
-                            onChangeFunction={(e) => setStudentMobileNumber(e.target.value)}
+                            placeholder="Optional if email is provided"
+                            value={studentMobileNumber}
+                            onChange={(_, value) => setStudentMobileNumber(value)}
+                            validate={false}
                         />
                     </div>
                 )}
@@ -596,7 +598,7 @@ function CompleteFormStepDialog({
                 {fieldsQuery.isLoading ? (
                     <ProfileSkeleton blocks={1} />
                 ) : fields.length === 0 ? (
-                    !createsStudent && (
+                    !touchesIdentity && (
                         <p className="text-body text-neutral-500">
                             This step has no attached fields — marking it complete needs no input.
                         </p>


### PR DESCRIPTION
…parent/student resolution + phone convention

"Attach an existing field" in the step builder reused the picker's original institute_custom_fields row id directly -- that row's own type/typeId still pointed wherever it was originally defined (e.g. the institute's general DEFAULT_CUSTOM_FIELD catalog), not at this step. Every ONBOARDING_STEP feature-fields lookup (both the side-view's complete/view-form dialogs and the learner app's self-service form) filters by type=ONBOARDING_STEP + typeId=stepId, so attached-existing fields were invisible to all of them -- only "create new field inline" happened to work, since that path already created a step-scoped mapping. Now every attach path resolves to a mapping scoped to (customFieldId, ONBOARDING_STEP, stepId), reusing one idempotently across re-saves.

Generalized the parent/student "who is this for" resolution: it now runs once, centrally, before ANY identity-touching side effect (grant STUDENT role, send credentials, or course enrollment) rather than being scoped only to the create_student step -- those three can each live on their own, independent step in a flow.

Also swapped the plain-text "student's mobile number" field for the existing PhoneNumberInput (country-code selector), matching convention used elsewhere in the admin app.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
