### PR TITLE
feat(notifications): render real WhatsApp template message across inb…

### DIFF
--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
@@ -1,15 +1,11 @@
 package vacademy.io.notification_service.features.chatbot_flow.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import vacademy.io.notification_service.features.chatbot_flow.dto.InboxConversationDTO;
 import vacademy.io.notification_service.features.chatbot_flow.dto.InboxMessageDTO;
 import vacademy.io.notification_service.features.chatbot_flow.engine.provider.ChatbotMessageProvider;
-import vacademy.io.notification_service.features.chatbot_flow.entity.NotificationTemplate;
-import vacademy.io.notification_service.features.chatbot_flow.repository.NotificationTemplateRepository;
 import vacademy.io.notification_service.features.combot.entity.ChannelToInstituteMapping;
 import vacademy.io.notification_service.features.combot.repository.ChannelToInstituteMappingRepository;
 import vacademy.io.notification_service.features.notification_log.entity.NotificationLog;
@@ -17,8 +13,6 @@ import vacademy.io.notification_service.features.notification_log.repository.Not
 
 import java.time.Instant;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,12 +22,8 @@ public class WhatsAppInboxService {
 
     private final NotificationLogRepository notificationLogRepository;
     private final ChannelToInstituteMappingRepository channelMappingRepository;
-    private final NotificationTemplateRepository notificationTemplateRepository;
+    private final WhatsAppTemplateRenderer templateRenderer;
     private final List<ChatbotMessageProvider> messageProviders;
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-    /** Matches {{1}} / {{ name }} placeholders (token filled in per-call). */
-    private static final String PLACEHOLDER_FMT = "\\{\\{\\s*%s\\s*\\}\\}";
 
     public List<InboxConversationDTO> getConversations(String instituteId, int offset, int limit) {
         if (instituteId == null || instituteId.isBlank()) return List.of();
@@ -41,7 +31,7 @@ public class WhatsAppInboxService {
         List<NotificationLog> logs = notificationLogRepository.findConversationsForInbox(instituteId, limit, offset);
         if (logs.isEmpty()) return List.of();
 
-        TemplateLookup lookup = buildTemplateLookup(instituteId);
+        Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache = templateRenderer.newCache();
 
         // Batch unread counts (single query, not N+1)
         List<String> phones = logs.stream().map(NotificationLog::getChannelId).collect(Collectors.toList());
@@ -59,7 +49,7 @@ public class WhatsAppInboxService {
                 .phone(nl.getChannelId())
                 .senderName(nl.getSenderName())
                 .userId(nl.getUserId())
-                .lastMessage(truncate(displayBody(nl, lookup), 60))
+                .lastMessage(truncate(templateRenderer.displayBody(nl, instituteId, templateCache), 60))
                 .lastMessageType(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
                 .lastMessageTime(nl.getNotificationDate())
                 .unreadCount(unreadMap.getOrDefault(nl.getChannelId(), 0L))
@@ -72,10 +62,10 @@ public class WhatsAppInboxService {
 
         List<NotificationLog> logs = notificationLogRepository.findMessagesForPhone(phone, instituteId, cursor, limit);
 
-        TemplateLookup lookup = buildTemplateLookup(instituteId);
+        Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache = templateRenderer.newCache();
 
         return logs.stream().map(nl -> {
-            RenderedMessage rm = renderTemplateMessage(nl, lookup);
+            WhatsAppTemplateRenderer.Rendered rm = templateRenderer.render(nl, instituteId, templateCache);
             // When we can rebuild the real template text, show it; otherwise fall back to the
             // stored body (free-text replies, incoming messages, or template no longer on file).
             String body = (rm != null && rm.body != null) ? rm.body : nl.getBody();
@@ -102,13 +92,13 @@ public class WhatsAppInboxService {
         String safeQuery = "%" + query.replace("%", "\\%").replace("_", "\\_") + "%";
         List<NotificationLog> logs = notificationLogRepository.searchConversations(instituteId, safeQuery);
 
-        TemplateLookup lookup = buildTemplateLookup(instituteId);
+        Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache = templateRenderer.newCache();
 
         return logs.stream().map(nl -> InboxConversationDTO.builder()
                 .phone(nl.getChannelId())
                 .senderName(nl.getSenderName())
                 .userId(nl.getUserId())
-                .lastMessage(truncate(displayBody(nl, lookup), 60))
+                .lastMessage(truncate(templateRenderer.displayBody(nl, instituteId, templateCache), 60))
                 .lastMessageType(nl.getNotificationType().contains("OUTGOING") ? "OUTGOING" : "INCOMING")
                 .lastMessageTime(nl.getNotificationDate())
                 .build()
@@ -236,212 +226,5 @@ public class WhatsAppInboxService {
     private String truncate(String text, int maxLen) {
         if (text == null) return null;
         return text.length() <= maxLen ? text : text.substring(0, maxLen) + "...";
-    }
-
-    // ==================== Template message rendering ====================
-    //
-    // Outgoing template sends are stored with an opaque summary body
-    // ("WhatsApp Template: launchoffer | Provider: META | Status: SUCCESS | Params: {...}").
-    // The structured send context (templateName + bodyParams) is preserved separately on
-    // NotificationLog.messagePayload, so we can rebuild the real message a recipient saw by
-    // joining it with the stored template body and substituting the params — no schema change
-    // and it works retroactively for every historical row.
-
-    /** Rendered display text (or original body) for a log — used for conversation-list previews. */
-    private String displayBody(NotificationLog nl, TemplateLookup lookup) {
-        RenderedMessage rm = renderTemplateMessage(nl, lookup);
-        return (rm != null && rm.body != null) ? rm.body : nl.getBody();
-    }
-
-    /**
-     * Rebuilds the actual message body for an outgoing template send. Returns {@code null} for
-     * anything that isn't a structured template send (incoming messages, free-text replies), and
-     * a {@link RenderedMessage} whose {@code body} is {@code null} when the template is no longer
-     * on file (caller then falls back to the stored summary body).
-     */
-    private RenderedMessage renderTemplateMessage(NotificationLog nl, TemplateLookup lookup) {
-        if (nl == null || nl.getNotificationType() == null
-                || !nl.getNotificationType().contains("OUTGOING")) {
-            return null;
-        }
-        String payloadJson = nl.getMessagePayload();
-        if (payloadJson == null || payloadJson.isBlank()) return null;
-
-        try {
-            Map<String, Object> payload = objectMapper.readValue(payloadJson,
-                    new TypeReference<Map<String, Object>>() {});
-            Object templateNameObj = payload.get("templateName");
-            if (templateNameObj == null) return null;
-
-            RenderedMessage rm = new RenderedMessage();
-            rm.templateName = templateNameObj.toString();
-            rm.provider = asString(payload.get("provider"));
-            rm.error = asString(payload.get("error"));
-            rm.deliveryStatus = rm.error != null ? "FAILED" : "SUCCESS";
-
-            Map<String, String> bodyParams = asStringMap(payload.get("bodyParams"));
-            Map<String, String> headerParams = asStringMap(payload.get("headerParams"));
-            String language = asString(payload.get("languageCode"));
-
-            NotificationTemplate tmpl = lookup.find(rm.templateName, language);
-            if (tmpl != null) {
-                rm.headerType = tmpl.getHeaderType();
-                rm.body = composeMessage(tmpl, bodyParams, headerParams);
-            }
-            return rm;
-        } catch (Exception e) {
-            log.debug("Failed to render template message {}: {}", nl.getId(), e.getMessage());
-            return null;
-        }
-    }
-
-    /** Header text + substituted body + footer, joined the way it renders in WhatsApp. */
-    private String composeMessage(NotificationTemplate tmpl, Map<String, String> bodyParams,
-                                  Map<String, String> headerParams) {
-        StringBuilder sb = new StringBuilder();
-
-        String headerType = tmpl.getHeaderType();
-        if ("TEXT".equalsIgnoreCase(headerType) && isNotBlank(tmpl.getHeaderText())) {
-            String header = substitute(tmpl.getHeaderText(), null, headerParams).trim();
-            if (!header.isEmpty()) sb.append(header).append("\n\n");
-        } else if (isMediaHeader(headerType)) {
-            sb.append("[").append(headerType.substring(0, 1).toUpperCase())
-                    .append(headerType.substring(1).toLowerCase()).append("]\n\n");
-        }
-
-        String body = substitute(tmpl.getBodyText(), tmpl.getBodyVariableNames(), bodyParams);
-        if (isNotBlank(body)) sb.append(body.trim());
-
-        if (isNotBlank(tmpl.getFooterText())) {
-            sb.append("\n\n").append(tmpl.getFooterText().trim());
-        }
-
-        String out = sb.toString().trim();
-        return out.isEmpty() ? null : out;
-    }
-
-    /**
-     * Substitutes template placeholders with param values. Covers both flavours WhatsApp
-     * templates use: named ({@code {{name}}}) and positional ({@code {{1}}}). Positional mapping
-     * uses the template's ordered variable-name array — position i maps to {@code {{i+1}}}.
-     */
-    private String substitute(String text, String orderingJson, Map<String, String> params) {
-        if (text == null || params == null || params.isEmpty()) return text;
-
-        String result = text;
-        // Named-style placeholders — also covers positional templates whose params are keyed "1","2".
-        for (Map.Entry<String, String> e : params.entrySet()) {
-            if (e.getKey() == null) continue;
-            String value = e.getValue() != null ? e.getValue() : "";
-            result = replacePlaceholder(result, e.getKey(), value);
-            result = replacePlaceholder(result, cleanName(e.getKey()), value);
-        }
-        // Positional placeholders resolved through the ordered variable names.
-        List<String> ordering = parseStringArray(orderingJson);
-        for (int i = 0; i < ordering.size(); i++) {
-            String value = lookupParam(params, ordering.get(i));
-            if (value != null) {
-                result = replacePlaceholder(result, String.valueOf(i + 1), value);
-            }
-        }
-        return result;
-    }
-
-    private String replacePlaceholder(String text, String token, String value) {
-        if (token == null || token.isEmpty()) return text;
-        Pattern p = Pattern.compile(String.format(PLACEHOLDER_FMT, Pattern.quote(token)));
-        return p.matcher(text).replaceAll(Matcher.quoteReplacement(value));
-    }
-
-    private String lookupParam(Map<String, String> params, String name) {
-        if (name == null) return null;
-        if (params.containsKey(name)) return params.get(name);
-        String clean = cleanName(name);
-        for (Map.Entry<String, String> e : params.entrySet()) {
-            if (cleanName(e.getKey()).equals(clean)) return e.getValue();
-        }
-        return null;
-    }
-
-    /** Same normalisation the unified send path uses for named→positional resolution. */
-    private String cleanName(String name) {
-        return name == null ? "" : name.trim().toLowerCase().replaceAll("[^a-z0-9_]", "_");
-    }
-
-    private List<String> parseStringArray(String json) {
-        if (json == null || json.isBlank()) return List.of();
-        try {
-            return Arrays.asList(objectMapper.readValue(json, String[].class));
-        } catch (Exception e) {
-            return List.of();
-        }
-    }
-
-    private Map<String, String> asStringMap(Object obj) {
-        Map<String, String> out = new LinkedHashMap<>();
-        if (obj instanceof Map<?, ?> map) {
-            for (Map.Entry<?, ?> e : map.entrySet()) {
-                if (e.getKey() != null && e.getValue() != null) {
-                    out.put(e.getKey().toString(), e.getValue().toString());
-                }
-            }
-        }
-        return out;
-    }
-
-    private String asString(Object obj) {
-        return obj != null ? obj.toString() : null;
-    }
-
-    private boolean isNotBlank(String s) {
-        return s != null && !s.isBlank();
-    }
-
-    private boolean isMediaHeader(String headerType) {
-        return "IMAGE".equalsIgnoreCase(headerType)
-                || "VIDEO".equalsIgnoreCase(headerType)
-                || "DOCUMENT".equalsIgnoreCase(headerType);
-    }
-
-    /** Loads every template for an institute once, so per-message rendering is a map lookup. */
-    private TemplateLookup buildTemplateLookup(String instituteId) {
-        Map<String, NotificationTemplate> byName = new HashMap<>();
-        Map<String, NotificationTemplate> byNameLang = new HashMap<>();
-        try {
-            for (NotificationTemplate t : notificationTemplateRepository
-                    .findByInstituteIdOrderByUpdatedAtDesc(instituteId)) {
-                if (t.getName() == null) continue;
-                String nameLower = t.getName().toLowerCase();
-                byName.putIfAbsent(nameLower, t); // most-recently-updated wins
-                String lang = t.getLanguage() != null ? t.getLanguage().toLowerCase() : "en";
-                byNameLang.putIfAbsent(nameLower + "|" + lang, t);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to load templates for institute {}: {}", instituteId, e.getMessage());
-        }
-        return new TemplateLookup(byName, byNameLang);
-    }
-
-    /** Case-insensitive template resolver, preferring an exact language match. */
-    private record TemplateLookup(Map<String, NotificationTemplate> byName,
-                                  Map<String, NotificationTemplate> byNameLang) {
-        NotificationTemplate find(String name, String language) {
-            if (name == null) return null;
-            String nameLower = name.toLowerCase();
-            if (language != null && !language.isBlank()) {
-                NotificationTemplate t = byNameLang.get(nameLower + "|" + language.toLowerCase());
-                if (t != null) return t;
-            }
-            return byName.get(nameLower);
-        }
-    }
-
-    private static class RenderedMessage {
-        String body;           // rebuilt message text, or null when template unavailable
-        String templateName;
-        String provider;
-        String deliveryStatus; // SUCCESS / FAILED
-        String error;
-        String headerType;
     }
 }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppTemplateRenderer.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppTemplateRenderer.java
@@ -1,0 +1,267 @@
+package vacademy.io.notification_service.features.chatbot_flow.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import vacademy.io.notification_service.features.chatbot_flow.entity.NotificationTemplate;
+import vacademy.io.notification_service.features.chatbot_flow.repository.NotificationTemplateRepository;
+import vacademy.io.notification_service.features.notification_log.entity.NotificationLog;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rebuilds the real message a recipient saw for an outgoing WhatsApp <b>template</b> send.
+ *
+ * <p>Template sends are stored on {@link NotificationLog} with an opaque summary body
+ * ("WhatsApp Template: launchoffer | Provider: META | Status: SUCCESS | Params: {...}"), while the
+ * structured send context (templateName + bodyParams + provider) is preserved separately on
+ * {@link NotificationLog#getMessagePayload()}. Joining that payload with the stored template body and
+ * substituting the params reconstructs the actual text — retroactively for every historical row and
+ * without ever mutating stored data.
+ *
+ * <p>Shared by every surface that lists these logs (WhatsApp Inbox, per-student communication
+ * timeline) so the substitution logic lives in exactly one place. Callers create a short-lived
+ * {@link #newCache()} per request and pass it into each {@link #render} call so templates are loaded
+ * once per institute, not once per message.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WhatsAppTemplateRenderer {
+
+    private final NotificationTemplateRepository notificationTemplateRepository;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    /** Matches {{1}} / {{ name }} placeholders (token filled in per-call). */
+    private static final String PLACEHOLDER_FMT = "\\{\\{\\s*%s\\s*\\}\\}";
+
+    /** Result of rebuilding a template message. */
+    public static class Rendered {
+        /** Rebuilt message text, or {@code null} when the template is no longer on file. */
+        public String body;
+        public String templateName;
+        public String provider;
+        /** SUCCESS or FAILED — whether the provider accepted the send. */
+        public String deliveryStatus;
+        /** Provider rejection reason, when deliveryStatus == FAILED. */
+        public String error;
+        /** Template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT. */
+        public String headerType;
+    }
+
+    /** Create a fresh per-request template cache (institute id → its templates). */
+    public Map<String, InstituteTemplates> newCache() {
+        return new HashMap<>();
+    }
+
+    /**
+     * Rebuilds the message body for an outgoing template send. Returns {@code null} for anything
+     * that isn't a structured template send (incoming messages, free-text replies, other payload
+     * shapes), and a {@link Rendered} whose {@code body} is {@code null} when the template can't be
+     * found (caller then falls back to the stored summary body).
+     *
+     * @param fallbackInstituteId used when the log row itself has no institute stamped (legacy rows)
+     */
+    public Rendered render(NotificationLog nl, String fallbackInstituteId,
+                           Map<String, InstituteTemplates> cache) {
+        if (nl == null || nl.getNotificationType() == null
+                || !nl.getNotificationType().contains("OUTGOING")) {
+            return null;
+        }
+        String payloadJson = nl.getMessagePayload();
+        if (payloadJson == null || payloadJson.isBlank()) return null;
+
+        try {
+            Map<String, Object> payload = objectMapper.readValue(payloadJson,
+                    new TypeReference<Map<String, Object>>() {});
+            Object templateNameObj = payload.get("templateName");
+            if (templateNameObj == null) return null;
+
+            Rendered rm = new Rendered();
+            rm.templateName = templateNameObj.toString();
+            rm.provider = asString(payload.get("provider"));
+            rm.error = asString(payload.get("error"));
+            rm.deliveryStatus = rm.error != null ? "FAILED" : "SUCCESS";
+
+            Map<String, String> bodyParams = asStringMap(payload.get("bodyParams"));
+            Map<String, String> headerParams = asStringMap(payload.get("headerParams"));
+            String language = asString(payload.get("languageCode"));
+
+            String instituteId = (nl.getInstituteId() != null && !nl.getInstituteId().isBlank())
+                    ? nl.getInstituteId() : fallbackInstituteId;
+
+            NotificationTemplate tmpl = lookupTemplate(instituteId, rm.templateName, language, cache);
+            if (tmpl != null) {
+                rm.headerType = tmpl.getHeaderType();
+                rm.body = composeMessage(tmpl, bodyParams, headerParams);
+            }
+            return rm;
+        } catch (Exception e) {
+            log.debug("Failed to render template message {}: {}", nl.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    /** Convenience: rendered message text, or the stored body when it can't be rebuilt. */
+    public String displayBody(NotificationLog nl, String fallbackInstituteId,
+                              Map<String, InstituteTemplates> cache) {
+        Rendered rm = render(nl, fallbackInstituteId, cache);
+        return (rm != null && rm.body != null) ? rm.body : (nl != null ? nl.getBody() : null);
+    }
+
+    // ==================== Rendering ====================
+
+    /** Header text + substituted body + footer, joined the way it renders in WhatsApp. */
+    private String composeMessage(NotificationTemplate tmpl, Map<String, String> bodyParams,
+                                  Map<String, String> headerParams) {
+        StringBuilder sb = new StringBuilder();
+
+        String headerType = tmpl.getHeaderType();
+        if ("TEXT".equalsIgnoreCase(headerType) && isNotBlank(tmpl.getHeaderText())) {
+            String header = substitute(tmpl.getHeaderText(), null, headerParams).trim();
+            if (!header.isEmpty()) sb.append(header).append("\n\n");
+        } else if (isMediaHeader(headerType)) {
+            sb.append("[").append(headerType.substring(0, 1).toUpperCase())
+                    .append(headerType.substring(1).toLowerCase()).append("]\n\n");
+        }
+
+        String body = substitute(tmpl.getBodyText(), tmpl.getBodyVariableNames(), bodyParams);
+        if (isNotBlank(body)) sb.append(body.trim());
+
+        if (isNotBlank(tmpl.getFooterText())) {
+            sb.append("\n\n").append(tmpl.getFooterText().trim());
+        }
+
+        String out = sb.toString().trim();
+        return out.isEmpty() ? null : out;
+    }
+
+    /**
+     * Substitutes template placeholders with param values. Covers both flavours WhatsApp templates
+     * use: named ({@code {{name}}}) and positional ({@code {{1}}}). Positional mapping uses the
+     * template's ordered variable-name array — position i maps to {@code {{i+1}}}.
+     */
+    private String substitute(String text, String orderingJson, Map<String, String> params) {
+        if (text == null || params == null || params.isEmpty()) return text;
+
+        String result = text;
+        // Named-style placeholders — also covers positional templates whose params are keyed "1","2".
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            if (e.getKey() == null) continue;
+            String value = e.getValue() != null ? e.getValue() : "";
+            result = replacePlaceholder(result, e.getKey(), value);
+            result = replacePlaceholder(result, cleanName(e.getKey()), value);
+        }
+        // Positional placeholders resolved through the ordered variable names.
+        List<String> ordering = parseStringArray(orderingJson);
+        for (int i = 0; i < ordering.size(); i++) {
+            String value = lookupParam(params, ordering.get(i));
+            if (value != null) {
+                result = replacePlaceholder(result, String.valueOf(i + 1), value);
+            }
+        }
+        return result;
+    }
+
+    private String replacePlaceholder(String text, String token, String value) {
+        if (token == null || token.isEmpty()) return text;
+        Pattern p = Pattern.compile(String.format(PLACEHOLDER_FMT, Pattern.quote(token)));
+        return p.matcher(text).replaceAll(Matcher.quoteReplacement(value));
+    }
+
+    private String lookupParam(Map<String, String> params, String name) {
+        if (name == null) return null;
+        if (params.containsKey(name)) return params.get(name);
+        String clean = cleanName(name);
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            if (cleanName(e.getKey()).equals(clean)) return e.getValue();
+        }
+        return null;
+    }
+
+    /** Same normalisation the unified send path uses for named→positional resolution. */
+    private String cleanName(String name) {
+        return name == null ? "" : name.trim().toLowerCase().replaceAll("[^a-z0-9_]", "_");
+    }
+
+    private List<String> parseStringArray(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return Arrays.asList(objectMapper.readValue(json, String[].class));
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private Map<String, String> asStringMap(Object obj) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (obj instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    out.put(e.getKey().toString(), e.getValue().toString());
+                }
+            }
+        }
+        return out;
+    }
+
+    private String asString(Object obj) {
+        return obj != null ? obj.toString() : null;
+    }
+
+    private boolean isNotBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    private boolean isMediaHeader(String headerType) {
+        return "IMAGE".equalsIgnoreCase(headerType)
+                || "VIDEO".equalsIgnoreCase(headerType)
+                || "DOCUMENT".equalsIgnoreCase(headerType);
+    }
+
+    // ==================== Template lookup (cached per institute) ====================
+
+    private NotificationTemplate lookupTemplate(String instituteId, String templateName,
+                                                String language, Map<String, InstituteTemplates> cache) {
+        if (instituteId == null || instituteId.isBlank() || templateName == null) return null;
+        InstituteTemplates templates = cache.computeIfAbsent(instituteId, this::loadInstituteTemplates);
+        return templates.find(templateName, language);
+    }
+
+    /** Loads every template for an institute once, so per-message rendering is a map lookup. */
+    private InstituteTemplates loadInstituteTemplates(String instituteId) {
+        Map<String, NotificationTemplate> byName = new HashMap<>();
+        Map<String, NotificationTemplate> byNameLang = new HashMap<>();
+        try {
+            for (NotificationTemplate t : notificationTemplateRepository
+                    .findByInstituteIdOrderByUpdatedAtDesc(instituteId)) {
+                if (t.getName() == null) continue;
+                String nameLower = t.getName().toLowerCase();
+                byName.putIfAbsent(nameLower, t); // most-recently-updated wins
+                String lang = t.getLanguage() != null ? t.getLanguage().toLowerCase() : "en";
+                byNameLang.putIfAbsent(nameLower + "|" + lang, t);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load templates for institute {}: {}", instituteId, e.getMessage());
+        }
+        return new InstituteTemplates(byName, byNameLang);
+    }
+
+    /** Case-insensitive template resolver for a single institute, preferring an exact language match. */
+    public record InstituteTemplates(Map<String, NotificationTemplate> byName,
+                                     Map<String, NotificationTemplate> byNameLang) {
+        NotificationTemplate find(String name, String language) {
+            if (name == null) return null;
+            String nameLower = name.toLowerCase();
+            if (language != null && !language.isBlank()) {
+                NotificationTemplate t = byNameLang.get(nameLower + "|" + language.toLowerCase());
+                if (t != null) return t;
+            }
+            return byName.get(nameLower);
+        }
+    }
+}

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/service/CommunicationTimelineService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/service/CommunicationTimelineService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.notification_service.features.chatbot_flow.service.WhatsAppTemplateRenderer;
 import vacademy.io.notification_service.features.communication_timeline.dto.CommunicationTimelineRequest;
 import vacademy.io.notification_service.features.communication_timeline.dto.UnifiedCommunicationDTO;
 import vacademy.io.notification_service.features.notification_log.entity.NotificationLog;
@@ -25,6 +26,7 @@ public class CommunicationTimelineService {
 
     private final NotificationLogRepository notificationLogRepository;
     private final ObjectMapper objectMapper;
+    private final WhatsAppTemplateRenderer templateRenderer;
 
     private static final Map<String, String[]> TYPE_TO_CHANNEL_DIRECTION = Map.of(
             "EMAIL", new String[]{"EMAIL", "OUTBOUND"},
@@ -91,8 +93,9 @@ public class CommunicationTimelineService {
         }
 
         // Map to DTOs
+        Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache = templateRenderer.newCache();
         List<UnifiedCommunicationDTO> dtos = logs.getContent().stream()
-                .map(nl -> mapToDTO(nl, latestEmailEvents, allEmailEvents))
+                .map(nl -> mapToDTO(nl, latestEmailEvents, allEmailEvents, templateCache))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(dtos, pageable, logs.getTotalElements());
@@ -142,7 +145,8 @@ public class CommunicationTimelineService {
     private UnifiedCommunicationDTO mapToDTO(
             NotificationLog nl,
             Map<String, NotificationLog> latestEmailEvents,
-            Map<String, List<NotificationLog>> allEmailEvents) {
+            Map<String, List<NotificationLog>> allEmailEvents,
+            Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache) {
 
         String[] channelDirection = TYPE_TO_CHANNEL_DIRECTION.getOrDefault(
                 nl.getNotificationType(), new String[]{"UNKNOWN", "UNKNOWN"});
@@ -166,7 +170,7 @@ public class CommunicationTimelineService {
         } else if ("EMAIL".equals(channel)) {
             mapEmailFields(builder, nl, latestEmailEvents, allEmailEvents);
         } else if ("WHATSAPP".equals(channel)) {
-            mapWhatsAppFields(builder, nl);
+            mapWhatsAppFields(builder, nl, templateCache);
         }
 
         return builder.build();
@@ -282,7 +286,8 @@ public class CommunicationTimelineService {
 
     private void mapWhatsAppFields(
             UnifiedCommunicationDTO.UnifiedCommunicationDTOBuilder builder,
-            NotificationLog nl) {
+            NotificationLog nl,
+            Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache) {
 
         String direction = TYPE_TO_CHANNEL_DIRECTION.getOrDefault(
                 nl.getNotificationType(), new String[]{"UNKNOWN", "UNKNOWN"})[1];
@@ -330,18 +335,32 @@ public class CommunicationTimelineService {
             }
         }
 
+        // Rebuild the actual template message (real text with params substituted) from the stored
+        // send payload + template — same renderer the WhatsApp Inbox uses. Only overrides the body
+        // for structured template sends; other payload shapes keep the legacy parse above, and the
+        // send-failure surfaces as a FAILED status instead of the misleading default DELIVERED.
+        String status = "DELIVERED"; // WA messages in log are typically already delivered
+        WhatsAppTemplateRenderer.Rendered rendered =
+                templateRenderer.render(nl, nl.getInstituteId(), templateCache);
+        if (rendered != null) {
+            if (rendered.templateName != null) templateName = rendered.templateName;
+            if (rendered.body != null) messageBody = rendered.body;
+            if ("FAILED".equals(rendered.deliveryStatus)) status = "FAILED";
+        }
+
         String title = templateName != null ? templateName : truncate(body, 60);
         builder.title(title);
         builder.templateName(templateName);
         builder.bodyPreview(truncate(messageBody != null ? messageBody : body, 150));
         builder.fullBody(messageBody != null ? messageBody : body);
-        builder.status("DELIVERED"); // WA messages in log are typically already delivered
+        builder.status(status);
         builder.metadata(metadata.isEmpty() ? null : metadata);
 
         // Simple status timeline for WA
+        String outboundStatus = "FAILED".equals(status) ? "FAILED" : "SENT";
         List<UnifiedCommunicationDTO.StatusEvent> timeline = new ArrayList<>();
         timeline.add(UnifiedCommunicationDTO.StatusEvent.builder()
-                .status("INBOUND".equals(direction) ? "RECEIVED" : "SENT")
+                .status("INBOUND".equals(direction) ? "RECEIVED" : outboundStatus)
                 .timestamp(nl.getNotificationDate())
                 .details(body)
                 .build());
@@ -464,8 +483,9 @@ public class CommunicationTimelineService {
             }
         }
 
+        Map<String, WhatsAppTemplateRenderer.InstituteTemplates> templateCache = templateRenderer.newCache();
         List<UnifiedCommunicationDTO> dtos = logs.getContent().stream()
-                .map(nl -> mapToDTO(nl, latestEmailEvents, allEmailEvents))
+                .map(nl -> mapToDTO(nl, latestEmailEvents, allEmailEvents, templateCache))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(dtos, pageable, logs.getTotalElements());


### PR DESCRIPTION
…ox + student timeline

Extract the WhatsApp template-rendering (used by the WhatsApp Inbox) into a shared WhatsAppTemplateRenderer and reuse it in the per-student communication timeline, so all read paths rebuild the actual message from one source of truth. The student Notifications tab now shows the substituted text instead of the opaque 'WhatsApp Template: ... | Params' summary, and marks failed sends as FAILED instead of a blanket DELIVERED. Rendering is additive: non-template / legacy payload shapes keep the existing parse.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
