### PR TITLE
feat(audience): auto-capture public live-class registrants as CRM leads

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -56,6 +56,7 @@ import vacademy.io.admin_core_service.features.notification.dto.NotificationTemp
 import vacademy.io.admin_core_service.features.notification_service.service.SendUniqueLinkService;
 import vacademy.io.admin_core_service.features.notification_service.service.NotificationService;
 import vacademy.io.admin_core_service.features.common.entity.CustomFields;
+import vacademy.io.admin_core_service.features.common.entity.InstituteCustomField;
 import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
 import vacademy.io.admin_core_service.features.audience.enums.CustomFieldValueSourceType;
@@ -594,6 +595,197 @@ public class AudienceService {
                             saved.getId(), instituteId);
                     return saved;
                 });
+    }
+
+    /** Campaign name for the auto-provisioned per-institute live-class / webinar lead audience. */
+    private static final String LIVE_CLASS_AUDIENCE_NAME = "Public Webinar - Live Session";
+
+    /**
+     * Capture a lead from a public live-class (webinar) guest registration.
+     *
+     * <p>Live-session guest registration ({@code RegistrationService.saveGuestUserDetails})
+     * writes only {@code session_guest_registrations} + EXTERNAL_PARTICIPANT custom field
+     * values and never created an {@code audience_response}, so webinar registrants were
+     * invisible in the CRM lead list. This routes them into a single per-institute
+     * "Public Webinar - Live Session" audience so they show up in Audience Manager →
+     * Recent Leads, exactly like {@link #submitCatalogueLead} does for catalogue leads.
+     *
+     * <p>Mirrors submitCatalogueLead deliberately: NOT {@code @Transactional} (its
+     * best-effort sub-calls must not mark a surrounding tx rollback-only), and it does
+     * NOT fire the {@code AUDIENCE_LEAD_SUBMISSION} workflow — the registrant already
+     * receives the {@code LIVE_SESSION_FORM_SUBMISSION} seat-confirmation, and firing the
+     * audience workflow too would double-message them.
+     *
+     * <p>Best-effort: returns null rather than throwing when it cannot create a lead, so
+     * the caller — an already-committed public registration — is never disturbed.
+     */
+    public String submitLiveClassLead(String instituteId, String fullName, String email,
+                                      String mobileNumber, Map<String, String> extraCustomFieldValues,
+                                      String sourceId) {
+        if (!StringUtils.hasText(instituteId) || !StringUtils.hasText(email)) {
+            return null;
+        }
+
+        Audience audience = getOrCreateLiveClassAudience(instituteId);
+
+        UserDTO userDTO = UserDTO.builder()
+                .fullName(fullName)
+                .email(email)
+                .mobileNumber(mobileNumber)
+                .build();
+
+        // The webinar form's extra fields (anything beyond name/email/phone — e.g. "CUET
+        // Marks") arrive keyed by their custom_field_id. Attach each to this audience's
+        // AUDIENCE_FORM schema (idempotent) so it renders as a lead column; the value is
+        // saved below. This keeps the lead's fields in sync with the registration form for
+        // ANY institute — even one whose live-class audience was just auto-created — without
+        // any manual campaign setup.
+        if (extraCustomFieldValues != null && !extraCustomFieldValues.isEmpty()) {
+            int order = 3; // base identity fields occupy 0..2
+            for (String customFieldId : extraCustomFieldValues.keySet()) {
+                try {
+                    ensureAudienceFormField(instituteId, audience.getId(), customFieldId, order++);
+                } catch (Exception e) {
+                    logger.error("Live-class lead: attaching field {} to audience {} failed: {}",
+                            customFieldId, audience.getId(), e.getMessage());
+                }
+            }
+        }
+
+        final String src = StringUtils.hasText(sourceId) ? sourceId : "live-class";
+
+        // Institute-configured hard dedup — before creating the auth user.
+        java.util.Optional<String> dedupRejection = leadDeduplicationService.checkForRejection(
+                instituteId, audience.getId(), email, mobileNumber);
+        if (dedupRejection.isPresent()) {
+            return dedupRejection.get();
+        }
+
+        // 1. Create/fetch the lead's user in auth_service (no credentials email).
+        UserDTO createdUser = authService.createUserFromAuthService(userDTO, audience.getInstituteId(), false);
+        String userId = createdUser != null ? createdUser.getId() : null;
+
+        // 2. Per-person-per-campaign dedup — revive a soft-deleted lead rather than duplicate.
+        if (StringUtils.hasText(userId)
+                && audienceResponseRepository.existsByAudienceIdAndUserId(audience.getId(), userId)) {
+            reactivateSoftDeletedLeads(audience.getId(), userId);
+            return "You are already captured as a lead for this campaign";
+        }
+
+        // 3. Persist the lead — this is what Audience Manager → Recent Leads reads.
+        AudienceResponse savedResponse = audienceResponseRepository.save(AudienceResponse.builder()
+                .audienceId(audience.getId())
+                .sourceType("LIVE_SESSION")
+                .sourceId(src)
+                .userId(userId)
+                .parentName(fullName)
+                .parentEmail(email)
+                .parentMobile(truncateForParentMobileColumn(mobileNumber))
+                .workflowActivateDayAt(calculateWorkflowActivateDayAt(audience))
+                .initialScore(audience.getDefaultInitialScore())
+                .build());
+
+        // 4. Enrichment — best-effort; never block the saved lead.
+        try {
+            logLeadSubmitted(savedResponse);
+        } catch (Exception e) {
+            logger.error("Live-class lead {}: logLeadSubmitted failed: {}", savedResponse.getId(), e.getMessage());
+        }
+        try {
+            // Build the values to persist so every key resolves to a field that actually
+            // exists on this audience — otherwise saveCustomFieldValues' single saveAll would
+            // FK-fail on an unknown key and drop the whole batch (incl. the extras). Extras
+            // were attached above, so they resolve. Base identity keys are included only when
+            // the audience already has them (a freshly auto-created audience does not — the
+            // name/email/phone still surface on the lead via parent_name/parent_email/parent_mobile).
+            Map<String, String> valuesToSave = extraCustomFieldValues != null
+                    ? new HashMap<>(extraCustomFieldValues)
+                    : new HashMap<>();
+            Set<String> audienceFieldKeys = new HashSet<>();
+            for (Object[] row : instituteCustomFieldRepository.findInstituteCustomFieldsWithDetails(
+                    audience.getInstituteId(), CustomFieldTypeEnum.AUDIENCE_FORM.name(), audience.getId())) {
+                CustomFields cf = (CustomFields) row[1];
+                if (cf.getFieldKey() != null) audienceFieldKeys.add(cf.getFieldKey().toLowerCase().trim());
+            }
+            if (StringUtils.hasText(fullName) && audienceFieldKeys.contains("full_name")) {
+                valuesToSave.put("full_name", fullName);
+            }
+            if (StringUtils.hasText(email) && audienceFieldKeys.contains("email")) {
+                valuesToSave.put("email", email);
+            }
+            if (StringUtils.hasText(mobileNumber) && audienceFieldKeys.contains("phone_number")) {
+                valuesToSave.put("phone_number", mobileNumber);
+            }
+            if (!CollectionUtils.isEmpty(valuesToSave)) {
+                saveCustomFieldValues(savedResponse.getId(), valuesToSave, audience.getInstituteId(),
+                        audience.getId());
+            }
+        } catch (Exception e) {
+            logger.error("Live-class lead {}: saveCustomFieldValues failed: {}", savedResponse.getId(), e.getMessage());
+        }
+        try {
+            leadScoringService.calculateAndSaveScore(savedResponse.getId(), savedResponse.getAudienceId(),
+                    audience.getInstituteId(), savedResponse.getSourceType(), savedResponse.getEnquiryId());
+        } catch (Exception e) {
+            logger.error("Live-class lead {}: lead score failed: {}", savedResponse.getId(), e.getMessage());
+        }
+
+        // Pool auto-assignment — live-class leads carry no counsellor, so this is pure pool routing.
+        autoAssignCounsellorOnIntake(savedResponse, userId, audience.getInstituteId(),
+                null, null, createdUser != null ? createdUser.getFullName() : null,
+                audience.getCampaignName());
+
+        return savedResponse.getId();
+    }
+
+    /**
+     * Resolve the per-institute live-class / webinar lead audience, creating a minimal
+     * ACTIVE one on first use so no manual campaign setup is required. Resolved by name,
+     * so an institute that already has a "Public Webinar - Live Session" campaign reuses it.
+     */
+    private Audience getOrCreateLiveClassAudience(String instituteId) {
+        return audienceRepository.findFirstByInstituteIdAndCampaignName(instituteId, LIVE_CLASS_AUDIENCE_NAME)
+                .orElseGet(() -> {
+                    Audience audience = Audience.builder()
+                            .id(UUID.randomUUID().toString())
+                            .instituteId(instituteId)
+                            .campaignName(LIVE_CLASS_AUDIENCE_NAME)
+                            .campaignType("WEBSITE")
+                            .campaignObjective("LEAD_GENERATION")
+                            .description("Leads captured from public live-class / webinar registrations")
+                            .status("ACTIVE")
+                            .defaultInitialScore(20)
+                            .build();
+                    Audience saved = audienceRepository.save(audience);
+                    logger.info("Auto-provisioned live-class lead audience {} for institute {}",
+                            saved.getId(), instituteId);
+                    return saved;
+                });
+    }
+
+    /**
+     * Attach a custom field to an audience's AUDIENCE_FORM schema if it isn't already,
+     * so a value saved against it renders as a column in the lead list. Idempotent — a
+     * no-op when the link already exists. Used to mirror a live-class registration form's
+     * extra fields onto its lead audience.
+     */
+    private void ensureAudienceFormField(String instituteId, String audienceId, String customFieldId, int order) {
+        if (!StringUtils.hasText(customFieldId)) return;
+        boolean alreadyLinked = instituteCustomFieldRepository
+                .findTopByInstituteIdAndCustomFieldIdAndTypeAndTypeIdAndStatusOrderByCreatedAtDesc(
+                        instituteId, customFieldId, "AUDIENCE_FORM", audienceId, "ACTIVE")
+                .isPresent();
+        if (alreadyLinked) return;
+        instituteCustomFieldRepository.save(InstituteCustomField.builder()
+                .instituteId(instituteId)
+                .customFieldId(customFieldId)
+                .type("AUDIENCE_FORM")
+                .typeId(audienceId)
+                .status("ACTIVE")
+                .isMandatory(false)
+                .individualOrder(order)
+                .groupInternalOrder(0)
+                .build());
     }
 
     private static final String PHONE_ENQUIRIES_AUDIENCE_NAME = "Phone Enquiries";

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LiveSessionWorkflowAsyncHelper.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LiveSessionWorkflowAsyncHelper.java
@@ -2,8 +2,11 @@ package vacademy.io.admin_core_service.features.live_session.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import vacademy.io.admin_core_service.features.audience.service.AudienceService;
 import vacademy.io.admin_core_service.features.live_session.entity.LiveSession;
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
 import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
@@ -27,6 +30,15 @@ import java.util.Map;
 public class LiveSessionWorkflowAsyncHelper {
 
     private final WorkflowTriggerService workflowTriggerService;
+
+    /**
+     * Field-injected and {@code @Lazy}: the CRM {@link AudienceService} is a large bean
+     * with a wide dependency graph, so a lazy proxy here keeps a stray back-reference
+     * from ever forming a startup bean cycle through this helper.
+     */
+    @Autowired
+    @Lazy
+    private AudienceService audienceService;
 
     /**
      * Fire-and-forget workflow trigger. Errors are logged and swallowed —
@@ -77,6 +89,30 @@ public class LiveSessionWorkflowAsyncHelper {
         } catch (Exception e) {
             log.warn("Async LIVE_SESSION_FORM_SUBMISSION workflow failed for sessionId={}: {}",
                     sessionId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Turns a public live-class registration into a CRM lead off the request thread.
+     *
+     * <p>Every public live-class registrant should surface in Audience Manager → Recent
+     * Leads. {@link AudienceService#submitLiveClassLead} creates the auth-service user and
+     * the {@code audience_response} without firing any workflow, so the registrant is not
+     * double-messaged on top of their seat-confirmation. Pinned to the same bounded
+     * {@code workflowTaskExecutor} as form-submission so a webinar burst cannot spawn
+     * unbounded threads; fire-and-forget, errors logged and swallowed.
+     */
+    @Async("workflowTaskExecutor")
+    public void createLiveClassLeadAsync(String instituteId, String fullName, String email,
+                                         String mobileNumber, Map<String, String> extraFieldsById,
+                                         String sessionId) {
+        if (instituteId == null || email == null || email.isBlank()) return;
+        try {
+            audienceService.submitLiveClassLead(instituteId, fullName, email, mobileNumber,
+                    extraFieldsById, sessionId);
+        } catch (Exception e) {
+            log.warn("Async live-class lead capture failed for institute={} session={}: {}",
+                    instituteId, sessionId, e.getMessage(), e);
         }
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/RegistrationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/RegistrationService.java
@@ -85,7 +85,60 @@ public class RegistrationService {
         }
 
         scheduleFormSubmissionWorkflow(requestDto, guestUserId);
+        scheduleLiveClassLeadCapture(requestDto);
         return guestUserId;
+    }
+
+    /**
+     * Schedules CRM lead capture to run strictly AFTER the registration commits, for the
+     * same reasons as {@link #scheduleFormSubmissionWorkflow}: nothing here runs inside the
+     * registration transaction (no early flush, no swallowed constraint failure), and
+     * {@code afterCommit} fires only on a committed registration so a rolled-back one never
+     * creates a lead.
+     */
+    private void scheduleLiveClassLeadCapture(GuestRegistrationRequestDTO requestDto) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    dispatchLiveClassLeadCapture(requestDto);
+                }
+            });
+        } else {
+            dispatchLiveClassLeadCapture(requestDto);
+        }
+    }
+
+    /**
+     * Turns a public live-class registration into a CRM lead so the registrant appears in
+     * Audience Manager → Recent Leads (previously they only landed in
+     * {@code session_guest_registrations}, which no lead screen reads).
+     *
+     * <p>Best-effort and never throwing — the registration has already committed by the
+     * time this runs and must not be disturbed. Resolves the session's institute and the
+     * guest's name/email/phone (same admin-defined-field resolution as the workflow
+     * context), then hands off to the bounded async executor. Deliberately unconditional
+     * (no trigger gate): guest registration only happens for public sessions, so this is
+     * already scoped to public webinars, and every such registrant is a lead.
+     */
+    private void dispatchLiveClassLeadCapture(GuestRegistrationRequestDTO requestDto) {
+        try {
+            Optional<LiveSession> sessionOpt = liveSessionRepository.findById(requestDto.getSessionId());
+            if (sessionOpt.isEmpty()) return;
+            LiveSession session = sessionOpt.get();
+            String instituteId = session.getInstituteId();
+            if (instituteId == null || instituteId.isBlank()) return;
+
+            GuestIdentity identity = resolveIdentity(requestDto);
+            if (identity.email == null || identity.email.isBlank()) return; // no email → no lead
+
+            liveSessionWorkflowAsyncHelper.createLiveClassLeadAsync(
+                    instituteId, identity.fullName, identity.email, identity.mobileNumber,
+                    identity.extraById, session.getId());
+        } catch (Exception e) {
+            log.warn("Failed to capture live-class lead for sessionId={}: {}",
+                    requestDto.getSessionId(), e.getMessage(), e);
+        }
     }
 
     /**
@@ -189,6 +242,45 @@ public class RegistrationService {
                                              String guestUserId,
                                              LiveSession session,
                                              String instituteId) {
+        GuestIdentity id = resolveIdentity(requestDto);
+
+        Map<String, Object> guest = new LinkedHashMap<>();
+        guest.put("guestRegistrationId", guestUserId);
+        guest.put("fullName", id.fullName);
+        guest.put("mobileNumber", id.mobileNumber);
+        guest.put("email", id.email);
+        guest.put("sessionId", session.getId());
+        guest.put("sessionTitle", session.getTitle());
+        guest.putAll(id.byName);
+
+        List<Map<String, Object>> guests = new ArrayList<>();
+        guests.add(guest);
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("instituteId", instituteId);
+        contextData.put("instituteIdForWhatsapp", instituteId);
+        contextData.put("sessionId", session.getId());
+        contextData.put("sessionTitle", session.getTitle());
+        contextData.put("guestRegistrationId", guestUserId);
+        contextData.put("fullName", id.fullName);
+        contextData.put("mobileNumber", id.mobileNumber);
+        contextData.put("email", id.email);
+        contextData.put("customFields", id.byKey);
+        contextData.put("customFieldsByName", id.byName);
+        contextData.put("liveSession", session);
+        contextData.put("guests", guests);
+        return contextData;
+    }
+
+    /**
+     * Resolves the "who is this person" fields from a guest submission. The form is
+     * entirely admin-defined custom fields, so name/phone/email are classified via
+     * {@link GuestFormFieldResolver} rather than read from fixed columns. Answers are also
+     * collected by field key and by (lowercased) label. Shared by the workflow context
+     * ({@link #buildContext}) and CRM lead capture ({@link #dispatchLiveClassLeadCapture})
+     * so both read identity the exact same way.
+     */
+    private GuestIdentity resolveIdentity(GuestRegistrationRequestDTO requestDto) {
         List<GuestRegistrationRequestDTO.CustomFieldValueDTO> submitted =
                 requestDto.getCustomFields() == null ? List.of() : requestDto.getCustomFields();
 
@@ -206,6 +298,9 @@ public class RegistrationService {
 
         Map<String, Object> byKey = new LinkedHashMap<>();
         Map<String, Object> byName = new LinkedHashMap<>();
+        // Non-identity answers (everything that isn't name/email/phone), keyed by
+        // custom_field_id → value, so lead capture can mirror them onto the lead audience.
+        Map<String, String> extraById = new LinkedHashMap<>();
         String fullName = null;
         String mobileNumber = null;
         String email = requestDto.getEmail();
@@ -230,35 +325,35 @@ public class RegistrationService {
                     if (email == null || email.isBlank()) email = value.trim();
                 }
                 default -> {
+                    if (answer.getCustomFieldId() != null) {
+                        extraById.put(answer.getCustomFieldId(), value.trim());
+                    }
                 }
             }
         }
 
-        Map<String, Object> guest = new LinkedHashMap<>();
-        guest.put("guestRegistrationId", guestUserId);
-        guest.put("fullName", fullName);
-        guest.put("mobileNumber", mobileNumber);
-        guest.put("email", email);
-        guest.put("sessionId", session.getId());
-        guest.put("sessionTitle", session.getTitle());
-        guest.putAll(byName);
+        return new GuestIdentity(fullName, mobileNumber, email, byKey, byName, extraById);
+    }
 
-        List<Map<String, Object>> guests = new ArrayList<>();
-        guests.add(guest);
+    /** Immutable holder for the identity + answer maps resolved from a guest submission. */
+    private static final class GuestIdentity {
+        final String fullName;
+        final String mobileNumber;
+        final String email;
+        final Map<String, Object> byKey;
+        final Map<String, Object> byName;
+        /** Non-identity answers keyed by custom_field_id → value (e.g. "CUET Marks"). */
+        final Map<String, String> extraById;
 
-        Map<String, Object> contextData = new HashMap<>();
-        contextData.put("instituteId", instituteId);
-        contextData.put("instituteIdForWhatsapp", instituteId);
-        contextData.put("sessionId", session.getId());
-        contextData.put("sessionTitle", session.getTitle());
-        contextData.put("guestRegistrationId", guestUserId);
-        contextData.put("fullName", fullName);
-        contextData.put("mobileNumber", mobileNumber);
-        contextData.put("email", email);
-        contextData.put("customFields", byKey);
-        contextData.put("customFieldsByName", byName);
-        contextData.put("liveSession", session);
-        contextData.put("guests", guests);
-        return contextData;
+        GuestIdentity(String fullName, String mobileNumber, String email,
+                      Map<String, Object> byKey, Map<String, Object> byName,
+                      Map<String, String> extraById) {
+            this.fullName = fullName;
+            this.mobileNumber = mobileNumber;
+            this.email = email;
+            this.byKey = byKey;
+            this.byName = byName;
+            this.extraById = extraById;
+        }
     }
 }


### PR DESCRIPTION
## What
Public live-class (webinar) guest registrations now automatically become CRM leads, for **any** institute — no manual campaign setup.

When a guest registers via `/register/live-class` (`RegistrationService.saveGuestUserDetails`), we now also:
- **Get-or-create** a per-institute `Public Webinar - Live Session` audience (auto-provisioned, shows in the campaign list like the existing "Course Catalogue Leads").
- Create an `audience_response` lead so the registrant appears in Audience Manager → Recent Leads and the lead profile.
- **Mirror the registration form's custom fields** (name/email/phone + any extras, e.g. "CUET Marks") onto the lead by attaching them to the audience schema and saving their values — so they render as lead columns / in the lead profile.

## How / safety
- Runs **post-commit + async + best-effort** — a lead-capture failure can never fail or delay a registration.
- **Fires no `AUDIENCE_LEAD_SUBMISSION` workflow** — registrants already get their `LIVE_SESSION_FORM_SUBMISSION` seat-confirmation, so this avoids double-messaging.
- Mirrors the proven `submitCatalogueLead` path (same dedup, user creation, scoring, counsellor routing). No existing method's behavior changed; the `buildContext` refactor is behavior-preserving.
- Base identity keys are only written when the audience already has them, so the atomic `saveAll` never FK-fails on a freshly auto-created audience (identity still surfaces via `parent_*`).
- `source_type = "LIVE_SESSION"` is free-form and display/scoring-safe (no `SourceTypeEnum.valueOf`; scoring defaults unknown → 50).

## Files (all `admin_core_service`)
- `audience/service/AudienceService.java` — `submitLiveClassLead`, `getOrCreateLiveClassAudience`, `ensureAudienceFormField`
- `live_session/service/RegistrationService.java` — wires capture into `saveGuestUserDetails`, `resolveIdentity` refactor
- `live_session/service/LiveSessionWorkflowAsyncHelper.java` — `createLiveClassLeadAsync`

## Verification
- Compiles clean under JDK 17 (0 errors).
- Data/display path traced end-to-end (audience_response cfv → leads-list metadata → FE `lead-view-model` profile card).
- Existing Elevate webinar (session `c5095124…`, 85 registrants) was backfilled directly in prod as validation.

## Deploy
Requires an **`admin_core_service`** deploy to take effect for new registrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)