### PR TITLE
feat(sub-org): data-driven multi-select registration filters + list pagination

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/repository/CustomFieldValuesRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/repository/CustomFieldValuesRepository.java
@@ -54,6 +54,19 @@ public interface CustomFieldValuesRepository extends JpaRepository<CustomFieldVa
     List<CustomFieldValues> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 
     /**
+     * Distinct (customFieldId, value) pairs collected for one type_id under a source
+     * type — powers the admin registration listing's per-custom-field filter options.
+     * Blank values excluded; each row is [customFieldId, value].
+     */
+    @Query("SELECT DISTINCT cfv.customFieldId, cfv.value FROM CustomFieldValues cfv " +
+            "WHERE cfv.sourceType = :sourceType AND cfv.typeId = :typeId " +
+            "AND cfv.value IS NOT NULL AND TRIM(cfv.value) <> '' " +
+            "ORDER BY cfv.customFieldId, cfv.value")
+    List<Object[]> findDistinctFieldValuesByTypeId(
+            @Param("sourceType") String sourceType,
+            @Param("typeId") String typeId);
+
+    /**
      * Distinct audience_response IDs whose value for a given custom field is one
      * of the supplied values. Single indexed lookup (idx_cfv_field_source_value)
      * used to pre-resolve the leads custom-field filter into a concrete id set,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteSubOrgRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteSubOrgRepository.java
@@ -1,5 +1,7 @@
 package vacademy.io.admin_core_service.features.institute.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import vacademy.io.admin_core_service.features.institute.entity.InstituteSubOrg;
@@ -9,6 +11,9 @@ import java.util.List;
 @Repository
 public interface InstituteSubOrgRepository extends JpaRepository<InstituteSubOrg, String> {
     List<InstituteSubOrg> findByInstituteId(String instituteId);
+
+    /** Paginated variant for the Manage VLEs listing (sort + page carried by Pageable). */
+    Page<InstituteSubOrg> findByInstituteId(String instituteId, Pageable pageable);
 
     List<InstituteSubOrg> findBySuborgId(String suborgId);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/controller/SubOrgController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/controller/SubOrgController.java
@@ -2,6 +2,10 @@ package vacademy.io.admin_core_service.features.suborg.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -66,14 +70,18 @@ public class SubOrgController {
         return ResponseEntity.ok(subOrgService.getSubOrgs(parentInstituteId));
     }
 
-    /** Enriched list for the Manage VLEs table: admin email/phone, plan status, seats + invite.
-     *  Guarded to the caller's own institute — the row returns admin PII (email/phone). */
+    /** Enriched, paginated list for the Manage VLEs table: admin email/phone, plan status,
+     *  seats + invite. Newest sub-orgs first. Guarded to the caller's own institute — the
+     *  row returns admin PII (email/phone). */
     @GetMapping("/get-all-with-details")
-    public ResponseEntity<List<SubOrgListItemDTO>> getSubOrgsWithDetails(
+    public ResponseEntity<Page<SubOrgListItemDTO>> getSubOrgsWithDetails(
             @RequestParam String parentInstituteId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestAttribute(value = "user", required = false) CustomUserDetails user) {
         assertInstituteAdmin(user, parentInstituteId);
-        return ResponseEntity.ok(subOrgListService.getSubOrgsWithDetails(parentInstituteId));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return ResponseEntity.ok(subOrgListService.getSubOrgsWithDetails(parentInstituteId, pageable));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/controller/SubOrgRegistrationAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/controller/SubOrgRegistrationAdminController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.CreateRegistrationTemplateDTO;
+import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.RegistrationFacetsDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.RegistrationListItemDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.TemplateListItemDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.TemplateDetailDTO;
@@ -19,6 +20,8 @@ import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.auth.repository.UserRoleRepository;
 import vacademy.io.common.exceptions.VacademyException;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -85,18 +88,56 @@ public class SubOrgRegistrationAdminController {
     public ResponseEntity<Page<RegistrationListItemDTO>> listRegistrations(
             @RequestParam("templateInviteId") String templateInviteId,
             @RequestParam("instituteId") String instituteId,
-            @RequestParam(value = "city", required = false) String city,
-            @RequestParam(value = "state", required = false) String state,
-            @RequestParam(value = "pincode", required = false) String pincode,
+            @RequestParam(value = "cities", required = false) List<String> cities,
+            @RequestParam(value = "states", required = false) List<String> states,
+            @RequestParam(value = "pincodes", required = false) List<String> pincodes,
             @RequestParam(value = "status", required = false) String status,
             @RequestParam(value = "search", required = false) String search,
+            // Per-custom-field filters as repeated "fieldId:value" params (colon-delimited;
+            // the field id is a UUID so it never contains a colon — split on the first one).
+            @RequestParam(value = "customField", required = false) List<String> customField,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestAttribute(value = "user", required = false) CustomUserDetails user) {
         assertInstituteAdmin(user, instituteId);
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return ResponseEntity.ok(templateService.listRegistrations(
-                templateInviteId, instituteId, city, state, pincode, status, search, pageable));
+                templateInviteId, instituteId, cities, states, pincodes, status, search,
+                parseCustomFieldFilters(customField), pageable));
+    }
+
+    /** Groups repeated "fieldId:value" params into {fieldId -> [values]}. */
+    private Map<String, List<String>> parseCustomFieldFilters(List<String> customField) {
+        Map<String, List<String>> filters = new LinkedHashMap<>();
+        if (customField == null) {
+            return filters;
+        }
+        for (String entry : customField) {
+            if (entry == null) {
+                continue;
+            }
+            int idx = entry.indexOf(':');
+            if (idx <= 0 || idx == entry.length() - 1) {
+                continue; // need a non-empty fieldId and value
+            }
+            String fieldId = entry.substring(0, idx).trim();
+            String value = entry.substring(idx + 1).trim();
+            if (fieldId.isEmpty() || value.isEmpty()) {
+                continue;
+            }
+            filters.computeIfAbsent(fieldId, k -> new ArrayList<>()).add(value);
+        }
+        return filters;
+    }
+
+    /** Distinct City/State/Pincode values across this link's registrations — populates the listing filters. */
+    @GetMapping("/registrations/facets")
+    public ResponseEntity<RegistrationFacetsDTO> registrationFacets(
+            @RequestParam("templateInviteId") String templateInviteId,
+            @RequestParam("instituteId") String instituteId,
+            @RequestAttribute(value = "user", required = false) CustomUserDetails user) {
+        assertInstituteAdmin(user, instituteId);
+        return ResponseEntity.ok(templateService.getRegistrationFacets(templateInviteId, instituteId));
     }
 
     // ── Authorization guard ──────────────────────────────────────────────────

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/dto/SubOrgRegistrationFlowDTOs.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/dto/SubOrgRegistrationFlowDTOs.java
@@ -347,4 +347,42 @@ public final class SubOrgRegistrationFlowDTOs {
         /** Null = KYC not started / not required. */
         private String kycStatus;
     }
+
+    /**
+     * Distinct values actually present in a template's registrations — used to
+     * populate the admin listing's multi-select filters with real, searchable
+     * options (nothing hardcoded).
+     *
+     * `cities`/`states`/`pincodes` are the fixed address columns (present only
+     * when the template collects address); `customFields` is one entry per
+     * form-collected custom field that is worth filtering on (its distinct
+     * submitted values), so the filter set adapts to whatever each form asks.
+     * All lists are empty when nothing was collected yet.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class RegistrationFacetsDTO {
+        private List<String> cities;
+        private List<String> states;
+        private List<String> pincodes;
+        private List<CustomFieldFacetDTO> customFields;
+    }
+
+    /** One filterable custom field + the distinct values its registrants submitted. */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class CustomFieldFacetDTO {
+        /** The custom_field id (matches CustomFieldValues.customFieldId). */
+        private String id;
+        /** Human label shown on the filter (the field name). */
+        private String label;
+        /** Distinct, non-blank, sorted values submitted for this field. */
+        private List<String> values;
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationRepository.java
@@ -40,4 +40,22 @@ public interface SubOrgRegistrationRepository
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM SubOrgRegistration r WHERE r.id = :id")
     Optional<SubOrgRegistration> findWithLockById(@Param("id") String id);
+
+    // ── Distinct address facets (drive the admin listing's multi-select filters) ──
+    // Non-blank, sorted, deduped values as the registrants typed them.
+
+    @Query("SELECT DISTINCT r.city FROM SubOrgRegistration r " +
+            "WHERE r.templateInviteId = :templateInviteId AND r.city IS NOT NULL AND TRIM(r.city) <> '' " +
+            "ORDER BY r.city")
+    List<String> findDistinctCities(@Param("templateInviteId") String templateInviteId);
+
+    @Query("SELECT DISTINCT r.state FROM SubOrgRegistration r " +
+            "WHERE r.templateInviteId = :templateInviteId AND r.state IS NOT NULL AND TRIM(r.state) <> '' " +
+            "ORDER BY r.state")
+    List<String> findDistinctStates(@Param("templateInviteId") String templateInviteId);
+
+    @Query("SELECT DISTINCT r.pincode FROM SubOrgRegistration r " +
+            "WHERE r.templateInviteId = :templateInviteId AND r.pincode IS NOT NULL AND TRIM(r.pincode) <> '' " +
+            "ORDER BY r.pincode")
+    List<String> findDistinctPincodes(@Param("templateInviteId") String templateInviteId);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationSpecification.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationSpecification.java
@@ -1,28 +1,45 @@
 package vacademy.io.admin_core_service.features.suborg.registration.repository;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.common.entity.CustomFieldValues;
+import vacademy.io.admin_core_service.features.common.enums.CustomFieldValueSourceTypeEnum;
 import vacademy.io.admin_core_service.features.suborg.registration.entity.SubOrgRegistration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Dynamic JPA Specification for the admin registrations listing. The template
  * scope is always required; city/state/pincode are optional case-insensitive
- * "contains" filters (address values are free-text as the registrant typed them);
- * status is an exact match; search is a case-insensitive "contains" across the
- * org name / admin name / admin email.
+ * multi-value "match any of" filters — the admin picks exact values from the
+ * distinct-facets multi-select, so a value is matched when it equals (ignoring
+ * case) any of the selected options; each entry in {@code customFieldFilters}
+ * (custom_field id → selected values) narrows to registrations that submitted
+ * one of those values for that field; status is an exact match; search is a
+ * case-insensitive "contains" across the org name / admin name / admin email.
  */
 public class SubOrgRegistrationSpecification {
+
+    /** Custom-field values are stored under this source type for sub-org registrations. */
+    private static final String CFV_SOURCE_TYPE =
+            CustomFieldValueSourceTypeEnum.SUB_ORG_REGISTRATION.name();
 
     private SubOrgRegistrationSpecification() {
     }
 
     public static Specification<SubOrgRegistration> withFilters(
-            String templateInviteId, String city, String state, String pincode,
-            String status, String search) {
+            String templateInviteId, List<String> cities, List<String> states, List<String> pincodes,
+            String status, String search, Map<String, List<String>> customFieldFilters) {
 
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
@@ -30,18 +47,10 @@ public class SubOrgRegistrationSpecification {
             // Always scope to the one template link being viewed.
             predicates.add(cb.equal(root.get("templateInviteId"), templateInviteId));
 
-            if (StringUtils.hasText(city)) {
-                predicates.add(cb.like(cb.lower(root.get("city")),
-                        "%" + city.trim().toLowerCase() + "%"));
-            }
-            if (StringUtils.hasText(state)) {
-                predicates.add(cb.like(cb.lower(root.get("state")),
-                        "%" + state.trim().toLowerCase() + "%"));
-            }
-            if (StringUtils.hasText(pincode)) {
-                predicates.add(cb.like(cb.lower(root.get("pincode")),
-                        "%" + pincode.trim().toLowerCase() + "%"));
-            }
+            addInAnyOf(predicates, cb, root.get("city"), cities);
+            addInAnyOf(predicates, cb, root.get("state"), states);
+            addInAnyOf(predicates, cb, root.get("pincode"), pincodes);
+
             if (StringUtils.hasText(status)) {
                 predicates.add(cb.equal(root.get("status"), status.trim()));
             }
@@ -53,7 +62,72 @@ public class SubOrgRegistrationSpecification {
                         cb.like(cb.lower(root.get("adminEmail")), like)));
             }
 
+            addCustomFieldFilters(predicates, root, query, cb, customFieldFilters);
+
             return cb.and(predicates.toArray(new Predicate[0]));
         };
+    }
+
+    /**
+     * Adds a case-insensitive "column matches any of the selected values" predicate.
+     * Blank selections are ignored; no-op when the list is empty/null.
+     */
+    private static void addInAnyOf(
+            List<Predicate> predicates,
+            CriteriaBuilder cb,
+            Path<String> column,
+            List<String> values) {
+        List<String> normalized = normalize(values);
+        if (normalized.isEmpty()) {
+            return;
+        }
+        predicates.add(cb.lower(column).in(normalized));
+    }
+
+    /**
+     * For each selected custom field, restrict to registrations that submitted one
+     * of the chosen values. Each field is its own EXISTS-style subquery over
+     * custom_field_values (ANDed across fields, ORed within a field's values), so
+     * a registration must satisfy every active field filter.
+     */
+    private static void addCustomFieldFilters(
+            List<Predicate> predicates,
+            Root<SubOrgRegistration> root,
+            CriteriaQuery<?> query,
+            CriteriaBuilder cb,
+            Map<String, List<String>> customFieldFilters) {
+        if (CollectionUtils.isEmpty(customFieldFilters) || query == null) {
+            return;
+        }
+        for (Map.Entry<String, List<String>> entry : customFieldFilters.entrySet()) {
+            String fieldId = entry.getKey();
+            if (!StringUtils.hasText(fieldId)) {
+                continue;
+            }
+            List<String> values = normalize(entry.getValue());
+            if (values.isEmpty()) {
+                continue;
+            }
+            Subquery<String> sub = query.subquery(String.class);
+            Root<CustomFieldValues> cfv = sub.from(CustomFieldValues.class);
+            sub.select(cfv.get("sourceId"))
+                    .where(cb.and(
+                            cb.equal(cfv.get("sourceType"), CFV_SOURCE_TYPE),
+                            cb.equal(cfv.get("customFieldId"), fieldId.trim()),
+                            cb.lower(cfv.get("value")).in(values)));
+            predicates.add(root.get("id").in(sub));
+        }
+    }
+
+    /** Trim, drop blanks, lowercase and dedupe — for case-insensitive IN matching. */
+    private static List<String> normalize(List<String> values) {
+        if (CollectionUtils.isEmpty(values)) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(StringUtils::hasText)
+                .map(v -> v.trim().toLowerCase())
+                .distinct()
+                .collect(Collectors.toList());
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/service/SubOrgRegistrationTemplateService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/service/SubOrgRegistrationTemplateService.java
@@ -9,8 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.common.dto.InstituteCustomFieldDTO;
 import vacademy.io.admin_core_service.features.common.enums.CustomFieldTypeEnum;
+import vacademy.io.admin_core_service.features.common.enums.CustomFieldValueSourceTypeEnum;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
+import vacademy.io.admin_core_service.features.common.repository.CustomFieldValuesRepository;
 import vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService;
 import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
 import vacademy.io.admin_core_service.features.enroll_invite.entity.PackageSessionLearnerInvitationToPaymentOption;
@@ -20,6 +23,8 @@ import vacademy.io.admin_core_service.features.enroll_invite.service.PackageSess
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.packages.service.PackageSessionService;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.CreateRegistrationTemplateDTO;
+import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.CustomFieldFacetDTO;
+import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.RegistrationFacetsDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.RegistrationListItemDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationFlowDTOs.TemplateListItemDTO;
 import vacademy.io.admin_core_service.features.suborg.registration.dto.SubOrgRegistrationSettingDTO;
@@ -42,6 +47,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -64,7 +70,16 @@ public class SubOrgRegistrationTemplateService {
     private final PackageSessionEnrollInviteToPaymentOptionService pslipoService;
     private final InstituteCustomFiledService instituteCustomFiledService;
     private final SubOrgRegistrationRepository registrationRepository;
+    private final CustomFieldValuesRepository customFieldValuesRepository;
     private final StudentSessionInstituteGroupMappingRepository ssigmRepository;
+
+    /**
+     * A custom field becomes a filter only if it has at most this many distinct
+     * submitted values. Keeps per-registration-unique fields (name/email/phone/free
+     * text) out of the filter bar while letting real choice fields through — the
+     * guard is data-driven, not a hardcoded field allow-list.
+     */
+    private static final int MAX_CUSTOM_FIELD_FACET_VALUES = 50;
 
     @Transactional
     public Map<String, Object> createTemplate(CreateRegistrationTemplateDTO request, String instituteId) {
@@ -371,8 +386,9 @@ public class SubOrgRegistrationTemplateService {
 
     public Page<RegistrationListItemDTO> listRegistrations(
             String templateId, String instituteId,
-            String city, String state, String pincode,
-            String status, String search, Pageable pageable) {
+            List<String> cities, List<String> states, List<String> pincodes,
+            String status, String search, Map<String, List<String>> customFieldFilters,
+            Pageable pageable) {
         EnrollInvite template = requireTemplate(templateId, instituteId);
         // Seat capacity is the template's member_count — same for every sub-org spawned
         // from this link, so resolve it once per page rather than per row.
@@ -382,7 +398,7 @@ public class SubOrgRegistrationTemplateService {
 
         Specification<SubOrgRegistration> spec =
                 SubOrgRegistrationSpecification.withFilters(
-                        templateId, city, state, pincode, status, search);
+                        templateId, cities, states, pincodes, status, search, customFieldFilters);
         Page<SubOrgRegistration> page = registrationRepository.findAll(spec, pageable);
 
         // One bulk query for the used-seat counts of every spawned sub-org on this page.
@@ -413,6 +429,101 @@ public class SubOrgRegistrationTemplateService {
                     .kycStatus(r.getKycStatus())
                     .build();
         });
+    }
+
+    /**
+     * Distinct filter options present in this template's registrations, for the admin
+     * listing's multi-select filters: the fixed City/State/Pincode address columns PLUS
+     * one entry per form-collected custom field worth filtering on (see
+     * {@link #buildCustomFieldFacets}). Scoped + auth-guarded via requireTemplate so one
+     * institute can't read another's facets.
+     */
+    public RegistrationFacetsDTO getRegistrationFacets(String templateId, String instituteId) {
+        EnrollInvite template = requireTemplate(templateId, instituteId);
+        return RegistrationFacetsDTO.builder()
+                .cities(registrationRepository.findDistinctCities(templateId))
+                .states(registrationRepository.findDistinctStates(templateId))
+                .pincodes(registrationRepository.findDistinctPincodes(templateId))
+                .customFields(buildCustomFieldFacets(template))
+                .build();
+    }
+
+    /**
+     * One facet per custom field the form collected values for — label from the field
+     * definition, options = distinct submitted values. Fields whose distinct-value count
+     * exceeds {@link #MAX_CUSTOM_FIELD_FACET_VALUES} (identity/free-text like name, email,
+     * phone) are dropped so only genuine choice-like fields become filters. Ordered by the
+     * field's form order so filters read in the same order as the form.
+     */
+    private List<CustomFieldFacetDTO> buildCustomFieldFacets(EnrollInvite template) {
+        // custom_field_id -> distinct submitted values (sorted, case-insensitive dedupe).
+        List<Object[]> rows = customFieldValuesRepository.findDistinctFieldValuesByTypeId(
+                CustomFieldValueSourceTypeEnum.SUB_ORG_REGISTRATION.name(), template.getId());
+        if (CollectionUtils.isEmpty(rows)) {
+            return List.of();
+        }
+        Map<String, Set<String>> valuesByField = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row[0] == null || row[1] == null) {
+                continue;
+            }
+            String fieldId = String.valueOf(row[0]);
+            String value = String.valueOf(row[1]).trim();
+            if (value.isEmpty()) {
+                continue;
+            }
+            valuesByField.computeIfAbsent(fieldId, k -> new LinkedHashSet<>()).add(value);
+        }
+        if (valuesByField.isEmpty()) {
+            return List.of();
+        }
+
+        // Field id -> (label, order) from the template's custom-field definitions, so we
+        // show human labels and drop values for fields no longer on the form.
+        List<InstituteCustomFieldDTO> definitions = instituteCustomFiledService.findCustomFieldsAsJson(
+                template.getInstituteId(), CustomFieldTypeEnum.ENROLL_INVITE.name(), template.getId());
+        Map<String, String> labelByFieldId = new HashMap<>();
+        Map<String, Integer> orderByFieldId = new HashMap<>();
+        if (definitions != null) {
+            int fallbackOrder = 0;
+            for (InstituteCustomFieldDTO def : definitions) {
+                if (def == null || def.getCustomField() == null) {
+                    continue;
+                }
+                String id = def.getCustomField().getId();
+                if (!StringUtils.hasText(id)) {
+                    continue;
+                }
+                labelByFieldId.put(id, def.getCustomField().getFieldName());
+                Integer order = def.getIndividualOrder() != null
+                        ? def.getIndividualOrder()
+                        : def.getCustomField().getFormOrder();
+                orderByFieldId.put(id, order != null ? order : fallbackOrder);
+                fallbackOrder++;
+            }
+        }
+
+        List<CustomFieldFacetDTO> facets = new ArrayList<>();
+        for (Map.Entry<String, Set<String>> entry : valuesByField.entrySet()) {
+            String fieldId = entry.getKey();
+            // Only surface fields still defined on the form (gives us a label), and skip
+            // high-cardinality identity/free-text fields.
+            if (!labelByFieldId.containsKey(fieldId)
+                    || entry.getValue().size() > MAX_CUSTOM_FIELD_FACET_VALUES) {
+                continue;
+            }
+            Set<String> sortedValues = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            sortedValues.addAll(entry.getValue());
+            facets.add(CustomFieldFacetDTO.builder()
+                    .id(fieldId)
+                    .label(labelByFieldId.get(fieldId))
+                    .values(new ArrayList<>(sortedValues))
+                    .build());
+        }
+        facets.sort((a, b) -> Integer.compare(
+                orderByFieldId.getOrDefault(a.getId(), Integer.MAX_VALUE),
+                orderByFieldId.getOrDefault(b.getId(), Integer.MAX_VALUE)));
+        return facets;
     }
 
     /** Active learner-seat count per sub-org, in one bulk query. Empty map for no ids. */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgListService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgListService.java
@@ -3,6 +3,9 @@ package vacademy.io.admin_core_service.features.suborg.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -47,10 +50,11 @@ public class SubOrgListService {
     private final EnrollInviteRepository enrollInviteRepository;
 
     @Transactional(readOnly = true)
-    public List<SubOrgListItemDTO> getSubOrgsWithDetails(String parentInstituteId) {
-        List<InstituteSubOrg> subOrgs = instituteSubOrgRepository.findByInstituteId(parentInstituteId);
+    public Page<SubOrgListItemDTO> getSubOrgsWithDetails(String parentInstituteId, Pageable pageable) {
+        Page<InstituteSubOrg> subOrgPage = instituteSubOrgRepository.findByInstituteId(parentInstituteId, pageable);
+        List<InstituteSubOrg> subOrgs = subOrgPage.getContent();
         if (subOrgs.isEmpty()) {
-            return List.of();
+            return new PageImpl<>(List.of(), pageable, subOrgPage.getTotalElements());
         }
 
         List<String> subOrgIds = subOrgs.stream()
@@ -151,7 +155,9 @@ public class SubOrgListService {
                     .createdAt(so.getCreatedAt())
                     .build());
         }
-        return result;
+        // Preserve the page's paging metadata (total count / number / size) while returning
+        // the enriched rows for just this page.
+        return new PageImpl<>(result, pageable, subOrgPage.getTotalElements());
     }
 
     /** Read the sub-org's seat cap (MEMBER_COUNT) off the org-level invite's settingJson. */

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -1034,6 +1034,7 @@ export const SUB_ORG_REGISTRATION_TEMPLATE_DETAIL = (templateId: string) =>
 export const SUB_ORG_REGISTRATION_TEMPLATE_UPDATE = (templateId: string) =>
     `${SUB_ORG_REGISTRATION_BASE}/template/${templateId}`;
 export const SUB_ORG_REGISTRATION_REGISTRATIONS = `${SUB_ORG_REGISTRATION_BASE}/registrations`;
+export const SUB_ORG_REGISTRATION_REGISTRATION_FACETS = `${SUB_ORG_REGISTRATION_BASE}/registrations/facets`;
 // Invoices
 export const GET_INVOICES_BY_USER = (userId: string) =>
     `${BASE_URL}/admin-core-service/v1/invoices/user/${userId}`;

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
@@ -183,17 +183,51 @@ export interface SubOrgListItem {
     created_at?: string | number | null;
 }
 
-/** Manage VLEs list — one call returns admin email/phone, plan status, seats and invite per sub-org. */
+/** Paginated Manage VLEs list (snake_case rows in a camelCase Spring Page wrapper). */
+export interface SubOrgListPage {
+    content: SubOrgListItem[];
+    total_pages: number;
+    total_elements: number;
+    /** 0-based current page. */
+    page_no: number;
+    page_size: number;
+    last: boolean;
+}
+
+/**
+ * Manage VLEs list — one call returns admin email/phone, plan status, seats and invite per
+ * sub-org, paginated (newest first). Tolerates a bare array in case an older API is hit.
+ */
 export const getSubOrgsWithDetails = async (
-    parentInstituteId?: string
-): Promise<SubOrgListItem[]> => {
+    parentInstituteId?: string,
+    page = 0,
+    size = 10
+): Promise<SubOrgListPage> => {
     const id = parentInstituteId || getCurrentInstituteId();
     const response = await authenticatedAxiosInstance({
         method: 'GET',
         url: GET_SUB_ORGS_WITH_DETAILS,
-        params: { parentInstituteId: id },
+        params: { parentInstituteId: id, page, size },
     });
-    return Array.isArray(response.data) ? response.data : [];
+    const data = response.data;
+    if (Array.isArray(data)) {
+        return {
+            content: data,
+            total_pages: 1,
+            total_elements: data.length,
+            page_no: 0,
+            page_size: data.length,
+            last: true,
+        };
+    }
+    return {
+        content: Array.isArray(data?.content) ? data.content : [],
+        total_pages: data?.totalPages ?? 1,
+        total_elements: data?.totalElements ?? 0,
+        page_no: data?.number ?? 0,
+        page_size: data?.size ?? size,
+        last: data?.last ?? true,
+    };
 };
 
 export const getAllRoles = async () => {

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/sub-org-registration-services.ts
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/sub-org-registration-services.ts
@@ -6,6 +6,7 @@ import {
     SUB_ORG_REGISTRATION_TEMPLATE_DETAIL,
     SUB_ORG_REGISTRATION_TEMPLATE_UPDATE,
     SUB_ORG_REGISTRATION_REGISTRATIONS,
+    SUB_ORG_REGISTRATION_REGISTRATION_FACETS,
 } from '@/constants/urls';
 
 /**
@@ -173,14 +174,60 @@ export interface ListTemplateRegistrationsParams {
     instituteId: string;
     page?: number;
     size?: number;
-    city?: string;
-    state?: string;
-    pincode?: string;
+    /** Match any of the selected cities (exact, case-insensitive). Empty/undefined = no filter. */
+    cities?: string[];
+    /** Match any of the selected states. */
+    states?: string[];
+    /** Match any of the selected pincodes. */
+    pincodes?: string[];
+    /**
+     * Per-custom-field filters: custom_field id → selected values. A registration must
+     * match at least one selected value for EACH field with a non-empty selection.
+     */
+    customFieldFilters?: Record<string, string[]>;
     /** Exact registration status (DRAFT | OTP_VERIFIED | PENDING_PAYMENT | COMPLETED | FAILED). */
     status?: string;
     /** Free-text search across org name / admin name / admin email. */
     search?: string;
 }
+
+/** One filterable custom field + the distinct values its registrants submitted. */
+export interface CustomFieldFacet {
+    id: string;
+    label: string;
+    values: string[];
+}
+
+/** Distinct values present in a template's registrations — drive the listing filters. */
+export interface RegistrationFacets {
+    cities: string[];
+    states: string[];
+    pincodes: string[];
+    /** One entry per form-collected custom field worth filtering on. */
+    customFields: CustomFieldFacet[];
+}
+
+/** Drop blank entries; return undefined when nothing is selected so the param is omitted. */
+const cleanList = (values?: string[]): string[] | undefined => {
+    if (!values) return undefined;
+    const cleaned = values.map((v) => v.trim()).filter(Boolean);
+    return cleaned.length ? cleaned : undefined;
+};
+
+/** Flatten {fieldId: [v1, v2]} into ["fieldId:v1", "fieldId:v2"] for repeated `customField` params. */
+const encodeCustomFieldFilters = (
+    filters?: Record<string, string[]>
+): string[] | undefined => {
+    if (!filters) return undefined;
+    const pairs: string[] = [];
+    Object.entries(filters).forEach(([fieldId, values]) => {
+        (values || []).forEach((value) => {
+            const v = value?.trim();
+            if (fieldId && v) pairs.push(`${fieldId}:${v}`);
+        });
+    });
+    return pairs.length ? pairs : undefined;
+};
 
 /** Raw Spring Page<> passthrough (camelCase wrapper, snake_case rows). */
 export interface SubOrgRegistrationPage {
@@ -261,28 +308,59 @@ export const updateRegistrationTemplateStatus = async (
     return response.data;
 };
 
+export const getRegistrationFacets = async (
+    templateInviteId: string,
+    instituteId: string
+): Promise<RegistrationFacets> => {
+    const response = await authenticatedAxiosInstance({
+        method: 'GET',
+        url: SUB_ORG_REGISTRATION_REGISTRATION_FACETS,
+        params: { templateInviteId, instituteId },
+    });
+    const data = response.data ?? {};
+    return {
+        cities: Array.isArray(data.cities) ? data.cities : [],
+        states: Array.isArray(data.states) ? data.states : [],
+        pincodes: Array.isArray(data.pincodes) ? data.pincodes : [],
+        customFields: Array.isArray(data.custom_fields)
+            ? data.custom_fields
+                  .filter((f: CustomFieldFacet) => f && f.id && Array.isArray(f.values))
+                  .map((f: CustomFieldFacet) => ({
+                      id: f.id,
+                      label: f.label || f.id,
+                      values: f.values,
+                  }))
+            : [],
+    };
+};
+
 export const listTemplateRegistrations = async ({
     templateInviteId,
     instituteId,
     page = 0,
     size = 10,
-    city,
-    state,
-    pincode,
+    cities,
+    states,
+    pincodes,
+    customFieldFilters,
     status,
     search,
 }: ListTemplateRegistrationsParams): Promise<SubOrgRegistrationPage> => {
     const response = await authenticatedAxiosInstance({
         method: 'GET',
         url: SUB_ORG_REGISTRATION_REGISTRATIONS,
+        // indexes:null → arrays serialize as repeated keys (cities=A&cities=B), which
+        // Spring binds to List<String>. Bracketed keys (the axios default) would not.
+        paramsSerializer: { indexes: null },
         params: {
             templateInviteId,
             instituteId,
             page,
             size,
-            city: city?.trim() || undefined,
-            state: state?.trim() || undefined,
-            pincode: pincode?.trim() || undefined,
+            cities: cleanList(cities),
+            states: cleanList(states),
+            pincodes: cleanList(pincodes),
+            customField: encodeCustomFieldFilters(customFieldFilters),
             status: status || undefined,
             search: search?.trim() || undefined,
         },

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/registration-links-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/registration-links-tab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -7,6 +7,7 @@ import {
     DownloadSimple,
     LinkSimple,
     MagnifyingGlass,
+    MapPin,
     PencilSimple,
     Plus,
     UsersThree,
@@ -35,6 +36,7 @@ import createSubOrgRegistrationLink from '@/routes/manage-students/invite/-utils
 import {
     fetchAllTemplateRegistrations,
     getRegistrationTemplateDetail,
+    getRegistrationFacets,
     listRegistrationTemplates,
     listTemplateRegistrations,
     updateRegistrationTemplateStatus,
@@ -43,7 +45,12 @@ import {
     type TemplateDetail,
 } from '../../-services/sub-org-registration-services';
 import { RegistrationLinkCreateModal } from './registration-link-create-modal';
+import { MultiSelectFilter } from '@/components/shared/leads/multi-select-filter';
 import { humanizeStatus, statusToneClass } from '../../-utils/status-display';
+
+/** Distinct facet values → MultiSelectFilter options (value === label; searchable by label). */
+const toFilterOptions = (values: string[] | undefined) =>
+    (values ?? []).map((v) => ({ value: v, label: v }));
 
 // The list response only carries `steps`; paid templates include a "PAYMENT" step and
 // templates with DigiLocker identity verification include a "KYC" step.
@@ -490,51 +497,73 @@ function RegistrationsDialog({
 }) {
     const instituteId = getCurrentInstituteId();
 
-    // Raw filter inputs (what the user types) vs the debounced values sent to the API.
+    // Free-text search is debounced; the discrete selectors (status + City/State/Pincode
+    // multi-selects) apply immediately.
     const [searchInput, setSearchInput] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
     const [statusFilter, setStatusFilter] = useState('');
-    const [cityInput, setCityInput] = useState('');
-    const [stateInput, setStateInput] = useState('');
-    const [pincodeInput, setPincodeInput] = useState('');
-    const [filters, setFilters] = useState({
-        search: '',
-        status: '',
-        city: '',
-        state: '',
-        pincode: '',
-    });
+    const [cityFilter, setCityFilter] = useState<string[]>([]);
+    const [stateFilter, setStateFilter] = useState<string[]>([]);
+    const [pincodeFilter, setPincodeFilter] = useState<string[]>([]);
+    // Per-custom-field selections, keyed by custom_field id.
+    const [customFieldFilters, setCustomFieldFilters] = useState<Record<string, string[]>>({});
     const [page, setPage] = useState(0);
     const [isExporting, setIsExporting] = useState(false);
 
     // Reset all filter + page state when a different template's dialog opens.
     useEffect(() => {
         setSearchInput('');
+        setDebouncedSearch('');
         setStatusFilter('');
-        setCityInput('');
-        setStateInput('');
-        setPincodeInput('');
-        setFilters({ search: '', status: '', city: '', state: '', pincode: '' });
+        setCityFilter([]);
+        setStateFilter([]);
+        setPincodeFilter([]);
+        setCustomFieldFilters({});
         setPage(0);
     }, [template?.id]);
 
-    // Debounce the raw inputs (300ms) into the committed filters that drive the query.
+    // Debounce the free-text search (300ms).
     useEffect(() => {
-        const timeout = setTimeout(() => {
-            setFilters({
-                search: searchInput.trim(),
-                status: statusFilter,
-                city: cityInput.trim(),
-                state: stateInput.trim(),
-                pincode: pincodeInput.trim(),
-            });
-        }, 300);
+        const timeout = setTimeout(() => setDebouncedSearch(searchInput.trim()), 300);
         return () => clearTimeout(timeout);
-    }, [searchInput, statusFilter, cityInput, stateInput, pincodeInput]);
+    }, [searchInput]);
+
+    const filters = useMemo(
+        () => ({
+            search: debouncedSearch,
+            status: statusFilter,
+            cities: cityFilter,
+            states: stateFilter,
+            pincodes: pincodeFilter,
+            customFieldFilters,
+        }),
+        [debouncedSearch, statusFilter, cityFilter, stateFilter, pincodeFilter, customFieldFilters]
+    );
 
     // Any filter change jumps back to the first page.
     useEffect(() => {
         setPage(0);
     }, [filters]);
+
+    // Distinct City/State/Pincode values actually present in this link's registrations —
+    // populate the multi-select filters by default (nothing hardcoded).
+    const { data: facets } = useQuery({
+        queryKey: ['sub-org-registration-facets', template?.id, instituteId],
+        queryFn: () => getRegistrationFacets(template?.id || '', instituteId || ''),
+        enabled: !!template?.id && !!instituteId,
+    });
+    const cityOptions = useMemo(() => toFilterOptions(facets?.cities), [facets?.cities]);
+    const stateOptions = useMemo(() => toFilterOptions(facets?.states), [facets?.states]);
+    const pincodeOptions = useMemo(() => toFilterOptions(facets?.pincodes), [facets?.pincodes]);
+    const customFieldFacets = facets?.customFields ?? [];
+
+    const setCustomFieldSelection = (fieldId: string, values: string[]) =>
+        setCustomFieldFilters((prev) => {
+            const next = { ...prev };
+            if (values.length) next[fieldId] = values;
+            else delete next[fieldId];
+            return next;
+        });
 
     const { data, isLoading, isFetching } = useQuery({
         queryKey: ['sub-org-registrations', template?.id, instituteId, page, filters],
@@ -546,9 +575,10 @@ function RegistrationsDialog({
                 size: REGISTRATIONS_PAGE_SIZE,
                 search: filters.search,
                 status: filters.status,
-                city: filters.city,
-                state: filters.state,
-                pincode: filters.pincode,
+                cities: filters.cities,
+                states: filters.states,
+                pincodes: filters.pincodes,
+                customFieldFilters: filters.customFieldFilters,
             }),
         enabled: !!template?.id && !!instituteId,
         placeholderData: keepPreviousData,
@@ -557,20 +587,25 @@ function RegistrationsDialog({
     const registrations = data?.content ?? [];
     const totalPages = data?.total_pages ?? 1;
     const totalElements = data?.total_elements ?? 0;
+    const activeCustomFieldCount = Object.values(filters.customFieldFilters).filter(
+        (v) => v.length
+    ).length;
     const hasActiveFilters = !!(
         filters.search ||
         filters.status ||
-        filters.city ||
-        filters.state ||
-        filters.pincode
+        filters.cities.length ||
+        filters.states.length ||
+        filters.pincodes.length ||
+        activeCustomFieldCount
     );
 
     const clearFilters = () => {
         setSearchInput('');
         setStatusFilter('');
-        setCityInput('');
-        setStateInput('');
-        setPincodeInput('');
+        setCityFilter([]);
+        setStateFilter([]);
+        setPincodeFilter([]);
+        setCustomFieldFilters({});
     };
 
     // Export ALL rows matching the current filters (not just the visible page).
@@ -583,9 +618,10 @@ function RegistrationsDialog({
                 instituteId,
                 search: filters.search,
                 status: filters.status,
-                city: filters.city,
-                state: filters.state,
-                pincode: filters.pincode,
+                cities: filters.cities,
+                states: filters.states,
+                pincodes: filters.pincodes,
+                customFieldFilters: filters.customFieldFilters,
             });
             if (rows.length === 0) {
                 toast.info('No registrations to export.');
@@ -611,8 +647,10 @@ function RegistrationsDialog({
             dialogWidth="max-w-5xl"
         >
             <div className="space-y-3">
-                {/* Filters: search + status + City/State/Pincode. Address columns show "-"
-                    for links created without "Collect full address". */}
+                {/* Filters: search + status + the fixed City/State/Pincode address columns +
+                    one searchable multi-select per form-collected custom field. Every option
+                    list is pulled live from submitted data (facets) — nothing hardcoded. A
+                    filter only appears when there is data to filter on. */}
                 <div className="rounded-lg border bg-neutral-50 p-3">
                     <div className="flex flex-wrap items-center gap-2">
                         <div className="relative min-w-0 flex-1 sm:max-w-xs">
@@ -635,24 +673,48 @@ function RegistrationsDialog({
                             }}
                             className="w-44"
                         />
-                        <Input
-                            value={cityInput}
-                            onChange={(e) => setCityInput(e.target.value)}
-                            placeholder="City"
-                            className="h-9 w-28"
-                        />
-                        <Input
-                            value={stateInput}
-                            onChange={(e) => setStateInput(e.target.value)}
-                            placeholder="State"
-                            className="h-9 w-32"
-                        />
-                        <Input
-                            value={pincodeInput}
-                            onChange={(e) => setPincodeInput(e.target.value)}
-                            placeholder="Pincode"
-                            className="h-9 w-28"
-                        />
+                        {cityOptions.length > 0 && (
+                            <MultiSelectFilter
+                                label="City"
+                                icon={<MapPin className="size-4 text-neutral-400" />}
+                                options={cityOptions}
+                                selected={cityFilter}
+                                onChange={setCityFilter}
+                                placeholder="Search city…"
+                                widthClass="w-36"
+                            />
+                        )}
+                        {stateOptions.length > 0 && (
+                            <MultiSelectFilter
+                                label="State"
+                                options={stateOptions}
+                                selected={stateFilter}
+                                onChange={setStateFilter}
+                                placeholder="Search state…"
+                                widthClass="w-36"
+                            />
+                        )}
+                        {pincodeOptions.length > 0 && (
+                            <MultiSelectFilter
+                                label="Pincode"
+                                options={pincodeOptions}
+                                selected={pincodeFilter}
+                                onChange={setPincodeFilter}
+                                placeholder="Search pincode…"
+                                widthClass="w-36"
+                            />
+                        )}
+                        {customFieldFacets.map((field) => (
+                            <MultiSelectFilter
+                                key={field.id}
+                                label={field.label}
+                                options={toFilterOptions(field.values)}
+                                selected={customFieldFilters[field.id] ?? []}
+                                onChange={(values) => setCustomFieldSelection(field.id, values)}
+                                placeholder={`Search ${field.label.toLowerCase()}…`}
+                                widthClass="w-40"
+                            />
+                        ))}
                     </div>
                     <div className="mt-3 flex items-center justify-between">
                         <p className="text-xs text-muted-foreground">

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import {
     getSubOrgsWithDetails,
     type SubOrgListItem,
@@ -21,6 +21,7 @@ import { Plus, Buildings, Copy, LinkSimple } from '@phosphor-icons/react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { CreateSubOrgModal } from './create-sub-org-modal';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
+import { MyPagination } from '@/components/design-system/pagination';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import { buildSubOrgSlug } from '@/routes/manage-suborg-teams/-utils/sub-org-slug';
@@ -28,8 +29,12 @@ import { humanizeStatus, statusToneClass } from '../../-utils/status-display';
 import createInviteLink from '@/routes/manage-students/invite/-utils/createInviteLink';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 
+/** Rows-per-page for the Manage VLEs listing. */
+const SUB_ORG_PAGE_SIZE = 10;
+
 export function SubOrgList() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [page, setPage] = useState(0);
     const navigate = useNavigate();
 
     const instituteId = getCurrentInstituteId();
@@ -37,11 +42,14 @@ export function SubOrgList() {
     // the institute's own portal; a backend `short_url` (already domain-correct)
     // still wins when present.
     const { instituteDetails } = useInstituteDetailsStore();
-    const { data: subOrgs = [], isLoading } = useQuery({
-        queryKey: ['sub-orgs-with-details', instituteId],
-        queryFn: () => getSubOrgsWithDetails(instituteId),
+    const { data, isLoading, isFetching } = useQuery({
+        queryKey: ['sub-orgs-with-details', instituteId, page],
+        queryFn: () => getSubOrgsWithDetails(instituteId, page, SUB_ORG_PAGE_SIZE),
         enabled: !!instituteId,
+        placeholderData: keepPreviousData,
     });
+    const subOrgs = data?.content ?? [];
+    const totalPages = data?.total_pages ?? 1;
 
     // Row click navigates to the institute-admin deep page for that sub-org.
     const openSubOrg = (org: SubOrgListItem) => {
@@ -193,6 +201,16 @@ export function SubOrgList() {
                     </TableBody>
                 </Table>
             </div>
+
+            {totalPages > 1 && (
+                <div className={isFetching ? 'opacity-60' : ''}>
+                    <MyPagination
+                        currentPage={page}
+                        totalPages={totalPages}
+                        onPageChange={setPage}
+                    />
+                </div>
+            )}
 
             <CreateSubOrgModal open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen} />
         </div>


### PR DESCRIPTION
## What & why

Two asks for the **Manage VLEs / Sub-Org Registration** area:

1. Make the registration listing filters **searchable multi-selects populated from real submitted data** (no hardcoded value lists), and drive them from the form's **custom fields** — not just fixed columns.
2. **Paginate** the sub-org list API.

## Registrations dialog filters (`RegistrationsDialog`)

- Free-text **City / State / Pincode** inputs → **searchable multi-select** dropdowns (reusing the existing `MultiSelectFilter`).
- **One multi-select per form-collected custom field**, so the filter set adapts to whatever each form asks. City/State/Pincode are fixed schema columns (collected via "Collect full address"); the form's real custom fields live in `custom_field_values` — both are surfaced.
- New **`GET /sub-org-registration/registrations/facets`** → distinct `cities`/`states`/`pincodes` + `customFields: [{id,label,values}]`. Custom-field facets read from `custom_field_values` (`source_type=SUB_ORG_REGISTRATION`), labelled from the template's field definitions, ordered by form order, with a **distinct-value cardinality guard (≤50)** that keeps identity/free-text fields (name/email/phone) out of the filter bar. Nothing hardcoded.
- `/registrations` filters go **multi-value**: `cities`/`states`/`pincodes` as case-insensitive `IN`; repeated `customField=<fieldId>:<value>` pairs filtered via a `custom_field_values` subquery (**AND** across fields, **OR** within a field). FE sends arrays via axios `paramsSerializer: { indexes: null }`.
- CSV export honours the custom-field filters (columns unchanged).

## Sub-org list pagination (`SubOrgList`)

- `GET /sub-org/get-all-with-details`: bare `List` → Spring **`Page`** (`page`/`size`, default 10, newest first). Enrichment (admin/plan/seats/invite bulk queries) now runs on the page slice. Added a `Pageable` overload on `InstituteSubOrgRepository.findByInstituteId` and **kept** the non-paginated method (3 other callers). FE adds `MyPagination`.

## Verification

- Backend `./mvnw -o compile` → clean.
- Frontend `design-lint` + `tsc` → clean on changed files.
- Custom-field subquery idiom mirrors the existing `StudentFeePaymentSpecification`.

## ⚠️ Deploy ordering

Two response/param shapes changed (`/get-all-with-details` List→Page; `/registrations` param rename + new `/facets`). **Deploy FE-first or together** — the new FE degrades gracefully against an old backend, but a **backend-first** deploy would make the *current prod FE* show an empty sub-org list until the FE ships. Can add dual-shape backward compatibility if independent deploys are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)