### PR TITLE
parent rewards: render the student app's badge visuals (BadgeVisual)

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/parent/child/$childId/rewards/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/parent/child/$childId/rewards/index.tsx
@@ -2,6 +2,9 @@ import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Medal, Star, Certificate, Trophy } from "@phosphor-icons/react";
 import { ModuleScaffold } from "../../-components/ModuleScaffold";
+// Same renderer the student app uses — built-in medallion icons or the
+// admin-uploaded badge artwork, so parent and student see identical badges.
+import { BadgeVisual } from "@/routes/dashboard/-components/badge-icons";
 import { cn } from "@/lib/utils";
 import {
   useChildBadges,
@@ -97,8 +100,16 @@ function RewardsScreen() {
                       "transition-transform hover:-translate-y-0.5",
                     )}
                   >
-                    <span className="flex size-14 items-center justify-center rounded-full bg-cp-gold-tint">
-                      <Medal weight="fill" className="size-8 text-cp-gold" aria-hidden />
+                    <span className="flex size-14 items-center justify-center overflow-hidden rounded-full bg-cp-gold-tint">
+                      <BadgeVisual
+                        icon={String(
+                          (b.iconFileId as string | undefined) ?? (b.icon as string | undefined) ?? "Medal",
+                        )}
+                        fill
+                        weight="fill"
+                        size={30}
+                        className="text-cp-gold"
+                      />
                     </span>
                     <span className="text-caption font-semibold text-foreground">
                       {String(b.name ?? b.badgeName ?? t("rewards.badge"))}


### PR DESCRIPTION
Badge cards now use the shared BadgeVisual renderer — the admin-uploaded badge artwork (iconFileId resolved via getPublicUrl) or the curated medallion icon set — instead of a generic medal, so parents see exactly the badges their child sees in the student app.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
