### PR TITLE
feat(slide-editor): course-scoped unsaved-drafts UX, 3-level navigato…

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/chapter-navigator.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/chapter-navigator.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 import { getDraftUserId, useSlideDrafts } from '../-hooks/use-slide-drafts';
+import { useContentStore } from '../-stores/chapter-sidebar-store';
 
 interface ChapterNavigatorProps {
     currentChapterId: string;
@@ -280,6 +281,11 @@ export const ChapterNavigator = ({
                 sessionId,
             },
         });
+        // Same-chapter jump: the sidebar's URL→active sync early-returns while the
+        // current slide still exists, so a slideId-only change won't switch. Set
+        // the target active directly (cross-chapter resolves via the fresh list).
+        const target = useContentStore.getState().items.find((s) => s.id === slideId);
+        if (target) useContentStore.getState().setActiveItem(target);
     };
 
     // Switching subject lands on that subject's module listing — its

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/chapter-navigator.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/chapter-navigator.tsx
@@ -1,19 +1,43 @@
-import { useState, useMemo } from 'react';
+/**
+ * Course navigator for the slide editor sidebar.
+ *
+ * One popover covering the WHOLE subject: every module as a collapsible group
+ * with its chapters underneath, each chapter expandable to its SLIDES for a
+ * direct jump; search across all chapters; and (when the course has more than
+ * one subject) a subject switcher row. Chapters/slides with local unsaved
+ * drafts get an amber dot; module headers show a rollup count. Prev/next walks
+ * chapters ACROSS module boundaries.
+ *
+ * Modules/chapters/subjects are already client-side (stores). Slides are
+ * lazy-fetched per chapter on first expand and cached in component state —
+ * a separate lightweight fetch, NOT the ['slides', chapterId] react-query
+ * cache, whose entries flow through use-slides' cleaning pipeline.
+ */
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useRouter } from '@tanstack/react-router';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { GET_SLIDES } from '@/constants/urls';
+import { getIcon } from './slides-sidebar/slides-sidebar-slides';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useModulesWithChaptersStore } from '@/stores/study-library/use-modules-with-chapters-store';
+import { useStudyLibraryStore } from '@/stores/study-library/use-study-library-store';
 import {
     CaretDown,
     CaretLeft,
     CaretRight,
     Check,
     File,
+    FolderSimple,
     MagnifyingGlass,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
-import { getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { getDraftUserId, useSlideDrafts } from '../-hooks/use-slide-drafts';
 
 interface ChapterNavigatorProps {
     currentChapterId: string;
@@ -23,6 +47,15 @@ interface ChapterNavigatorProps {
     subjectId: string;
     sessionId: string;
 }
+
+/** Minimal slide row for the navigator tree (full Slide type not needed). */
+interface NavSlide {
+    id: string;
+    title: string;
+    sourceType: string;
+    docType?: string;
+}
+type ChapterSlidesState = NavSlide[] | 'loading' | 'error';
 
 export const ChapterNavigator = ({
     currentChapterId,
@@ -35,47 +68,196 @@ export const ChapterNavigator = ({
     const navigate = useNavigate();
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
+    const [isSubjectListOpen, setIsSubjectListOpen] = useState(false);
     const { modulesWithChaptersData } = useModulesWithChaptersStore();
+    const { studyLibraryData } = useStudyLibraryStore();
 
-    // Get current module and its chapters
-    const currentModule = useMemo(() => {
-        return modulesWithChaptersData?.find((m) => m.module.id === currentModuleId);
-    }, [modulesWithChaptersData, currentModuleId]);
+    // Local unsaved drafts of this course — amber dot per chapter/slide, rollup per module.
+    const [draftUserId] = useState<string>(() => getDraftUserId());
+    const { drafts: courseDrafts, dirtySlideIds } = useSlideDrafts(draftUserId, courseId);
 
-    const chapters = useMemo(() => {
-        if (!currentModule) return [];
-        return currentModule.chapters
-            .filter((ch) => ch.chapter.status !== 'DELETED')
-            .sort((a, b) => a.chapter.chapter_order - b.chapter.chapter_order);
-    }, [currentModule]);
+    // Highlight the slide currently open in the editor.
+    const router = useRouter();
+    const currentSlideId: string = router.state.location.search.slideId || '';
 
-    // Get current chapter info
-    const currentChapter = useMemo(() => {
-        return chapters.find((ch) => ch.chapter.id === currentChapterId);
-    }, [chapters, currentChapterId]);
+    // ---- per-chapter slides (lazy) ---------------------------------------
+    const [expandedChapterIds, setExpandedChapterIds] = useState<Set<string>>(
+        () => new Set([currentChapterId])
+    );
+    const [slidesByChapter, setSlidesByChapter] = useState<Record<string, ChapterSlidesState>>({});
 
-    const currentChapterIndex = useMemo(() => {
-        return chapters.findIndex((ch) => ch.chapter.id === currentChapterId);
-    }, [chapters, currentChapterId]);
+    const loadChapterSlides = (chapterId: string) => {
+        setSlidesByChapter((prev) => {
+            // Already loaded or in flight — nothing to do (retry only after error).
+            if (prev[chapterId] && prev[chapterId] !== 'error') return prev;
+            return { ...prev, [chapterId]: 'loading' };
+        });
+        authenticatedAxiosInstance
+            .get(`${GET_SLIDES}?chapterId=${chapterId}`)
+            .then((res) => {
+                const slides: NavSlide[] = (Array.isArray(res.data) ? res.data : [])
+                    .filter((s: { status?: string }) => s.status !== 'DELETED')
+                    .map(
+                        (s: {
+                            id: string;
+                            title?: string;
+                            source_type?: string;
+                            document_slide?: { title?: string; type?: string };
+                            video_slide?: { title?: string };
+                        }) => ({
+                            id: s.id,
+                            title:
+                                s.document_slide?.title ||
+                                s.video_slide?.title ||
+                                s.title ||
+                                'Untitled',
+                            sourceType: s.source_type ?? '',
+                            docType: s.document_slide?.type,
+                        })
+                    );
+                setSlidesByChapter((prev) => ({ ...prev, [chapterId]: slides }));
+            })
+            .catch(() => {
+                setSlidesByChapter((prev) => ({ ...prev, [chapterId]: 'error' }));
+            });
+    };
 
-    // Filter chapters based on search
-    const filteredChapters = useMemo(() => {
-        if (!searchQuery.trim()) return chapters;
-        const query = searchQuery.toLowerCase();
-        return chapters.filter((ch) => (ch.chapter?.chapter_name ?? '').toLowerCase().includes(query));
-    }, [chapters, searchQuery]);
+    const toggleChapterSlides = (chapterId: string) => {
+        setExpandedChapterIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(chapterId)) {
+                next.delete(chapterId);
+            } else {
+                next.add(chapterId);
+                loadChapterSlides(chapterId);
+            }
+            return next;
+        });
+    };
 
-    // Navigation handlers
-    const navigateToChapter = (chapterId: string) => {
+    // Keep the chapter you're in expanded (and its slides loaded) when the
+    // popover opens — one fetch, cached for the popover's lifetime.
+    useEffect(() => {
+        if (!isOpen) return;
+        setExpandedChapterIds((prev) => {
+            if (prev.has(currentChapterId)) return prev;
+            const next = new Set(prev);
+            next.add(currentChapterId);
+            return next;
+        });
+        loadChapterSlides(currentChapterId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen, currentChapterId]);
+
+    // ---- data shaping -----------------------------------------------------
+    const moduleGroups = useMemo(() => {
+        return (modulesWithChaptersData ?? [])
+            .filter((m) => m.module.status !== 'DELETED')
+            .map((m) => ({
+                module: m.module,
+                chapters: m.chapters
+                    .filter((ch) => ch.chapter.status !== 'DELETED')
+                    .sort((a, b) => a.chapter.chapter_order - b.chapter.chapter_order),
+            }))
+            .filter((g) => g.chapters.length > 0);
+    }, [modulesWithChaptersData]);
+
+    // Flat chapter list across ALL modules — prev/next walks module boundaries.
+    const flatChapters = useMemo(
+        () =>
+            moduleGroups.flatMap((g) =>
+                g.chapters.map((ch) => ({ moduleId: g.module.id, entry: ch }))
+            ),
+        [moduleGroups]
+    );
+    const currentFlatIndex = useMemo(
+        () => flatChapters.findIndex((f) => f.entry.chapter.id === currentChapterId),
+        [flatChapters, currentChapterId]
+    );
+    const currentChapter = currentFlatIndex >= 0 ? flatChapters[currentFlatIndex] : undefined;
+
+    const dirtyCountByChapter = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const draft of courseDrafts) {
+            const chapterKey = draft.context?.chapterId;
+            if (chapterKey) counts.set(chapterKey, (counts.get(chapterKey) ?? 0) + 1);
+        }
+        return counts;
+    }, [courseDrafts]);
+    const dirtyCountByModule = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const draft of courseDrafts) {
+            const moduleKey = draft.context?.moduleId;
+            if (moduleKey) counts.set(moduleKey, (counts.get(moduleKey) ?? 0) + 1);
+        }
+        return counts;
+    }, [courseDrafts]);
+
+    // ---- expand / collapse ------------------------------------------------
+    const [expandedModuleIds, setExpandedModuleIds] = useState<Set<string>>(
+        () => new Set([currentModuleId])
+    );
+    useEffect(() => {
+        // Keep the module you're in expanded when you land in a new one.
+        setExpandedModuleIds((prev) => {
+            if (prev.has(currentModuleId)) return prev;
+            const next = new Set(prev);
+            next.add(currentModuleId);
+            return next;
+        });
+    }, [currentModuleId]);
+    const toggleModule = (moduleId: string) => {
+        setExpandedModuleIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(moduleId)) next.delete(moduleId);
+            else next.add(moduleId);
+            return next;
+        });
+    };
+
+    // ---- search (whole subject) ------------------------------------------
+    const query = searchQuery.trim().toLowerCase();
+    const visibleGroups = useMemo(() => {
+        if (!query) return moduleGroups;
+        return moduleGroups
+            .map((g) => ({
+                ...g,
+                chapters: g.chapters.filter((ch) =>
+                    (ch.chapter.chapter_name ?? '').toLowerCase().includes(query)
+                ),
+            }))
+            .filter((g) => g.chapters.length > 0);
+    }, [moduleGroups, query]);
+
+    // ---- subjects (row only when the course has more than one) -----------
+    const subjects = useMemo(() => {
+        const course = studyLibraryData?.find((c) => c.course.id === courseId);
+        const session =
+            course?.sessions.find((s) => s.session_dto.id === sessionId) ?? course?.sessions[0];
+        const level =
+            session?.level_with_details.find((l) => l.id === levelId) ??
+            session?.level_with_details[0];
+        return level?.subjects ?? [];
+    }, [studyLibraryData, courseId, sessionId, levelId]);
+    const showSubjectRow = subjects.length > 1;
+    const currentSubjectName = subjects.find((s) => s.id === subjectId)?.subject_name;
+
+    // ---- navigation -------------------------------------------------------
+    const closePopover = () => {
         setIsOpen(false);
         setSearchQuery('');
+        setIsSubjectListOpen(false);
+    };
+
+    const navigateToChapter = (targetModuleId: string, chapterId: string) => {
+        closePopover();
         navigate({
             to: '/study-library/courses/course-details/subjects/modules/chapters/slides',
             search: {
                 courseId,
                 levelId,
                 subjectId,
-                moduleId: currentModuleId,
+                moduleId: targetModuleId,
                 chapterId,
                 slideId: '',
                 sessionId,
@@ -83,60 +265,89 @@ export const ChapterNavigator = ({
         });
     };
 
-    const goToPreviousChapter = () => {
-        if (currentChapterIndex > 0) {
-            const prevChapter = chapters[currentChapterIndex - 1];
-            if (prevChapter) {
-                navigateToChapter(prevChapter.chapter.id);
-            }
-        }
+    // Direct jump to a specific slide, anywhere in the subject.
+    const navigateToSlide = (targetModuleId: string, chapterId: string, slideId: string) => {
+        closePopover();
+        navigate({
+            to: '/study-library/courses/course-details/subjects/modules/chapters/slides',
+            search: {
+                courseId,
+                levelId,
+                subjectId,
+                moduleId: targetModuleId,
+                chapterId,
+                slideId,
+                sessionId,
+            },
+        });
     };
 
-    const goToNextChapter = () => {
-        if (currentChapterIndex < chapters.length - 1) {
-            const nextChapter = chapters[currentChapterIndex + 1];
-            if (nextChapter) {
-                navigateToChapter(nextChapter.chapter.id);
-            }
+    // Switching subject lands on that subject's module listing — its
+    // modules/chapters aren't loaded client-side, so the listing page is the
+    // natural entry point.
+    const navigateToSubject = (targetSubjectId: string) => {
+        if (targetSubjectId === subjectId) {
+            setIsSubjectListOpen(false);
+            return;
         }
+        closePopover();
+        navigate({
+            to: '/study-library/courses/course-details/subjects/modules',
+            search: { courseId, levelId, subjectId: targetSubjectId, sessionId },
+        });
     };
 
-    const hasPrevious = currentChapterIndex > 0;
-    const hasNext = currentChapterIndex < chapters.length - 1;
+    const previous = currentFlatIndex > 0 ? flatChapters[currentFlatIndex - 1] : undefined;
+    const next =
+        currentFlatIndex >= 0 && currentFlatIndex < flatChapters.length - 1
+            ? flatChapters[currentFlatIndex + 1]
+            : undefined;
 
-    // Get slide count for a chapter
-    const getSlideCount = (ch: (typeof chapters)[0]) => {
-        const counts = ch.slides_count;
+    const chapterTermPlural = getTerminologyPlural(ContentTerms.Chapter, SystemTerms.Chapter);
+    const subjectTerm = getTerminology(ContentTerms.Subject, SystemTerms.Subject);
+
+    // Slide count badge per chapter row (unchanged from previous behaviour).
+    const getSlideCount = (entry: (typeof flatChapters)[number]['entry']) => {
+        const counts = entry.slides_count;
         return counts.video_count + counts.pdf_count + counts.doc_count + counts.unknown_count;
     };
 
-    if (!currentModule || chapters.length === 0) {
+    if (moduleGroups.length === 0) {
         return null;
     }
 
     return (
         <div className="flex w-full max-w-full items-center gap-1 overflow-hidden px-1">
-            {/* Previous Chapter Button */}
+            {/* Previous chapter (crosses module boundaries) */}
             <button
-                onClick={goToPreviousChapter}
-                disabled={!hasPrevious}
+                onClick={() => previous && navigateToChapter(previous.moduleId, previous.entry.chapter.id)}
+                disabled={!previous}
                 className={cn(
                     'flex size-6 shrink-0 items-center justify-center rounded-md transition-all duration-200',
-                    hasPrevious
+                    previous
                         ? 'bg-white/80 text-neutral-600 hover:bg-primary-100 hover:text-primary-600 active:scale-95'
                         : 'cursor-not-allowed bg-neutral-100/50 text-neutral-300'
                 )}
                 title={
-                    hasPrevious
-                        ? `Previous: ${chapters[currentChapterIndex - 1]?.chapter.chapter_name}`
-                        : 'No previous chapter'
+                    previous
+                        ? `Previous: ${previous.entry.chapter.chapter_name}`
+                        : `No previous ${getTerminology(ContentTerms.Chapter, SystemTerms.Chapter).toLowerCase()}`
                 }
             >
                 <CaretLeft className="size-4" weight="bold" />
             </button>
 
-            {/* Chapter Selector Popover */}
-            <Popover open={isOpen} onOpenChange={setIsOpen}>
+            {/* Navigator popover */}
+            <Popover
+                open={isOpen}
+                onOpenChange={(open) => {
+                    setIsOpen(open);
+                    if (!open) {
+                        setSearchQuery('');
+                        setIsSubjectListOpen(false);
+                    }
+                }}
+            >
                 <PopoverTrigger asChild>
                     <button
                         className={cn(
@@ -151,12 +362,14 @@ export const ChapterNavigator = ({
                         <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
                             <File className="size-3.5 shrink-0 text-primary-500" weight="duotone" />
                             <span className="truncate text-xs">
-                                {currentChapter?.chapter.chapter_name || 'Select Chapter'}
+                                {currentChapter?.entry.chapter.chapter_name ||
+                                    `Select ${getTerminology(ContentTerms.Chapter, SystemTerms.Chapter)}`}
                             </span>
                         </div>
                         <div className="flex shrink-0 items-center gap-1">
                             <span className="rounded-full bg-neutral-100 px-1 py-0.5 text-2xs text-neutral-500 group-hover:bg-primary-100 group-hover:text-primary-600">
-                                {currentChapterIndex + 1}/{chapters.length}
+                                {currentFlatIndex >= 0 ? currentFlatIndex + 1 : '–'}/
+                                {flatChapters.length}
                             </span>
                             <CaretDown
                                 className={cn(
@@ -169,14 +382,14 @@ export const ChapterNavigator = ({
                     </button>
                 </PopoverTrigger>
 
-                <PopoverContent className="w-72 p-0" align="center" side="bottom" sideOffset={8}>
+                <PopoverContent className="w-80 p-0" align="center" side="bottom" sideOffset={8}>
                     <div className="flex flex-col">
-                        {/* Search Input */}
+                        {/* Search — spans every module of the subject */}
                         <div className="border-b border-neutral-100 p-2">
                             <div className="relative">
                                 <MagnifyingGlass className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-neutral-400" />
                                 <Input
-                                    placeholder="Search chapters..."
+                                    placeholder={`Search all ${chapterTermPlural.toLowerCase()}...`}
                                     value={searchQuery}
                                     onChange={(e) => setSearchQuery(e.target.value)}
                                     className="h-8 pl-8 text-sm"
@@ -185,102 +398,353 @@ export const ChapterNavigator = ({
                             </div>
                         </div>
 
-                        {/* Module Name Header */}
-                        <div className="border-b border-neutral-100 bg-neutral-50/50 px-3 py-2">
-                            <p className="text-xs font-medium text-neutral-500">
-                                {currentModule.module.module_name}
-                            </p>
-                        </div>
-
-                        {/* Chapter List */}
-                        {/* Plain overflow div: Radix ScrollArea's viewport (h-full) can't resolve
-                            against a max-h-only root, so the list gets clipped instead of scrolling */}
-                        <div className="max-h-64 overflow-y-auto">
-                            <div className="p-1">
-                                {filteredChapters.length === 0 ? (
-                                    <div className="px-3 py-6 text-center text-sm text-neutral-400">
-                                        {`No ${getTerminologyPlural(ContentTerms.Chapter, SystemTerms.Chapter).toLowerCase()} found`}
-                                    </div>
-                                ) : (
-                                    filteredChapters.map((ch, index) => {
-                                        const isActive = ch.chapter.id === currentChapterId;
-                                        const slideCount = getSlideCount(ch);
-                                        const originalIndex = chapters.findIndex(
-                                            (c) => c.chapter.id === ch.chapter.id
-                                        );
-
-                                        return (
+                        {/* Subject switcher — only when the course has >1 subject */}
+                        {showSubjectRow && (
+                            <div className="border-b border-neutral-100 bg-neutral-50/50">
+                                <button
+                                    onClick={() => setIsSubjectListOpen((v) => !v)}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left"
+                                >
+                                    <span className="text-xs text-neutral-400">{subjectTerm}</span>
+                                    <span className="min-w-0 flex-1 truncate text-xs font-semibold text-primary-600">
+                                        {currentSubjectName || '—'}
+                                    </span>
+                                    <CaretDown
+                                        className={cn(
+                                            'size-3 shrink-0 text-neutral-400 transition-transform duration-200',
+                                            isSubjectListOpen && 'rotate-180'
+                                        )}
+                                        weight="bold"
+                                    />
+                                </button>
+                                {isSubjectListOpen && (
+                                    <div className="flex flex-col gap-0.5 px-2 pb-2">
+                                        {subjects.map((subject) => (
                                             <button
-                                                key={ch.chapter.id}
-                                                onClick={() => navigateToChapter(ch.chapter.id)}
+                                                key={subject.id}
+                                                onClick={() => navigateToSubject(subject.id)}
                                                 className={cn(
-                                                    'flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-all duration-150',
-                                                    isActive
-                                                        ? 'bg-primary-100 text-primary-700'
+                                                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                                                    subject.id === subjectId
+                                                        ? 'bg-primary-100 font-semibold text-primary-700'
                                                         : 'text-neutral-600 hover:bg-neutral-100'
                                                 )}
                                             >
-                                                {/* Chapter Number */}
-                                                <div
-                                                    className={cn(
-                                                        'flex size-6 shrink-0 items-center justify-center rounded text-xs font-semibold',
-                                                        isActive
-                                                            ? 'bg-primary-500 text-white'
-                                                            : 'bg-neutral-200 text-neutral-500'
-                                                    )}
-                                                >
-                                                    {originalIndex + 1}
-                                                </div>
-
-                                                {/* Chapter Name */}
-                                                <div className="min-w-0 flex-1">
-                                                    <p
-                                                        className={cn(
-                                                            'truncate text-sm font-medium',
-                                                            isActive
-                                                                ? 'text-primary-700'
-                                                                : 'text-neutral-700'
-                                                        )}
-                                                    >
-                                                        {ch.chapter.chapter_name}
-                                                    </p>
-                                                    <p className="text-xs text-neutral-400">
-                                                        {slideCount}{' '}
-                                                        {slideCount === 1 ? 'slide' : 'slides'}
-                                                    </p>
-                                                </div>
-
-                                                {/* Active Indicator */}
-                                                {isActive && (
+                                                <span className="min-w-0 flex-1 truncate">
+                                                    {subject.subject_name}
+                                                </span>
+                                                {subject.id === subjectId && (
                                                     <Check
-                                                        className="size-4 shrink-0 text-primary-500"
+                                                        className="size-3.5 shrink-0 text-primary-500"
                                                         weight="bold"
                                                     />
                                                 )}
                                             </button>
-                                        );
-                                    })
+                                        ))}
+                                    </div>
                                 )}
                             </div>
+                        )}
+
+                        {/* Module groups with chapters. Plain overflow container —
+                            NOT Radix ScrollArea, whose 100%-height viewport never
+                            becomes scrollable under a max-height root (the old
+                            "popover doesn't scroll, page behind does" bug). */}
+                        <div className="max-h-72 overflow-y-auto overscroll-contain p-1">
+                            {visibleGroups.length === 0 ? (
+                                <div className="px-3 py-6 text-center text-sm text-neutral-400">
+                                    {`No ${chapterTermPlural.toLowerCase()} found`}
+                                </div>
+                            ) : (
+                                visibleGroups.map((group) => {
+                                    // While searching, every matching group is open.
+                                    const isExpanded =
+                                        !!query || expandedModuleIds.has(group.module.id);
+                                    const moduleDirtyCount =
+                                        dirtyCountByModule.get(group.module.id) ?? 0;
+                                    return (
+                                        <div key={group.module.id}>
+                                            <button
+                                                onClick={() => toggleModule(group.module.id)}
+                                                className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-neutral-100"
+                                            >
+                                                <CaretDown
+                                                    className={cn(
+                                                        'size-3 shrink-0 text-neutral-400 transition-transform duration-200',
+                                                        !isExpanded && '-rotate-90'
+                                                    )}
+                                                    weight="bold"
+                                                />
+                                                <FolderSimple
+                                                    className={cn(
+                                                        'size-4 shrink-0',
+                                                        group.module.id === currentModuleId
+                                                            ? 'text-primary-500'
+                                                            : 'text-neutral-400'
+                                                    )}
+                                                    weight="duotone"
+                                                />
+                                                <span
+                                                    className={cn(
+                                                        'min-w-0 flex-1 truncate text-xs font-semibold',
+                                                        group.module.id === currentModuleId
+                                                            ? 'text-primary-700'
+                                                            : 'text-neutral-600'
+                                                    )}
+                                                >
+                                                    {group.module.module_name}
+                                                </span>
+                                                {moduleDirtyCount > 0 && (
+                                                    <span className="shrink-0 rounded-full border border-warning-300 bg-warning-50 px-1.5 py-0.5 text-2xs font-semibold text-warning-600">
+                                                        {moduleDirtyCount} unsaved
+                                                    </span>
+                                                )}
+                                                <span className="shrink-0 text-2xs text-neutral-400">
+                                                    {group.chapters.length}
+                                                </span>
+                                            </button>
+
+                                            {isExpanded && (
+                                                <div className="flex flex-col pb-1 pl-4">
+                                                    {group.chapters.map((entry, index) => {
+                                                        const isActive =
+                                                            entry.chapter.id === currentChapterId;
+                                                        const chapterDirtyCount =
+                                                            dirtyCountByChapter.get(
+                                                                entry.chapter.id
+                                                            ) ?? 0;
+                                                        const slideCount = getSlideCount(entry);
+                                                        // Slides sub-list collapses while searching
+                                                        // (search is chapter-level).
+                                                        const isChapterExpanded =
+                                                            !query &&
+                                                            expandedChapterIds.has(entry.chapter.id);
+                                                        const chapterSlides =
+                                                            slidesByChapter[entry.chapter.id];
+                                                        return (
+                                                            <div key={entry.chapter.id}>
+                                                                <div
+                                                                    className={cn(
+                                                                        'flex w-full items-center rounded-md transition-all duration-150',
+                                                                        isActive
+                                                                            ? 'bg-primary-100'
+                                                                            : 'hover:bg-neutral-100'
+                                                                    )}
+                                                                >
+                                                                    {/* Expand slides — separate hit
+                                                                        target so the name still
+                                                                        navigates to the chapter */}
+                                                                    <button
+                                                                        onClick={() =>
+                                                                            toggleChapterSlides(
+                                                                                entry.chapter.id
+                                                                            )
+                                                                        }
+                                                                        title={`Show ${getTerminologyPlural(ContentTerms.Slide, SystemTerms.Slide).toLowerCase()}`}
+                                                                        className="flex size-7 shrink-0 items-center justify-center rounded-md text-neutral-400 hover:text-primary-600"
+                                                                    >
+                                                                        <CaretDown
+                                                                            className={cn(
+                                                                                'size-3 transition-transform duration-200',
+                                                                                !isChapterExpanded &&
+                                                                                    '-rotate-90'
+                                                                            )}
+                                                                            weight="bold"
+                                                                        />
+                                                                    </button>
+                                                                    <button
+                                                                        onClick={() =>
+                                                                            navigateToChapter(
+                                                                                group.module.id,
+                                                                                entry.chapter.id
+                                                                            )
+                                                                        }
+                                                                        className={cn(
+                                                                            'flex min-w-0 flex-1 items-center gap-2 py-2 pr-2 text-left',
+                                                                            isActive
+                                                                                ? 'text-primary-700'
+                                                                                : 'text-neutral-600'
+                                                                        )}
+                                                                    >
+                                                                        <div
+                                                                            className={cn(
+                                                                                'flex size-6 shrink-0 items-center justify-center rounded text-xs font-semibold',
+                                                                                isActive
+                                                                                    ? 'bg-primary-500 text-white'
+                                                                                    : 'bg-neutral-200 text-neutral-500'
+                                                                            )}
+                                                                        >
+                                                                            {index + 1}
+                                                                        </div>
+                                                                        <div className="min-w-0 flex-1">
+                                                                            <p
+                                                                                className={cn(
+                                                                                    'truncate text-sm font-medium',
+                                                                                    isActive
+                                                                                        ? 'text-primary-700'
+                                                                                        : 'text-neutral-700'
+                                                                                )}
+                                                                            >
+                                                                                {
+                                                                                    entry.chapter
+                                                                                        .chapter_name
+                                                                                }
+                                                                            </p>
+                                                                            <p className="text-xs text-neutral-400">
+                                                                                {slideCount}{' '}
+                                                                                {slideCount === 1
+                                                                                    ? getTerminology(
+                                                                                          ContentTerms.Slide,
+                                                                                          SystemTerms.Slide
+                                                                                      ).toLowerCase()
+                                                                                    : getTerminologyPlural(
+                                                                                          ContentTerms.Slide,
+                                                                                          SystemTerms.Slide
+                                                                                      ).toLowerCase()}
+                                                                                {chapterDirtyCount >
+                                                                                    0 &&
+                                                                                    ` · ${chapterDirtyCount} unsaved`}
+                                                                            </p>
+                                                                        </div>
+                                                                        {chapterDirtyCount > 0 && (
+                                                                            <span
+                                                                                className="size-2 shrink-0 rounded-full bg-warning-500 ring-2 ring-warning-100"
+                                                                                title="Unsaved changes"
+                                                                            />
+                                                                        )}
+                                                                        {isActive && (
+                                                                            <Check
+                                                                                className="size-4 shrink-0 text-primary-500"
+                                                                                weight="bold"
+                                                                            />
+                                                                        )}
+                                                                    </button>
+                                                                </div>
+
+                                                                {/* Slides of this chapter — direct jump */}
+                                                                {isChapterExpanded && (
+                                                                    <div className="flex flex-col pb-1 pl-9">
+                                                                        {chapterSlides ===
+                                                                            'loading' && (
+                                                                            <p className="px-2 py-1.5 text-xs text-neutral-400">
+                                                                                Loading…
+                                                                            </p>
+                                                                        )}
+                                                                        {chapterSlides ===
+                                                                            'error' && (
+                                                                            <button
+                                                                                onClick={() =>
+                                                                                    loadChapterSlides(
+                                                                                        entry.chapter
+                                                                                            .id
+                                                                                    )
+                                                                                }
+                                                                                className="px-2 py-1.5 text-left text-xs text-danger-600 hover:underline"
+                                                                            >
+                                                                                Couldn&apos;t load —
+                                                                                retry
+                                                                            </button>
+                                                                        )}
+                                                                        {Array.isArray(
+                                                                            chapterSlides
+                                                                        ) &&
+                                                                            chapterSlides.length ===
+                                                                                0 && (
+                                                                                <p className="px-2 py-1.5 text-xs text-neutral-400">
+                                                                                    {`No ${getTerminologyPlural(ContentTerms.Slide, SystemTerms.Slide).toLowerCase()} yet`}
+                                                                                </p>
+                                                                            )}
+                                                                        {Array.isArray(
+                                                                            chapterSlides
+                                                                        ) &&
+                                                                            chapterSlides.map(
+                                                                                (slide) => {
+                                                                                    const isSlideActive =
+                                                                                        slide.id ===
+                                                                                        currentSlideId;
+                                                                                    return (
+                                                                                        <button
+                                                                                            key={
+                                                                                                slide.id
+                                                                                            }
+                                                                                            onClick={() =>
+                                                                                                navigateToSlide(
+                                                                                                    group
+                                                                                                        .module
+                                                                                                        .id,
+                                                                                                    entry
+                                                                                                        .chapter
+                                                                                                        .id,
+                                                                                                    slide.id
+                                                                                                )
+                                                                                            }
+                                                                                            className={cn(
+                                                                                                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors',
+                                                                                                isSlideActive
+                                                                                                    ? 'bg-primary-50 text-primary-700'
+                                                                                                    : 'text-neutral-600 hover:bg-neutral-100'
+                                                                                            )}
+                                                                                        >
+                                                                                            <span className="shrink-0">
+                                                                                                {getIcon(
+                                                                                                    slide.sourceType,
+                                                                                                    slide.docType,
+                                                                                                    '4'
+                                                                                                )}
+                                                                                            </span>
+                                                                                            <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                                                                                                {
+                                                                                                    slide.title
+                                                                                                }
+                                                                                            </span>
+                                                                                            {dirtySlideIds.has(
+                                                                                                slide.id
+                                                                                            ) && (
+                                                                                                <span
+                                                                                                    className="size-1.5 shrink-0 rounded-full bg-warning-500 ring-2 ring-warning-100"
+                                                                                                    title="Unsaved changes"
+                                                                                                />
+                                                                                            )}
+                                                                                            {isSlideActive && (
+                                                                                                <Check
+                                                                                                    className="size-3.5 shrink-0 text-primary-500"
+                                                                                                    weight="bold"
+                                                                                                />
+                                                                                            )}
+                                                                                        </button>
+                                                                                    );
+                                                                                }
+                                                                            )}
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    })}
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })
+                            )}
                         </div>
                     </div>
                 </PopoverContent>
             </Popover>
 
-            {/* Next Chapter Button */}
+            {/* Next chapter (crosses module boundaries) */}
             <button
-                onClick={goToNextChapter}
-                disabled={!hasNext}
+                onClick={() => next && navigateToChapter(next.moduleId, next.entry.chapter.id)}
+                disabled={!next}
                 className={cn(
                     'flex size-6 shrink-0 items-center justify-center rounded-md transition-all duration-200',
-                    hasNext
+                    next
                         ? 'bg-white/80 text-neutral-600 hover:bg-primary-100 hover:text-primary-600 active:scale-95'
                         : 'cursor-not-allowed bg-neutral-100/50 text-neutral-300'
                 )}
                 title={
-                    hasNext
-                        ? `Next: ${chapters[currentChapterIndex + 1]?.chapter.chapter_name}`
-                        : 'No next chapter'
+                    next
+                        ? `Next: ${next.entry.chapter.chapter_name}`
+                        : `No next ${getTerminology(ContentTerms.Chapter, SystemTerms.Chapter).toLowerCase()}`
                 }
             >
                 <CaretRight className="size-4" weight="bold" />

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/course-unsaved-banner.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/course-unsaved-banner.tsx
@@ -1,0 +1,51 @@
+/**
+ * Course-level unsaved-changes banner (the ONE course-scope signal).
+ *
+ * Amber strip in the editor sidebar — under the breadcrumb, above the chapter
+ * navigator — so it reads as "about the course", not the open slide. Renders
+ * nothing while the course has no local unsaved drafts; clicking opens the
+ * grouped drafts dialog (subject → module → chapter → slide, jump links).
+ */
+import { useState } from 'react';
+import { Warning, CaretRight } from '@phosphor-icons/react';
+import { getDraftUserId, useSlideDrafts } from '../-hooks/use-slide-drafts';
+import { UnsavedDraftsDialog } from './unsaved-drafts-dialog';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+
+export const CourseUnsavedBanner = ({ courseId }: { courseId: string }) => {
+    const [userId] = useState<string>(() => getDraftUserId());
+    const { drafts } = useSlideDrafts(userId, courseId);
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+    // Old-format drafts without course metadata aren't counted here — they
+    // self-place (metadata backfill in slide-material) once their chapter is
+    // opened, and age out in ≤14 days otherwise. Deliberately no special UI.
+    if (drafts.length === 0) return null;
+
+    return (
+        <div className="w-full px-2 pb-1">
+            <button
+                type="button"
+                onClick={() => setIsDialogOpen(true)}
+                className="flex w-full items-center gap-2 rounded-lg border border-warning-300 bg-warning-50 px-3 py-2 text-left transition-colors hover:bg-warning-100"
+            >
+                <Warning weight="fill" className="size-4 shrink-0 text-warning-600" />
+                <span className="flex-1 text-xs font-semibold text-neutral-700">
+                    {drafts.length} unsaved in this{' '}
+                    {getTerminology(ContentTerms.Course, SystemTerms.Course).toLowerCase()}
+                </span>
+                <span className="flex items-center gap-0.5 text-xs font-bold text-warning-600">
+                    Review
+                    <CaretRight className="size-3" weight="bold" />
+                </span>
+            </button>
+            <UnsavedDraftsDialog
+                open={isDialogOpen}
+                onOpenChange={setIsDialogOpen}
+                mode="review"
+                drafts={drafts}
+            />
+        </div>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-history-dialog.tsx
@@ -67,12 +67,25 @@ export const SlideHistoryDialog = ({
     activeItem,
     chapterId,
     onRestored,
+    open: controlledOpen,
+    onOpenChange,
+    hideTrigger = false,
 }: {
     activeItem: Slide;
     chapterId: string;
     onRestored: (restoredValue: string, slideStatus: string) => void;
+    /** Controlled mode (e.g. opened from the ⋯ menu): pass open + onOpenChange and hideTrigger. */
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    hideTrigger?: boolean;
 }) => {
-    const [open, setOpen] = useState(false);
+    const [internalOpen, setInternalOpen] = useState(false);
+    const isControlled = controlledOpen !== undefined;
+    const open = isControlled ? controlledOpen : internalOpen;
+    const setOpen = (o: boolean) => {
+        if (isControlled) onOpenChange?.(o);
+        else setInternalOpen(o);
+    };
     const [selectedId, setSelectedId] = useState<number | null>(null);
     const [previewSource, setPreviewSource] = useState<SnapshotSource>('DRAFT');
     const [confirmingRestore, setConfirmingRestore] = useState(false);
@@ -154,20 +167,22 @@ export const SlideHistoryDialog = ({
 
     return (
         <>
-            <MyButton
-                buttonType="secondary"
-                scale="medium"
-                layoutVariant="default"
-                title="View and restore previous versions"
-                onClick={() => {
-                    setSelectedId(null);
-                    setConfirmingRestore(false);
-                    setOpen(true);
-                }}
-            >
-                <ClockCounterClockwise size={18} />
-                <span className="hidden md:inline">History</span>
-            </MyButton>
+            {!hideTrigger && (
+                <MyButton
+                    buttonType="secondary"
+                    scale="medium"
+                    layoutVariant="default"
+                    title="View and restore previous versions"
+                    onClick={() => {
+                        setSelectedId(null);
+                        setConfirmingRestore(false);
+                        setOpen(true);
+                    }}
+                >
+                    <ClockCounterClockwise size={18} />
+                    <span className="hidden md:inline">History</span>
+                </MyButton>
+            )}
             <MyDialog
                 heading="Version history"
                 open={open}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -80,6 +80,7 @@ import {
     dirtySlideIds as getDirtySlideIds,
     pruneOldDrafts,
     hasDraft as hasLocalDraft,
+    SLIDE_DRAFTS_CHANGED_EVENT,
     type SlideDraftContext,
 } from '../-utils/slide-draft-store';
 import { UnsavedDraftsDialog } from './unsaved-drafts-dialog';
@@ -421,6 +422,10 @@ export const SlideMaterial = ({
     });
     // One blank-load re-apply attempt per slide (see captureInitialDocSnapshot).
     const blankLoadRetrySlideIdRef = useRef<string | null>(null);
+    // Whether the last explicit SaveDraft run actually persisted to the DB.
+    // SaveDraft swallows most failures without throwing, so this ref is the
+    // ONLY reliable success signal (see the note at SaveDraft's entry).
+    const lastSaveDraftOutcomeRef = useRef<'success' | 'failure'>('failure');
     // Last successfully-serialized DOC editor HTML, TAGGED with the slide it came
     // from. It's the fallback when html.serialize throws (a degenerate custom-block
     // Slate state). Without the slideId, that fallback could hand back a DIFFERENT
@@ -683,6 +688,27 @@ export const SlideMaterial = ({
     const { drafts: courseDrafts } = useSlideDrafts(currentUserId, courseId || '');
     const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
     const [isCompareOpen, setIsCompareOpen] = useState(false);
+    // Content hash of the ACTIVE slide's draft, kept live via draft-change
+    // events. dirtySlideIdSet deliberately keeps the same reference when
+    // membership is unchanged (render optimisation), so content-only stash
+    // rewrites would otherwise never recompute the memos below — the pill /
+    // Compare / Discard would freeze on a stale verdict for the whole session.
+    const [activeDraftHash, setActiveDraftHash] = useState<string | null>(null);
+    useEffect(() => {
+        const update = () => {
+            const draft = activeItem?.id
+                ? loadLocalDraft<string>(currentUserId, activeItem.id)
+                : null;
+            setActiveDraftHash(draft?.contentHash ?? null);
+        };
+        update();
+        window.addEventListener(SLIDE_DRAFTS_CHANGED_EVENT, update);
+        window.addEventListener('storage', update);
+        return () => {
+            window.removeEventListener(SLIDE_DRAFTS_CHANGED_EVENT, update);
+            window.removeEventListener('storage', update);
+        };
+    }, [activeItem?.id, currentUserId]);
     // Occasional-use header actions relocated into the ⋯ menu — dialogs are
     // controlled from here, triggers hidden.
     const [isStatsOpen, setIsStatsOpen] = useState(false);
@@ -706,6 +732,7 @@ export const SlideMaterial = ({
         activeItem?.status,
         activeItem?.document_slide?.data,
         activeItem?.document_slide?.published_data,
+        activeDraftHash,
         currentUserId,
     ]);
     // Show "Discard changes" only when the ACTIVE slide's local draft actually
@@ -713,7 +740,7 @@ export const SlideMaterial = ({
     // has nothing to discard. Normalized compare on both sides so serializer
     // round-trip noise (empty blocks, wrapper divs) doesn't fake a difference.
     const activeSlideHasRealChanges = useMemo(() => {
-        if (!activeItem?.id || !dirtySlideIdSet.has(activeItem.id)) return false;
+        if (!activeItem?.id || !activeDraftHash) return false;
         const draft = loadLocalDraft<string>(currentUserId, activeItem.id);
         if (!draft || typeof draft.content !== 'string') return false;
         const savedHtml =
@@ -729,7 +756,7 @@ export const SlideMaterial = ({
         activeItem?.status,
         activeItem?.document_slide?.data,
         activeItem?.document_slide?.published_data,
-        dirtySlideIdSet,
+        activeDraftHash,
         currentUserId,
     ]);
     const clearCourseDrafts = useCallback(() => {
@@ -767,6 +794,10 @@ export const SlideMaterial = ({
         withResolver: true,
         disabled: courseDrafts.length === 0,
         shouldBlockFn: ({ current, next }) => current.pathname !== next.pathname,
+        // TanStack defaults this to TRUE, silently re-adding the browser-native
+        // refresh/close prompt we deliberately removed (drafts persist in
+        // localStorage and restore on reopen — the prompt's warning is false).
+        enableBeforeUnload: false,
     });
     const [isUnpublishDialogOpen, setIsUnpublishDialogOpen] = useState(false);
     const [isEditLinkDialogOpen, setIsEditLinkDialogOpen] = useState(false);
@@ -1812,9 +1843,13 @@ export const SlideMaterial = ({
             initialDocHtmlRef.current.slideId === previous.id
                 ? initialDocHtmlRef.current.html
                 : getCurrentEditorHTMLContent();
-        // Always read latest editor state at the moment of handling to avoid stale saves
+        // Always read latest editor state at the moment of handling to avoid stale saves.
+        // NORMALIZED compare (same rule as the onChange path): a no-op click adds an
+        // empty paragraph, and a raw !== here would stash a phantom "unsaved" draft
+        // that arms the banner/badges/leave-guard for a never-edited slide.
         const currentHtml = getCurrentEditorHTMLContent() || initialHtml;
-        const hasEditorChanged = currentHtml !== initialHtml;
+        const hasEditorChanged =
+            normalizeHtmlForDirtyCompare(currentHtml) !== normalizeHtmlForDirtyCompare(initialHtml);
 
         // Only act if the user actually changed something in the editor
         if (!hasEditorChanged) {
@@ -1859,7 +1894,10 @@ export const SlideMaterial = ({
                     ? initialDocHtmlRef.current.html
                     : snapshotHtml; // fallback: treat as unchanged if we have no baseline
 
-            const hasEditorChanged = snapshotHtml !== initialHtml;
+            // NORMALIZED compare — same reasoning as handleUnsavedDoc above.
+            const hasEditorChanged =
+                normalizeHtmlForDirtyCompare(snapshotHtml) !==
+                normalizeHtmlForDirtyCompare(initialHtml);
 
             // Only act if the user actually changed something
             if (!hasEditorChanged) {
@@ -3063,6 +3101,12 @@ export const SlideMaterial = ({
 
     const SaveDraft = async (slideToSave?: Slide | null) => {
         setIsSaving(true);
+        // Pessimistic until a branch actually persists: SaveDraft swallows most
+        // failures (guard refusals, declined 409 confirm, network errors) with a
+        // toast but NO throw, so callers can't infer success from "didn't throw".
+        // Draft-clearing MUST key off this ref, not heuristics — clearing after
+        // a refused save deletes the browser's only copy of the edits.
+        lastSaveDraftOutcomeRef.current = 'failure';
         try {
             const slide = slideToSave ? slideToSave : activeItem;
             // Determine the correct status based on slide type and current state
@@ -3419,6 +3463,7 @@ export const SlideMaterial = ({
                                       ? `Split Screen ${activeItem.document_slide.type.replace('SPLIT_', '')}`
                                       : 'Interactive Slide';
                         toast.success(`${slideTypeName} is already up to date!`);
+                        lastSaveDraftOutcomeRef.current = 'success'; // no-op, nothing to persist
                         return;
                     }
 
@@ -3454,6 +3499,7 @@ export const SlideMaterial = ({
                                   ? `Split Screen ${activeItem.document_slide.type.replace('SPLIT_', '')}`
                                   : 'Interactive Slide';
                     toast.success(`${slideTypeName} saved successfully!`);
+                    lastSaveDraftOutcomeRef.current = 'success';
                 } catch (error) {
                     console.error(`Error saving ${activeItem.document_slide.type} slide:`, error);
                     toast.error(
@@ -3480,7 +3526,10 @@ export const SlideMaterial = ({
                     slide.document_slide?.published_data ||
                     '';
                 const saved = await saveHtmlDocDraft(slide, htmlString, { silent: false });
-                if (saved) toast.success('slide saved in draft successfully!');
+                if (saved) {
+                    toast.success('slide saved in draft successfully!');
+                    lastSaveDraftOutcomeRef.current = 'success';
+                }
                 return;
             }
 
@@ -3529,6 +3578,7 @@ export const SlideMaterial = ({
                         notify: false,
                     });
                     toast.success(`slide saved in draft successfully!`);
+                    lastSaveDraftOutcomeRef.current = 'success';
                 } catch {
                     toast.error(`Error in saving the slide`);
                 }
@@ -3633,6 +3683,7 @@ export const SlideMaterial = ({
 
             try {
                 await saveDocDraft(false);
+                lastSaveDraftOutcomeRef.current = 'success';
                 if (!containsBase64Images(currentHtml) || uploadedImagesCount === 0) {
                     toast.success(`slide saved in draft successfully!`);
                 }
@@ -3651,6 +3702,7 @@ export const SlideMaterial = ({
                     try {
                         await saveDocDraft(true);
                         toast.success('Slide saved (forced override).');
+                        lastSaveDraftOutcomeRef.current = 'success';
                     } catch {
                         toast.error('Error in saving the slide');
                     }
@@ -3797,26 +3849,22 @@ export const SlideMaterial = ({
                 }
             }
 
-            // Clear the browser draft ONLY when the save could actually have
-            // gone through. SaveDraft REFUSES empty/degraded serializations
-            // (mid-reload editor) with a toast but no throw — clearing in that
-            // case deletes the browser's only copy of edits the DB never
-            // received (draft gone + DB stale = silent loss).
-            const canClearDraftAfterSave = () => {
-                const isEditableDoc =
-                    activeItem?.source_type === 'DOCUMENT' &&
-                    (activeItem?.document_slide?.type === 'DOC' ||
-                        activeItem?.document_slide?.type === HTML_DOC_TYPE);
-                if (!isEditableDoc) return true;
-                const editorHtml = getCurrentEditorHTMLContent();
-                return !checkIsHtmlEmpty(editorHtml) && !lastSerializeDegradedRef.current;
-            };
+            const isEditableDocSlide =
+                activeItem?.source_type === 'DOCUMENT' &&
+                (activeItem?.document_slide?.type === 'DOC' ||
+                    activeItem?.document_slide?.type === HTML_DOC_TYPE);
 
-            // Use custom save function if provided (for non-admin users)
+            // Use custom save function if provided (for non-admin users).
+            // The custom fn isn't instrumented for success, so fall back to the
+            // editor-readability heuristic before clearing the browser draft.
             if (customSaveFunction && activeItem) {
                 console.log('🔄 Using custom save function for non-admin');
                 await customSaveFunction(activeItem);
-                if (canClearDraftAfterSave()) clearLocalDraft(activeItem?.id);
+                const editorReadable =
+                    !isEditableDocSlide ||
+                    (!checkIsHtmlEmpty(getCurrentEditorHTMLContent()) &&
+                        !lastSerializeDegradedRef.current);
+                if (editorReadable) clearLocalDraft(activeItem?.id);
                 return; // Don't show additional toast as custom function handles it
             }
 
@@ -3825,8 +3873,16 @@ export const SlideMaterial = ({
             // here — it produced duplicate success toasts on every save and a
             // success-after-error stack when the DOC branch guarded empty
             // editor content.
+            //
+            // Clear the browser draft ONLY on a confirmed persist. SaveDraft
+            // swallows guard refusals / declined 409s / network errors without
+            // throwing, so "didn't throw" is NOT success — the outcome ref is.
+            // Clearing after a refused save deletes the browser's only copy of
+            // edits the DB never received (draft gone + DB stale = silent loss).
             await SaveDraft(activeItem);
-            if (canClearDraftAfterSave()) clearLocalDraft(activeItem?.id);
+            if (!isEditableDocSlide || lastSaveDraftOutcomeRef.current === 'success') {
+                clearLocalDraft(activeItem?.id);
+            }
         } catch {
             toast.error('error saving document');
         }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -29,7 +29,7 @@ import {
     useSlidesMutations,
 } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides';
 import { toast } from 'sonner';
-import { Check, DownloadSimple, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning } from '@phosphor-icons/react';
+import { Check, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning } from '@phosphor-icons/react';
 import { AlertCircle } from 'lucide-react';
 import {
     converDataToAssignmentFormat,
@@ -51,6 +51,7 @@ import {
     flattenSemanticWrappers,
     detectDeserializeLoss,
     countSerializedBlocks,
+    normalizeHtmlForDirtyCompare,
 } from './slide-operations/doc-slide-integrity/reload';
 import { handleConvertAndUpload } from './slide-operations/handleConvertUpload';
 import { HtmlDocAiAuthor } from './html-doc/html-doc-ai-author';
@@ -78,7 +79,17 @@ import {
     removeDraft as removeLocalDraft,
     dirtySlideIds as getDirtySlideIds,
     pruneOldDrafts,
+    hasDraft as hasLocalDraft,
+    type SlideDraftContext,
 } from '../-utils/slide-draft-store';
+import { UnsavedDraftsDialog } from './unsaved-drafts-dialog';
+import { UnsavedCompareDialog } from './unsaved-compare-dialog';
+import { useSlideDrafts } from '../-hooks/use-slide-drafts';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import type { DropdownItem } from '@/components/design-system/utils/types/dropdown-types';
+import { useModulesWithChaptersStore } from '@/stores/study-library/use-modules-with-chapters-store';
+import { useStudyLibraryStore } from '@/stores/study-library/use-study-library-store';
 import QuizPreview from './QuizPreview';
 import { createQuizSlidePayload } from './quiz/utils/api-helpers';
 import { getDisplaySettings, getDisplaySettingsFromCache } from '@/services/display-settings';
@@ -400,6 +411,16 @@ export const SlideMaterial = ({
         slideId: null,
         html: '',
     });
+    // Whether the DOC slide's editor was loaded from a restored LOCAL draft
+    // (vs. server content). Decides if "content returned to the load-time
+    // baseline" may auto-clear the draft: only when the baseline IS the server
+    // state — clearing on draft-baseline equality would delete real unsaved work.
+    const loadedDocFromDraftRef = useRef<{ slideId: string | null; fromDraft: boolean }>({
+        slideId: null,
+        fromDraft: false,
+    });
+    // One blank-load re-apply attempt per slide (see captureInitialDocSnapshot).
+    const blankLoadRetrySlideIdRef = useRef<string | null>(null);
     // Last successfully-serialized DOC editor HTML, TAGGED with the slide it came
     // from. It's the fallback when html.serialize throws (a degenerate custom-block
     // Slate state). Without the slideId, that fallback could hand back a DIFFERENT
@@ -536,6 +557,95 @@ export const SlideMaterial = ({
         pruneOldDrafts(currentUserId);
         refreshDirtySlides();
     }, [currentUserId, refreshDirtySlides]);
+    // Hierarchy metadata stamped onto every stashed draft so the course-scoped
+    // unsaved-changes dialog can name, group (subject → module → chapter) and
+    // deep-link the slide — even when it's opened from a different chapter.
+    const { modulesWithChaptersData } = useModulesWithChaptersStore();
+    const { studyLibraryData } = useStudyLibraryStore();
+    const buildDraftContext = useCallback(
+        (slideId: string): SlideDraftContext => {
+            const contentState = useContentStore.getState();
+            const slide =
+                (contentState.items as Slide[] | undefined)?.find((s) => s.id === slideId) ??
+                (contentState.activeItem?.id === slideId ? contentState.activeItem : null);
+            const slideTitle =
+                slide?.document_slide?.title || slide?.video_slide?.title || slide?.title || null;
+
+            // Both stash paths only ever write slides of the currently-open
+            // chapter, so the module/chapter names come from the loaded subject.
+            let chapterName: string | null = null;
+            let moduleName: string | null = null;
+            for (const m of modulesWithChaptersData ?? []) {
+                const match = m.chapters.find((c) => c.chapter.id === chapterId);
+                if (match) {
+                    chapterName = match.chapter.chapter_name;
+                    moduleName = m.module.module_name;
+                    break;
+                }
+            }
+
+            const courseEntry = studyLibraryData?.find((c) => c.course.id === courseId);
+            let subjectName: string | null = null;
+            for (const session of courseEntry?.sessions ?? []) {
+                for (const level of session.level_with_details) {
+                    const subject = level.subjects.find((s) => s.id === subjectId);
+                    if (subject) {
+                        subjectName = subject.subject_name;
+                        break;
+                    }
+                }
+                if (subjectName) break;
+            }
+
+            return {
+                slideTitle,
+                chapterId: chapterId || null,
+                chapterName,
+                moduleId: moduleId || null,
+                moduleName,
+                subjectId: subjectId || null,
+                subjectName,
+                courseId: courseId || null,
+                courseName: courseEntry?.course.package_name ?? null,
+                levelId: levelId || null,
+                sessionId: sessionId || null,
+            };
+        },
+        [
+            modulesWithChaptersData,
+            studyLibraryData,
+            chapterId,
+            moduleId,
+            subjectId,
+            courseId,
+            levelId,
+            sessionId,
+        ]
+    );
+    // BACKFILL: drafts written before the metadata upgrade have no context, so
+    // the course banner/dialog can't name or place them. Whenever this chapter's
+    // slides are loaded we know the full location of any such draft belonging
+    // to them — stamp it in, and they surface in the course-scoped UI with real
+    // names. Drafts from not-yet-visited chapters stay unplaced until visited.
+    useEffect(() => {
+        const slidesNow = items as Slide[] | undefined;
+        if (!slidesNow?.length) return;
+        for (const slide of slidesNow) {
+            const draft = loadLocalDraft<string>(currentUserId, slide.id);
+            if (draft && !draft.context && typeof draft.content === 'string') {
+                saveLocalDraft(
+                    currentUserId,
+                    slide.id,
+                    draft.content,
+                    draft.baselineUpdatedAt,
+                    buildDraftContext(slide.id)
+                );
+            }
+        }
+        refreshDirtySlides();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [items, currentUserId, buildDraftContext]);
+
     const stashDocDraftLocally = useCallback(
         (slideId: string, htmlString: string, guardShrink = true) => {
             if (!slideId) return;
@@ -554,10 +664,10 @@ export const SlideMaterial = ({
                     return;
                 }
             }
-            saveLocalDraft(currentUserId, slideId, htmlString);
+            saveLocalDraft(currentUserId, slideId, htmlString, undefined, buildDraftContext(slideId));
             refreshDirtySlides();
         },
-        [currentUserId, refreshDirtySlides]
+        [currentUserId, refreshDirtySlides, buildDraftContext]
     );
     const clearLocalDraft = useCallback(
         (slideId?: string | null) => {
@@ -567,10 +677,65 @@ export const SlideMaterial = ({
         },
         [currentUserId, refreshDirtySlides]
     );
-    const clearAllLocalDrafts = useCallback(() => {
-        dirtySlideIdSet.forEach((id) => removeLocalDraft(currentUserId, id));
+    // Course-scoped view of the local drafts — the ONLY scope the leave guard
+    // and the unsaved-changes dialog operate on. Drafts from other courses
+    // never block navigation here and are never discarded from here.
+    const { drafts: courseDrafts } = useSlideDrafts(currentUserId, courseId || '');
+    const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
+    const [isCompareOpen, setIsCompareOpen] = useState(false);
+    // Occasional-use header actions relocated into the ⋯ menu — dialogs are
+    // controlled from here, triggers hidden.
+    const [isStatsOpen, setIsStatsOpen] = useState(false);
+    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+    // Saved-vs-current panes for the compare dialog. Saved side uses the same
+    // baseline rule as dirty detection (what the editor loaded from); current
+    // side is the localStorage draft. Recomputed only while the dialog is open.
+    const compareContents = useMemo(() => {
+        if (!isCompareOpen || !activeItem?.id) return { saved: '', current: '' };
+        const saved =
+            (activeItem.status === 'PUBLISHED'
+                ? activeItem.document_slide?.published_data
+                : activeItem.document_slide?.data ||
+                  activeItem.document_slide?.published_data) || '';
+        const draft = loadLocalDraft<string>(currentUserId, activeItem.id);
+        const current = typeof draft?.content === 'string' ? draft.content : '';
+        return { saved, current };
+    }, [
+        isCompareOpen,
+        activeItem?.id,
+        activeItem?.status,
+        activeItem?.document_slide?.data,
+        activeItem?.document_slide?.published_data,
+        currentUserId,
+    ]);
+    // Show "Discard changes" only when the ACTIVE slide's local draft actually
+    // DIFFERS from the saved version — a draft that matches what's in the DB
+    // has nothing to discard. Normalized compare on both sides so serializer
+    // round-trip noise (empty blocks, wrapper divs) doesn't fake a difference.
+    const activeSlideHasRealChanges = useMemo(() => {
+        if (!activeItem?.id || !dirtySlideIdSet.has(activeItem.id)) return false;
+        const draft = loadLocalDraft<string>(currentUserId, activeItem.id);
+        if (!draft || typeof draft.content !== 'string') return false;
+        const savedHtml =
+            (activeItem.status === 'PUBLISHED'
+                ? activeItem.document_slide?.published_data
+                : activeItem.document_slide?.data ||
+                  activeItem.document_slide?.published_data) || '';
+        return (
+            normalizeHtmlForDirtyCompare(draft.content) !== normalizeHtmlForDirtyCompare(savedHtml)
+        );
+    }, [
+        activeItem?.id,
+        activeItem?.status,
+        activeItem?.document_slide?.data,
+        activeItem?.document_slide?.published_data,
+        dirtySlideIdSet,
+        currentUserId,
+    ]);
+    const clearCourseDrafts = useCallback(() => {
+        courseDrafts.forEach((draft) => removeLocalDraft(currentUserId, draft.slideId));
         refreshDirtySlides();
-    }, [dirtySlideIdSet, currentUserId, refreshDirtySlides]);
+    }, [courseDrafts, currentUserId, refreshDirtySlides]);
     const getRestorableLocalDraftHtml = useCallback(
         (slide?: Slide | null): string | null => {
             if (!slide?.id) return null;
@@ -587,27 +752,20 @@ export const SlideMaterial = ({
         },
         [currentUserId]
     );
-    // Warn only on a real browser close/refresh while a slide has unsaved local edits.
-    // We intentionally do NOT block in-app slide-switching or navigation: edits are
-    // stashed to localStorage and restored on return, so switching is always safe
-    // (blocking it prompted even on unchanged slides — bug).
-    useEffect(() => {
-        if (dirtySlideIdSet.size === 0) return;
-        const handler = (e: BeforeUnloadEvent) => {
-            e.preventDefault();
-            e.returnValue = '';
-        };
-        window.addEventListener('beforeunload', handler);
-        return () => window.removeEventListener('beforeunload', handler);
-    }, [dirtySlideIdSet.size]);
+    // NOTE: no beforeunload warning here (removed deliberately). Refresh/close
+    // loses nothing — unsaved edits are stashed in localStorage and restored on
+    // reopen, and the in-app surfaces (course banner, bottom pill, amber rows)
+    // carry the unsaved state. The browser-native "may not be saved" prompt was
+    // both redundant and factually wrong under this model.
     // In-app navigation guard: when leaving the slides editor (a real pathname
-    // change — NOT a slide-switch, which only mutates the ?slideId search param)
-    // while any slide has an unsaved local draft, block and offer a styled dialog
-    // instead of losing the edits silently. Slide-switching stays intentionally
-    // unblocked (see the beforeunload note above).
+    // change — NOT a slide/chapter switch, which only mutates search params)
+    // while a slide of THIS COURSE has an unsaved local draft, block and show the
+    // course-scoped drafts dialog. Drafts from other courses never block here —
+    // they're findable via the same dialog from their own course's editor.
+    // Slide/chapter switching stays intentionally unblocked (see beforeunload note).
     const leaveBlocker = useBlocker({
         withResolver: true,
-        disabled: dirtySlideIdSet.size === 0,
+        disabled: courseDrafts.length === 0,
         shouldBlockFn: ({ current, next }) => current.pathname !== next.pathname,
     });
     const [isUnpublishDialogOpen, setIsUnpublishDialogOpen] = useState(false);
@@ -828,9 +986,32 @@ export const SlideMaterial = ({
                                         initialDocHtmlRef.current.slideId === targetSlideId
                                             ? initialDocHtmlRef.current.html
                                             : null;
+                                    // NORMALIZED compare: Yoopta appends an empty paragraph
+                                    // when the author merely clicks below the content, so a
+                                    // raw string compare marks a no-op click as an edit.
+                                    // Only meaningful content differences count.
                                     const isRealEdit =
                                         initialForThisSlide !== null &&
-                                        serializedHtml !== initialForThisSlide;
+                                        normalizeHtmlForDirtyCompare(serializedHtml) !==
+                                            normalizeHtmlForDirtyCompare(initialForThisSlide);
+                                    // Content returned to the load-time baseline (e.g. the
+                                    // author deleted what they'd just added). If that baseline
+                                    // was SERVER content — not a restored draft — the stashed
+                                    // draft no longer represents an edit: drop it so the
+                                    // dirty badge clears again.
+                                    if (
+                                        !isRealEdit &&
+                                        initialForThisSlide !== null &&
+                                        targetSlideId &&
+                                        !(
+                                            loadedDocFromDraftRef.current.slideId ===
+                                                targetSlideId &&
+                                            loadedDocFromDraftRef.current.fromDraft
+                                        ) &&
+                                        hasLocalDraft(currentUserId, targetSlideId)
+                                    ) {
+                                        clearLocalDraft(targetSlideId);
+                                    }
                                     // Never stash a serialization that lost blocks relative to
                                     // the editor value. The stashed draft OUTRANKS server
                                     // content on reopen, so laundering a collapsed serialize
@@ -953,6 +1134,10 @@ export const SlideMaterial = ({
         // Restore an unsaved LOCAL draft (stashed on a previous switch/refresh) over
         // the server content so in-progress edits are never lost on reopen.
         const restorableLocalDraft = getRestorableLocalDraftHtml(activeItem);
+        loadedDocFromDraftRef.current = {
+            slideId: activeItem?.id ?? null,
+            fromDraft: restorableLocalDraft != null,
+        };
         const docData =
             restorableLocalDraft ??
             (activeItem?.status == 'PUBLISHED'
@@ -1405,6 +1590,30 @@ export const SlideMaterial = ({
             // Use a short delay so Yoopta finishes rendering before we snapshot
             snapshotTimeoutRef.current = setTimeout(() => {
                 const editorHtml = getCurrentEditorHTMLContent();
+                // SELF-HEAL for "slide opens blank until refresh": the source
+                // content is non-empty but the editor ended up empty after the
+                // load (deserialize raced/dropped everything). Re-apply once —
+                // bounded by the per-slide flag so a genuinely empty slide or a
+                // persistent failure can't loop.
+                const sourceHtml =
+                    (activeItem.status === 'PUBLISHED'
+                        ? activeItem.document_slide?.published_data
+                        : activeItem.document_slide?.data ||
+                          activeItem.document_slide?.published_data) || '';
+                if (
+                    checkIsHtmlEmpty(editorHtml) &&
+                    !checkIsHtmlEmpty(sourceHtml) &&
+                    blankLoadRetrySlideIdRef.current !== activeItem.id
+                ) {
+                    blankLoadRetrySlideIdRef.current = activeItem.id;
+                    console.error(
+                        '[DOC-LOAD] editor empty after load but source has content — re-applying once.',
+                        { slideId: activeItem.id, sourceLength: sourceHtml.length }
+                    );
+                    applyDocContentToEditor();
+                    captureInitialDocSnapshot();
+                    return;
+                }
                 initialDocHtmlRef.current = { slideId: activeItem.id, html: editorHtml };
                 currentDocHtmlRef.current = { slideId: activeItem.id, html: editorHtml };
             }, 300);
@@ -1923,7 +2132,16 @@ export const SlideMaterial = ({
         // branch uses this to avoid a destructive re-deserialize. Record the id
         // for the next run before any early return.
         const isSameSlideRerun = lastLoadContentSlideIdRef.current === activeItem?.id;
-        lastLoadContentSlideIdRef.current = activeItem?.id ?? null;
+        // PLACEHOLDER activeItem: while the slides query is in flight the sidebar
+        // stubs {id: slideId, source_type: ''} (slides-sidebar-slides.tsx). That
+        // run renders the "No study material" fallback — recording its id would
+        // make the REAL slide's arrival (same id, real source_type) look like a
+        // same-slide rerun, which the DOC/HTML branches deliberately skip → the
+        // slide stays blank until a full refresh. Record null instead so the real
+        // data renders as a fresh load. (This was the "slide shows nothing until
+        // I refresh" bug.)
+        const isPlaceholderItem = activeItem != null && !activeItem.source_type;
+        lastLoadContentSlideIdRef.current = isPlaceholderItem ? null : (activeItem?.id ?? null);
 
         if (activeItem == null) {
             setContent(
@@ -3579,11 +3797,26 @@ export const SlideMaterial = ({
                 }
             }
 
+            // Clear the browser draft ONLY when the save could actually have
+            // gone through. SaveDraft REFUSES empty/degraded serializations
+            // (mid-reload editor) with a toast but no throw — clearing in that
+            // case deletes the browser's only copy of edits the DB never
+            // received (draft gone + DB stale = silent loss).
+            const canClearDraftAfterSave = () => {
+                const isEditableDoc =
+                    activeItem?.source_type === 'DOCUMENT' &&
+                    (activeItem?.document_slide?.type === 'DOC' ||
+                        activeItem?.document_slide?.type === HTML_DOC_TYPE);
+                if (!isEditableDoc) return true;
+                const editorHtml = getCurrentEditorHTMLContent();
+                return !checkIsHtmlEmpty(editorHtml) && !lastSerializeDegradedRef.current;
+            };
+
             // Use custom save function if provided (for non-admin users)
             if (customSaveFunction && activeItem) {
                 console.log('🔄 Using custom save function for non-admin');
                 await customSaveFunction(activeItem);
-                clearLocalDraft(activeItem?.id);
+                if (canClearDraftAfterSave()) clearLocalDraft(activeItem?.id);
                 return; // Don't show additional toast as custom function handles it
             }
 
@@ -3593,7 +3826,7 @@ export const SlideMaterial = ({
             // success-after-error stack when the DOC branch guarded empty
             // editor content.
             await SaveDraft(activeItem);
-            clearLocalDraft(activeItem?.id);
+            if (canClearDraftAfterSave()) clearLocalDraft(activeItem?.id);
         } catch {
             toast.error('error saving document');
         }
@@ -3705,6 +3938,58 @@ export const SlideMaterial = ({
         historyRestoreNonce,
     ]);
 
+    // ⋯ menu entries for the relocated header actions, per slide type.
+    const slidesExtraMenuOptions = useMemo<DropdownItem[]>(() => {
+        const options: DropdownItem[] = [{ label: 'Activity Stats', value: 'activity-stats' }];
+        if (
+            activeItem?.source_type === 'DOCUMENT' &&
+            activeItem?.document_slide?.type !== 'PRESENTATION'
+        ) {
+            options.push({ label: 'Version History', value: 'history' });
+        }
+        if (
+            activeItem?.source_type === 'DOCUMENT' &&
+            (activeItem?.document_slide?.type === 'DOC' ||
+                activeItem?.document_slide?.type === HTML_DOC_TYPE)
+        ) {
+            options.push({ label: 'Export as PDF', value: 'export-pdf' });
+        }
+        return options;
+    }, [activeItem?.source_type, activeItem?.document_slide?.type]);
+
+    const handleExtraMenuSelect = async (value: string) => {
+        if (value === 'activity-stats') {
+            setIsStatsOpen(true);
+        } else if (value === 'history') {
+            setIsHistoryOpen(true);
+        } else if (value === 'export-pdf' && activeItem) {
+            if (activeItem.status === 'PUBLISHED') {
+                // Don't re-save a published slide on download — SaveDraft would
+                // flip it to UNSYNC (un-publish it). Export the persisted
+                // published content as-is.
+                await handleConvertAndUpload(activeItem.document_slide?.published_data || null);
+            } else {
+                // Draft/unsync: persist the latest edits first so the exported
+                // PDF reflects them.
+                await SaveDraft(activeItem);
+                await handleConvertAndUpload(activeItem.document_slide?.data || null);
+            }
+        }
+    };
+
+    // Discard the active slide's local unsaved draft and reload the editor
+    // from the last saved (server) content — same reload mechanism as a
+    // history restore: drop the draft, reset the same-slide guard, bump the
+    // nonce so loadContent re-runs without the draft shadowing the content.
+    const handleDiscardActiveDraft = () => {
+        if (!activeItem) return;
+        clearLocalDraft(activeItem.id);
+        lastLoadContentSlideIdRef.current = null;
+        setHistoryRestoreNonce((n) => n + 1);
+        setIsDiscardConfirmOpen(false);
+        toast.success('Changes discarded — restored to the last saved version.');
+    };
+
     // A version-history snapshot was copied into this slide's draft on the
     // backend. Mirror it into the store and force a full editor reload: clear
     // the local (unsaved) draft so it can't shadow the restored content, and
@@ -3768,68 +4053,56 @@ export const SlideMaterial = ({
             className="flex h-[calc(100vh-76px)] w-full flex-1 flex-col overflow-y-auto overflow-x-hidden transition-all duration-300 ease-in-out sm:h-[calc(100vh-84px)] md:h-[calc(100vh-108px)] lg:h-[calc(100vh-132px)]"
             ref={selectionRef}
         >
-            {/* Bug 2: styled leave-guard dialog (replaces the browser-default prompt)
-                when navigating away from the slides editor with unsaved local edits. */}
+            {/* Leave-editor guard: course-scoped drafts dialog listing each unsaved
+                slide (grouped subject → module → chapter) with jump links. */}
             {leaveBlocker.status === 'blocked' && (
-                <MyDialog
-                    heading="Unsaved changes"
+                <UnsavedDraftsDialog
                     open
+                    mode="leave"
+                    drafts={courseDrafts}
                     onOpenChange={(open) => {
                         if (!open) leaveBlocker.reset?.();
                     }}
-                    dialogWidth="w-full max-w-md"
-                    footer={
-                        <div className="flex w-full flex-col gap-3">
-                            <p className="text-caption text-neutral-500">
-                                Kept only on this device — logging out or clearing browser
-                                data will lose these changes.
-                            </p>
-                            <div className="flex flex-wrap items-center justify-end gap-2">
-                                <MyButton
-                                    buttonType="secondary"
-                                    scale="medium"
-                                    onClick={() => leaveBlocker.proceed?.()}
-                                >
-                                    Keep in browser
-                                </MyButton>
-                                <MyButton
-                                    buttonType="secondary"
-                                    scale="medium"
-                                    className="border-danger-400 text-danger-600 hover:bg-danger-50"
-                                    onClick={() => {
-                                        clearAllLocalDrafts();
-                                        leaveBlocker.proceed?.();
-                                    }}
-                                >
-                                    Discard changes
-                                </MyButton>
-                                <MyButton
-                                    buttonType="primary"
-                                    scale="medium"
-                                    disabled={isSaving}
-                                    className={cn(isSaving && 'pointer-events-none')}
-                                    onClick={async () => {
-                                        await handleSaveDraftClick();
-                                        leaveBlocker.proceed?.();
-                                    }}
-                                >
-                                    {isSaving ? 'Saving…' : 'Save draft'}
-                                </MyButton>
-                            </div>
-                        </div>
-                    }
-                >
-                    <div className="flex items-start gap-3">
-                        <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full bg-danger-50 text-danger-600">
-                            <Warning size={20} weight="fill" />
-                        </span>
-                        <p className="text-subtitle text-neutral-600">
-                            You have edits that haven&apos;t been saved to the database. Choose
-                            what to do before leaving this page.
-                        </p>
-                    </div>
-                </MyDialog>
+                    onBeforeJump={() => leaveBlocker.reset?.()}
+                    onKeep={() => leaveBlocker.proceed?.()}
+                    onDiscard={() => {
+                        clearCourseDrafts();
+                        leaveBlocker.proceed?.();
+                    }}
+                />
             )}
+            {/* Confirm discarding the active slide's unsaved local edits. */}
+            <MyDialog
+                heading="Discard changes"
+                open={isDiscardConfirmOpen}
+                onOpenChange={setIsDiscardConfirmOpen}
+                dialogWidth="w-full max-w-md"
+                footer={
+                    <div className="flex w-full flex-wrap items-center justify-end gap-2">
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            onClick={() => setIsDiscardConfirmOpen(false)}
+                        >
+                            Keep editing
+                        </MyButton>
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            className="border-danger-400 text-danger-600 hover:bg-danger-50"
+                            onClick={handleDiscardActiveDraft}
+                        >
+                            Discard changes
+                        </MyButton>
+                    </div>
+                }
+            >
+                <p className="text-subtitle text-neutral-600">
+                    This will throw away the unsaved edits on this{' '}
+                    {getTerminology(ContentTerms.Slide, SystemTerms.Slide).toLowerCase()} and
+                    restore the last saved version. This cannot be undone.
+                </p>
+            </MyDialog>
             {activeItem && (
                 <div className="sticky top-0 z-50 -mx-2 -mt-2 flex flex-col gap-2 border-b border-neutral-200 bg-white/80 px-2 py-1 shadow-sm backdrop-blur-sm sm:-mx-3 sm:-mt-3 sm:px-3 sm:py-1.5 md:-mx-4 md:-mt-4 md:px-4 md:py-2.5 lg:-mx-7 lg:-mt-7 lg:px-7 lg:py-3">
                     {/* Row 1 — editable title + actions. Wraps so the title truncates
@@ -3880,39 +4153,14 @@ export const SlideMaterial = ({
                     {!isLearnerView && (
                         <div className="flex shrink-0 flex-wrap items-center justify-end gap-1 sm:gap-2 md:gap-3">
                             <div className="flex items-center gap-1 sm:gap-2 md:gap-3">
-                                {activeItem.source_type === 'DOCUMENT' &&
-                                    (activeItem?.document_slide?.type === 'DOC' ||
-                                        activeItem?.document_slide?.type === HTML_DOC_TYPE) && (
-                                        <MyButton
-                                            layoutVariant="icon"
-                                            onClick={async () => {
-                                                if (activeItem.status === 'PUBLISHED') {
-                                                    // Don't re-save a published slide on download —
-                                                    // SaveDraft would flip it to UNSYNC (un-publish it).
-                                                    // The published content is already persisted; just
-                                                    // export it as-is.
-                                                    await handleConvertAndUpload(
-                                                        activeItem.document_slide?.published_data ||
-                                                            null
-                                                    );
-                                                } else {
-                                                    // Draft/unsync: persist the latest edits first so the
-                                                    // exported PDF reflects them.
-                                                    await SaveDraft(activeItem);
-                                                    await handleConvertAndUpload(
-                                                        activeItem.document_slide?.data || null
-                                                    );
-                                                }
-                                            }}
-                                        >
-                                            <DownloadSimple size={30} />
-                                        </MyButton>
-                                    )}
-
-                                <ActivityStatsSidebar />
-
-                                {/* Version history + restore — content snapshots are
-                                    trigger-written for document slides (V363). */}
+                                {/* Occasional-use actions (Activity Stats, History, Export)
+                                    live in the ⋯ menu — see slidesExtraMenuOptions. Their
+                                    dialogs render controlled below. */}
+                                <ActivityStatsSidebar
+                                    hideTrigger
+                                    open={isStatsOpen}
+                                    onOpenChange={setIsStatsOpen}
+                                />
                                 {activeItem.source_type === 'DOCUMENT' &&
                                     activeItem?.document_slide?.type !== 'PRESENTATION' && (
                                         <SlideHistoryDialog
@@ -3920,6 +4168,9 @@ export const SlideMaterial = ({
                                             activeItem={activeItem}
                                             chapterId={chapterId || ''}
                                             onRestored={handleHistoryRestored}
+                                            hideTrigger
+                                            open={isHistoryOpen}
+                                            onOpenChange={setIsHistoryOpen}
                                         />
                                     )}
 
@@ -4201,27 +4452,55 @@ export const SlideMaterial = ({
                                     <ChatCircleDots className="size-5" />
                                 </MyButton>
                             )}
-                            {/* Slides Menu Option */}
-                            <SlidesMenuOption />
+                            {/* Slides Menu Option — includes relocated occasional-use
+                                actions (Activity Stats / History / Export PDF). */}
+                            <SlidesMenuOption
+                                extraOptions={slidesExtraMenuOptions}
+                                onExtraSelect={handleExtraMenuSelect}
+                            />
                         </div>
                     )}
                     </div>
-                    {/* Bug 4 — unsaved notice on its own row so it never crowds or
-                        overlaps the title / action buttons at any viewport width. */}
-                    {!isLearnerView && activeItem?.id && dirtySlideIdSet.has(activeItem.id) && (
-                        <div
-                            role="status"
-                            className="flex w-fit items-center gap-1.5 rounded-md bg-danger-50 px-2 py-1 text-caption font-semibold text-danger-600"
-                        >
-                            <Warning size={16} weight="fill" className="shrink-0" />
-                            <span>
-                                Unsaved — not saved to the database. Use Save Draft or Publish
-                                to persist.
-                            </span>
-                        </div>
-                    )}
                 </div>
             )}
+
+            {/* Bottom floating bar — the ONE active-slide unsaved signal. Discard
+                is deliberately isolated here, away from Save Draft/Publish, to
+                prevent accidental destructive clicks. */}
+            {!isLearnerView && activeSlideHasRealChanges && (
+                <div
+                    role="region"
+                    aria-label="Unsaved changes"
+                    className="fixed bottom-6 left-1/2 z-40 flex -translate-x-1/2 items-center gap-3 rounded-full border border-warning-300 bg-white/95 py-1.5 pl-4 pr-2 shadow-xl backdrop-blur animate-in fade-in slide-in-from-bottom-2"
+                >
+                    <div className="flex items-center gap-2 whitespace-nowrap text-sm font-medium text-neutral-700">
+                        <Warning className="size-4 shrink-0 text-warning-600" weight="fill" />
+                        Unsaved changes
+                    </div>
+                    <MyButton
+                        buttonType="text"
+                        scale="small"
+                        onClick={() => setIsCompareOpen(true)}
+                    >
+                        View changes
+                    </MyButton>
+                    <MyButton
+                        buttonType="secondary"
+                        scale="small"
+                        onClick={() => setIsDiscardConfirmOpen(true)}
+                        className="!rounded-full border-danger-300 text-danger-600 hover:bg-danger-50"
+                    >
+                        Discard changes
+                    </MyButton>
+                </div>
+            )}
+            {/* Saved vs current side-by-side comparison */}
+            <UnsavedCompareDialog
+                open={isCompareOpen}
+                onOpenChange={setIsCompareOpen}
+                savedHtml={compareContents.saved}
+                currentHtml={compareContents.current}
+            />
 
             <div
                 className={`relative z-20 mx-auto mt-14 w-full ${

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
@@ -172,6 +172,78 @@ export function countSerializedBlocks(serializedHtml: string): number {
     }
 }
 
+/**
+ * Canonical form of serialized editor HTML for "did the user actually change
+ * anything?" comparisons. Yoopta appends an empty paragraph block when the
+ * author merely clicks below the content, so a raw string compare flags a
+ * no-op click as an edit (false dirty badge). Drops elements that carry no
+ * text and no embedded content, then collapses whitespace. Both sides of a
+ * comparison must be normalized with this same function.
+ */
+export function normalizeHtmlForDirtyCompare(html: string): string {
+    if (!html) return '';
+    try {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const isMeaningful = (el: Element): boolean => {
+            if ((el.textContent ?? '').replace(/\u00a0/g, ' ').trim().length > 0) return true;
+            // Content-bearing embeds count even with no text.
+            return !!el.querySelector(
+                'img,iframe,video,audio,table,input,canvas,svg,embed,object,hr'
+            );
+        };
+        // Repeatedly drop empty elements until stable — the serializer nests
+        // blank paragraphs inside wrapper divs, so one pass isn't enough.
+        let changed = true;
+        while (changed) {
+            changed = false;
+            for (const el of Array.from(doc.body.querySelectorAll('*'))) {
+                if (!el.isConnected) continue;
+                const tag = el.tagName;
+                if (
+                    !isMeaningful(el) &&
+                    tag !== 'IMG' &&
+                    tag !== 'IFRAME' &&
+                    tag !== 'VIDEO' &&
+                    tag !== 'AUDIO' &&
+                    tag !== 'INPUT' &&
+                    tag !== 'CANVAS' &&
+                    tag !== 'SVG' &&
+                    tag !== 'EMBED' &&
+                    tag !== 'OBJECT' &&
+                    tag !== 'HR'
+                ) {
+                    el.remove();
+                    changed = true;
+                }
+            }
+        }
+        // Unwrap plain wrapper <div>s (formatHTMLString nests blocks in styled
+        // divs) so wrapper-depth differences don't read as edits. Divs that ARE
+        // a block — any data-* attribute, or the mermaid container — keep their
+        // identity so block-level changes still count.
+        let unwrapped = true;
+        while (unwrapped) {
+            unwrapped = false;
+            for (const div of Array.from(doc.body.querySelectorAll('div'))) {
+                if (!div.isConnected) continue;
+                const isRealBlock =
+                    Array.from(div.attributes).some((a) => a.name.startsWith('data-')) ||
+                    div.classList.contains('mermaid');
+                if (isRealBlock) continue;
+                const parent = div.parentNode;
+                if (!parent) continue;
+                while (div.firstChild) parent.insertBefore(div.firstChild, div);
+                parent.removeChild(div);
+                unwrapped = true;
+            }
+        }
+        return (doc.body.innerHTML || '').replace(/\s+/g, ' ').trim();
+    } catch {
+        // Comparison helper must never throw — fall back to the raw string.
+        return html;
+    }
+}
+
 export function appReloadPreprocess(storedHtml: string): string {
     let sanitized = stripAwsQueryParamsFromUrls(storedHtml || '');
     let contentForDeserialization = sanitized || '';

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/test.tsx
@@ -18,7 +18,12 @@ import { createYooptaEditor } from '@yoopta/editor';
 import { html } from '@yoopta/exports';
 import { plugins } from '@/constants/study-library/yoopta-editor-plugins-tools';
 import { formatHTMLString, stripAwsQueryParamsFromUrls } from '../formatHtmlString';
-import { appReloadPreprocess, detectDeserializeLoss, countSerializedBlocks } from './reload';
+import {
+    appReloadPreprocess,
+    detectDeserializeLoss,
+    countSerializedBlocks,
+    normalizeHtmlForDirtyCompare,
+} from './reload';
 
 // Register the app's real plugins onto a bare editor, mirroring
 // slide-material.tsx applyDocContentToEditor() so serialize/deserialize
@@ -659,5 +664,40 @@ describe('countSerializedBlocks — save-side block accounting', () => {
     it('stays silent when counting fails rather than blocking a save', () => {
         expect(countSerializedBlocks('')).toBe(0);
         expect(isDegraded(119, 0)).toBe(false); // out=0 disables the comparison
+    });
+});
+
+describe('normalizeHtmlForDirtyCompare: no-op clicks never count as edits', () => {
+    it('ignores an appended empty paragraph (click below content)', () => {
+        const before = '<div><p>Hello world</p></div>';
+        const after = '<div><p>Hello world</p><p></p></div>';
+        expect(normalizeHtmlForDirtyCompare(after)).toBe(normalizeHtmlForDirtyCompare(before));
+    });
+
+    it('ignores nested empty wrapper divs and nbsp-only paragraphs', () => {
+        const before = '<p>Content</p>';
+        const after = '<div><p>Content</p><div><p>&nbsp;</p></div><div></div></div>';
+        expect(normalizeHtmlForDirtyCompare(after)).toBe(normalizeHtmlForDirtyCompare(before));
+    });
+
+    it('still detects a real text edit', () => {
+        expect(normalizeHtmlForDirtyCompare('<p>Hello</p>')).not.toBe(
+            normalizeHtmlForDirtyCompare('<p>Hello!</p>')
+        );
+    });
+
+    it('an added image/table/divider counts as a real edit even with no text', () => {
+        const base = '<p>Text</p>';
+        expect(normalizeHtmlForDirtyCompare(`${base}<div><img src="x.png"/></div>`)).not.toBe(
+            normalizeHtmlForDirtyCompare(base)
+        );
+        expect(normalizeHtmlForDirtyCompare(`${base}<hr/>`)).not.toBe(
+            normalizeHtmlForDirtyCompare(base)
+        );
+    });
+
+    it('never throws on garbage input', () => {
+        expect(normalizeHtmlForDirtyCompare('')).toBe('');
+        expect(() => normalizeHtmlForDirtyCompare('<not <valid <<html')).not.toThrow();
     });
 });

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-menu-options/slides-menu-option.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-menu-options/slides-menu-option.tsx
@@ -14,7 +14,17 @@ import type { DripCondition } from '@/types/course-settings';
 import { toast } from 'sonner';
 import type { DropdownItem } from '@/components/design-system/utils/types/dropdown-types';
 
-export const SlidesMenuOption = () => {
+export const SlidesMenuOption = ({
+    extraOptions = [],
+    onExtraSelect,
+}: {
+    /**
+     * Occasional-use actions relocated from the header (Activity Stats,
+     * History, Export…) — prepended above the base copy/move/delete options.
+     */
+    extraOptions?: DropdownItem[];
+    onExtraSelect?: (value: string) => void;
+} = {}) => {
     const [openDialog, setOpenDialog] = useState<
         'copy' | 'move' | 'delete' | 'drip-conditions' | null
     >(null);
@@ -53,11 +63,11 @@ export const SlidesMenuOption = () => {
     // Filter menu options based on drip conditions setting
     const menuOptions = useMemo<DropdownItem[]>(() => {
         const baseOptions = getSlidesMenuOptions();
-        if (!dripConditionsEnabled) {
-            return baseOptions.filter((item) => item.value !== 'drip-conditions');
-        }
-        return baseOptions;
-    }, [dripConditionsEnabled]);
+        const filtered = dripConditionsEnabled
+            ? baseOptions
+            : baseOptions.filter((item) => item.value !== 'drip-conditions');
+        return [...extraOptions, ...filtered];
+    }, [dripConditionsEnabled, extraOptions]);
 
     const handleSelect = async (value: string) => {
         switch (value) {
@@ -74,6 +84,9 @@ export const SlidesMenuOption = () => {
                 await loadDripConditions();
                 setOpenDialog('drip-conditions');
                 break;
+            default:
+                // Relocated header actions (activity-stats / history / export…)
+                onExtraSelect?.(value);
         }
     };
 

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/slides-sidebar-slides.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/slides-sidebar-slides.tsx
@@ -9,8 +9,8 @@ import {
     ClipboardText,
     ListChecks,
 } from '@phosphor-icons/react';
-import { Video, Sparkles } from 'lucide-react';
-import { ReactNode, useEffect, useMemo } from 'react';
+import { Video, Sparkle } from '@phosphor-icons/react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import {
     Slide,
     slideOrderPayloadType,
@@ -29,6 +29,7 @@ import {
     Package,
     Question,
 } from '@phosphor-icons/react';
+import { getDraftUserId, useSlideDrafts } from '../../-hooks/use-slide-drafts';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useLearnerViewStore } from '../../-stores/learner-view-store';
 import { getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
@@ -105,7 +106,7 @@ export const getIcon = (
         return (
             <div className="relative inline-block">
                 <Video className={`${iconClass} text-blue-500`} />
-                <Sparkles className={`absolute -right-0.5 -top-0.5 ${sparkleSize} text-blue-400`} />
+                <Sparkle className={`absolute -right-0.5 -top-0.5 ${sparkleSize} text-blue-400`} />
             </div>
         );
     }
@@ -154,6 +155,7 @@ const SlideItem = ({
     slide,
     index,
     isActive,
+    isDirty = false,
     onClick,
     assessmentOrdinal,
     showNumbering = true,
@@ -161,6 +163,8 @@ const SlideItem = ({
     slide: Slide;
     index: number;
     isActive: boolean;
+    /** Slide has a local (browser-only) unsaved draft — show the amber badge. */
+    isDirty?: boolean;
     onClick: () => void;
     /**
      * 1-indexed position of this slide among ASSESSMENT slides in the
@@ -249,7 +253,9 @@ const SlideItem = ({
                                 ? 'cursor-not-allowed border-red-200 bg-red-50/30 text-red-600 opacity-50'
                                 : isActive
                                   ? 'border-primary-300 bg-primary-50/80 text-primary-600 shadow-md shadow-primary-100/50'
-                                  : 'hover:bg-primary-25 border-neutral-100 bg-white/60 text-neutral-600 hover:border-primary-200 hover:text-primary-500 hover:shadow-sm'
+                                  : isDirty
+                                    ? 'border-warning-300 bg-warning-50/60 text-neutral-600 hover:border-warning-400 hover:shadow-sm'
+                                    : 'hover:bg-primary-25 border-neutral-100 bg-white/60 text-neutral-600 hover:border-primary-200 hover:text-primary-500 hover:shadow-sm'
                         }
                         ${slide.status !== 'DELETED' ? 'group-hover:shadow-md' : ''}
                     `}
@@ -298,8 +304,19 @@ const SlideItem = ({
                                         </p>
                                     </div>
 
-                                    {/* Status indicator */}
-                                    <div className="shrink-0">{getStatusBadge()}</div>
+                                    {/* Status indicator (+ amber dot while the slide has
+                                        unsaved local edits — shown alongside, never replacing,
+                                        the ✓/D/U badge; also readable on the ACTIVE row, whose
+                                        primary border overrides the amber dirty border) */}
+                                    <div className="flex shrink-0 items-center gap-1.5">
+                                        {isDirty && (
+                                            <span
+                                                title="Unsaved changes"
+                                                className="size-2 rounded-full bg-warning-500 ring-2 ring-warning-100"
+                                            />
+                                        )}
+                                        {getStatusBadge()}
+                                    </div>
                                 </div>
                             </TooltipTrigger>
                             <TooltipContent
@@ -357,6 +374,13 @@ export const ChapterSidebarSlides = ({
     const { chapterId, slideId, courseId, levelId, moduleId, subjectId, sessionId } = searchParams;
 
     const { slides, isLoading, refetch } = useSlidesQuery(chapterId || '');
+
+    // Local unsaved drafts (course-scoped) → amber border on dirty rows. The
+    // course-level rollup lives in CourseUnsavedBanner (sidebar top), and the
+    // DB status badge (✓/D/U) is deliberately left untouched — dirty is a
+    // separate fact from saved-status.
+    const [draftUserId] = useState<string>(() => getDraftUserId());
+    const { dirtySlideIds } = useSlideDrafts(draftUserId, courseId || '');
 
     // Memoize filtered slides to prevent infinite loops
     const filteredSlides = useMemo(() => {
@@ -524,6 +548,7 @@ export const ChapterSidebarSlides = ({
                                     slide={slide}
                                     index={index}
                                     isActive={slide.id === activeItem?.id}
+                                    isDirty={dirtySlideIds.has(slide.id)}
                                     onClick={() => handleSlideClick(slide)}
                                     assessmentOrdinal={assessmentOrdinal}
                                     showNumbering={showNumbering}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/stats-dialog/activity-sidebar.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/stats-dialog/activity-sidebar.tsx
@@ -16,8 +16,23 @@ import { useActivityStatsStore } from '@/routes/study-library/courses/course-det
 import { useContentStore } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-stores/chapter-sidebar-store';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 
-export const ActivityStatsSidebar = () => {
-    const [open, setOpen] = useState(false);
+export const ActivityStatsSidebar = ({
+    open: controlledOpen,
+    onOpenChange,
+    hideTrigger = false,
+}: {
+    /** Controlled mode (e.g. opened from the ⋯ menu): pass open + onOpenChange and hideTrigger. */
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    hideTrigger?: boolean;
+} = {}) => {
+    const [internalOpen, setInternalOpen] = useState(false);
+    const isControlled = controlledOpen !== undefined;
+    const open = isControlled ? controlledOpen : internalOpen;
+    const setOpen = (o: boolean) => {
+        if (isControlled) onOpenChange?.(o);
+        else setInternalOpen(o);
+    };
     const [isDownloading, setIsDownloading] = useState(false);
     const [searchInput, setSearchInput] = useState('');
 
@@ -165,17 +180,19 @@ export const ActivityStatsSidebar = () => {
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger asChild>
-                <MyButton
-                    buttonType="secondary"
-                    scale="medium"
-                    layoutVariant="default"
-                    title="Activity Stats"
-                >
-                    <ChartBar className="size-4 md:hidden" />
-                    <span className="hidden md:inline">Activity Stats</span>
-                </MyButton>
-            </DialogTrigger>
+            {!hideTrigger && (
+                <DialogTrigger asChild>
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        layoutVariant="default"
+                        title="Activity Stats"
+                    >
+                        <ChartBar className="size-4 md:hidden" />
+                        <span className="hidden md:inline">Activity Stats</span>
+                    </MyButton>
+                </DialogTrigger>
+            )}
             <DialogContent className="flex h-[680px] max-h-[92vh] w-[760px] max-w-[95vw] flex-col gap-0 overflow-hidden p-0 font-normal">
                 {/* Hero header */}
                 <DialogHeader className="flex shrink-0 flex-col gap-0 space-y-0">

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-compare-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-compare-dialog.tsx
@@ -1,0 +1,71 @@
+/**
+ * Side-by-side comparison of a slide's SAVED content vs the CURRENT (unsaved,
+ * browser-local) edits — so an author who stashed changes days ago can see
+ * what they changed before deciding to save or discard.
+ *
+ * v1 is deliberately render-only (two sandboxed iframes, same pattern as the
+ * version-history preview): no diff dependency, no highlight marks. If clients
+ * still struggle to spot small edits, the planned upgrade is word-level
+ * red/green highlighting on top of these panes.
+ */
+import { MyDialog } from '@/components/design-system/dialog';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+
+interface UnsavedCompareDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Last saved content (data / published_data — whatever the editor loaded from). */
+    savedHtml: string;
+    /** The unsaved local draft content. */
+    currentHtml: string;
+}
+
+const Pane = ({ label, html, accent }: { label: string; html: string; accent: string }) => (
+    <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <p className={`text-caption font-semibold uppercase tracking-wide ${accent}`}>{label}</p>
+        {html ? (
+            <iframe
+                title={label}
+                sandbox=""
+                srcDoc={html}
+                className="h-96 w-full rounded-md border border-neutral-200 bg-white"
+            />
+        ) : (
+            <div className="flex h-96 w-full items-center justify-center rounded-md border border-neutral-200 bg-neutral-50">
+                <p className="text-body text-neutral-400">No saved version yet</p>
+            </div>
+        )}
+    </div>
+);
+
+export const UnsavedCompareDialog = ({
+    open,
+    onOpenChange,
+    savedHtml,
+    currentHtml,
+}: UnsavedCompareDialogProps) => {
+    if (!open) return null;
+    return (
+        <MyDialog
+            heading="Compare with saved version"
+            open={open}
+            onOpenChange={onOpenChange}
+            dialogWidth="w-full max-w-5xl"
+        >
+            <div className="flex flex-col gap-3">
+                <p className="text-caption text-neutral-500">
+                    Left is the last saved version of this{' '}
+                    {getTerminology(ContentTerms.Slide, SystemTerms.Slide).toLowerCase()}; right is
+                    your current unsaved edit (kept only in this browser). Use Save Draft or
+                    Publish to keep the current version, or Discard changes to return to the saved
+                    one.
+                </p>
+                <div className="flex flex-col gap-3 md:flex-row">
+                    <Pane label="Saved" html={savedHtml} accent="text-neutral-500" />
+                    <Pane label="Current (unsaved)" html={currentHtml} accent="text-warning-600" />
+                </div>
+            </div>
+        </MyDialog>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-drafts-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-drafts-dialog.tsx
@@ -1,0 +1,263 @@
+/**
+ * Course-scoped "unsaved changes" dialog.
+ *
+ * Lists every slide in the CURRENT course that has a local (browser-only)
+ * unsaved draft, grouped subject → module → chapter, each row clickable to
+ * jump straight to that slide. Two entry points share it:
+ *
+ *  - mode="review": opened from the amber count chip / sidebar banner. Purely
+ *    informative — jump to a slide or close.
+ *  - mode="leave": shown by the leave-editor navigation blocker. Adds
+ *    "Keep in browser" (proceed) and "Discard changes" (drop the listed
+ *    drafts, then proceed).
+ *
+ * Deliberately NO "Save all": only document-type drafts are stashed locally,
+ * so a bulk save could not honestly cover every listed slide. Saving happens
+ * by opening a slide and saving it there.
+ */
+import { useMemo } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { Warning, ArrowSquareOut, FileDoc } from '@phosphor-icons/react';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyButton } from '@/components/design-system/button';
+import {
+    getTerminology,
+    getTerminologyPlural,
+} from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { type SlideDraft } from '../-utils/slide-draft-store';
+
+interface UnsavedDraftsDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Course-scoped drafts (already filtered via listCourseDrafts). */
+    drafts: SlideDraft[];
+    mode: 'review' | 'leave';
+    /** Called right before navigating to a listed slide (leave mode uses it to cancel the blocked navigation). */
+    onBeforeJump?: () => void;
+    /** leave mode: keep drafts in the browser and proceed with the navigation. */
+    onKeep?: () => void;
+    /** leave mode: discard the listed drafts and proceed with the navigation. */
+    onDiscard?: () => void;
+}
+
+/** subject → module → chapter grouping of the flat draft list. */
+interface ChapterGroup {
+    chapterId: string;
+    chapterName: string;
+    drafts: SlideDraft[];
+}
+interface ModuleGroup {
+    moduleId: string;
+    moduleName: string;
+    chapters: ChapterGroup[];
+}
+interface SubjectGroup {
+    subjectId: string;
+    subjectName: string;
+    modules: ModuleGroup[];
+}
+
+function groupDrafts(drafts: SlideDraft[]): SubjectGroup[] {
+    const subjects = new Map<string, SubjectGroup>();
+    for (const draft of drafts) {
+        const ctx = draft.context;
+        const subjectKey = ctx?.subjectId || 'unknown';
+        let subject = subjects.get(subjectKey);
+        if (!subject) {
+            subject = {
+                subjectId: subjectKey,
+                subjectName:
+                    ctx?.subjectName || getTerminology(ContentTerms.Subject, SystemTerms.Subject),
+                modules: [],
+            };
+            subjects.set(subjectKey, subject);
+        }
+        const moduleKey = ctx?.moduleId || 'unknown';
+        let moduleGroup = subject.modules.find((m) => m.moduleId === moduleKey);
+        if (!moduleGroup) {
+            moduleGroup = {
+                moduleId: moduleKey,
+                moduleName:
+                    ctx?.moduleName || getTerminology(ContentTerms.Module, SystemTerms.Module),
+                chapters: [],
+            };
+            subject.modules.push(moduleGroup);
+        }
+        const chapterKey = ctx?.chapterId || 'unknown';
+        let chapter = moduleGroup.chapters.find((c) => c.chapterId === chapterKey);
+        if (!chapter) {
+            chapter = {
+                chapterId: chapterKey,
+                chapterName:
+                    ctx?.chapterName || getTerminology(ContentTerms.Chapter, SystemTerms.Chapter),
+                drafts: [],
+            };
+            moduleGroup.chapters.push(chapter);
+        }
+        chapter.drafts.push(draft);
+    }
+    return [...subjects.values()];
+}
+
+function timeAgo(epochMs: number): string {
+    const mins = Math.max(0, Math.round((Date.now() - epochMs) / 60000));
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} min ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return `${hours} hr ago`;
+    const days = Math.round(hours / 24);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+export const UnsavedDraftsDialog = ({
+    open,
+    onOpenChange,
+    drafts,
+    mode,
+    onBeforeJump,
+    onKeep,
+    onDiscard,
+}: UnsavedDraftsDialogProps) => {
+    const navigate = useNavigate();
+    const subjectGroups = useMemo(() => groupDrafts(drafts), [drafts]);
+    const showSubjectHeaders = subjectGroups.length > 1;
+    const slideTerm = getTerminology(ContentTerms.Slide, SystemTerms.Slide).toLowerCase();
+    const slidesTermPlural = getTerminologyPlural(
+        ContentTerms.Slide,
+        SystemTerms.Slide
+    ).toLowerCase();
+
+    const jumpToSlide = (draft: SlideDraft) => {
+        const ctx = draft.context;
+        if (!ctx?.chapterId) return;
+        onBeforeJump?.();
+        onOpenChange(false);
+        navigate({
+            to: '/study-library/courses/course-details/subjects/modules/chapters/slides',
+            search: {
+                courseId: ctx.courseId || '',
+                levelId: ctx.levelId || '',
+                subjectId: ctx.subjectId || '',
+                moduleId: ctx.moduleId || '',
+                chapterId: ctx.chapterId || '',
+                slideId: draft.slideId,
+                sessionId: ctx.sessionId || '',
+            },
+        });
+    };
+
+    if (!open) return null;
+
+    return (
+        <MyDialog
+            heading="Unsaved changes"
+            open={open}
+            onOpenChange={onOpenChange}
+            dialogWidth="w-full max-w-lg"
+            footer={
+                <div className="flex w-full flex-col gap-3">
+                    <p className="text-caption text-neutral-500">
+                        Kept only on this device — logging out or clearing browser data will lose
+                        these changes. Open a {slideTerm} to save it.
+                    </p>
+                    <div className="flex flex-wrap items-center justify-end gap-2">
+                        {mode === 'leave' ? (
+                            <>
+                                <MyButton
+                                    buttonType="secondary"
+                                    scale="medium"
+                                    onClick={() => onKeep?.()}
+                                >
+                                    Keep in browser
+                                </MyButton>
+                                <MyButton
+                                    buttonType="secondary"
+                                    scale="medium"
+                                    className="border-danger-400 text-danger-600 hover:bg-danger-50"
+                                    onClick={() => onDiscard?.()}
+                                >
+                                    Discard changes
+                                </MyButton>
+                            </>
+                        ) : (
+                            <MyButton
+                                buttonType="primary"
+                                scale="medium"
+                                onClick={() => onOpenChange(false)}
+                            >
+                                Close
+                            </MyButton>
+                        )}
+                    </div>
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                <div className="flex items-start gap-3">
+                    <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full bg-warning-100 text-warning-600">
+                        <Warning size={20} weight="fill" />
+                    </span>
+                    <p className="text-subtitle text-neutral-600">
+                        {mode === 'leave'
+                            ? `These ${slidesTermPlural} have edits that haven't been saved to the database. Click one to open it, or choose what to do before leaving.`
+                            : `These ${slidesTermPlural} have edits that haven't been saved to the database. Click one to open it and save.`}
+                    </p>
+                </div>
+
+                <div className="flex max-h-80 flex-col gap-3 overflow-y-auto pr-1">
+                    {subjectGroups.map((subject) => (
+                        <div key={subject.subjectId} className="flex flex-col gap-2">
+                            {showSubjectHeaders && (
+                                <p className="text-caption font-semibold uppercase tracking-wide text-neutral-400">
+                                    {subject.subjectName}
+                                </p>
+                            )}
+                            {subject.modules.map((moduleGroup) => (
+                                <div key={moduleGroup.moduleId} className="flex flex-col gap-1.5">
+                                    <p className="text-caption font-semibold text-neutral-500">
+                                        {moduleGroup.moduleName}
+                                    </p>
+                                    {moduleGroup.chapters.map((chapter) => (
+                                        <div
+                                            key={chapter.chapterId}
+                                            className="flex flex-col gap-1 pl-3"
+                                        >
+                                            <p className="text-caption text-neutral-400">
+                                                {chapter.chapterName}
+                                            </p>
+                                            {chapter.drafts.map((draft) => (
+                                                <button
+                                                    key={draft.slideId}
+                                                    type="button"
+                                                    onClick={() => jumpToSlide(draft)}
+                                                    className="group flex w-full items-center gap-2 rounded-md border border-warning-200 bg-warning-50 px-3 py-2 text-left transition-colors hover:border-warning-400 hover:bg-warning-100"
+                                                >
+                                                    <FileDoc className="size-4 shrink-0 text-warning-600" />
+                                                    <span className="min-w-0 flex-1">
+                                                        <span className="block truncate text-body font-medium text-neutral-700">
+                                                            {draft.context?.slideTitle || 'Untitled'}
+                                                        </span>
+                                                        <span className="block text-caption text-neutral-500">
+                                                            edited {timeAgo(draft.savedAt)}
+                                                        </span>
+                                                    </span>
+                                                    <ArrowSquareOut className="size-4 shrink-0 text-neutral-400 transition-colors group-hover:text-warning-600" />
+                                                </button>
+                                            ))}
+                                        </div>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                    {drafts.length === 0 && (
+                        <p className="py-4 text-center text-body text-neutral-400">
+                            No unsaved changes in this course.
+                        </p>
+                    )}
+                </div>
+            </div>
+        </MyDialog>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-drafts-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/unsaved-drafts-dialog.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/common/layout-container/sidebar/utils';
 import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 import { type SlideDraft } from '../-utils/slide-draft-store';
+import { useContentStore } from '../-stores/chapter-sidebar-store';
 
 interface UnsavedDraftsDialogProps {
     open: boolean;
@@ -145,6 +146,14 @@ export const UnsavedDraftsDialog = ({
                 sessionId: ctx.sessionId || '',
             },
         });
+        // Same-chapter jump: the URL slideId changes but the sidebar's URL→active
+        // sync early-returns while the current slide still exists in the list, so
+        // it never switches. Set the target active directly (what a sidebar click
+        // does). Cross-chapter jumps refetch a fresh list and resolve via slideId.
+        const target = useContentStore
+            .getState()
+            .items.find((s) => s.id === draft.slideId);
+        if (target) useContentStore.getState().setActiveItem(target);
     };
 
     if (!open) return null;

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slide-drafts.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slide-drafts.ts
@@ -1,0 +1,74 @@
+/**
+ * Reactive view over the local slide-draft store (unsaved edits kept in
+ * localStorage). Re-reads when a draft is written/removed in this tab
+ * (SLIDE_DRAFTS_CHANGED_EVENT) or another tab (native `storage` event).
+ *
+ * The continuous editor stash rewrites the active draft every ~500ms, so the
+ * hook fingerprints what consumers actually render (membership + labels) and
+ * keeps the previous state reference when nothing visible changed — badge
+ * consumers don't re-render on every keystroke.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { getTokenDecodedData, getTokenFromCookie } from '@/lib/auth/sessionUtility';
+import { TokenKey } from '@/constants/auth/tokens';
+import {
+    SLIDE_DRAFTS_CHANGED_EVENT,
+    SlideDraft,
+    listCourseDrafts,
+    listDrafts,
+} from '../-utils/slide-draft-store';
+
+/** The userId key the draft store is partitioned by (JWT sub). */
+export function getDraftUserId(): string {
+    try {
+        const token = getTokenFromCookie(TokenKey.accessToken);
+        return (token ? getTokenDecodedData(token)?.sub : null) || 'anonymous';
+    } catch {
+        return 'anonymous';
+    }
+}
+
+interface SlideDraftsView {
+    /** Drafts in scope (course-scoped when courseId is given, else all). */
+    drafts: SlideDraft[];
+    /** slideIds of those drafts, for O(1) badge lookups. */
+    dirtySlideIds: Set<string>;
+}
+
+function fingerprintOf(drafts: SlideDraft[]): string {
+    return drafts
+        .map((d) => `${d.slideId}|${d.context?.slideTitle ?? ''}|${d.context?.chapterId ?? ''}`)
+        .sort()
+        .join('~');
+}
+
+export function useSlideDrafts(userId: string, courseId?: string): SlideDraftsView {
+    const read = useCallback(
+        (): SlideDraft[] => (courseId ? listCourseDrafts(userId, courseId) : listDrafts(userId)),
+        [userId, courseId]
+    );
+
+    const [view, setView] = useState<SlideDraftsView>(() => {
+        const drafts = read();
+        return { drafts, dirtySlideIds: new Set(drafts.map((d) => d.slideId)) };
+    });
+
+    useEffect(() => {
+        const refresh = () => {
+            setView((prev) => {
+                const drafts = read();
+                if (fingerprintOf(drafts) === fingerprintOf(prev.drafts)) return prev;
+                return { drafts, dirtySlideIds: new Set(drafts.map((d) => d.slideId)) };
+            });
+        };
+        refresh(); // scope (userId/courseId) may have changed since initial state
+        window.addEventListener(SLIDE_DRAFTS_CHANGED_EVENT, refresh);
+        window.addEventListener('storage', refresh);
+        return () => {
+            window.removeEventListener(SLIDE_DRAFTS_CHANGED_EVENT, refresh);
+            window.removeEventListener('storage', refresh);
+        };
+    }, [read]);
+
+    return view;
+}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-utils/slide-draft-store.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-utils/slide-draft-store.ts
@@ -12,6 +12,27 @@
  * `backend` object below so we can swap to IndexedDB later without touching callers.
  */
 
+/**
+ * Where the drafted slide lives in the course hierarchy, captured at stash time.
+ * Powers the course-scoped "unsaved changes" dialog (names + grouping) and the
+ * deep link back to the slide — without it a draft is an opaque slideId that
+ * can't be named, grouped, or jumped to from another chapter.
+ */
+export interface SlideDraftContext {
+    slideTitle?: string | null;
+    chapterId?: string | null;
+    chapterName?: string | null;
+    moduleId?: string | null;
+    moduleName?: string | null;
+    subjectId?: string | null;
+    subjectName?: string | null;
+    courseId?: string | null;
+    courseName?: string | null;
+    /** Extra route params needed to deep-link to the slide. */
+    levelId?: string | null;
+    sessionId?: string | null;
+}
+
 export interface SlideDraft<T = unknown> {
     slideId: string;
     /** The editor payload — HTML string, Excalidraw JSON, code data, etc. */
@@ -26,6 +47,23 @@ export interface SlideDraft<T = unknown> {
     baselineUpdatedAt?: string | null;
     /** epoch ms when this draft was last written locally. */
     savedAt: number;
+    /** Hierarchy metadata for scoping/labelling. Absent on legacy drafts. */
+    context?: SlideDraftContext;
+}
+
+/**
+ * Fired on window whenever a draft is written or removed, so badge/dialog
+ * consumers re-read without polling. Same-tab only — cross-tab updates ride the
+ * browser's native `storage` event; listen to both.
+ */
+export const SLIDE_DRAFTS_CHANGED_EVENT = 'slide-drafts-changed';
+
+function emitDraftsChanged(): void {
+    try {
+        window.dispatchEvent(new CustomEvent(SLIDE_DRAFTS_CHANGED_EVENT));
+    } catch {
+        /* SSR / test envs without window — ignore */
+    }
 }
 
 const PREFIX = 'slideDraft';
@@ -86,16 +124,22 @@ export function saveDraft<T>(
     userId: string,
     slideId: string,
     content: T,
-    baselineUpdatedAt?: string | null
+    baselineUpdatedAt?: string | null,
+    context?: SlideDraftContext
 ): SlideDraft<T> {
+    // Carry forward the previous stash's context when the caller doesn't pass
+    // one, so a code path that can't cheaply rebuild it never strips metadata.
+    const prior = context ? null : loadDraft<T>(userId, slideId);
     const draft: SlideDraft<T> = {
         slideId,
         content,
         contentHash: hashContent(content),
         baselineUpdatedAt: baselineUpdatedAt ?? null,
         savedAt: Date.now(),
+        context: context ?? prior?.context,
     };
     backend.set(keyFor(userId, slideId), JSON.stringify(draft));
+    emitDraftsChanged();
     return draft;
 }
 
@@ -112,6 +156,7 @@ export function loadDraft<T = unknown>(userId: string, slideId: string): SlideDr
 
 export function removeDraft(userId: string, slideId: string): void {
     backend.remove(keyFor(userId, slideId));
+    emitDraftsChanged();
 }
 
 export function hasDraft(userId: string, slideId: string): boolean {
@@ -140,10 +185,20 @@ export function dirtySlideIds(userId: string): Set<string> {
     return new Set(listDrafts(userId).map((d) => d.slideId));
 }
 
+/**
+ * Drafts belonging to one course. Legacy drafts without context metadata are
+ * excluded — they can't be named or navigated to, and age out via pruning.
+ */
+export function listCourseDrafts<T = unknown>(userId: string, courseId: string): SlideDraft<T>[] {
+    if (!courseId) return [];
+    return listDrafts<T>(userId).filter((d) => d.context?.courseId === courseId);
+}
+
 /** Drop drafts older than MAX_AGE_MS. Call once on mount. */
 export function pruneOldDrafts(userId: string): void {
     const wanted = `${PREFIX}:${userId}:`;
     const cutoff = Date.now() - MAX_AGE_MS;
+    let removedAny = false;
     for (const key of backend.keys()) {
         if (!key.startsWith(wanted)) continue;
         const raw = backend.get(key);
@@ -152,9 +207,12 @@ export function pruneOldDrafts(userId: string): void {
             const draft = JSON.parse(raw) as SlideDraft;
             if (typeof draft.savedAt !== 'number' || draft.savedAt < cutoff) {
                 backend.remove(key);
+                removedAny = true;
             }
         } catch {
             backend.remove(key);
+            removedAny = true;
         }
     }
+    if (removedAny) emitDraftsChanged();
 }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/admin/AdminSlidesView.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/admin/AdminSlidesView.tsx
@@ -2,6 +2,7 @@ import { LayoutContainer } from '@/components/common/layout-container/layout-con
 import { ChapterSidebarAddButton } from '../-components/slides-sidebar/slides-sidebar-add-button';
 import { ChapterSidebarSlides } from '../-components/slides-sidebar/slides-sidebar-slides';
 import { ChapterNavigator } from '../-components/chapter-navigator';
+import { CourseUnsavedBanner } from '../-components/course-unsaved-banner';
 import '../slides-sidebar-scrollbar.css';
 // import { studyLibrarySteps } from '@/constants/intro/steps';
 // import { StudyLibraryIntroKey } from '@/constants/storage/introKey';
@@ -281,6 +282,9 @@ export function AdminSlidesView({
                         );
                     })()}
                 </div>
+
+                {/* Course-level unsaved-changes banner (only while drafts exist) */}
+                <CourseUnsavedBanner courseId={courseId} />
 
                 {/* Chapter Navigator */}
                 <div className="w-full border-b border-primary-100 bg-white/50 p-2">

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/non-admin/NonAdminSlidesView.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/non-admin/NonAdminSlidesView.tsx
@@ -2,6 +2,7 @@ import { LayoutContainer } from '@/components/common/layout-container/layout-con
 import { ChapterSidebarAddButton } from '../-components/slides-sidebar/slides-sidebar-add-button';
 import { ChapterSidebarSlides } from '../-components/slides-sidebar/slides-sidebar-slides';
 import { ChapterNavigator } from '../-components/chapter-navigator';
+import { CourseUnsavedBanner } from '../-components/course-unsaved-banner';
 import '../slides-sidebar-scrollbar.css';
 // import { studyLibrarySteps } from '@/constants/intro/steps';
 // import { StudyLibraryIntroKey } from '@/constants/storage/introKey';
@@ -315,6 +316,9 @@ export function NonAdminSlidesView({
                         );
                     })()}
                 </div>
+
+                {/* Course-level unsaved-changes banner (only while drafts exist) */}
+                <CourseUnsavedBanner courseId={courseId} />
 
                 {/* Chapter Navigator */}
                 <div className="w-full border-b border-primary-100 bg-white/50 p-2">


### PR DESCRIPTION
## Summary of Changes

Redesigns the slide editor's unsaved-changes experience around the local (browser) draft store, upgrades the sidebar navigator into a full subject → module → chapter → slide tree, and fixes the "slide shows empty until refresh" bug that also caused the client-reported "Could not read editor content" save failures.

**Backend:**
- None

**Frontend:**
- Draft store: every stashed draft now carries hierarchy metadata (slide/chapter/module/subject/course ids + names + deep-link params); change events; course-scoped queries; legacy (pre-metadata) drafts self-backfill when their chapter loads
- One signal per scope: bottom floating bar on the active slide (Unsaved changes · View changes · Discard changes), amber course banner in the sidebar (opens a grouped dialog listing every unsaved slide with jump links), amber border + dot on dirty slide rows (status ✓/D/U badges untouched)
- Removed redundant signals: red "not saved to database" banner, header unsaved chip, browser beforeunload prompt (drafts persist in localStorage and restore on reopen)
- Leave-editor guard is now course-scoped (drafts from other courses never block) and shows the grouped dialog instead of a blind prompt; no bulk "Save all" by design
- Dirty detection: normalized HTML comparison (clicks/empty blocks no longer mark a slide unsaved); reverting to the loaded state auto-clears the draft; Discard shows only when the draft truly differs from the saved version
- "View changes": side-by-side Saved vs Current preview dialog (sandboxed iframes)
- Bug fix: blank-slide-until-refresh — the sidebar's placeholder activeItem recorded its id in the same-slide-rerun guard, so the real slide's arrival skipped rendering; placeholder runs no longer record the id; plus a bounded self-heal re-apply with a `[DOC-LOAD]` console breadcrumb
- Bug fix: a refused Save Draft (empty/degraded editor) no longer deletes the localStorage draft it failed to persist
- Navigator: all modules of the subject as collapsible groups, chapters expandable to their slides (lazy-fetched) with direct slide jump, subject-wide chapter search, subject switcher row when the course has >1 subject, cross-module prev/next, dirty dots/counts; fixed the popover list not scrolling (Radix ScrollArea max-height viewport bug) and chapter jumps sending the wrong moduleId
- Header decluttered: Activity Stats, Version History, and Export as PDF moved into the ⋯ menu (dialogs now support controlled open); Publish always on-screen

## Related Issue

Client-reported: slide save popups/failures, blank slides on load, confusing chapter navigation (meeting 2026-07-22)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Manual testing against local backend (Docker Postgres + admin-core on localhost): edit/revert/discard flows, badge and banner lifecycle, compare dialog, navigator tree navigation across modules and chapters, ⋯ menu actions
- Reproduced the blank-slide bug live before the fix and verified the save guards refused to overwrite content during the blank window (console evidence); verified normal rendering after the fix
- `doc-slide-integrity` suite: 36/36 passing (6 new tests for the normalized dirty-compare helper)
- `tsc --noEmit`: 0 errors; design-lint clean on all touched files

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
