### PR TITLE
feat(sub-org): VLE list CSV export + fix multi-batch seat inflation

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
@@ -461,10 +461,13 @@ public interface StudentSessionInstituteGroupMappingRepository
    * (avoids N+1 when listing many spawned sub-orgs). Membership + ROOT_ADMIN exclusion mirror
    * {@link #findActiveSubOrgRoster(String)}; each mapping is attributed to
    * COALESCE(ssigm.sub_org_id, enroll_invite.sub_org_id) — the stamp wins, else the invite the
-   * user_plan came from. Returns rows of [sub_org_id, used_count]; sub-orgs with zero are absent.
+   * user_plan came from. Counts DISTINCT users, not mappings — a learner enrolled in several
+   * of the sub-org's batches occupies ONE seat (COUNT(*) here overstated "used" for every
+   * multi-batch learner). Returns rows of [sub_org_id, used_count]; zero-count sub-orgs absent.
    */
   @Query(value = """
-      SELECT COALESCE(ssigm.sub_org_id, ei.sub_org_id) AS sub_org_id, COUNT(*) AS used_count
+      SELECT COALESCE(ssigm.sub_org_id, ei.sub_org_id) AS sub_org_id,
+             COUNT(DISTINCT ssigm.user_id) AS used_count
       FROM student_session_institute_group_mapping ssigm
       LEFT JOIN user_plan up ON up.id = ssigm.user_plan_id
       LEFT JOIN enroll_invite ei ON ei.id = up.enroll_invite_id

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/-utils/list-export.ts
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/-utils/list-export.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared CSV-export + date helpers for the Manage VLEs listings (the sub-org/VLE
+ * list and the registration-links Registrations dialog).
+ */
+
+/** RFC-4180 escaping: quote when the value contains a comma, quote, or newline. */
+export const csvCell = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    const s = String(value);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+/** Rows of already-picked values → one CSV string under the given header row. */
+export const buildCsv = (headers: readonly string[], rows: unknown[][]): string => {
+    const lines = [headers.join(',')];
+    rows.forEach((row) => lines.push(row.map(csvCell).join(',')));
+    return lines.join('\n');
+};
+
+export const downloadCsv = (csv: string, filename: string) => {
+    // Prefix a BOM so Excel opens UTF-8 (accented city/org names) correctly.
+    const blob = new Blob(['﻿', csv], { type: 'text/csv;charset=utf-8;' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    link.parentNode?.removeChild(link);
+    window.URL.revokeObjectURL(url);
+};
+
+/** "-" for missing/invalid dates; locale short date otherwise. */
+export const formatDate = (value?: string | number | null) => {
+    if (value === null || value === undefined || value === '') return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '-';
+    return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
+};

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/registration-links-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/registration-links-tab.tsx
@@ -47,6 +47,7 @@ import {
 import { RegistrationLinkCreateModal } from './registration-link-create-modal';
 import { MultiSelectFilter } from '@/components/shared/leads/multi-select-filter';
 import { humanizeStatus, statusToneClass } from '../../-utils/status-display';
+import { buildCsv, downloadCsv, formatDate } from '../../-utils/list-export';
 
 /** Distinct facet values → MultiSelectFilter options (value === label; searchable by label). */
 const toFilterOptions = (values: string[] | undefined) =>
@@ -74,17 +75,6 @@ const LINK_STATUS_LABELS = [ALL_STATUSES, ...LINK_STATUS_VALUES.map(humanizeStat
 const LINK_TYPE_LABELS = [ALL_TYPES, ...LINK_TYPE_VALUES.map(humanizeStatus)];
 const DIALOG_STATUS_LABELS = [ALL_STATUSES, ...REGISTRATION_STATUS_VALUES.map(humanizeStatus)];
 
-const formatDate = (value?: string | number | null) => {
-    if (value === null || value === undefined || value === '') return '-';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '-';
-    return date.toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-    });
-};
-
 const REGISTRATIONS_CSV_HEADERS = [
     'Organization',
     'Admin',
@@ -100,50 +90,24 @@ const REGISTRATIONS_CSV_HEADERS = [
     'Registered On',
 ] as const;
 
-/** RFC-4180 escaping: quote when the value contains a comma, quote, or newline. */
-const csvCell = (value: unknown): string => {
-    if (value === null || value === undefined) return '';
-    const s = String(value);
-    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-};
-
-const buildRegistrationsCsv = (rows: SubOrgRegistrationRow[]): string => {
-    const lines = [REGISTRATIONS_CSV_HEADERS.join(',')];
-    rows.forEach((r) => {
-        lines.push(
-            [
-                r.org_name,
-                r.admin_name,
-                r.admin_email,
-                r.admin_phone,
-                r.city,
-                r.state,
-                r.pincode,
-                r.used_seats ?? '',
-                r.total_seats ?? '',
-                humanizeStatus(r.status),
-                humanizeStatus(r.kyc_status),
-                formatDate(r.created_at),
-            ]
-                .map(csvCell)
-                .join(',')
-        );
-    });
-    return lines.join('\n');
-};
-
-const downloadCsv = (csv: string, filename: string) => {
-    // Prefix a BOM so Excel opens UTF-8 (accented city/org names) correctly.
-    const blob = new Blob(['﻿', csv], { type: 'text/csv;charset=utf-8;' });
-    const url = window.URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.setAttribute('download', filename);
-    document.body.appendChild(link);
-    link.click();
-    link.parentNode?.removeChild(link);
-    window.URL.revokeObjectURL(url);
-};
+const buildRegistrationsCsv = (rows: SubOrgRegistrationRow[]): string =>
+    buildCsv(
+        REGISTRATIONS_CSV_HEADERS,
+        rows.map((r) => [
+            r.org_name,
+            r.admin_name,
+            r.admin_email,
+            r.admin_phone,
+            r.city,
+            r.state,
+            r.pincode,
+            r.used_seats ?? '',
+            r.total_seats ?? '',
+            humanizeStatus(r.status),
+            humanizeStatus(r.kyc_status),
+            formatDate(r.created_at),
+        ])
+    );
 
 export function RegistrationLinksTab() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-custom-teams/sub-orgs/-components/sub-org-list.tsx
@@ -19,7 +19,17 @@ import { OtherTerms, SystemTerms } from '@/routes/settings/-components/NamingSet
 import { MyButton } from '@/components/design-system/button';
 import { Input } from '@/components/ui/input';
 import { MultiSelectFilter } from '@/components/shared/leads/multi-select-filter';
-import { Plus, Buildings, Copy, LinkSimple, MagnifyingGlass, MapPin, X } from '@phosphor-icons/react';
+import {
+    Plus,
+    Buildings,
+    Copy,
+    DownloadSimple,
+    LinkSimple,
+    MagnifyingGlass,
+    MapPin,
+    X,
+} from '@phosphor-icons/react';
+import { buildCsv, downloadCsv, formatDate } from '../../-utils/list-export';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { CreateSubOrgModal } from './create-sub-org-modal';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
@@ -36,6 +46,21 @@ const SUB_ORG_PAGE_SIZE = 10;
 
 /** Facet key for rows whose admin has no plan yet (plan_status null). */
 const NO_PLAN = '__NO_PLAN__';
+
+const SUB_ORG_CSV_HEADERS = [
+    'Name',
+    'Admin',
+    'Email',
+    'Phone',
+    'City',
+    'State',
+    'Pincode',
+    'Status',
+    'Seats Used',
+    'Seats Total',
+    'Invite Code',
+    'Created On',
+] as const;
 
 /** Distinct, sorted non-blank values of one field across the rows → filter options. */
 const facetOptions = (rows: SubOrgListItem[], pick: (row: SubOrgListItem) => string | null | undefined) => {
@@ -171,6 +196,41 @@ export function SubOrgList() {
         }
     };
 
+    // Export every row matching the current filters (all pages, not just the visible one).
+    const handleExport = () => {
+        if (filteredSubOrgs.length === 0) {
+            toast.info('Nothing to export.');
+            return;
+        }
+        const csv = buildCsv(
+            SUB_ORG_CSV_HEADERS,
+            filteredSubOrgs.map((o) => [
+                o.name,
+                o.admin_name,
+                o.admin_email,
+                o.admin_phone,
+                o.city,
+                o.state,
+                o.pincode,
+                o.plan_status ? humanizeStatus(o.plan_status) : '',
+                o.used_seats ?? '',
+                o.total_seats ?? '',
+                o.invite_code,
+                formatDate(o.created_at),
+            ])
+        );
+        const safeName = getTerminologyPlural(OtherTerms.SubOrg, SystemTerms.SubOrg)
+            .replace(/[^\w.-]+/g, '_');
+        downloadCsv(csv, `${safeName}_list.csv`);
+        toast.success(
+            `Exported ${filteredSubOrgs.length} ${
+                filteredSubOrgs.length === 1
+                    ? getTerminology(OtherTerms.SubOrg, SystemTerms.SubOrg).toLowerCase()
+                    : getTerminologyPlural(OtherTerms.SubOrg, SystemTerms.SubOrg).toLowerCase()
+            }.`
+        );
+    };
+
     if (isLoading) return <DashboardLoader />;
 
     return (
@@ -246,10 +306,20 @@ export function SubOrgList() {
                         </MyButton>
                     )}
                 </div>
-                <MyButton onClick={() => setIsCreateModalOpen(true)}>
-                    <Plus className="mr-2 h-4 w-4" />
-                    Create {getTerminology(OtherTerms.SubOrg, SystemTerms.SubOrg)}
-                </MyButton>
+                <div className="flex items-center gap-2">
+                    <MyButton
+                        buttonType="secondary"
+                        onClick={handleExport}
+                        disable={filteredSubOrgs.length === 0}
+                    >
+                        <DownloadSimple className="mr-2 size-4" />
+                        Export CSV
+                    </MyButton>
+                    <MyButton onClick={() => setIsCreateModalOpen(true)}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Create {getTerminology(OtherTerms.SubOrg, SystemTerms.SubOrg)}
+                    </MyButton>
+                </div>
             </div>
 
             {hasActiveFilters && (


### PR DESCRIPTION
## 1. Export CSV on the Manage VLEs list

New **Export CSV** button next to *Create VLE* — exports **every row matching the active filters** (all pages, not just the visible 10): Name, Admin, Email, Phone, City, State, Pincode, Status, Seats Used, Seats Total, Invite Code, Created On. Filename follows the institute's naming (e.g. `VLEs_list.csv`).

CSV plumbing (RFC-4180 escaping, UTF-8 BOM for Excel, date formatting) extracted into shared `manage-custom-teams/-utils/list-export.ts`; the Registrations dialog's existing export was refactored onto it — no behaviour change there.

## 2. Seats column — verified, one real bug fixed

Checked the Seats numbers against prod:

- **IDEED's current values are correct** — all 13 IDEED VLEs genuinely have 0 active learners, so `0/N` is accurate.
- **Bug found globally**: `countActiveLearnersBySubOrgIds` counted **mappings** (`COUNT(*)`), so a learner enrolled in several of a sub-org's batches occupied one seat *per batch*. Prod audit: **10 sub-orgs currently overstate seats — worst case shows 181 where only 85 real people exist.**
- Fix: `COUNT(DISTINCT ssigm.user_id)` — one person = one seat. Membership rules (stamp OR sub-org invite, ROOT_ADMIN excluded) unchanged. Fixes the Seats column on **both** the VLEs list and the Registrations dialog (same bulk query).

## Deploy safety

Backend change is display-only and additive-safe; FE change is self-contained. Safe in any deploy order.

## Verification

- Backend `./mvnw -o compile` clean; prod SQL audit of old vs new counting semantics.
- `design-lint` clean; **full app `tsc`: 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)