### PR TITLE
fix(audience-form): order public form fields by per-form individual_o…

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/audience-response/-components/audience-response-form.tsx
+++ b/frontend-learner-dashboard-app/src/routes/audience-response/-components/audience-response-form.tsx
@@ -51,7 +51,14 @@ const convertAudienceCustomFields = (
         id: customField.id,
         field_name: customField.fieldName,
         field_key: customField.fieldKey,
-        field_order: customField.individualOrder || customField.formOrder || 0,
+        // Order by the per-form mapping order (individual_order) so each form controls
+        // its own field sequence. Fall back to the nested/master order only when the
+        // mapping has none. Use ?? (not ||) so a valid 0 (first position) is respected.
+        field_order:
+          field.individual_order ??
+          customField.individualOrder ??
+          customField.formOrder ??
+          0,
         comma_separated_options: customField.config || "",
         config: customField.config || "{}",
         status: field.status || "ACTIVE",


### PR DESCRIPTION
…rder

The public audience/campaign response form sorted fields by the shared master custom_field.formOrder, ignoring the per-form institute_custom_fields.individual_order. Because form_order lives on masters shared across many forms (Email/Phone/Full Name span 60-90 forms), per-form ordering never took effect — and the admin drag-reorder, which writes individual_order, had no visible result on the public form.

Prefer the mapping's individual_order, falling back to the nested/master order only when unset. Use ?? (not ||) so a valid 0 (first position) is respected.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
