### PR TITLE
feat(custom-fields): render T&C/consent description on CHECKBOX fields

### DIFF
--- a/frontend-admin-dashboard/src/components/common/custom-fields/AddCustomFieldDialog.tsx
+++ b/frontend-admin-dashboard/src/components/common/custom-fields/AddCustomFieldDialog.tsx
@@ -35,6 +35,7 @@ export interface CustomFieldConfig {
     countryCode?: string;
     allowedFileTypes?: string[];
     maxSizeMB?: number;
+    description?: string;
 }
 
 interface AddCustomFieldDialogProps {
@@ -66,6 +67,7 @@ export const AddCustomFieldDialog = ({
     const [dropdownOptions, setDropdownOptions] = useState<DropdownOption[]>([]);
     const [defaultValue, setDefaultValue] = useState('');
     const [checkboxDefault, setCheckboxDefault] = useState(false);
+    const [checkboxDescription, setCheckboxDescription] = useState('');
     const [allowedFileTypes, setAllowedFileTypes] = useState<string[]>([]);
     const [maxSizeMB, setMaxSizeMB] = useState<number>(5);
 
@@ -114,6 +116,7 @@ export const AddCustomFieldDialog = ({
         setDropdownOptions([]);
         setDefaultValue('');
         setCheckboxDefault(false);
+        setCheckboxDescription('');
         setAllowedFileTypes([]);
         setMaxSizeMB(5);
     };
@@ -123,6 +126,9 @@ export const AddCustomFieldDialog = ({
 
         if (selectedType === 'checkbox') {
             config.defaultValue = checkboxDefault ? 'true' : 'false';
+            if (checkboxDescription.trim()) {
+                config.description = checkboxDescription.trim();
+            }
         } else if (selectedType === 'file') {
             if (allowedFileTypes.length > 0) config.allowedFileTypes = allowedFileTypes;
             config.maxSizeMB = maxSizeMB;
@@ -335,18 +341,37 @@ export const AddCustomFieldDialog = ({
                 );
             case 'checkbox':
                 return (
-                    <div className="mt-2 flex items-center gap-2">
-                        <Label className="text-sm font-medium">Default Value:</Label>
-                        <div className="flex items-center gap-2">
-                            <Checkbox
-                                checked={checkboxDefault}
-                                onCheckedChange={(checked) =>
-                                    setCheckboxDefault(checked === true)
-                                }
+                    <div className="mt-2 flex flex-col gap-3">
+                        <div className="flex flex-col gap-1">
+                            <Label className="text-sm font-medium">
+                                Description / Consent Text (Optional)
+                            </Label>
+                            <textarea
+                                placeholder="e.g. Terms & Conditions text shown above the checkbox. Line breaks are preserved."
+                                value={checkboxDescription}
+                                onChange={(e) => setCheckboxDescription(e.target.value)}
+                                className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
+                                rows={5}
                             />
-                            <span className="text-sm">
-                                {checkboxDefault ? 'Checked' : 'Unchecked'}
-                            </span>
+                            <p className="text-caption text-neutral-500">
+                                Shown as a scrollable block above the checkbox. Use the
+                                Field Name for the short consent label (e.g. &ldquo;Yes, I
+                                agree&rdquo;).
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Label className="text-sm font-medium">Default Value:</Label>
+                            <div className="flex items-center gap-2">
+                                <Checkbox
+                                    checked={checkboxDefault}
+                                    onCheckedChange={(checked) =>
+                                        setCheckboxDefault(checked === true)
+                                    }
+                                />
+                                <span className="text-sm">
+                                    {checkboxDefault ? 'Checked' : 'Unchecked'}
+                                </span>
+                            </div>
                         </div>
                     </div>
                 );
@@ -415,6 +440,7 @@ export const AddCustomFieldDialog = ({
                                 setDropdownOptions([]);
                                 setDefaultValue('');
                                 setCheckboxDefault(false);
+                                setCheckboxDescription('');
                                 setAllowedFileTypes([]);
                             }}
                         >

--- a/frontend-admin-dashboard/src/components/common/custom-fields/CustomFieldRenderer.tsx
+++ b/frontend-admin-dashboard/src/components/common/custom-fields/CustomFieldRenderer.tsx
@@ -32,6 +32,7 @@ interface CustomFieldRendererProps {
         defaultValue?: string;
         allowedFileTypes?: string[];
         maxSizeMB?: number;
+        description?: string;
     };
     onFileUpload?: (file: File) => void;
 }
@@ -228,19 +229,33 @@ export const CustomFieldRenderer = ({
                 />
             );
 
-        case 'checkbox':
+        case 'checkbox': {
+            // Optional long body (e.g. Terms & Conditions) shown above the box.
+            // whitespace-pre-line preserves the admin's line breaks; scrolls if long.
+            const description = config?.description;
             return (
-                <div className="flex items-center gap-2">
-                    <Checkbox
-                        checked={value === 'true'}
-                        onCheckedChange={(checked) =>
-                            handleChange(checked === true ? 'true' : 'false')
-                        }
-                        disabled={disabled}
-                    />
-                    <Label className="text-sm">{name}</Label>
+                <div className="flex flex-col gap-2">
+                    {description && (
+                        <div className="max-h-60 overflow-y-auto whitespace-pre-line rounded-md border border-neutral-200 bg-neutral-50 p-3 text-sm text-neutral-700">
+                            {description}
+                        </div>
+                    )}
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            checked={value === 'true'}
+                            onCheckedChange={(checked) =>
+                                handleChange(checked === true ? 'true' : 'false')
+                            }
+                            disabled={disabled}
+                        />
+                        <Label className="text-sm">
+                            {name}
+                            {required && <span className="text-danger-600"> *</span>}
+                        </Label>
+                    </div>
                 </div>
             );
+        }
 
         case 'dropdown':
             return (

--- a/frontend-admin-dashboard/src/services/custom-field-settings.ts
+++ b/frontend-admin-dashboard/src/services/custom-field-settings.ts
@@ -91,6 +91,11 @@ export interface CustomFieldFullConfig {
     countryCode?: string;
     allowedFileTypes?: string[];
     maxSizeMB?: number;
+    // Long descriptive body rendered above the input (e.g. a Terms & Conditions
+    // block above a "Yes, I agree" checkbox). Lives in config because fieldName
+    // is varchar(255); config is unbounded text. extractConfigExtras forwards
+    // it verbatim through buildConfigJson.
+    description?: string;
 }
 
 // API Response Types (what we get from GET_INSITITUTE_SETTINGS)

--- a/frontend-learner-dashboard-app/src/components/common/custom-fields/CustomFieldRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/custom-fields/CustomFieldRenderer.tsx
@@ -269,19 +269,34 @@ export const CustomFieldRenderer = ({
         />
       );
 
-    case FieldRenderType.CHECKBOX:
+    case FieldRenderType.CHECKBOX: {
+      // Optional long body (e.g. Terms & Conditions) shown above the checkbox.
+      // `whitespace-pre-line` preserves the admin's line breaks; the block
+      // scrolls if the text is long so it never dominates the form.
+      const description = parsedConfig?.description;
       return (
-        <div className="flex items-center gap-2">
-          <Checkbox
-            checked={value === "true"}
-            onCheckedChange={(checked) =>
-              handleChange(checked === true ? "true" : "false")
-            }
-            disabled={disabled}
-          />
-          <Label className="text-sm">{name}</Label>
+        <div className="flex flex-col gap-2">
+          {description && (
+            <div className="max-h-60 overflow-y-auto whitespace-pre-line rounded-md border border-neutral-200 bg-neutral-50 p-3 text-sm text-neutral-700">
+              {description}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={value === "true"}
+              onCheckedChange={(checked) =>
+                handleChange(checked === true ? "true" : "false")
+              }
+              disabled={disabled}
+            />
+            <Label className="text-sm">
+              {name}
+              {required && <span className="text-danger-600"> *</span>}
+            </Label>
+          </div>
         </div>
       );
+    }
 
     case FieldRenderType.DROPDOWN:
       return (

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/registration-step.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/registration-step.tsx
@@ -702,12 +702,18 @@ const RegistrationStep = ({
                       render={({ field: formField }) => (
                         <FormItem>
                           <div className="flex flex-col gap-1">
-                            <label className="text-subtitle font-regular">
-                              {capitalise(value.name)}
-                              {value.is_mandatory && (
-                                <span className="text-danger-600"> *</span>
-                              )}
-                            </label>
+                            {/* Checkbox fields render their own inline label
+                                (and optional description block) inside the
+                                renderer, so skip the label-above to avoid a
+                                duplicate. */}
+                            {renderType !== FieldRenderType.CHECKBOX && (
+                              <label className="text-subtitle font-regular">
+                                {capitalise(value.name)}
+                                {value.is_mandatory && (
+                                  <span className="text-danger-600"> *</span>
+                                )}
+                              </label>
+                            )}
                             <FormControl>
                               <CustomFieldRenderer
                                 type={renderType}

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/custom-field-helpers.ts
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-utils/custom-field-helpers.ts
@@ -126,6 +126,10 @@ export interface CustomFieldFullConfig {
   minDate?: string;
   maxDate?: string;
   maxLength?: number;
+  // Long descriptive body shown above the input (e.g. a Terms & Conditions
+  // block above a "Yes, I agree" checkbox). Stored here instead of fieldName
+  // because fieldName is varchar(255); config is unbounded text.
+  description?: string;
 }
 
 // Sentinel value for the admin's "All Files" option — equivalent to no

--- a/frontend-learner-dashboard-app/src/routes/audience-response/-components/audience-response-form.tsx
+++ b/frontend-learner-dashboard-app/src/routes/audience-response/-components/audience-response-form.tsx
@@ -504,12 +504,18 @@ const AudienceResponseForm = ({
                             render={({ field: formField }) => (
                               <FormItem>
                                 <div className="flex flex-col gap-1">
-                                  <label className="text-subtitle font-regular">
-                                    {capitalise(field.field_name)}
-                                    {field.is_mandatory && (
-                                      <span className="text-danger-600"> *</span>
-                                    )}
-                                  </label>
+                                  {/* Checkbox fields render their own inline
+                                      label (and optional description block)
+                                      inside the renderer — skip the label-above
+                                      to avoid a duplicate. */}
+                                  {fallbackRenderType !== FieldRenderType.CHECKBOX && (
+                                    <label className="text-subtitle font-regular">
+                                      {capitalise(field.field_name)}
+                                      {field.is_mandatory && (
+                                        <span className="text-danger-600"> *</span>
+                                      )}
+                                    </label>
+                                  )}
                                   <FormControl>
                                     <CustomFieldRenderer
                                       type={fallbackRenderType}
@@ -567,12 +573,18 @@ const AudienceResponseForm = ({
                           render={({ field: formField }) => (
                             <FormItem>
                               <div className="flex flex-col gap-1">
-                                <label className="text-subtitle font-regular">
-                                  {capitalise(value.name)}
-                                  {value.is_mandatory && (
-                                    <span className="text-danger-600"> *</span>
-                                  )}
-                                </label>
+                                {/* Checkbox fields render their own inline label
+                                    (and optional description block) inside the
+                                    renderer — skip the label-above to avoid a
+                                    duplicate. */}
+                                {renderType !== FieldRenderType.CHECKBOX && (
+                                  <label className="text-subtitle font-regular">
+                                    {capitalise(value.name)}
+                                    {value.is_mandatory && (
+                                      <span className="text-danger-600"> *</span>
+                                    )}
+                                  </label>
+                                )}
                                 <FormControl>
                                   <CustomFieldRenderer
                                     type={renderType}


### PR DESCRIPTION
CHECKBOX custom fields can now carry a long descriptive body (e.g. a Terms & Conditions block) in config.description, rendered as a scrollable block above the checkbox. fieldName stays the short consent label (e.g. "Yes, I agree") since it is varchar(255); config is unbounded text.

- Shared CustomFieldRenderer (learner + admin): render config.description above the checkbox; show the required asterisk inline.
- Learner enroll-invite registration-step + audience-response-form: skip the duplicate label-above for checkboxes (the renderer owns the inline label).
- Admin AddCustomFieldDialog: author the description via a textarea for checkbox fields; persisted through config.description.
- Types: add description to CustomFieldFullConfig in both apps.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
