### PR TITLE
fix(learner-auth): retry login with typed creds on lowercase failure;…

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/select-institute.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/forms/page/select-institute.tsx
@@ -58,7 +58,16 @@ export function InstituteSelection() {
     const { type, courseId } = (location.state as { type?: string; courseId?: string }) || {};
     const navigate = useNavigate();
     const search = useSearch({ from: "/institute-selection/" });
-    const redirect = (search as { redirect?: string })?.redirect;
+    const rawRedirect = (search as { redirect?: string })?.redirect;
+    // The page login forms forward their `redirect` search param here, which
+    // defaults to "/login/" when there's no real deep-link. Treat that sentinel
+    // (and any value pointing back at the login route) as "no redirect" so a
+    // normal multi-institute login lands on the dashboard instead of bouncing
+    // back to the login screen.
+    const redirect =
+        rawRedirect && !/^\/login\/?(?:[?#]|$)/.test(rawRedirect)
+            ? rawRedirect
+            : undefined;
 
     const form = useForm<FormValues>({
         resolver: zodResolver(instituteSelectionSchema),

--- a/frontend-learner-dashboard-app/src/components/common/auth/login/hooks/login-button.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/auth/login/hooks/login-button.tsx
@@ -28,24 +28,21 @@ export class SessionLimitError extends Error {
     }
 }
 
-// Dummy login function
-async function loginUser(
-    username: string,
+// Single credential attempt against the login endpoint. Returns the parsed
+// token payload, or throws (SessionLimitError for a valid-but-capped account,
+// a plain Error for any other failure).
+async function attemptLogin(
+    userName: string,
     password: string,
-    convertToLowercase?: boolean | null,
 ): Promise<z.infer<typeof loginResponseSchema>> {
-    // Convert username and password to lowercase if flag is true
-    const finalUsername = convertToLowercase === true ? username.toLowerCase() : username;
-    const finalPassword = convertToLowercase === true ? password.toLowerCase() : password;
-
     const response = await fetch(LOGIN_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
         },
         body: JSON.stringify({
-            user_name: finalUsername,
-            password: finalPassword,
+            user_name: userName,
+            password: password,
             client_name: "ADMIN_PORTAL",
             // institute_id: INSTITUTE_ID,
         }),
@@ -60,6 +57,38 @@ async function loginUser(
     // Check for session limit exceeded BEFORE storing tokens
     if (tokenData.session_limit_exceeded === true) {
         throw new SessionLimitError(tokenData.active_sessions || []);
+    }
+
+    return tokenData;
+}
+
+// Dummy login function
+async function loginUser(
+    username: string,
+    password: string,
+    convertToLowercase?: boolean | null,
+): Promise<z.infer<typeof loginResponseSchema>> {
+    let tokenData: z.infer<typeof loginResponseSchema>;
+
+    if (convertToLowercase === true) {
+        // Try the lowercased credentials first (per institute config), but if
+        // that is rejected, fall back to the values exactly as the user typed
+        // them — some accounts were created with mixed-case usernames/passwords.
+        try {
+            tokenData = await attemptLogin(
+                username.toLowerCase(),
+                password.toLowerCase(),
+            );
+        } catch (error) {
+            // A capped-but-valid account isn't a credentials failure — don't
+            // retry, surface the session-limit dialog instead.
+            if (error instanceof SessionLimitError) {
+                throw error;
+            }
+            tokenData = await attemptLogin(username, password);
+        }
+    } else {
+        tokenData = await attemptLogin(username, password);
     }
 
     // --- BUG FIX: Save tokens and instituteId to storage ---


### PR DESCRIPTION
… stop multi-institute bounce to /login

- loginUser now retries once with the credentials exactly as typed when the lowercased attempt fails (institutes with convertUsernamePasswordToLowercase), so mixed-case accounts can still log in. Session-limit responses are not retried.
- select-institute ignores a redirect that points back at the login route (the "/login/" sentinel the page login forms forward), so a multi-institute login lands on the dashboard instead of bouncing back to login.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
