### PR TITLE
parent assistant: precise language decision rule (English question an…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentAssistantService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/parent_portal/service/ParentAssistantService.java
@@ -60,13 +60,17 @@ public class ParentAssistantService {
             topic has no data at all, say so briefly and suggest the relevant section (Attendance, Tests,
             Fees, Rewards, Progress, Classes). Refer to the child by their first name. Keep answers to 1-4
             short, plain-language sentences with no jargon.
-            ALWAYS reply in the SAME language the parent asked the question in. This applies to EVERY
-            reply — including when you redirect, decline, or the question is off-topic or general
-            knowledge — so never default to English when the question was not in English. If the
-            question is in Hindi or a Hindi-English mix (Hinglish, i.e. Hindi written in Latin letters),
-            reply in Hindi using the Devanagari script (देवनागरी) — never romanised Hinglish — so the
-            answer both reads well and is pronounced correctly when spoken aloud. Match the parent's
-            language first, then answer.
+            LANGUAGE RULE — decide the reply language ONLY from the wording of the question itself,
+            never from the child's name, the data below, or any earlier question:
+            - Question written entirely in English words and grammar → reply in ENGLISH, even when
+              the names and data are Indian. Example: "Do I have to pay any fee?" → English reply.
+            - Question containing actual Hindi words — in Devanagari, or Hindi words typed in Latin
+              letters (e.g. "kya", "hai", "kaisa", "nahi", "bacche", "kal") → reply in Hindi using
+              the Devanagari script (देवनागरी), never romanised Hinglish, so it reads well and is
+              pronounced correctly when spoken aloud. Example: "kya fees baki hai?" → हिंदी में उत्तर।
+            - Any other language → mirror that language.
+            This applies to EVERY reply, including redirects, declines, and off-topic or
+            general-knowledge questions.
             """;
 
     private final GuardianAccessGuard guard;


### PR DESCRIPTION
…swered in Hindi)

A fully-English question ('do I have to pay any fee') was answered in Hindi: the previous wording emphasised Hinglish->Devanagari and 'never default to English' so strongly that short English questions in an Indian-child context over-triggered it. The rule is now a decision procedure with examples: judge ONLY the wording of the question itself (never the child's name/data), fully-English wording -> English, actual Hindi words (Devanagari or Latin-script like kya/hai/nahi) -> Devanagari Hindi, anything else mirrored.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
