### PR TITLE
Log LMS password-sync dispatch outcome in auth_service

### DIFF
--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/admin_core_service/service/InstitutePolicyService.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/admin_core_service/service/InstitutePolicyService.java
@@ -2,6 +2,8 @@ package vacademy.io.auth_service.feature.admin_core_service.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
@@ -15,6 +17,8 @@ import vacademy.io.common.core.internal_api_wrapper.InternalClientUtils;
 
 @Service
 public class InstitutePolicyService {
+
+    private static final Logger log = LoggerFactory.getLogger(InstitutePolicyService.class);
 
     @Autowired
     private InternalClientUtils internalClientUtils;
@@ -117,14 +121,19 @@ public class InstitutePolicyService {
             userDTO.setId(userId);
             userDTO.setEmail(email);
             userDTO.setPassword(password);
-            internalClientUtils.makeHmacRequest(
+            ResponseEntity<String> resp = internalClientUtils.makeHmacRequest(
                 applicationName,
                 HttpMethod.POST.name(),
                 adminCoreServiceBaseUrl,
                 "/admin-core-service/internal/learner/v1/sync-lms-password",
                 userDTO);
+            log.info("LMS password sync dispatched to admin-core for userId={}: HTTP {}",
+                userId, resp != null ? resp.getStatusCodeValue() : "no-response");
         } catch (Exception e) {
-            // best-effort: never surface an LMS-sync failure to the password change
+            // best-effort: never surface an LMS-sync failure to the password change,
+            // but log it — otherwise a rejected/undeployed internal call is invisible
+            // and the password silently fails to reach the LMS.
+            log.warn("LMS password sync to admin-core failed for userId={}: {}", userId, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
The syncLmsPassword call to admin-core swallowed every failure silently, so a rejected or undeployed internal call left the password change with no signal that the LMS never received it. Log the dispatch HTTP status on success and warn (with the reason) on failure, so the sync path is diagnosable from logs instead of guesswork. Still best-effort — the password change never fails.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
