### PR TITLE
feat(parent-portal): attendance session history + parent docs

### DIFF
--- a/docs/PARENT_PORTAL.md
+++ b/docs/PARENT_PORTAL.md
@@ -62,9 +62,9 @@ Base path `/admin-core-service/parent-portal/v1` (authenticated; **not** in
 | GET | `/children` | `ParentChildSummaryDTO[]` — enrolled children in the clientId institute (child-picker) |
 | GET | `/settings` | `ParentPortalSettingsDTO` |
 | GET | `/children/{id}/overview` | `ChildOverviewDTO` — counts + headline numbers (fault-isolated) |
-| GET | `/children/{id}/attendance` | `StudentAttendanceReportDTO` |
-| GET | `/children/{id}/live-sessions/{upcoming,past}` | grouped sessions |
-| GET | `/children/{id}/progress/subjects` | subject-wise progress |
+| GET | `/children/{id}/attendance` | `StudentAttendanceReportDTO` — `attendancePercentage` + `schedules[]` (per-session present/absent). Client passes a 1-year window (§2.6). |
+| GET | `/children/{id}/live-sessions/{upcoming,past}` | grouped sessions — **merged across all the child's courses** (§2.6) |
+| GET | `/children/{id}/progress/subjects` | `CourseProgressDTO[]` — **one per enrolled course** (`packageSessionId`, `courseName`, `subjects[]`); see §2.6 |
 | GET | `/children/{id}/assessments` | assessment history |
 | GET | `/children/{id}/payments/invoices` | `InvoiceDTO[]` |
 | GET | `/children/{id}/badges` | `LearnerBadgeDTO[]` |
@@ -95,6 +95,43 @@ Previously certificates were only reachable via the v2 report collector. Added:
 repo finders (incl. the ownership check), an IP-safe `IssuedCertificateDTO` (omits
 `templateHtmlSnapshot`), `CertificateReadService`, and `LearnerCertificateController`
 (`/admin-core-service/certificate/learner/v1/my-certificates`).
+
+### 2.5 ⚠️ Response field casing — camelCase vs snake_case (read before touching a screen)
+
+The BFF reuses domain DTOs **as-is**, and their JSON casing is **inconsistent** —
+several serialize snake_case (`@JsonNaming`/`@JsonProperty`), others camelCase.
+Reading the wrong field renders a **blank or `0` silently** (no error, no warning).
+This has bitten every reused screen at least once. Always check the DTO's
+annotations before reading a field.
+
+| Screen | Source DTO | Casing | Fields the FE must read |
+|---|---|---|---|
+| progress | `LearnerSubjectWiseProgressReportDTO` | **snake_case** | `subject_name`, `modules[].module_completion_percentage` |
+| attendance | `StudentAttendanceReportDTO` / `ScheduleDetailDTO` | camelCase | `attendancePercentage`, `schedules[].{attendanceStatus, sessionTitle, subject, meetingDate}` |
+| assessments | `AssessmentHistoryResponse` | camelCase | `assessments[].{name, percentage, assessmentId}` |
+| payments | `InvoiceDTO` | **snake_case** | `invoice_number`, `total_amount`, `currency`, `status`, `id` |
+| rewards | `LearnerBadgeDTO` | camelCase | `badgeName`, `id` |
+| live-classes | `GroupedSessionsByDateDTO` (group) / `LiveSessionListDTO` (session) | group camelCase, **session snake_case** | group `{date, sessions}`, session `{title, subject, start_time, session_id}` |
+
+### 2.6 All-courses aggregation
+
+`GuardedChild.packageSessionIds` can hold **more than one** course. Endpoints that
+used to serve only the primary batch now **fan out over every course** — unless an
+explicit `packageSessionId` is passed, which scopes to that one course (validated
+against the child's own enrolments → 403 otherwise). See
+`ParentPortalDetailService.targetPackageSessions(...)`.
+
+- **`/progress/subjects`** → `CourseProgressDTO[]`, one per course
+  (`packageSessionId`, `courseName`, `subjects[]`). `courseName` reuses the
+  "Level Package (Session)" label from `LearnerInstituteManager.getInstituteDetails`
+  (same idiom as `ParentPortalChildrenService`).
+- **`/live-sessions/upcoming`** → per-course results **merged by date** (a class on
+  the same day from another course lands under the same date group).
+- **`/live-sessions/past`** → concatenated across courses (per-course pagination
+  merged; the current UI doesn't render a Past tab).
+- **`overview.courseCompletionPercent`** → averaged across all courses.
+- **Attendance** still uses the primary batch; per-course attendance is a possible
+  future add.
 
 ---
 
@@ -175,5 +212,8 @@ fills the one missing icon (payments). Five of six already exist in
 - `V15` seed for the `PARENT` role; repair for legacy role-less guardians.
 - hi/ar real translations (currently English placeholders).
 - Read-aloud / voice; a date-grouped activity feed.
-- The `/overview` headline numbers (attendance %, tests, upcoming) require the
-  enrichment in `ParentPortalOverviewService` to be deployed.
+- **Deploy dependency:** the `/overview` headline numbers (attendance %,
+  `courseCompletionPercent`, tests, upcoming) and the all-courses aggregation +
+  wider attendance windows live in the backend — they need an **admin-core
+  redeploy**. The frontend field-mapping fixes (§2.5) and the client-side 1-year
+  attendance window work against the live backend immediately.

--- a/frontend-learner-dashboard-app/src/locales/ar/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/ar/parent.json
@@ -118,6 +118,12 @@
   "attendance": {
     "summary": "{{name}} has attended {{percent}}% of classes.",
     "noData": "We don't have attendance for {{name}} yet.",
+    "attended": "{{present}} of {{total}} classes attended",
+    "recentTitle": "Recent classes",
+    "present": "Present",
+    "absent": "Absent",
+    "late": "Late",
+    "notMarked": "Not marked",
     "emptyTitle": "No attendance yet",
     "emptyBody": "Attendance will show here once classes begin."
   },

--- a/frontend-learner-dashboard-app/src/locales/en/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/en/parent.json
@@ -118,6 +118,12 @@
   "attendance": {
     "summary": "{{name}} has attended {{percent}}% of classes.",
     "noData": "We don't have attendance for {{name}} yet.",
+    "attended": "{{present}} of {{total}} classes attended",
+    "recentTitle": "Recent classes",
+    "present": "Present",
+    "absent": "Absent",
+    "late": "Late",
+    "notMarked": "Not marked",
     "emptyTitle": "No attendance yet",
     "emptyBody": "Attendance will show here once classes begin."
   },

--- a/frontend-learner-dashboard-app/src/locales/hi/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/hi/parent.json
@@ -118,6 +118,12 @@
   "attendance": {
     "summary": "{{name}} has attended {{percent}}% of classes.",
     "noData": "We don't have attendance for {{name}} yet.",
+    "attended": "{{present}} of {{total}} classes attended",
+    "recentTitle": "Recent classes",
+    "present": "Present",
+    "absent": "Absent",
+    "late": "Late",
+    "notMarked": "Not marked",
     "emptyTitle": "No attendance yet",
     "emptyBody": "Attendance will show here once classes begin."
   },

--- a/frontend-learner-dashboard-app/src/routes/parent/child/$childId/attendance/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/$childId/attendance/index.tsx
@@ -1,13 +1,33 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { CalendarCheck } from "@phosphor-icons/react";
 import { ModuleScaffold } from "../../-components/ModuleScaffold";
 import { ParentStatusChip } from "../../-components/ParentStatusChip";
+import type { ParentStatusTone } from "../../-components/ParentStatusChip";
 import { useChildAttendance, useChildOverview } from "../../-hooks/use-parent-child";
 
 export const Route = createFileRoute("/parent/child/$childId/attendance/")({
   component: AttendanceScreen,
 });
+
+// present → green tick, absent → red cross, late → amber, anything else → neutral.
+// Always colour + icon + word (ParentStatusChip), never colour alone.
+function statusToneLabel(status: unknown, t: TFunction): { tone: ParentStatusTone; label: string } {
+  const s = String(status ?? "").toUpperCase();
+  if (s === "PRESENT") return { tone: "good", label: t("attendance.present") };
+  if (s === "ABSENT") return { tone: "action", label: t("attendance.absent") };
+  if (s === "LATE") return { tone: "watch", label: t("attendance.late") };
+  return { tone: "neutral", label: t("attendance.notMarked") };
+}
+
+function formatDate(meetingDate: unknown): string {
+  const raw = typeof meetingDate === "string" ? meetingDate : "";
+  if (!raw) return "";
+  const d = new Date(`${raw}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" });
+}
 
 function AttendanceScreen() {
   const { childId } = useParams({ from: "/parent/child/$childId/attendance/" });
@@ -19,7 +39,16 @@ function AttendanceScreen() {
   const percent = typeof data?.attendancePercentage === "number" ? Math.round(data.attendancePercentage) : null;
   const schedules = Array.isArray(data?.schedules) ? (data!.schedules as Record<string, unknown>[]) : [];
 
-  const tone = percent === null ? "neutral" : percent >= 75 ? "good" : percent >= 60 ? "watch" : "action";
+  // Most recent classes first.
+  const recent = [...schedules].sort((a, b) =>
+    String(b.meetingDate ?? "").localeCompare(String(a.meetingDate ?? "")),
+  );
+  const presentCount = schedules.filter(
+    (s) => String(s.attendanceStatus ?? "").toUpperCase() === "PRESENT",
+  ).length;
+
+  const summaryTone: ParentStatusTone =
+    percent === null ? "neutral" : percent >= 75 ? "good" : percent >= 60 ? "watch" : "action";
 
   return (
     <ModuleScaffold
@@ -39,11 +68,47 @@ function AttendanceScreen() {
       emptyTitle={t("attendance.emptyTitle")}
       emptyBody={t("attendance.emptyBody")}
     >
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-5">
+        {/* Headline: big % + how many classes attended */}
         {percent !== null ? (
-          <div className="flex items-center justify-between rounded-2xl bg-card shadow-sm px-5 py-4">
-            <span className="text-h1 font-semibold text-foreground">{percent}%</span>
-            <ParentStatusChip tone={tone} label={t(`tone.${tone}`)} />
+          <div className="flex items-center justify-between gap-3 rounded-2xl bg-card px-5 py-4 shadow-sm">
+            <div className="flex flex-col">
+              <span className="text-h1 font-semibold text-foreground">{percent}%</span>
+              {schedules.length > 0 ? (
+                <span className="text-caption text-muted-foreground">
+                  {t("attendance.attended", { present: presentCount, total: schedules.length })}
+                </span>
+              ) : null}
+            </div>
+            <ParentStatusChip tone={summaryTone} label={t(`tone.${summaryTone}`)} />
+          </div>
+        ) : null}
+
+        {/* Recent classes — each with a present / absent chip */}
+        {recent.length > 0 ? (
+          <div className="flex flex-col gap-3">
+            <h2 className="text-body font-semibold text-foreground">{t("attendance.recentTitle")}</h2>
+            <ul className="flex flex-col gap-2">
+              {recent.map((s, i) => {
+                const info = statusToneLabel(s.attendanceStatus, t);
+                const title = String(s.sessionTitle ?? s.subject ?? t("liveClasses.session"));
+                const dateLabel = formatDate(s.meetingDate);
+                return (
+                  <li
+                    key={String(s.scheduleId ?? i)}
+                    className="flex items-center justify-between gap-3 rounded-2xl bg-card px-4 py-3.5 shadow-sm"
+                  >
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-body font-medium text-foreground">{title}</span>
+                      {dateLabel ? (
+                        <span className="text-caption text-muted-foreground">{dateLabel}</span>
+                      ) : null}
+                    </div>
+                    <ParentStatusChip tone={info.tone} label={info.label} />
+                  </li>
+                );
+              })}
+            </ul>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
Attendance screen was showing only the percentage. It now also lists the child's recent classes with a per-session Present / Absent chip (colour + icon + word, colour-blind safe), most-recent first, plus an "X of Y classes attended" line. Reads the camelCase ScheduleDetailDTO fields (attendanceStatus, sessionTitle, subject, meetingDate). New i18n keys in en/hi/ar (present/absent/late/notMarked/recentTitle/attended).

Docs: expanded docs/PARENT_PORTAL.md so other developers can pick up the feature — added the camelCase-vs-snake_case response field-mapping table (the recurring silent-blank gotcha), the all-courses aggregation section (progress per course, live sessions merged), and the admin-core redeploy dependency.

Frontend works against the live backend now (attendance schedules are already returned by the deployed endpoint).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
