### PR TITLE
fix(sub-org): backward-compatible list shapes — restores empty VLE list on old admin bundles

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/controller/SubOrgController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/controller/SubOrgController.java
@@ -72,15 +72,28 @@ public class SubOrgController {
 
     /** Enriched, paginated list for the Manage VLEs table: admin email/phone, plan status,
      *  seats + invite. Newest sub-orgs first. Guarded to the caller's own institute — the
-     *  row returns admin PII (email/phone). */
+     *  row returns admin PII (email/phone).
+     *
+     *  Dual response shape for rollout safety: callers that pass NO paging params (older
+     *  web bundles and mobile-app builds that predate pagination and expect a bare JSON
+     *  array) get the full legacy {@code List}; passing {@code page} and/or {@code size}
+     *  opts into the Spring {@code Page} wrapper. Do not collapse this until every shipped
+     *  admin bundle sends paging params. */
     @GetMapping("/get-all-with-details")
-    public ResponseEntity<Page<SubOrgListItemDTO>> getSubOrgsWithDetails(
+    public ResponseEntity<?> getSubOrgsWithDetails(
             @RequestParam String parentInstituteId,
-            @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "size", required = false) Integer size,
             @RequestAttribute(value = "user", required = false) CustomUserDetails user) {
         assertInstituteAdmin(user, parentInstituteId);
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        if (page == null && size == null) {
+            // Legacy shape: everything in one bare array (page of MAX size keeps one code path).
+            return ResponseEntity.ok(subOrgListService
+                    .getSubOrgsWithDetails(parentInstituteId, PageRequest.of(0, Integer.MAX_VALUE, sort))
+                    .getContent());
+        }
+        Pageable pageable = PageRequest.of(page != null ? page : 0, size != null ? size : 10, sort);
         return ResponseEntity.ok(subOrgListService.getSubOrgsWithDetails(parentInstituteId, pageable));
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/controller/SubOrgRegistrationAdminController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/controller/SubOrgRegistrationAdminController.java
@@ -91,6 +91,11 @@ public class SubOrgRegistrationAdminController {
             @RequestParam(value = "cities", required = false) List<String> cities,
             @RequestParam(value = "states", required = false) List<String> states,
             @RequestParam(value = "pincodes", required = false) List<String> pincodes,
+            // Rollout-safety shim: older admin bundles send singular free-text params with
+            // "contains" semantics — honour them so a stale bundle's filter keeps filtering.
+            @RequestParam(value = "city", required = false) String legacyCity,
+            @RequestParam(value = "state", required = false) String legacyState,
+            @RequestParam(value = "pincode", required = false) String legacyPincode,
             @RequestParam(value = "status", required = false) String status,
             @RequestParam(value = "search", required = false) String search,
             // Per-custom-field filters as repeated "fieldId:value" params (colon-delimited;
@@ -102,7 +107,8 @@ public class SubOrgRegistrationAdminController {
         assertInstituteAdmin(user, instituteId);
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return ResponseEntity.ok(templateService.listRegistrations(
-                templateInviteId, instituteId, cities, states, pincodes, status, search,
+                templateInviteId, instituteId, cities, states, pincodes,
+                legacyCity, legacyState, legacyPincode, status, search,
                 parseCustomFieldFilters(customField), pageable));
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationSpecification.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/repository/SubOrgRegistrationSpecification.java
@@ -39,6 +39,7 @@ public class SubOrgRegistrationSpecification {
 
     public static Specification<SubOrgRegistration> withFilters(
             String templateInviteId, List<String> cities, List<String> states, List<String> pincodes,
+            String legacyCityContains, String legacyStateContains, String legacyPincodeContains,
             String status, String search, Map<String, List<String>> customFieldFilters) {
 
         return (root, query, cb) -> {
@@ -50,6 +51,14 @@ public class SubOrgRegistrationSpecification {
             addInAnyOf(predicates, cb, root.get("city"), cities);
             addInAnyOf(predicates, cb, root.get("state"), states);
             addInAnyOf(predicates, cb, root.get("pincode"), pincodes);
+
+            // Rollout-safety shim: older admin bundles send singular free-text `city`/
+            // `state`/`pincode` params with the original case-insensitive "contains"
+            // semantics. Honour them so a stale bundle's filter keeps filtering (instead
+            // of silently returning everything). Remove once no shipped bundle sends them.
+            addContains(predicates, cb, root.get("city"), legacyCityContains);
+            addContains(predicates, cb, root.get("state"), legacyStateContains);
+            addContains(predicates, cb, root.get("pincode"), legacyPincodeContains);
 
             if (StringUtils.hasText(status)) {
                 predicates.add(cb.equal(root.get("status"), status.trim()));
@@ -66,6 +75,18 @@ public class SubOrgRegistrationSpecification {
 
             return cb.and(predicates.toArray(new Predicate[0]));
         };
+    }
+
+    /** Legacy free-text filter: case-insensitive "contains"; no-op when blank. */
+    private static void addContains(
+            List<Predicate> predicates,
+            CriteriaBuilder cb,
+            Path<String> column,
+            String value) {
+        if (!StringUtils.hasText(value)) {
+            return;
+        }
+        predicates.add(cb.like(cb.lower(column), "%" + value.trim().toLowerCase() + "%"));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/service/SubOrgRegistrationTemplateService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/registration/service/SubOrgRegistrationTemplateService.java
@@ -387,6 +387,7 @@ public class SubOrgRegistrationTemplateService {
     public Page<RegistrationListItemDTO> listRegistrations(
             String templateId, String instituteId,
             List<String> cities, List<String> states, List<String> pincodes,
+            String legacyCity, String legacyState, String legacyPincode,
             String status, String search, Map<String, List<String>> customFieldFilters,
             Pageable pageable) {
         EnrollInvite template = requireTemplate(templateId, instituteId);
@@ -398,7 +399,9 @@ public class SubOrgRegistrationTemplateService {
 
         Specification<SubOrgRegistration> spec =
                 SubOrgRegistrationSpecification.withFilters(
-                        templateId, cities, states, pincodes, status, search, customFieldFilters);
+                        templateId, cities, states, pincodes,
+                        legacyCity, legacyState, legacyPincode,
+                        status, search, customFieldFilters);
         Page<SubOrgRegistration> page = registrationRepository.findAll(spec, pageable);
 
         // One bulk query for the used-seat counts of every spawned sub-org on this page.


### PR DESCRIPTION
## Incident

After #2294 merged, the **backend auto-deployed in ~9 min** (Deploy Admin to VET EKS / LKE) while the **Cloudflare Pages admin FE had not shipped the new bundle** (verified: the live `admin.ideedonline.org` bundle has no `registrations/facets` marker). Old bundles expect a **bare array** from `GET /sub-org/get-all-with-details`, received a Spring `Page` object, and rendered an **empty VLE/sub-org list** — reported on IDEED, affects all institutes. Mobile admin builds bundle the old FE and would stay broken until OTA.

## Fix — dual response shape (rollout-safety shim)

- **`/get-all-with-details`**: `page`/`size` now optional.
  - No paging params (old bundles) → legacy bare `List` — **old FE works again immediately**.
  - `page`/`size` present (new FE) → Spring `Page` as introduced in #2294.
- **`/registrations`**: also honours the legacy singular `city`/`state`/`pincode` free-text params with their original case-insensitive **"contains"** semantics, so a stale bundle's filter keeps filtering instead of silently returning everything (which could mislead a filtered CSV export).

Both shims are commented for removal once no shipped admin bundle predates pagination.

## Verification

- `./mvnw -o compile` → clean.
- New-FE path unchanged (`page=0&size=10` → `Page`); old-FE path returns the exact pre-#2294 array shape and ordering source.

**Merging this restores the VLE list for all currently-served old bundles as soon as the backend CI rolls out (~10 min).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)