### PR TITLE
feat(whatsapp-inbox): render actual template message instead of summary

### DIFF
--- a/frontend-admin-dashboard/src/routes/communication/inbox/-components/chat-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-components/chat-panel.tsx
@@ -101,8 +101,28 @@ export function ChatPanel({ onLoadOlder }: Props) {
                                 </p>
                             )}
 
-                            {/* Message body */}
+                            {/* Message body — the actual template text the recipient received */}
                             <p className="whitespace-pre-wrap break-words text-gray-800">{msg.body}</p>
+
+                            {/* Template context: which template it came from + any send failure */}
+                            {msg.templateName && (
+                                <p className="text-caption text-gray-500 mt-1 flex flex-wrap items-center gap-1">
+                                    <span className="italic">via template “{msg.templateName}”</span>
+                                    {msg.provider && (
+                                        <span className="px-1 py-px rounded bg-black/5 uppercase tracking-wide">
+                                            {msg.provider}
+                                        </span>
+                                    )}
+                                    {msg.deliveryStatus === 'FAILED' && (
+                                        <span className="px-1 py-px rounded bg-red-100 text-red-600 font-medium">
+                                            Failed
+                                        </span>
+                                    )}
+                                </p>
+                            )}
+                            {msg.deliveryStatus === 'FAILED' && msg.error && (
+                                <p className="text-caption text-red-500 mt-0.5 break-words">{msg.error}</p>
+                            )}
 
                             {/* Timestamp + status */}
                             <p className={`text-[10px] mt-1 text-right ${

--- a/frontend-admin-dashboard/src/routes/communication/inbox/-services/inbox-api.ts
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-services/inbox-api.ts
@@ -19,6 +19,12 @@ export interface InboxMessage {
     source?: string;
     senderName?: string;
     status?: string;
+    // Template-send context (present only on outgoing template messages)
+    templateName?: string;
+    provider?: string;
+    deliveryStatus?: 'SUCCESS' | 'FAILED';
+    error?: string;
+    headerType?: string;
 }
 
 export async function getConversations(

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/dto/InboxMessageDTO.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/dto/InboxMessageDTO.java
@@ -22,4 +22,16 @@ public class InboxMessageDTO {
     private String source;        // COMBOT, WATI, META
     private String senderName;
     private String status;        // notification_type raw value
+
+    // --- Template-send context (only present on outgoing template messages) ---
+    /** Name of the WhatsApp template this message was sent from, e.g. "launchoffer". */
+    private String templateName;
+    /** Sending provider recorded on the log: META, WATI, COMBOT, ... */
+    private String provider;
+    /** SUCCESS or FAILED — whether the provider accepted the send. */
+    private String deliveryStatus;
+    /** Provider rejection reason, when deliveryStatus == FAILED. */
+    private String error;
+    /** Template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT. */
+    private String headerType;
 }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
@@ -1,11 +1,15 @@
 package vacademy.io.notification_service.features.chatbot_flow.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import vacademy.io.notification_service.features.chatbot_flow.dto.InboxConversationDTO;
 import vacademy.io.notification_service.features.chatbot_flow.dto.InboxMessageDTO;
 import vacademy.io.notification_service.features.chatbot_flow.engine.provider.ChatbotMessageProvider;
+import vacademy.io.notification_service.features.chatbot_flow.entity.NotificationTemplate;
+import vacademy.io.notification_service.features.chatbot_flow.repository.NotificationTemplateRepository;
 import vacademy.io.notification_service.features.combot.entity.ChannelToInstituteMapping;
 import vacademy.io.notification_service.features.combot.repository.ChannelToInstituteMappingRepository;
 import vacademy.io.notification_service.features.notification_log.entity.NotificationLog;
@@ -13,6 +17,8 @@ import vacademy.io.notification_service.features.notification_log.repository.Not
 
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,13 +28,20 @@ public class WhatsAppInboxService {
 
     private final NotificationLogRepository notificationLogRepository;
     private final ChannelToInstituteMappingRepository channelMappingRepository;
+    private final NotificationTemplateRepository notificationTemplateRepository;
     private final List<ChatbotMessageProvider> messageProviders;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    /** Matches {{1}} / {{ name }} placeholders (token filled in per-call). */
+    private static final String PLACEHOLDER_FMT = "\\{\\{\\s*%s\\s*\\}\\}";
 
     public List<InboxConversationDTO> getConversations(String instituteId, int offset, int limit) {
         if (instituteId == null || instituteId.isBlank()) return List.of();
 
         List<NotificationLog> logs = notificationLogRepository.findConversationsForInbox(instituteId, limit, offset);
         if (logs.isEmpty()) return List.of();
+
+        TemplateLookup lookup = buildTemplateLookup(instituteId);
 
         // Batch unread counts (single query, not N+1)
         List<String> phones = logs.stream().map(NotificationLog::getChannelId).collect(Collectors.toList());
@@ -46,7 +59,7 @@ public class WhatsAppInboxService {
                 .phone(nl.getChannelId())
                 .senderName(nl.getSenderName())
                 .userId(nl.getUserId())
-                .lastMessage(truncate(nl.getBody(), 60))
+                .lastMessage(truncate(displayBody(nl, lookup), 60))
                 .lastMessageType(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
                 .lastMessageTime(nl.getNotificationDate())
                 .unreadCount(unreadMap.getOrDefault(nl.getChannelId(), 0L))
@@ -59,16 +72,28 @@ public class WhatsAppInboxService {
 
         List<NotificationLog> logs = notificationLogRepository.findMessagesForPhone(phone, instituteId, cursor, limit);
 
-        return logs.stream().map(nl -> InboxMessageDTO.builder()
-                .id(nl.getId())
-                .body(nl.getBody())
-                .direction(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
-                .timestamp(nl.getNotificationDate())
-                .source(nl.getSource())
-                .senderName(nl.getSenderName())
-                .status(nl.getNotificationType())
-                .build()
-        ).collect(Collectors.toList());
+        TemplateLookup lookup = buildTemplateLookup(instituteId);
+
+        return logs.stream().map(nl -> {
+            RenderedMessage rm = renderTemplateMessage(nl, lookup);
+            // When we can rebuild the real template text, show it; otherwise fall back to the
+            // stored body (free-text replies, incoming messages, or template no longer on file).
+            String body = (rm != null && rm.body != null) ? rm.body : nl.getBody();
+            return InboxMessageDTO.builder()
+                    .id(nl.getId())
+                    .body(body)
+                    .direction(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
+                    .timestamp(nl.getNotificationDate())
+                    .source(nl.getSource())
+                    .senderName(nl.getSenderName())
+                    .status(nl.getNotificationType())
+                    .templateName(rm != null ? rm.templateName : null)
+                    .provider(rm != null ? rm.provider : null)
+                    .deliveryStatus(rm != null ? rm.deliveryStatus : null)
+                    .error(rm != null ? rm.error : null)
+                    .headerType(rm != null ? rm.headerType : null)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
     public List<InboxConversationDTO> searchConversations(String instituteId, String query) {
@@ -77,11 +102,13 @@ public class WhatsAppInboxService {
         String safeQuery = "%" + query.replace("%", "\\%").replace("_", "\\_") + "%";
         List<NotificationLog> logs = notificationLogRepository.searchConversations(instituteId, safeQuery);
 
+        TemplateLookup lookup = buildTemplateLookup(instituteId);
+
         return logs.stream().map(nl -> InboxConversationDTO.builder()
                 .phone(nl.getChannelId())
                 .senderName(nl.getSenderName())
                 .userId(nl.getUserId())
-                .lastMessage(truncate(nl.getBody(), 60))
+                .lastMessage(truncate(displayBody(nl, lookup), 60))
                 .lastMessageType(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
                 .lastMessageTime(nl.getNotificationDate())
                 .build()
@@ -209,5 +236,212 @@ public class WhatsAppInboxService {
     private String truncate(String text, int maxLen) {
         if (text == null) return null;
         return text.length() <= maxLen ? text : text.substring(0, maxLen) + "...";
+    }
+
+    // ==================== Template message rendering ====================
+    //
+    // Outgoing template sends are stored with an opaque summary body
+    // ("WhatsApp Template: launchoffer | Provider: META | Status: SUCCESS | Params: {...}").
+    // The structured send context (templateName + bodyParams) is preserved separately on
+    // NotificationLog.messagePayload, so we can rebuild the real message a recipient saw by
+    // joining it with the stored template body and substituting the params — no schema change
+    // and it works retroactively for every historical row.
+
+    /** Rendered display text (or original body) for a log — used for conversation-list previews. */
+    private String displayBody(NotificationLog nl, TemplateLookup lookup) {
+        RenderedMessage rm = renderTemplateMessage(nl, lookup);
+        return (rm != null && rm.body != null) ? rm.body : nl.getBody();
+    }
+
+    /**
+     * Rebuilds the actual message body for an outgoing template send. Returns {@code null} for
+     * anything that isn't a structured template send (incoming messages, free-text replies), and
+     * a {@link RenderedMessage} whose {@code body} is {@code null} when the template is no longer
+     * on file (caller then falls back to the stored summary body).
+     */
+    private RenderedMessage renderTemplateMessage(NotificationLog nl, TemplateLookup lookup) {
+        if (nl == null || nl.getNotificationType() == null
+                || !nl.getNotificationType().contains("OUTGOING")) {
+            return null;
+        }
+        String payloadJson = nl.getMessagePayload();
+        if (payloadJson == null || payloadJson.isBlank()) return null;
+
+        try {
+            Map<String, Object> payload = objectMapper.readValue(payloadJson,
+                    new TypeReference<Map<String, Object>>() {});
+            Object templateNameObj = payload.get("templateName");
+            if (templateNameObj == null) return null;
+
+            RenderedMessage rm = new RenderedMessage();
+            rm.templateName = templateNameObj.toString();
+            rm.provider = asString(payload.get("provider"));
+            rm.error = asString(payload.get("error"));
+            rm.deliveryStatus = rm.error != null ? "FAILED" : "SUCCESS";
+
+            Map<String, String> bodyParams = asStringMap(payload.get("bodyParams"));
+            Map<String, String> headerParams = asStringMap(payload.get("headerParams"));
+            String language = asString(payload.get("languageCode"));
+
+            NotificationTemplate tmpl = lookup.find(rm.templateName, language);
+            if (tmpl != null) {
+                rm.headerType = tmpl.getHeaderType();
+                rm.body = composeMessage(tmpl, bodyParams, headerParams);
+            }
+            return rm;
+        } catch (Exception e) {
+            log.debug("Failed to render template message {}: {}", nl.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    /** Header text + substituted body + footer, joined the way it renders in WhatsApp. */
+    private String composeMessage(NotificationTemplate tmpl, Map<String, String> bodyParams,
+                                  Map<String, String> headerParams) {
+        StringBuilder sb = new StringBuilder();
+
+        String headerType = tmpl.getHeaderType();
+        if ("TEXT".equalsIgnoreCase(headerType) && isNotBlank(tmpl.getHeaderText())) {
+            String header = substitute(tmpl.getHeaderText(), null, headerParams).trim();
+            if (!header.isEmpty()) sb.append(header).append("\n\n");
+        } else if (isMediaHeader(headerType)) {
+            sb.append("[").append(headerType.substring(0, 1).toUpperCase())
+                    .append(headerType.substring(1).toLowerCase()).append("]\n\n");
+        }
+
+        String body = substitute(tmpl.getBodyText(), tmpl.getBodyVariableNames(), bodyParams);
+        if (isNotBlank(body)) sb.append(body.trim());
+
+        if (isNotBlank(tmpl.getFooterText())) {
+            sb.append("\n\n").append(tmpl.getFooterText().trim());
+        }
+
+        String out = sb.toString().trim();
+        return out.isEmpty() ? null : out;
+    }
+
+    /**
+     * Substitutes template placeholders with param values. Covers both flavours WhatsApp
+     * templates use: named ({@code {{name}}}) and positional ({@code {{1}}}). Positional mapping
+     * uses the template's ordered variable-name array — position i maps to {@code {{i+1}}}.
+     */
+    private String substitute(String text, String orderingJson, Map<String, String> params) {
+        if (text == null || params == null || params.isEmpty()) return text;
+
+        String result = text;
+        // Named-style placeholders — also covers positional templates whose params are keyed "1","2".
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            if (e.getKey() == null) continue;
+            String value = e.getValue() != null ? e.getValue() : "";
+            result = replacePlaceholder(result, e.getKey(), value);
+            result = replacePlaceholder(result, cleanName(e.getKey()), value);
+        }
+        // Positional placeholders resolved through the ordered variable names.
+        List<String> ordering = parseStringArray(orderingJson);
+        for (int i = 0; i < ordering.size(); i++) {
+            String value = lookupParam(params, ordering.get(i));
+            if (value != null) {
+                result = replacePlaceholder(result, String.valueOf(i + 1), value);
+            }
+        }
+        return result;
+    }
+
+    private String replacePlaceholder(String text, String token, String value) {
+        if (token == null || token.isEmpty()) return text;
+        Pattern p = Pattern.compile(String.format(PLACEHOLDER_FMT, Pattern.quote(token)));
+        return p.matcher(text).replaceAll(Matcher.quoteReplacement(value));
+    }
+
+    private String lookupParam(Map<String, String> params, String name) {
+        if (name == null) return null;
+        if (params.containsKey(name)) return params.get(name);
+        String clean = cleanName(name);
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            if (cleanName(e.getKey()).equals(clean)) return e.getValue();
+        }
+        return null;
+    }
+
+    /** Same normalisation the unified send path uses for named→positional resolution. */
+    private String cleanName(String name) {
+        return name == null ? "" : name.trim().toLowerCase().replaceAll("[^a-z0-9_]", "_");
+    }
+
+    private List<String> parseStringArray(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return Arrays.asList(objectMapper.readValue(json, String[].class));
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private Map<String, String> asStringMap(Object obj) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (obj instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    out.put(e.getKey().toString(), e.getValue().toString());
+                }
+            }
+        }
+        return out;
+    }
+
+    private String asString(Object obj) {
+        return obj != null ? obj.toString() : null;
+    }
+
+    private boolean isNotBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    private boolean isMediaHeader(String headerType) {
+        return "IMAGE".equalsIgnoreCase(headerType)
+                || "VIDEO".equalsIgnoreCase(headerType)
+                || "DOCUMENT".equalsIgnoreCase(headerType);
+    }
+
+    /** Loads every template for an institute once, so per-message rendering is a map lookup. */
+    private TemplateLookup buildTemplateLookup(String instituteId) {
+        Map<String, NotificationTemplate> byName = new HashMap<>();
+        Map<String, NotificationTemplate> byNameLang = new HashMap<>();
+        try {
+            for (NotificationTemplate t : notificationTemplateRepository
+                    .findByInstituteIdOrderByUpdatedAtDesc(instituteId)) {
+                if (t.getName() == null) continue;
+                String nameLower = t.getName().toLowerCase();
+                byName.putIfAbsent(nameLower, t); // most-recently-updated wins
+                String lang = t.getLanguage() != null ? t.getLanguage().toLowerCase() : "en";
+                byNameLang.putIfAbsent(nameLower + "|" + lang, t);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load templates for institute {}: {}", instituteId, e.getMessage());
+        }
+        return new TemplateLookup(byName, byNameLang);
+    }
+
+    /** Case-insensitive template resolver, preferring an exact language match. */
+    private record TemplateLookup(Map<String, NotificationTemplate> byName,
+                                  Map<String, NotificationTemplate> byNameLang) {
+        NotificationTemplate find(String name, String language) {
+            if (name == null) return null;
+            String nameLower = name.toLowerCase();
+            if (language != null && !language.isBlank()) {
+                NotificationTemplate t = byNameLang.get(nameLower + "|" + language.toLowerCase());
+                if (t != null) return t;
+            }
+            return byName.get(nameLower);
+        }
+    }
+
+    private static class RenderedMessage {
+        String body;           // rebuilt message text, or null when template unavailable
+        String templateName;
+        String provider;
+        String deliveryStatus; // SUCCESS / FAILED
+        String error;
+        String headerType;
     }
 }


### PR DESCRIPTION
The WhatsApp Inbox showed outgoing template sends as an opaque summary ("WhatsApp Template: launchoffer | Provider: META | Status: SUCCESS | Params: {...}") in both the chat panel and the conversation-list preview.

Rebuild the real message at read-time by joining the structured send context already stored on NotificationLog.messagePayload (templateName + bodyParams) with the stored template body, using the same named->positional substitution the send path uses. Works retroactively for all existing rows with no data migration; stored NotificationLog.body is never mutated.

Also surface templateName/provider/deliveryStatus/error/headerType so the UI can show a 'via template' caption and a Failed badge (previously invisible in inbox). Non-template rows (incoming, free-text replies) and rows whose template is no longer on file fall back to the stored body unchanged.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
