### PR TITLE
parent portal: branded picker loader + fix TTS replay/queue race

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/parent/child/-lib/use-parent-voice.ts
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/-lib/use-parent-voice.ts
@@ -53,6 +53,12 @@ export function useParentVoice(locale: string) {
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
   // The currently playing server-TTS audio element (edge-tts MP3).
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Monotonic token: every speak()/cancelSpeak() bumps it, and the DELAYED
+  // browser-speak only fires when its token is still current. Without this,
+  // a cancel that lands inside the 60ms delay cannot stop the utterance —
+  // rapid speaks then QUEUE behind each other (the "read every message from
+  // the start" bug) and a pending timer can replay after close.
+  const speakSeqRef = useRef(0);
 
   const stopAudio = useCallback(() => {
     const a = audioRef.current;
@@ -116,6 +122,7 @@ export function useParentVoice(locale: string) {
   );
 
   const cancelSpeak = useCallback(() => {
+    speakSeqRef.current += 1; // invalidate any pending delayed speak
     stopAudio();
     if (browserSpeechSupported) {
       try {
@@ -146,9 +153,14 @@ export function useParentVoice(locale: string) {
         // Chrome quirks: speak() issued synchronously after cancel() is sometimes
         // silently dropped, and a paused queue swallows every later utterance
         // (cancel-while-paused leaves it stuck). resume() + a short delay makes
-        // the speak reliable.
+        // the speak reliable — but the delayed call MUST re-check the token so a
+        // cancel/newer speak that landed inside the delay wins.
+        const seq = ++speakSeqRef.current;
         synth.resume();
-        window.setTimeout(() => synth.speak(utter), 60);
+        window.setTimeout(() => {
+          if (speakSeqRef.current !== seq) return; // cancelled / superseded
+          synth.speak(utter);
+        }, 60);
       } catch {
         setSpeaking(false);
       }
@@ -176,7 +188,9 @@ export function useParentVoice(locale: string) {
         return;
       }
 
-      // Stop anything already talking before starting the new answer.
+      // Stop anything already talking before starting the new answer — and
+      // invalidate any browser-speak still waiting inside its 60ms delay.
+      speakSeqRef.current += 1;
       stopAudio();
       if (browserSpeechSupported) {
         try {

--- a/frontend-learner-dashboard-app/src/routes/parent/child/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/index.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Users } from "@phosphor-icons/react";
-import { LoadingState, ErrorState, EmptyState } from "@/components/design-system/states";
+import { ErrorState, EmptyState } from "@/components/design-system/states";
+import { FullScreenLoader } from "@/components/common/FullScreenLoader";
 import { ChildPickerGrid } from "./-components/ChildPickerGrid";
 import { useChildren, useParentSettings } from "./-hooks/use-parent-child";
 
@@ -28,7 +29,9 @@ function ParentChildPicker() {
     }
   }, [children, navigate]);
 
-  if (isLoading || settings.isLoading) return <LoadingState variant="list" />;
+  // Branded full-screen loader — the bare list skeleton rendered here without
+  // the page container (squished to the left) and read as a broken screen.
+  if (isLoading || settings.isLoading) return <FullScreenLoader />;
 
   if (settings.data && !settings.data.enabled) {
     return (
@@ -60,7 +63,7 @@ function ParentChildPicker() {
     );
   }
 
-  if (children.length === 1) return <LoadingState variant="list" />; // navigating
+  if (children.length === 1) return <FullScreenLoader />; // navigating to the only child
 
   return (
     <ChildPickerGrid


### PR DESCRIPTION
Picker: the initial load returned a bare list skeleton without the page container (squished to the left edge, read as a broken screen) — both loading returns now use the branded FullScreenLoader, continuous with the boot splash.

TTS race: the browser-fallback speaks on a 60ms delayed timer (Chrome cancel-then-speak workaround), so a cancel or newer speak landing inside that delay could not stop it — rapid speaks then queued behind each other in the speechSynthesis queue ('read every message from the start') and a timer surviving a close replayed the last answer. A monotonic token now guards the delayed call: every speak()/cancelSpeak() bumps it and the timer only fires if its token is still current.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
