### PR TITLE
feat(sub-org): search + data-driven Status filter on the VLEs list

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
@@ -196,17 +196,21 @@ export interface SubOrgListPage {
 
 /**
  * Manage VLEs list — one call returns admin email/phone, plan status, seats and invite per
- * sub-org, paginated (newest first). Tolerates a bare array in case an older API is hit.
+ * sub-org (newest first). Omit page/size to fetch EVERYTHING (the backend's legacy bare-array
+ * shape) — used by the list screen so search/status filters can match across the whole
+ * dataset (admin email/phone/plan status come from cross-service enrichment, so they can't
+ * be filtered in the DB query). Pass page+size for the paginated Spring Page shape.
  */
 export const getSubOrgsWithDetails = async (
     parentInstituteId?: string,
-    page = 0,
-    size = 10
+    page?: number,
+    size?: number
 ): Promise<SubOrgListPage> => {
     const id = parentInstituteId || getCurrentInstituteId();
     const response = await authenticatedAxiosInstance({
         method: 'GET',
         url: GET_SUB_ORGS_WITH_DETAILS,
+        // axios drops undefined params — no page/size sent → backend returns the full bare array.
         params: { parentInstituteId: id, page, size },
     });
     const data = response.data;
@@ -225,7 +229,7 @@ export const getSubOrgsWithDetails = async (
         total_pages: data?.totalPages ?? 1,
         total_elements: data?.totalElements ?? 0,
         page_no: data?.number ?? 0,
-        page_size: data?.size ?? size,
+        page_size: data?.size ?? size ?? 10,
         last: data?.last ?? true,
     };
 };

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
     getSubOrgsWithDetails,
     type SubOrgListItem,
@@ -17,7 +17,9 @@ import {
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { OtherTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 import { MyButton } from '@/components/design-system/button';
-import { Plus, Buildings, Copy, LinkSimple } from '@phosphor-icons/react';
+import { Input } from '@/components/ui/input';
+import { MultiSelectFilter } from '@/components/shared/leads/multi-select-filter';
+import { Plus, Buildings, Copy, LinkSimple, MagnifyingGlass, X } from '@phosphor-icons/react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { CreateSubOrgModal } from './create-sub-org-modal';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
@@ -32,8 +34,13 @@ import { useInstituteDetailsStore } from '@/stores/students/students-list/useIns
 /** Rows-per-page for the Manage VLEs listing. */
 const SUB_ORG_PAGE_SIZE = 10;
 
+/** Facet key for rows whose admin has no plan yet (plan_status null). */
+const NO_PLAN = '__NO_PLAN__';
+
 export function SubOrgList() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [searchInput, setSearchInput] = useState('');
+    const [statusFilter, setStatusFilter] = useState<string[]>([]);
     const [page, setPage] = useState(0);
     const navigate = useNavigate();
 
@@ -42,14 +49,69 @@ export function SubOrgList() {
     // the institute's own portal; a backend `short_url` (already domain-correct)
     // still wins when present.
     const { instituteDetails } = useInstituteDetailsStore();
-    const { data, isLoading, isFetching } = useQuery({
-        queryKey: ['sub-orgs-with-details', instituteId, page],
-        queryFn: () => getSubOrgsWithDetails(instituteId, page, SUB_ORG_PAGE_SIZE),
+    // Fetch the WHOLE list (no page/size): search matches admin email/phone and the
+    // status filter matches plan status — enrichment fields that live outside this
+    // service's DB, so filtering must happen over the full dataset client-side.
+    const { data, isLoading } = useQuery({
+        queryKey: ['sub-orgs-with-details', instituteId],
+        queryFn: () => getSubOrgsWithDetails(instituteId),
         enabled: !!instituteId,
-        placeholderData: keepPreviousData,
     });
-    const subOrgs = data?.content ?? [];
-    const totalPages = data?.total_pages ?? 1;
+    const allSubOrgs = useMemo(() => data?.content ?? [], [data?.content]);
+
+    // Status filter options come from the data itself (nothing hardcoded): the
+    // distinct plan statuses present, plus "No plan" only when such rows exist.
+    const statusOptions = useMemo(() => {
+        const present = new Set<string>();
+        let hasNoPlan = false;
+        allSubOrgs.forEach((o) => {
+            if (o.plan_status) present.add(o.plan_status);
+            else hasNoPlan = true;
+        });
+        const options = [...present]
+            .sort()
+            .map((value) => ({ value, label: humanizeStatus(value) }));
+        if (hasNoPlan) options.push({ value: NO_PLAN, label: 'No plan' });
+        return options;
+    }, [allSubOrgs]);
+
+    const q = searchInput.trim().toLowerCase();
+    const filteredSubOrgs = useMemo(
+        () =>
+            allSubOrgs.filter((o) => {
+                if (statusFilter.length) {
+                    const key = o.plan_status || NO_PLAN;
+                    if (!statusFilter.includes(key)) return false;
+                }
+                if (q) {
+                    const haystack = [
+                        o.name,
+                        o.admin_name,
+                        o.admin_email,
+                        o.admin_phone,
+                        o.invite_code,
+                    ]
+                        .filter(Boolean)
+                        .join(' ')
+                        .toLowerCase();
+                    if (!haystack.includes(q)) return false;
+                }
+                return true;
+            }),
+        [allSubOrgs, q, statusFilter]
+    );
+    const hasActiveFilters = !!q || statusFilter.length > 0;
+
+    // Any filter change jumps back to the first page.
+    useEffect(() => {
+        setPage(0);
+    }, [q, statusFilter]);
+
+    const totalPages = Math.max(1, Math.ceil(filteredSubOrgs.length / SUB_ORG_PAGE_SIZE));
+    const subOrgs = filteredSubOrgs.slice(
+        page * SUB_ORG_PAGE_SIZE,
+        (page + 1) * SUB_ORG_PAGE_SIZE
+    );
 
     // Row click navigates to the institute-admin deep page for that sub-org.
     const openSubOrg = (org: SubOrgListItem) => {
@@ -82,12 +144,56 @@ export function SubOrgList() {
 
     return (
         <div className="space-y-4">
-            <div className="flex justify-end">
+            {/* Search + Status filter left, Create button right. The status options are
+                derived from the loaded rows (see statusOptions) — nothing hardcoded. */}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-1 flex-wrap items-center gap-2">
+                    <div className="relative min-w-0 flex-1 sm:max-w-xs">
+                        <MagnifyingGlass className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-neutral-400" />
+                        <Input
+                            value={searchInput}
+                            onChange={(e) => setSearchInput(e.target.value)}
+                            placeholder={`Search ${getTerminology(OtherTerms.SubOrg, SystemTerms.SubOrg).toLowerCase()}, email or phone`}
+                            className="h-9 pl-8"
+                        />
+                    </div>
+                    {statusOptions.length > 0 && (
+                        <MultiSelectFilter
+                            label="Status"
+                            options={statusOptions}
+                            selected={statusFilter}
+                            onChange={setStatusFilter}
+                            placeholder="Search status…"
+                            widthClass="w-36"
+                        />
+                    )}
+                    {hasActiveFilters && (
+                        <MyButton
+                            buttonType="secondary"
+                            scale="small"
+                            onClick={() => {
+                                setSearchInput('');
+                                setStatusFilter([]);
+                            }}
+                        >
+                            <X className="mr-1 size-3.5" />
+                            Clear
+                        </MyButton>
+                    )}
+                </div>
                 <MyButton onClick={() => setIsCreateModalOpen(true)}>
                     <Plus className="mr-2 h-4 w-4" />
                     Create {getTerminology(OtherTerms.SubOrg, SystemTerms.SubOrg)}
                 </MyButton>
             </div>
+
+            {hasActiveFilters && (
+                <p className="text-xs text-muted-foreground">
+                    {filteredSubOrgs.length} of {allSubOrgs.length}{' '}
+                    {getTerminologyPlural(OtherTerms.SubOrg, SystemTerms.SubOrg).toLowerCase()}{' '}
+                    match your filters
+                </p>
+            )}
 
             <div className="rounded-md border">
                 <Table>
@@ -108,12 +214,15 @@ export function SubOrgList() {
                                     <div className="flex flex-col items-center justify-center gap-2 text-gray-500">
                                         <Buildings className="h-8 w-8 opacity-50" />
                                         <p>
-                                            No{' '}
-                                            {getTerminologyPlural(
-                                                OtherTerms.SubOrg,
-                                                SystemTerms.SubOrg
-                                            ).toLowerCase()}{' '}
-                                            found.
+                                            {hasActiveFilters
+                                                ? `No ${getTerminologyPlural(
+                                                      OtherTerms.SubOrg,
+                                                      SystemTerms.SubOrg
+                                                  ).toLowerCase()} match your filters.`
+                                                : `No ${getTerminologyPlural(
+                                                      OtherTerms.SubOrg,
+                                                      SystemTerms.SubOrg
+                                                  ).toLowerCase()} found.`}
                                         </p>
                                     </div>
                                 </TableCell>
@@ -203,13 +312,7 @@ export function SubOrgList() {
             </div>
 
             {totalPages > 1 && (
-                <div className={isFetching ? 'opacity-60' : ''}>
-                    <MyPagination
-                        currentPage={page}
-                        totalPages={totalPages}
-                        onPageChange={setPage}
-                    />
-                </div>
+                <MyPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
             )}
 
             <CreateSubOrgModal open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen} />


### PR DESCRIPTION
## What

The **Manage VLEs → VLEs tab** gets the same filter treatment as the Registrations dialog:

- **Search box** — matches sub-org name, admin name, email, phone, and invite code.
- **Status multi-select** (searchable, count badge) — options are **derived from the loaded rows' plan statuses**, plus a "No plan" option that appears only when such rows exist. Nothing hardcoded.
- Clear button + "N of M match your filters" line + filtered empty state.

## How

Client-side filtering over the full list: the filterable columns (admin email/phone from **auth-service**, plan status from **user_plan**) are cross-service enrichment the DB query can't filter. The screen now fetches the whole dataset — omitting `page`/`size` hits the backend's legacy bare-array shape kept by #2295 — and paginates client-side (same 10/page UI, `MyPagination`).

**FE-only change** — no backend deploy involved, so no repeat of the #2294 rollout-ordering incident. Server-side pagination stays available in the API for any consumer that wants it; if VLE counts ever reach thousands, filters can move server-side then.

## Verification

- `design-lint` clean; **full app `tsc`: 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)