### PR TITLE
fix(audience): scope sub-org admin lead visibility to their sub-org's…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -133,6 +133,10 @@ public class AudienceService {
     @Autowired
     private vacademy.io.admin_core_service.features.counsellor_workbench.service.CounsellorScopeService counsellorScopeService;
 
+    /** Resolves a sub-org admin's lead scope (their sub-org's members) — see getLeads. */
+    @Autowired
+    private vacademy.io.admin_core_service.features.suborg.service.SubOrgLeadScopeService subOrgLeadScopeService;
+
     @Autowired
     private InstituteCustomFieldRepository instituteCustomFieldRepository;
 
@@ -2418,6 +2422,34 @@ public class AudienceService {
             return LeadCounsellorOptionsDTO.builder().scoped(false).counsellors(List.of()).build();
         }
 
+        // Sub-org admin: scope the counsellor roster to their sub-org, consistent
+        // with the sub-org-scoped leads in getLeads. Detected by the ACTIVE SUB_ORG
+        // FSPSSM linkage (a sub-org admin also holds the parent ADMIN role and would
+        // otherwise get the full institute roster). This one branch covers BOTH the
+        // filter dropdown (assignable=false) and the assignment pickers
+        // (assignable=true), so a sub-org admin can neither filter by nor assign to
+        // counsellors outside their sub-org. scoped=true tells the frontend the
+        // roster is narrowed server-side.
+        List<String> subOrgMembers = subOrgLeadScopeService
+                .subOrgScopedCounsellorUserIds(caller.getUserId());
+        if (!subOrgMembers.isEmpty()) {
+            // Show only the sub-org's actual COUNSELLORS — not the sub-org admin
+            // themselves or other non-counsellor team members (teachers, etc.).
+            // Intersect the sub-org members with the institute's COUNSELLOR-role
+            // roster. Fall back to the full member set only if that intersection is
+            // empty, so a sub-org whose counsellors don't yet carry the COUNSELLOR
+            // role still gets a usable picker rather than an empty dropdown.
+            Set<String> counsellorRoster = new HashSet<>(
+                    counsellorScopeService.allCounsellorUserIds(instituteId));
+            List<String> subOrgCounsellors = subOrgMembers.stream()
+                    .filter(counsellorRoster::contains)
+                    .collect(Collectors.toList());
+            List<String> rosterIds = subOrgCounsellors.isEmpty() ? subOrgMembers : subOrgCounsellors;
+            List<vacademy.io.common.auth.dto.UserDTO> subOrgUsers =
+                    authService.getUsersFromAuthServiceByUserIds(rosterIds);
+            return LeadCounsellorOptionsDTO.builder().scoped(true).counsellors(subOrgUsers).build();
+        }
+
         boolean scoped = counsellorScopeService.isScopedCaller(instituteId, caller);
         // assignable=true resolves ASSIGNMENT targets (bulk-assign dialog,
         // telephony/IVR routing config): ADMIN-role callers get the
@@ -2480,7 +2512,32 @@ public class AudienceService {
         // sending assignedCounselorId.
         String assignedCounselorIdsCsv = null;
         boolean rbacApplied = false;
+
+        // Sub-org admin scoping (highest precedence). A sub-org admin is ALSO
+        // granted the parent institute's ADMIN role, so without this they'd
+        // resolve to DEFAULT above and see the entire parent lead pool. Detection
+        // is by ACTIVE SUB_ORG FSPSSM linkage (SubOrgLeadScopeService) — the only
+        // reliable fingerprint, since by role they're indistinguishable from a
+        // true institute admin. We hard-scope their visible leads to the members
+        // of the sub-org(s) they administer, reusing the same assignedCounselorIdsCsv
+        // filter the counsellor-hierarchy RBAC below uses. The member set always
+        // includes the admin themselves, so a non-empty result also means "is a
+        // sub-org admin"; an empty result means a normal admin/user and this
+        // branch is a no-op that preserves the pre-existing behaviour exactly.
+        boolean subOrgScopeApplied = false;
         if (user != null && user.getUserId() != null
+                && filterDTO.getInstituteId() != null
+                && !filterDTO.getInstituteId().isBlank()) {
+            List<String> subOrgScope = subOrgLeadScopeService
+                    .subOrgScopedCounsellorUserIds(user.getUserId());
+            if (!subOrgScope.isEmpty()) {
+                assignedCounselorIdsCsv = String.join(",", subOrgScope);
+                rbacApplied = true;
+                subOrgScopeApplied = true;
+            }
+        }
+
+        if (!subOrgScopeApplied && user != null && user.getUserId() != null
                 && filterDTO.getInstituteId() != null
                 && !filterDTO.getInstituteId().isBlank()) {
             String instituteId = filterDTO.getInstituteId();
@@ -2512,7 +2569,10 @@ public class AudienceService {
         // we drop unassigned leads (no counsellor on either linked_users or
         // user_lead_profile) from the result; any other mode keeps them visible
         // to anyone in scope, as before.
-        boolean includeUnassigned = access.getMode() != Mode.COUNSELOR;
+        // A sub-org admin sees ONLY leads assigned to their sub-org's members;
+        // the shared unassigned pool belongs to the parent institute, so it is
+        // excluded from their view alongside the COUNSELOR-mode exclusion.
+        boolean includeUnassigned = access.getMode() != Mode.COUNSELOR && !subOrgScopeApplied;
 
         String allowedAudienceIdsCsv = null;
         if (access.getMode() == Mode.AUDIENCE_LIST) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgLeadScopeService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgLeadScopeService.java
@@ -1,0 +1,87 @@
+package vacademy.io.admin_core_service.features.suborg.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import vacademy.io.admin_core_service.features.faculty.repository.FacultySubjectPackageSessionMappingRepository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Resolves the lead-visibility scope for a <b>sub-org admin</b>.
+ *
+ * <p>Why this exists as its own detector rather than a role check or an
+ * institute setting: a sub-org admin is <i>also granted the parent institute's
+ * {@code ADMIN} role</i> (see {@code SubOrgTeamService.ensureCallerCanAccessSubOrg}),
+ * so by role they are indistinguishable from a true institute admin. The only
+ * reliable fingerprint of a sub-org admin is the presence of ACTIVE
+ * {@code SUB_ORG}-linked {@code FacultySubjectPackageSessionMapping} rows — the
+ * exact same signal the sub-org team-management code uses. Because of that, the
+ * "should this caller be scoped" decision cannot live in the role-keyed
+ * audience-access setting; it has to be resolved from FSPSSM at request time.
+ *
+ * <p>A sub-org admin must see only the leads assigned to members of the
+ * sub-org(s) they administer — never the parent institute's full lead pool.
+ * This is a data-isolation requirement, not a configurable display preference,
+ * so it is enforced by default with no setting toggle.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubOrgLeadScopeService {
+
+    private static final List<String> ACTIVE = List.of("ACTIVE");
+
+    private final FacultySubjectPackageSessionMappingRepository facultyMappingRepository;
+
+    /**
+     * The sub-orgs the caller currently administers (ACTIVE {@code SUB_ORG}
+     * FSPSSM linkage). Empty for a true institute admin / any non-sub-org user.
+     */
+    public List<String> callerSubOrgIds(String callerUserId) {
+        if (callerUserId == null || callerUserId.isBlank()) return Collections.emptyList();
+        try {
+            return facultyMappingRepository
+                    .findDistinctSubOrgIdsByUserAndLinkage(callerUserId, ACTIVE);
+        } catch (Exception e) {
+            // Fail closed to "not a sub-org admin" — a DB hiccup must not silently
+            // widen a sub-org admin's view to the whole parent institute. The
+            // caller then falls through to the normal (admin/counsellor) rules.
+            log.warn("callerSubOrgIds({}) failed, treating as non-sub-org: {}",
+                    callerUserId, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /** True when the caller administers at least one sub-org. */
+    public boolean isSubOrgAdmin(String callerUserId) {
+        return !callerSubOrgIds(callerUserId).isEmpty();
+    }
+
+    /**
+     * Distinct member user_ids across every sub-org the caller administers —
+     * i.e. the counsellors (and the sub-org admin themselves) whose assigned
+     * leads a sub-org admin is allowed to see. Returns an empty list when the
+     * caller is not a sub-org admin, so callers can treat "empty" as "no
+     * sub-org scoping applies".
+     */
+    public List<String> subOrgScopedCounsellorUserIds(String callerUserId) {
+        List<String> subOrgIds = callerSubOrgIds(callerUserId);
+        if (subOrgIds.isEmpty()) return Collections.emptyList();
+        LinkedHashSet<String> members = new LinkedHashSet<>();
+        for (String subOrgId : subOrgIds) {
+            if (subOrgId == null || subOrgId.isBlank()) continue;
+            try {
+                members.addAll(facultyMappingRepository
+                        .findDistinctUserIdsBySubOrgIdAndLinkage(subOrgId, ACTIVE));
+            } catch (Exception e) {
+                log.warn("subOrgScopedCounsellorUserIds: members lookup for sub-org {} failed: {}",
+                        subOrgId, e.getMessage());
+            }
+        }
+        return new ArrayList<>(members);
+    }
+}


### PR DESCRIPTION
… counsellors

A sub-org admin also holds the parent institute's ADMIN role, so lead visibility (scoped only by institute_id + counsellor org-team hierarchy) resolved to DEFAULT and showed the whole parent lead pool, with no way to see just their sub-org's counsellors' leads.

- Add SubOrgLeadScopeService: detect a sub-org admin by ACTIVE SUB_ORG FSPSSM linkage (role is unreliable — they share the ADMIN role with true admins) and resolve the sub-org's member user ids.
- getLeads: highest-precedence sub-org branch scopes assignedCounselorIdsCsv to the sub-org's members and excludes the shared unassigned pool. Reuses the existing STRING_TO_ARRAY(...) = ANY predicate — no SQL change.
- leadCounsellorOptions: scope the filter dropdown and both assign pickers to the sub-org's actual counsellors (members intersected with the COUNSELLOR roster; fallback to members if empty).

Non-sub-org callers get an empty sub-org scope, so every branch is a no-op and existing behaviour is unchanged. Compile-verified.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
