### PR TITLE
feat(sub-org): City/State/Pincode columns + filters on the VLEs list

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/dto/SubOrgListItemDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/dto/SubOrgListItemDTO.java
@@ -27,6 +27,11 @@ public class SubOrgListItemDTO {
     private String adminName;
     private String adminEmail;
     private String adminPhone;
+    /** Address of the spawned institute (stamped at registration when the link collects
+     *  address; null for manually-created sub-orgs or links without address collection). */
+    private String city;
+    private String state;
+    private String pincode;
     /** The admin's UserPlan status (ACTIVE, PENDING_FOR_PAYMENT, …); null when no plan. */
     private String planStatus;
     /** Active learner-seat count; null total = no cap configured. */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgListService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/suborg/service/SubOrgListService.java
@@ -15,12 +15,14 @@ import vacademy.io.admin_core_service.features.enroll_invite.dto.EnrollInviteSet
 import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
 import vacademy.io.admin_core_service.features.enroll_invite.repository.EnrollInviteRepository;
 import vacademy.io.admin_core_service.features.institute.entity.InstituteSubOrg;
+import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
 import vacademy.io.admin_core_service.features.institute.repository.InstituteSubOrgRepository;
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.suborg.dto.SubOrgListItemDTO;
 import vacademy.io.admin_core_service.features.user_subscription.entity.UserPlan;
 import vacademy.io.admin_core_service.features.user_subscription.repository.UserPlanRepository;
 import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.institute.entity.Institute;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,6 +46,7 @@ public class SubOrgListService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final InstituteSubOrgRepository instituteSubOrgRepository;
+    private final InstituteRepository instituteRepository;
     private final StudentSessionInstituteGroupMappingRepository ssigmRepository;
     private final AuthService authService;
     private final UserPlanRepository userPlanRepository;
@@ -99,6 +102,14 @@ public class SubOrgListService {
             }
         }
 
+        // 5. The spawned institutes themselves, in one query — carry the address the
+        // registration stamped on them (city/state/pincode; null when never collected).
+        Map<String, Institute> instituteBySubOrg = new HashMap<>();
+        if (!subOrgIds.isEmpty()) {
+            instituteRepository.findAllById(subOrgIds)
+                    .forEach(inst -> instituteBySubOrg.put(inst.getId(), inst));
+        }
+
         List<SubOrgListItemDTO> result = new ArrayList<>(subOrgs.size());
         for (InstituteSubOrg so : subOrgs) {
             String soId = so.getSuborgId();
@@ -140,6 +151,8 @@ public class SubOrgListService {
                 }
             }
 
+            Institute spawned = StringUtils.hasText(soId) ? instituteBySubOrg.get(soId) : null;
+
             result.add(SubOrgListItemDTO.builder()
                     .suborgId(soId)
                     .name(so.getName())
@@ -147,6 +160,9 @@ public class SubOrgListService {
                     .adminName(user != null ? user.getFullName() : null)
                     .adminEmail(user != null ? user.getEmail() : null)
                     .adminPhone(user != null ? user.getMobileNumber() : null)
+                    .city(spawned != null ? spawned.getCity() : null)
+                    .state(spawned != null ? spawned.getState() : null)
+                    .pincode(spawned != null ? spawned.getPinCode() : null)
                     .planStatus(planStatus)
                     .usedSeats(StringUtils.hasText(soId) ? usedBySubOrg.getOrDefault(soId, 0L) : null)
                     .totalSeats(totalSeats)

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/-services/custom-team-services.ts
@@ -174,6 +174,10 @@ export interface SubOrgListItem {
     admin_name?: string | null;
     admin_email?: string | null;
     admin_phone?: string | null;
+    /** Address stamped on the spawned institute at registration; null when never collected. */
+    city?: string | null;
+    state?: string | null;
+    pincode?: string | null;
     /** Admin's UserPlan status (ACTIVE, PENDING_FOR_PAYMENT, …); null when no plan. */
     plan_status?: string | null;
     used_seats?: number | null;

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
@@ -19,7 +19,7 @@ import { OtherTerms, SystemTerms } from '@/routes/settings/-components/NamingSet
 import { MyButton } from '@/components/design-system/button';
 import { Input } from '@/components/ui/input';
 import { MultiSelectFilter } from '@/components/shared/leads/multi-select-filter';
-import { Plus, Buildings, Copy, LinkSimple, MagnifyingGlass, X } from '@phosphor-icons/react';
+import { Plus, Buildings, Copy, LinkSimple, MagnifyingGlass, MapPin, X } from '@phosphor-icons/react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { CreateSubOrgModal } from './create-sub-org-modal';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
@@ -37,10 +37,23 @@ const SUB_ORG_PAGE_SIZE = 10;
 /** Facet key for rows whose admin has no plan yet (plan_status null). */
 const NO_PLAN = '__NO_PLAN__';
 
+/** Distinct, sorted non-blank values of one field across the rows → filter options. */
+const facetOptions = (rows: SubOrgListItem[], pick: (row: SubOrgListItem) => string | null | undefined) => {
+    const values = new Set<string>();
+    rows.forEach((row) => {
+        const v = pick(row)?.trim();
+        if (v) values.add(v);
+    });
+    return [...values].sort((a, b) => a.localeCompare(b)).map((value) => ({ value, label: value }));
+};
+
 export function SubOrgList() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [searchInput, setSearchInput] = useState('');
     const [statusFilter, setStatusFilter] = useState<string[]>([]);
+    const [cityFilter, setCityFilter] = useState<string[]>([]);
+    const [stateFilter, setStateFilter] = useState<string[]>([]);
+    const [pincodeFilter, setPincodeFilter] = useState<string[]>([]);
     const [page, setPage] = useState(0);
     const navigate = useNavigate();
 
@@ -75,6 +88,12 @@ export function SubOrgList() {
         return options;
     }, [allSubOrgs]);
 
+    // City/State/Pincode options come from the loaded rows too (address stamped on the
+    // spawned institute at registration) — a filter only appears when values exist.
+    const cityOptions = useMemo(() => facetOptions(allSubOrgs, (o) => o.city), [allSubOrgs]);
+    const stateOptions = useMemo(() => facetOptions(allSubOrgs, (o) => o.state), [allSubOrgs]);
+    const pincodeOptions = useMemo(() => facetOptions(allSubOrgs, (o) => o.pincode), [allSubOrgs]);
+
     const q = searchInput.trim().toLowerCase();
     const filteredSubOrgs = useMemo(
         () =>
@@ -83,12 +102,19 @@ export function SubOrgList() {
                     const key = o.plan_status || NO_PLAN;
                     if (!statusFilter.includes(key)) return false;
                 }
+                if (cityFilter.length && !cityFilter.includes(o.city?.trim() || '')) return false;
+                if (stateFilter.length && !stateFilter.includes(o.state?.trim() || '')) return false;
+                if (pincodeFilter.length && !pincodeFilter.includes(o.pincode?.trim() || ''))
+                    return false;
                 if (q) {
                     const haystack = [
                         o.name,
                         o.admin_name,
                         o.admin_email,
                         o.admin_phone,
+                        o.city,
+                        o.state,
+                        o.pincode,
                         o.invite_code,
                     ]
                         .filter(Boolean)
@@ -98,14 +124,19 @@ export function SubOrgList() {
                 }
                 return true;
             }),
-        [allSubOrgs, q, statusFilter]
+        [allSubOrgs, q, statusFilter, cityFilter, stateFilter, pincodeFilter]
     );
-    const hasActiveFilters = !!q || statusFilter.length > 0;
+    const hasActiveFilters =
+        !!q ||
+        statusFilter.length > 0 ||
+        cityFilter.length > 0 ||
+        stateFilter.length > 0 ||
+        pincodeFilter.length > 0;
 
     // Any filter change jumps back to the first page.
     useEffect(() => {
         setPage(0);
-    }, [q, statusFilter]);
+    }, [q, statusFilter, cityFilter, stateFilter, pincodeFilter]);
 
     const totalPages = Math.max(1, Math.ceil(filteredSubOrgs.length / SUB_ORG_PAGE_SIZE));
     const subOrgs = filteredSubOrgs.slice(
@@ -167,6 +198,37 @@ export function SubOrgList() {
                             widthClass="w-36"
                         />
                     )}
+                    {cityOptions.length > 0 && (
+                        <MultiSelectFilter
+                            label="City"
+                            icon={<MapPin className="size-4 text-neutral-400" />}
+                            options={cityOptions}
+                            selected={cityFilter}
+                            onChange={setCityFilter}
+                            placeholder="Search city…"
+                            widthClass="w-36"
+                        />
+                    )}
+                    {stateOptions.length > 0 && (
+                        <MultiSelectFilter
+                            label="State"
+                            options={stateOptions}
+                            selected={stateFilter}
+                            onChange={setStateFilter}
+                            placeholder="Search state…"
+                            widthClass="w-36"
+                        />
+                    )}
+                    {pincodeOptions.length > 0 && (
+                        <MultiSelectFilter
+                            label="Pincode"
+                            options={pincodeOptions}
+                            selected={pincodeFilter}
+                            onChange={setPincodeFilter}
+                            placeholder="Search pincode…"
+                            widthClass="w-36"
+                        />
+                    )}
                     {hasActiveFilters && (
                         <MyButton
                             buttonType="secondary"
@@ -174,6 +236,9 @@ export function SubOrgList() {
                             onClick={() => {
                                 setSearchInput('');
                                 setStatusFilter([]);
+                                setCityFilter([]);
+                                setStateFilter([]);
+                                setPincodeFilter([]);
                             }}
                         >
                             <X className="mr-1 size-3.5" />
@@ -202,6 +267,9 @@ export function SubOrgList() {
                             <TableHead>Name</TableHead>
                             <TableHead>Email</TableHead>
                             <TableHead>Phone</TableHead>
+                            <TableHead>City</TableHead>
+                            <TableHead>State</TableHead>
+                            <TableHead>Pincode</TableHead>
                             <TableHead>Status</TableHead>
                             <TableHead>Seats</TableHead>
                             <TableHead>{getTerminology(OtherTerms.Invite, SystemTerms.Invite)}</TableHead>
@@ -210,7 +278,7 @@ export function SubOrgList() {
                     <TableBody>
                         {!subOrgs || subOrgs.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={6} className="h-24 text-center">
+                                <TableCell colSpan={9} className="h-24 text-center">
                                     <div className="flex flex-col items-center justify-center gap-2 text-gray-500">
                                         <Buildings className="h-8 w-8 opacity-50" />
                                         <p>
@@ -255,6 +323,9 @@ export function SubOrgList() {
                                         </TableCell>
                                         <TableCell>{org.admin_email || '-'}</TableCell>
                                         <TableCell>{org.admin_phone || '-'}</TableCell>
+                                        <TableCell>{org.city || '-'}</TableCell>
+                                        <TableCell>{org.state || '-'}</TableCell>
+                                        <TableCell>{org.pincode || '-'}</TableCell>
                                         <TableCell>
                                             {org.plan_status ? (
                                                 <Badge


### PR DESCRIPTION
## What

The **Manage VLEs → VLEs tab** now shows each VLE's **City / State / Pincode** as columns (after Phone) and offers them as **searchable multi-select filters**, matching the Registrations dialog.

## Where the address comes from

The registration wizard stamps the collected address onto the **spawned institute** (`institutes.city/state/pin_code`) — that's the canonical source surfaced here. Manually-created VLEs (or links without "Collect full address") have no address and show `-`.

## How

- **Backend (additive)**: `SubOrgListItemDTO` gains `city`/`state`/`pincode`, resolved via **one** bulk `instituteRepository.findAllById` over the page's suborg ids — no per-row fan-out. Purely additive to the response: **safe in either deploy order** (old FE ignores the fields; new FE shows `-` until the backend ships). No repeat of the #2294 rollout incident.
- **Frontend**: three columns + three multi-select filters (City with a MapPin icon), options = distinct values present in the loaded rows — each filter **appears only when there's data for it**, nothing hardcoded. Address fields also join the free-text search haystack.

## Verification

- Backend `./mvnw -o compile` clean.
- `design-lint` clean; **full app `tsc`: 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)