### PR TITLE
Fix crash rendering the learner onboarding form (missing FormProvider)

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/onboarding/-components/onboarding-step-form.tsx
+++ b/frontend-learner-dashboard-app/src/routes/onboarding/-components/onboarding-step-form.tsx
@@ -8,6 +8,7 @@ import { CheckCircle, ListChecks, Lock, SpinnerGap } from "@phosphor-icons/react
 import { MyInput } from "@/components/design-system/input";
 import { MyButton } from "@/components/design-system/button";
 import { ModernCard } from "@/components/design-system/modern-card";
+import { Form } from "@/components/ui/form";
 import {
   getResolvedStepFields,
   submitStepInstance,
@@ -166,64 +167,66 @@ export const OnboardingStepForm = ({
           </MyButton>
         </div>
       ) : (
-        <form
-          onSubmit={form.handleSubmit(handleSubmit)}
-          className="flex w-full flex-col gap-5"
-        >
-          {readOnlyFields.map((field) => (
-            <div
-              key={field.institute_custom_field_id}
-              className="flex flex-col gap-1"
-            >
-              <span className="flex items-center gap-1.5 text-sm font-medium text-neutral-600">
-                <Lock className="size-3.5 text-neutral-400" />
-                {field.field_name ?? "Field"}
-              </span>
-              <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-500">
-                {field.value || "Not filled in"}
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="flex w-full flex-col gap-5"
+          >
+            {readOnlyFields.map((field) => (
+              <div
+                key={field.institute_custom_field_id}
+                className="flex flex-col gap-1"
+              >
+                <span className="flex items-center gap-1.5 text-sm font-medium text-neutral-600">
+                  <Lock className="size-3.5 text-neutral-400" />
+                  {field.field_name ?? "Field"}
+                </span>
+                <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-500">
+                  {field.value || "Not filled in"}
+                </div>
               </div>
+            ))}
+
+            {editableFields.map((field) => (
+              <MyInput
+                key={field.institute_custom_field_id}
+                label={field.field_name ?? "Field"}
+                required={Boolean(field.is_mandatory)}
+                inputType="text"
+                input={form.watch(field.institute_custom_field_id) ?? ""}
+                onChangeFunction={(e) =>
+                  form.setValue(field.institute_custom_field_id, e.target.value, {
+                    shouldValidate: form.formState.isSubmitted,
+                  })
+                }
+                error={
+                  form.formState.errors[field.institute_custom_field_id]
+                    ?.message as string | undefined
+                }
+              />
+            ))}
+
+            <div className="mt-2 flex justify-end">
+              <MyButton
+                type="submit"
+                buttonType="primary"
+                scale="large"
+                layoutVariant="default"
+                disable={submitMutation.isPending}
+                className="w-full sm:w-auto"
+              >
+                {submitMutation.isPending ? (
+                  <>
+                    <SpinnerGap className="mr-2 size-4 animate-spin" />
+                    Submitting...
+                  </>
+                ) : (
+                  "Submit"
+                )}
+              </MyButton>
             </div>
-          ))}
-
-          {editableFields.map((field) => (
-            <MyInput
-              key={field.institute_custom_field_id}
-              label={field.field_name ?? "Field"}
-              required={Boolean(field.is_mandatory)}
-              inputType="text"
-              input={form.watch(field.institute_custom_field_id) ?? ""}
-              onChangeFunction={(e) =>
-                form.setValue(field.institute_custom_field_id, e.target.value, {
-                  shouldValidate: form.formState.isSubmitted,
-                })
-              }
-              error={
-                form.formState.errors[field.institute_custom_field_id]
-                  ?.message as string | undefined
-              }
-            />
-          ))}
-
-          <div className="mt-2 flex justify-end">
-            <MyButton
-              type="submit"
-              buttonType="primary"
-              scale="large"
-              layoutVariant="default"
-              disable={submitMutation.isPending}
-              className="w-full sm:w-auto"
-            >
-              {submitMutation.isPending ? (
-                <>
-                  <SpinnerGap className="mr-2 size-4 animate-spin" />
-                  Submitting...
-                </>
-              ) : (
-                "Submit"
-              )}
-            </MyButton>
-          </div>
-        </form>
+          </form>
+        </Form>
       )}
     </ModernCard>
   );


### PR DESCRIPTION
MyInput (frontend-learner-dashboard-app's design-system input) renders a FormLabel from @/components/ui/form whenever a label prop is given. FormLabel internally calls useFormField(), which destructures getFieldState off useFormContext() -- and that's null without an ancestor <Form> (FormProvider). OnboardingStepForm rendered every editable field via <MyInput label={...} .../> inside a plain HTML <form>, never wrapped in <Form {...form}>, so the moment a step actually had a labeled field to render, the whole thing crashed ("Cannot destructure property 'getFieldState' of ... as it is null") instead of showing the form at all.

The admin dashboard's own MyInput uses a plain Label, not FormLabel, so it was never affected -- this was specific to the learner app's component.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
