### PR TITLE
attendance: never call a class absent before it starts; assistant day…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentAssistantService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentAssistantService.java
@@ -25,8 +25,12 @@ import vacademy.io.admin_core_service.features.student_analysis.client.Assessmen
 import vacademy.io.common.auth.model.CustomUserDetails;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * The parent AI assistant. Answers a free-form parent question about their
@@ -133,11 +137,21 @@ public class ParentAssistantService {
                 StudentAttendanceReportDTO att = attendanceReportService.getStudentReport(
                         child.childUserId(), primaryBatch, LocalDate.now().minusDays(365), LocalDate.now());
                 if (att != null) {
-                    sb.append("Attendance: ").append(Math.round(att.getAttendancePercentage())).append("% present.\n");
                     List<ScheduleDetailDTO> schedules = att.getSchedules();
+                    Integer dayWise = dayWiseAttendancePercent(schedules);
+                    if (dayWise != null) {
+                        // Day-wise, matching what the parent/student apps display —
+                        // NOT the raw session-wise report percentage.
+                        sb.append("Attendance: ").append(dayWise).append("% present.\n");
+                    }
                     if (schedules != null && !schedules.isEmpty()) {
-                        sb.append("Recent classes (most recent first):\n");
+                        LocalDateTime nowDt = LocalDateTime.now();
+                        // Classes that have NOT started yet are excluded — they are
+                        // listed under "Upcoming classes" and must never be described
+                        // as absent or not-marked.
+                        sb.append("Recent classes (most recent first; classes that have not started yet are excluded):\n");
                         schedules.stream()
+                                .filter(s -> hasStarted(s, nowDt))
                                 .sorted((a, b) -> nullSafe(b.getMeetingDate()).compareTo(nullSafe(a.getMeetingDate())))
                                 .limit(15)
                                 .forEach(s -> sb.append("- ")
@@ -273,5 +287,45 @@ public class ParentAssistantService {
 
     private String nullSafe(java.time.LocalDate d) {
         return d != null ? d.toString() : "";
+    }
+
+    /** A schedule has started once its date + start time is not in the future. */
+    private static boolean hasStarted(ScheduleDetailDTO s, LocalDateTime now) {
+        if (s.getMeetingDate() == null) return true;
+        LocalTime t = s.getStartTime() != null ? s.getStartTime() : LocalTime.MIN;
+        return !LocalDateTime.of(s.getMeetingDate(), t).isAfter(now);
+    }
+
+    /**
+     * Day-wise attendance %, matching the apps' computeAttendanceStats: multiple
+     * classes in one day count as ONE day, PRESENT if any class that day was
+     * attended; a day whose unattended classes have not started yet is skipped
+     * entirely (in progress ≠ absent); UNMARKED days count in the denominator.
+     * Returns null when no day is countable.
+     */
+    private static Integer dayWiseAttendancePercent(List<ScheduleDetailDTO> schedules) {
+        if (schedules == null || schedules.isEmpty()) return null;
+        LocalDateTime now = LocalDateTime.now();
+        Map<LocalDate, List<ScheduleDetailDTO>> byDay = schedules.stream()
+                .filter(s -> s.getMeetingDate() != null)
+                .collect(Collectors.groupingBy(ScheduleDetailDTO::getMeetingDate));
+        int present = 0;
+        int counted = 0;
+        for (List<ScheduleDetailDTO> day : byDay.values()) {
+            boolean anyPresent = day.stream()
+                    .anyMatch(s -> "PRESENT".equalsIgnoreCase(s.getAttendanceStatus()));
+            if (anyPresent) {
+                present++;
+                counted++;
+                continue;
+            }
+            boolean anyNotStarted = day.stream().anyMatch(s -> !hasStarted(s, now)
+                    && (s.getAttendanceStatus() == null
+                            || "UNMARKED".equalsIgnoreCase(s.getAttendanceStatus())));
+            if (anyNotStarted) continue; // day still upcoming / in progress — not absent
+            counted++;
+        }
+        if (counted == 0) return null;
+        return (int) Math.round(present * 100.0 / counted);
     }
 }

--- a/frontend-learner-dashboard-app/src/locales/ar/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/ar/parent.json
@@ -156,6 +156,7 @@
     "unmarkedDays": "Unmarked",
     "streak": "Day streak",
     "timeInClassTitle": "الوقت المستغرق في الحصة",
+    "upcomingChip": "قادمة",
     "attendedFor": "حضر {{duration}}"
   },
   "progress": {
@@ -206,6 +207,11 @@
     "emptyTitle": "No rewards yet",
     "emptyBody": "Badges and points will show here as {{name}} learns.",
     "points": "Points earned",
-    "rank": "Rank #{{value}}"
+    "rank": "Rank #{{value}}",
+    "badgesTitle": "الشارات",
+    "certificatesTitle": "الشهادات",
+    "certificate": "شهادة",
+    "earnedOn": "حصل عليها في {{date}}",
+    "completed": "اكتمل {{percent}}%"
   }
 }

--- a/frontend-learner-dashboard-app/src/locales/en/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/en/parent.json
@@ -156,6 +156,7 @@
     "unmarkedDays": "Unmarked",
     "streak": "Day streak",
     "timeInClassTitle": "Time spent in class",
+    "upcomingChip": "Upcoming",
     "attendedFor": "Attended {{duration}}"
   },
   "progress": {
@@ -206,6 +207,11 @@
     "emptyTitle": "No rewards yet",
     "emptyBody": "Badges and points will show here as {{name}} learns.",
     "points": "Points earned",
-    "rank": "Rank #{{value}}"
+    "rank": "Rank #{{value}}",
+    "badgesTitle": "Badges",
+    "certificatesTitle": "Certificates",
+    "certificate": "Certificate",
+    "earnedOn": "Earned {{date}}",
+    "completed": "{{percent}}% completed"
   }
 }

--- a/frontend-learner-dashboard-app/src/locales/hi/parent.json
+++ b/frontend-learner-dashboard-app/src/locales/hi/parent.json
@@ -156,6 +156,7 @@
     "unmarkedDays": "Unmarked",
     "streak": "Day streak",
     "timeInClassTitle": "कक्षा में बिताया गया समय",
+    "upcomingChip": "आगामी",
     "attendedFor": "{{duration}} उपस्थित रहे"
   },
   "progress": {
@@ -206,6 +207,11 @@
     "emptyTitle": "No rewards yet",
     "emptyBody": "Badges and points will show here as {{name}} learns.",
     "points": "Points earned",
-    "rank": "Rank #{{value}}"
+    "rank": "Rank #{{value}}",
+    "badgesTitle": "बैज",
+    "certificatesTitle": "प्रमाणपत्र",
+    "certificate": "प्रमाणपत्र",
+    "earnedOn": "{{date}} को अर्जित",
+    "completed": "{{percent}}% पूर्ण"
   }
 }

--- a/frontend-learner-dashboard-app/src/routes/parent/child/$childId/attendance/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/$childId/attendance/index.tsx
@@ -6,7 +6,7 @@ import { CalendarCheck, Fire, Clock } from "@phosphor-icons/react";
 import { ModuleScaffold } from "../../-components/ModuleScaffold";
 import { ParentStatusChip } from "../../-components/ParentStatusChip";
 import type { ParentStatusTone } from "../../-components/ParentStatusChip";
-import { computeAttendanceStats } from "@/services/attendance/useAttendanceStats";
+import { computeAttendanceStats, notStartedYet } from "@/services/attendance/useAttendanceStats";
 import type { ScheduleItem } from "@/services/attendance/getAttendanceReport";
 import { cn } from "@/lib/utils";
 import { useChildAttendance, useChildOverview } from "../../-hooks/use-parent-child";
@@ -165,7 +165,14 @@ function AttendanceScreen() {
             <h2 className="text-body font-semibold text-foreground">{t("attendance.recentTitle")}</h2>
             <ul className="flex flex-col gap-2">
               {recent.map((s, i) => {
-                const info = statusToneLabel(s.attendanceStatus, t);
+                // A class that has not started yet is "Upcoming" — never
+                // "Not marked"/"Absent" (the backend coalesces it to UNMARKED).
+                const upcoming =
+                  String(s.attendanceStatus ?? "UNMARKED").toUpperCase() === "UNMARKED" &&
+                  notStartedYet(s as unknown as ScheduleItem, new Date());
+                const info = upcoming
+                  ? { tone: "neutral" as ParentStatusTone, label: t("attendance.upcomingChip") }
+                  : statusToneLabel(s.attendanceStatus, t);
                 const title = String(s.sessionTitle ?? s.subject ?? t("liveClasses.session"));
                 const dateLabel = formatDate(s.meetingDate);
                 const mins = Number(s.durationMinutes) || 0;

--- a/frontend-learner-dashboard-app/src/routes/parent/child/$childId/rewards/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/$childId/rewards/index.tsx
@@ -1,22 +1,37 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Medal, Star } from "@phosphor-icons/react";
+import { Medal, Star, Certificate, Trophy } from "@phosphor-icons/react";
 import { ModuleScaffold } from "../../-components/ModuleScaffold";
-import { useChildBadges, useChildPoints, useChildOverview } from "../../-hooks/use-parent-child";
+import { cn } from "@/lib/utils";
+import {
+  useChildBadges,
+  useChildCertificates,
+  useChildPoints,
+  useChildOverview,
+} from "../../-hooks/use-parent-child";
 
 export const Route = createFileRoute("/parent/child/$childId/rewards/")({
   component: RewardsScreen,
 });
+
+function formatDate(raw?: string | null): string {
+  if (!raw) return "";
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+}
 
 function RewardsScreen() {
   const { childId } = useParams({ from: "/parent/child/$childId/rewards/" });
   const { t } = useTranslation("parent");
   const overview = useChildOverview(childId);
   const { data: badges, isLoading, isError, refetch } = useChildBadges(childId);
+  const { data: certificates } = useChildCertificates(childId);
   const { data: points } = useChildPoints(childId);
 
   const childName = overview.data?.child?.fullName || t("common.yourChild");
-  const count = badges?.length ?? 0;
+  const badgeCount = badges?.length ?? 0;
+  const certCount = certificates?.length ?? 0;
   const pointsValue = points?.points ?? 0;
 
   return (
@@ -24,53 +39,119 @@ function RewardsScreen() {
       childId={childId}
       title={t("tiles.rewards")}
       icon="rewards"
-      summary={t("rewards.summary", { name: childName, count })}
+      summary={t("rewards.summary", { name: childName, count: badgeCount })}
       isLoading={isLoading}
       isError={isError}
       onRetry={() => refetch()}
-      isEmpty={count === 0 && pointsValue === 0}
+      isEmpty={badgeCount === 0 && certCount === 0 && pointsValue === 0}
       emptyIcon={Medal}
       emptyTitle={t("rewards.emptyTitle")}
       emptyBody={t("rewards.emptyBody")}
     >
       <div className="flex flex-col gap-5">
-        {/* Points earned + rank */}
-        {points ? (
-          <div className="flex items-center justify-between gap-3 rounded-2xl bg-card px-5 py-4 shadow-sm">
-            <div className="flex items-center gap-3">
-              <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-cp-gold-tint">
-                <Star weight="fill" className="size-6 text-cp-gold" aria-hidden />
-              </span>
-              <div className="flex flex-col">
-                <span className="text-h2 font-bold tabular-nums text-foreground">{pointsValue}</span>
-                <span className="text-caption text-muted-foreground">{t("rewards.points")}</span>
-              </div>
+        {/* ── Gold hero: points + rank ── */}
+        <div className="flex items-center justify-between gap-3 rounded-2xl bg-gradient-to-br from-cp-gold-tint to-card px-5 py-5 shadow-sm">
+          <div className="flex items-center gap-4">
+            <span className="flex size-14 shrink-0 items-center justify-center rounded-full bg-cp-gold-tint shadow-sm">
+              <Star weight="fill" className="size-8 text-cp-gold" aria-hidden />
+            </span>
+            <div className="flex flex-col">
+              <span className="text-h1 font-bold tabular-nums text-foreground">{pointsValue}</span>
+              <span className="text-caption text-muted-foreground">{t("rewards.points")}</span>
             </div>
-            {points.rank != null ? (
-              <span className="rounded-full bg-primary-50 px-3 py-1 text-caption font-semibold text-primary-500">
-                {t("rewards.rank", { value: points.rank })}
-              </span>
-            ) : null}
+          </div>
+          {points?.rank != null ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-caption font-semibold text-foreground shadow-sm">
+              <Trophy weight="fill" className="size-4 text-cp-gold" aria-hidden />
+              {t("rewards.rank", { value: points.rank })}
+            </span>
+          ) : null}
+        </div>
+
+        {/* ── At-a-glance tiles ── */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col items-center gap-1 rounded-2xl bg-card px-3 py-4 text-center shadow-sm">
+            <Medal weight="fill" className="size-6 text-cp-gold" aria-hidden />
+            <span className="text-h2 font-bold tabular-nums text-foreground">{badgeCount}</span>
+            <span className="text-caption text-muted-foreground">{t("rewards.badgesTitle")}</span>
+          </div>
+          <div className="flex flex-col items-center gap-1 rounded-2xl bg-card px-3 py-4 text-center shadow-sm">
+            <Certificate weight="fill" className="size-6 text-primary-500" aria-hidden />
+            <span className="text-h2 font-bold tabular-nums text-foreground">{certCount}</span>
+            <span className="text-caption text-muted-foreground">{t("rewards.certificatesTitle")}</span>
+          </div>
+        </div>
+
+        {/* ── Badges ── */}
+        {badgeCount > 0 ? (
+          <div className="flex flex-col gap-3">
+            <h2 className="text-body font-semibold text-foreground">{t("rewards.badgesTitle")}</h2>
+            <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {badges?.map((b, i) => {
+                const awarded = formatDate(typeof b.awardedAt === "string" ? b.awardedAt : null);
+                return (
+                  <li
+                    key={String(b.id ?? b.badgeId ?? i)}
+                    className={cn(
+                      "flex flex-col items-center gap-2 rounded-2xl bg-card p-4 text-center shadow-sm",
+                      "transition-transform hover:-translate-y-0.5",
+                    )}
+                  >
+                    <span className="flex size-14 items-center justify-center rounded-full bg-cp-gold-tint">
+                      <Medal weight="fill" className="size-8 text-cp-gold" aria-hidden />
+                    </span>
+                    <span className="text-caption font-semibold text-foreground">
+                      {String(b.name ?? b.badgeName ?? t("rewards.badge"))}
+                    </span>
+                    {awarded ? (
+                      <span className="text-caption text-muted-foreground">
+                        {t("rewards.earnedOn", { date: awarded })}
+                      </span>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
           </div>
         ) : null}
 
-        {/* Badges */}
-        {count > 0 ? (
-          <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            {badges?.map((b, i) => (
-              <li
-                key={String(b.id ?? b.badgeId ?? i)}
-                className="flex flex-col items-center gap-2 rounded-2xl bg-card p-4 text-center shadow-sm"
-              >
-                <span className="flex size-14 items-center justify-center rounded-full bg-cp-gold-tint">
-                  <Medal weight="fill" className="size-8 text-cp-gold" aria-hidden />
-                </span>
-                <span className="text-caption font-medium text-foreground">
-                  {String(b.badgeName ?? b.name ?? t("rewards.badge"))}
-                </span>
-              </li>
-            ))}
-          </ul>
+        {/* ── Certificates ── */}
+        {certCount > 0 ? (
+          <div className="flex flex-col gap-3">
+            <h2 className="text-body font-semibold text-foreground">
+              {t("rewards.certificatesTitle")}
+            </h2>
+            <ul className="flex flex-col gap-2">
+              {certificates?.map((c) => {
+                const issued = formatDate(c.issuedAt);
+                return (
+                  <li
+                    key={c.certificateId}
+                    className="flex items-center gap-3 rounded-2xl bg-card px-4 py-3.5 shadow-sm"
+                  >
+                    <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary-50">
+                      <Certificate weight="fill" className="size-6 text-primary-500" aria-hidden />
+                    </span>
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-body font-medium text-foreground">
+                        {c.courseName || t("rewards.certificate")}
+                      </span>
+                      <span className="text-caption text-muted-foreground">
+                        {[
+                          issued ? t("rewards.earnedOn", { date: issued }) : null,
+                          c.completionPercentage != null
+                            ? t("rewards.completed", { percent: Math.round(c.completionPercentage) })
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         ) : null}
       </div>
     </ModuleScaffold>

--- a/frontend-learner-dashboard-app/src/services/attendance/useAttendanceStats.ts
+++ b/frontend-learner-dashboard-app/src/services/attendance/useAttendanceStats.ts
@@ -16,6 +16,17 @@ export interface AttendanceStats {
 }
 
 /**
+ * A class that has not STARTED yet (today's later classes, future classes).
+ * The backend coalesces missing attendance to "UNMARKED", so without a time
+ * check these would count as unmarked/absent before the class even began.
+ */
+export function notStartedYet(s: ScheduleItem, now: Date): boolean {
+  if (!s.meetingDate) return false;
+  const start = new Date(`${s.meetingDate}T${s.startTime || "00:00:00"}`);
+  return !Number.isNaN(start.getTime()) && start > now;
+}
+
+/**
  * Pure function: compute day-wise attendance stats from raw schedules.
  * Multiple classes in one day count as one day.
  * PRESENT if any class that day was attended.
@@ -48,6 +59,7 @@ export function computeAttendanceStats(
   // Compute per-day status
   const dayStatuses: { date: string; status: "PRESENT" | "ABSENT" | "UNMARKED" }[] = [];
 
+  const now = new Date();
   for (const [dateKey, daySchedules] of dayMap) {
     const dayDate = parseISO(dateKey);
     const isDayInPast = isPast(dayDate) && !isToday(dayDate);
@@ -55,7 +67,14 @@ export function computeAttendanceStats(
     const hasAnyPresent = daySchedules.some(
       (s) => s.attendanceStatus === "PRESENT"
     );
-    const hasAnyPending = daySchedules.some((s) => !s.attendanceStatus);
+    // Pending = no status yet, OR the class simply hasn't started (the backend
+    // reports not-yet-started classes as UNMARKED, which must not read as
+    // absent/unmarked before the class begins).
+    const hasAnyPending = daySchedules.some(
+      (s) =>
+        !s.attendanceStatus ||
+        (s.attendanceStatus === "UNMARKED" && notStartedYet(s, now))
+    );
     const hasAnyUnmarked = daySchedules.some(
       (s) => s.attendanceStatus === "UNMARKED"
     );


### PR DESCRIPTION
…-wise %; richer rewards screen

Not-yet-started classes: the backend coalesces missing attendance logs to UNMARKED, so today's later classes showed as unmarked/absent in the apps and the assistant claimed attendance 'not marked yet'. computeAttendanceStats now treats an UNMARKED class whose date+startTime is still in the future as pending (day skipped, not absent) — shared fix, benefits the student app too; the parent attendance list shows an 'Upcoming' chip for them; and the assistant context excludes unstarted classes from 'Recent classes' (they already appear under 'Upcoming classes').

Assistant %: buildContext now computes the same DAY-WISE percentage the apps display (present if any class that day attended, in-progress days skipped) instead of the raw session-wise report number, so the bot and the screens agree.

Rewards screen: gold hero (points + rank chip), badges/certificates count tiles, badge cards with earned dates, and a new certificates section (course, issue date, completion %) — visual parity with the other modules.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
