### PR TITLE
fix boot splash blocking mount; brand all loaders with the institute …

### DIFF
--- a/frontend-learner-dashboard-app/index.html
+++ b/frontend-learner-dashboard-app/index.html
@@ -204,17 +204,12 @@
           },
           true
         );
-        // Clear the guard once the app has actually rendered. The boot splash
-        // lives INSIDE #root until React replaces it, so "has children" is not
-        // enough — the splash must be gone too.
+        // Clear the guard once the app has actually rendered. (The boot splash
+        // lives OUTSIDE #root, so root children = real app render.)
         window.addEventListener("load", function () {
           setTimeout(function () {
             var root = document.getElementById("root");
-            if (
-              root &&
-              root.childElementCount > 0 &&
-              !root.querySelector(".boot-splash")
-            ) {
+            if (root && root.childElementCount > 0) {
               try {
                 sessionStorage.removeItem(KEY);
               } catch (e) {}
@@ -238,37 +233,97 @@
     <title>Course Catalogue</title>
 
     <!-- Boot splash: shown instantly on every hard load (cold start, login
-         redirects, switching in/out of student view) until React mounts and
-         replaces #root's children. Colors inline on purpose — the app CSS has
-         not loaded yet at this point; hsl(24 85% 54%) = the brand primary. -->
+         redirects, switching in/out of student view) until the app mounts and
+         removes it (see __root.tsx). It lives OUTSIDE #root — main.tsx refuses
+         to mount when #root already has content. Branded from the
+         localStorage "InstituteBranding" cache (logo + theme colour) when
+         available; falls back to the neutral bar on a first-ever visit.
+         Colors inline on purpose — the app CSS has not loaded yet. -->
     <style>
-      .boot-splash {
+      #boot-splash {
         position: fixed;
         inset: 0;
+        z-index: 9999;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
+        gap: 20px;
         background: #fff;
+        transition: opacity 0.25s ease;
       }
-      .boot-splash-ring {
-        width: 56px;
-        height: 56px;
-        border-radius: 50%;
-        border: 4px solid hsl(24 85% 54% / 0.15);
-        border-top-color: hsl(24 85% 54%);
-        animation: boot-spin 0.8s linear infinite;
+      .boot-splash-logo {
+        height: 64px;
+        max-width: 200px;
+        object-fit: contain;
+        display: none;
+        animation: boot-pulse 1.6s ease-in-out infinite;
       }
-      @keyframes boot-spin {
-        to {
-          transform: rotate(360deg);
+      .boot-splash-track {
+        width: 160px;
+        height: 4px;
+        border-radius: 9999px;
+        background: #f1f5f9;
+        overflow: hidden;
+      }
+      .boot-splash-bar {
+        height: 100%;
+        border-radius: 9999px;
+        background: hsl(24 85% 54%);
+        animation: boot-progress 2s ease-in-out infinite;
+      }
+      @keyframes boot-pulse {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(1.06);
+          opacity: 0.85;
+        }
+      }
+      @keyframes boot-progress {
+        0% {
+          width: 0%;
+          margin-left: 0%;
+        }
+        50% {
+          width: 70%;
+          margin-left: 15%;
+        }
+        100% {
+          width: 0%;
+          margin-left: 100%;
         }
       }
     </style>
   </head>
   <body>
-    <div id="root">
-      <div class="boot-splash"><div class="boot-splash-ring"></div></div>
+    <div id="root"></div>
+    <div id="boot-splash">
+      <img id="boot-splash-logo" class="boot-splash-logo" alt="" />
+      <div class="boot-splash-track"><div id="boot-splash-bar" class="boot-splash-bar"></div></div>
     </div>
+    <script>
+      // Brand the splash from the cached institute branding (same cache the
+      // in-app DashboardLoader uses). Safe no-op on a first-ever visit.
+      (function () {
+        try {
+          var b = JSON.parse(localStorage.getItem("InstituteBranding") || "null");
+          if (b && b.instituteLogoUrl) {
+            var img = document.getElementById("boot-splash-logo");
+            img.onload = function () {
+              img.style.display = "block";
+            };
+            img.src = b.instituteLogoUrl;
+          }
+          if (b && b.instituteThemeCode) {
+            document.getElementById("boot-splash-bar").style.background = b.instituteThemeCode;
+          }
+        } catch (e) {}
+      })();
+    </script>
     <div id="portal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend-learner-dashboard-app/src/components/common/FullScreenLoader.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/FullScreenLoader.tsx
@@ -1,22 +1,31 @@
+import { DashboardLoader } from "@/components/core/dashboard-loader";
+
 interface FullScreenLoaderProps {
-  /** short human message under the spinner, e.g. "Signing you in…" */
+  /** short human message under the loader, e.g. "Signing you in…" */
   label?: string;
 }
 
 /**
  * Full-screen blocking loader for identity transitions (login, switching into /
- * out of student view) — moments where the app would otherwise show a blank
- * screen while sessions hydrate or a hard reload is prepared. Matches the boot
- * splash in index.html so the transition reads as one continuous loader.
+ * out of student view) — moments where the app would otherwise sit blank while
+ * sessions hydrate or a hard reload is prepared. Renders the BRANDED
+ * DashboardLoader (institute logo + theme-coloured progress bar), matching the
+ * index.html boot splash so the transition reads as one continuous loader.
  */
 export function FullScreenLoader({ label }: FullScreenLoaderProps) {
   return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-background">
-      <div className="relative size-14" role="status" aria-live="polite" aria-label={label || "Loading"}>
-        <div className="absolute inset-0 rounded-full border-4 border-primary-100" />
-        <div className="absolute inset-0 animate-spin rounded-full border-4 border-transparent border-t-primary-500" />
-      </div>
-      {label ? <p className="text-body font-medium text-muted-foreground">{label}</p> : null}
+    <div
+      className="fixed inset-0 z-50 bg-background"
+      role="status"
+      aria-live="polite"
+      aria-label={label || "Loading"}
+    >
+      <DashboardLoader fullscreen />
+      {label ? (
+        <p className="absolute inset-x-0 top-2/3 text-center text-body font-medium text-muted-foreground">
+          {label}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend-learner-dashboard-app/src/routes/__root.tsx
+++ b/frontend-learner-dashboard-app/src/routes/__root.tsx
@@ -242,6 +242,17 @@ const RootComponent = () => {
   const { setInstituteId } = useInstituteFeatureStore();
   const [isChatbotEnabled, setIsChatbotEnabled] = useState(false);
 
+  // Dismiss the index.html boot splash once the app has actually mounted.
+  // (It lives OUTSIDE #root — main.tsx refuses to mount into a non-empty root —
+  // so the app must remove it explicitly.)
+  useEffect(() => {
+    const splash = document.getElementById("boot-splash");
+    if (!splash) return;
+    splash.style.opacity = "0";
+    const t = window.setTimeout(() => splash.remove(), 250);
+    return () => window.clearTimeout(t);
+  }, []);
+
   const setPrimaryColorFromStorage = async () => {
     const details = await Preferences.get({ key: "InstituteDetails" });
     const parsedDetails = details.value ? JSON.parse(details.value) : null;


### PR DESCRIPTION
…logo

ROOT CAUSE of the broken screens: main.tsx guards with if (!rootElement.innerHTML) before mounting — the splash I placed INSIDE #root made it non-empty, so React never rendered and only the splash showed. The splash now lives OUTSIDE #root (root stays empty), the chunk-recovery check is reverted to plain childElementCount, and __root.tsx removes the splash explicitly (with a fade) once the app mounts.

Branding: the splash now reads the localStorage InstituteBranding cache (same source as DashboardLoader) — institute logo with a soft pulse + the theme-coloured progress bar; neutral bar on a first-ever visit. FullScreenLoader is now a thin wrapper around the branded DashboardLoader (logo + progress) with an optional label, so login/student-view transitions and the boot splash all read as one continuous branded loader.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
