### PR TITLE
fix(copy): preserve slide order when copying course/chapter content

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/service/CourseContentCopyService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course/service/CourseContentCopyService.java
@@ -600,6 +600,13 @@ public class CourseContentCopyService {
         List<ChapterToSlides> sourceLinks = chapterToSlidesRepository.findByChapterId(sourceChapter.getId());
         if (sourceLinks == null || sourceLinks.isEmpty()) return;
 
+        // Sort into the rendered order (slide_order, then slide.created_at DESC) and
+        // stamp a fresh sequential slide_order below, so the clone preserves the
+        // source's visible order. Clones share one batch-insert created_at, so without
+        // a unique slide_order a slide_order=0 chapter would copy in arbitrary order.
+        sourceLinks = new ArrayList<>(sourceLinks);
+        sourceLinks.sort(SlideService.renderOrderComparator());
+
         // First persist the new Slide rows (so they're managed) without source ids.
         List<Slide> newSlides = new ArrayList<>(sourceLinks.size());
         for (ChapterToSlides link : sourceLinks) {
@@ -621,8 +628,10 @@ public class CourseContentCopyService {
             newSlide.setSourceId(newSourceId);
 
             slideIdMap.put(oldSlide.getId(), newSlide.getId());
+            // slide_order = position in the sorted (rendered) order so the clone is
+            // deterministic and preserves the source's visible slide order.
             newLinks.add(new ChapterToSlides(newChapter, newSlide,
-                    oldLink.getSlideOrder(), oldLink.getStatus()));
+                    i, oldLink.getStatus()));
         }
         slideRepository.saveAll(persistedSlides);
         chapterToSlidesRepository.saveAll(newLinks);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -733,8 +733,40 @@ public class SlideService {
         }
     }
 
+    /**
+     * Orders chapter→slide links the way the learner/admin outline renders them:
+     * slide_order NULLs first, then slide_order ascending, then the slide's
+     * created_at DESC (newest first) as the tie-break. The copy paths use this to
+     * re-stamp a fresh, unique, sequential slide_order on the clones so a copied
+     * chapter keeps the source's visible order — even when the source slides all
+     * share slide_order=0 and the clones share one batch-insert created_at (which
+     * would otherwise leave the copy in an arbitrary, unstable order).
+     */
+    public static Comparator<ChapterToSlides> renderOrderComparator() {
+        return (a, b) -> {
+            boolean aNull = a.getSlideOrder() == null;
+            boolean bNull = b.getSlideOrder() == null;
+            if (aNull != bNull) return aNull ? -1 : 1;          // NULL slide_order first
+            if (!aNull) {
+                int c = Integer.compare(a.getSlideOrder(), b.getSlideOrder());
+                if (c != 0) return c;                            // slide_order ascending
+            }
+            Timestamp at = a.getSlide() == null ? null : a.getSlide().getCreatedAt();
+            Timestamp bt = b.getSlide() == null ? null : b.getSlide().getCreatedAt();
+            if (at == null && bt == null) return 0;
+            if (at == null) return 1;                            // nulls last
+            if (bt == null) return -1;
+            return bt.compareTo(at);                             // created_at DESC
+        };
+    }
+
     public void copySlidesOfChapter(Chapter oldChapter, Chapter newChapter) {
-        List<ChapterToSlides> chapterToSlides = chapterToSlidesRepository.findByChapterId(oldChapter.getId());
+        // Sort into the rendered order, then stamp a fresh sequential slide_order
+        // (below) so the copy preserves the source's visible slide order
+        // deterministically instead of relying on the (tied) created_at tie-break.
+        List<ChapterToSlides> chapterToSlides = new ArrayList<>(
+                chapterToSlidesRepository.findByChapterId(oldChapter.getId()));
+        chapterToSlides.sort(renderOrderComparator());
         List<Slide> newSlides = new ArrayList<>();
         List<ChapterToSlides> newChapterToSlides = new ArrayList<>();
 
@@ -758,9 +790,9 @@ public class SlideService {
             String newSourceId = copySlideSourceByType(oldSlide);
             newSlide.setSourceId(newSourceId);
 
-            // Create ChapterToSlides mapping
-            newChapterToSlides.add(new ChapterToSlides(newChapter, newSlide,
-                    chapterToSlides.get(i).getSlideOrder(),
+            // Create ChapterToSlides mapping — slide_order = position in the sorted
+            // (rendered) order, so the copy is deterministic and matches the source.
+            newChapterToSlides.add(new ChapterToSlides(newChapter, newSlide, i,
                     chapterToSlides.get(i).getStatus()));
         }
 


### PR DESCRIPTION
Copied slides shared one batch-insert created_at and slide_order=0, collapsing the render tie-break into an arbitrary order. Sort source slides into rendered order and stamp a fresh sequential slide_order on the clones so copies stay deterministic and match the source.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
