### PR TITLE
feat(whatsapp): show template header media (image/video/document) in …

### DIFF
--- a/frontend-admin-dashboard/src/routes/communication/inbox/-components/chat-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-components/chat-panel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useInboxStore } from '../-stores/inbox-store';
 import { ReplyBox } from './reply-box';
-import { ChatCircle, User, Robot, ArrowUp, ArrowLeft } from '@phosphor-icons/react';
+import { ChatCircle, User, Robot, ArrowUp, ArrowLeft, FileText } from '@phosphor-icons/react';
 
 interface Props {
     onLoadOlder: () => void;
@@ -101,8 +101,20 @@ export function ChatPanel({ onLoadOlder }: Props) {
                                 </p>
                             )}
 
+                            {/* Template header media (image / video / document) actually sent */}
+                            {msg.headerMediaUrl && (
+                                <MessageHeaderMedia
+                                    type={msg.headerType}
+                                    url={msg.headerMediaUrl}
+                                />
+                            )}
+
                             {/* Message body — the actual template text the recipient received */}
-                            <p className="whitespace-pre-wrap break-words text-gray-800">{msg.body}</p>
+                            {msg.body && (
+                                <p className="whitespace-pre-wrap break-words text-gray-800">
+                                    {msg.body}
+                                </p>
+                            )}
 
                             {/* Template context: which template it came from + any send failure */}
                             {msg.templateName && (
@@ -154,4 +166,48 @@ function formatTime(timestamp: string): string {
     } catch {
         return '';
     }
+}
+
+/** Renders the template header attachment (image/video/document) actually sent with the message. */
+function MessageHeaderMedia({ type, url }: { type?: string; url: string }) {
+    const t = (type || 'IMAGE').toUpperCase();
+
+    if (t === 'VIDEO') {
+        return (
+            <video
+                src={url}
+                controls
+                className="mb-1.5 max-h-64 w-full rounded-md bg-black/5"
+            />
+        );
+    }
+
+    if (t === 'DOCUMENT') {
+        return (
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-1.5 flex items-center gap-1.5 rounded-md bg-black/5 px-2 py-1.5 text-caption text-blue-600 hover:underline"
+            >
+                <FileText size={14} /> View document
+            </a>
+        );
+    }
+
+    // IMAGE (default) — clickable to open full size; hides itself if the URL is dead/expired.
+    return (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+            <img
+                src={url}
+                alt="attachment"
+                loading="lazy"
+                onError={(e) => {
+                    const anchor = e.currentTarget.closest('a');
+                    if (anchor) anchor.style.display = 'none';
+                }}
+                className="mb-1.5 max-h-64 w-full rounded-md bg-black/5 object-contain"
+            />
+        </a>
+    );
 }

--- a/frontend-admin-dashboard/src/routes/communication/inbox/-services/inbox-api.ts
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-services/inbox-api.ts
@@ -25,6 +25,8 @@ export interface InboxMessage {
     deliveryStatus?: 'SUCCESS' | 'FAILED';
     error?: string;
     headerType?: string;
+    /** Media URL for an IMAGE/VIDEO/DOCUMENT template header. */
+    headerMediaUrl?: string;
 }
 
 export async function getConversations(

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
@@ -18,6 +18,7 @@ import {
     ArrowDown,
     CaretDown,
     CaretUp,
+    FileText,
     type Icon as PhosphorIcon,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
@@ -252,6 +253,46 @@ function StatusPill({ statusKey }: { statusKey: string }) {
     );
 }
 
+// ─── WhatsApp header media (image / video / document) ────────────────────────
+// Renders the actual attachment sent in a template's media header.
+
+function TimelineHeaderMedia({ type, url }: { type?: string; url: string }) {
+    const t = (type || 'IMAGE').toUpperCase();
+
+    if (t === 'VIDEO') {
+        return <video src={url} controls className="mb-2 max-h-64 w-full rounded-md bg-neutral-100" />;
+    }
+
+    if (t === 'DOCUMENT') {
+        return (
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-2 inline-flex items-center gap-1.5 rounded-md bg-neutral-100 px-2 py-1.5 text-xs text-info-600 hover:underline"
+            >
+                <FileText className="size-3.5" /> View document
+            </a>
+        );
+    }
+
+    // IMAGE (default) — click to open full size; hides itself if the URL is dead/expired.
+    return (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+            <img
+                src={url}
+                alt="attachment"
+                loading="lazy"
+                onError={(e) => {
+                    const anchor = e.currentTarget.closest('a');
+                    if (anchor) anchor.style.display = 'none';
+                }}
+                className="mb-2 max-h-64 w-full rounded-md bg-neutral-100 object-contain"
+            />
+        </a>
+    );
+}
+
 // ─── Expanded Detail Body ───────────────────────────────────────────────────
 // Rendered as the `body` slot of a ProfileTimelineItem when the item is
 // expanded.  Click propagation is stopped so expanding text-selection inside
@@ -321,14 +362,22 @@ function ExpandedDetail({
                     />
                 </div>
             ) : (
-                item.fullBody && (
+                (item.fullBody || item.headerMediaUrl) && (
                     <div className="rounded-md border border-neutral-100 bg-neutral-50 p-2.5">
                         <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-neutral-500">
                             Message
                         </p>
-                        <p className="max-h-80 overflow-y-auto whitespace-pre-wrap text-xs text-neutral-700">
-                            {item.fullBody}
-                        </p>
+                        {item.headerMediaUrl && (
+                            <TimelineHeaderMedia
+                                type={item.headerType}
+                                url={item.headerMediaUrl}
+                            />
+                        )}
+                        {item.fullBody && (
+                            <p className="max-h-80 overflow-y-auto whitespace-pre-wrap text-xs text-neutral-700">
+                                {item.fullBody}
+                            </p>
+                        )}
                     </div>
                 )
             )}

--- a/frontend-admin-dashboard/src/services/communication-timeline-service.ts
+++ b/frontend-admin-dashboard/src/services/communication-timeline-service.ts
@@ -15,6 +15,10 @@ export interface CommunicationItem {
     bodyPreview: string;
     fullBody?: string;
     templateName?: string;
+    /** WhatsApp template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT. */
+    headerType?: string;
+    /** Media URL for an IMAGE/VIDEO/DOCUMENT template header. */
+    headerMediaUrl?: string;
     status: string;
     statusTimeline: StatusEvent[];
     senderInfo: string;

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/dto/InboxMessageDTO.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/dto/InboxMessageDTO.java
@@ -34,4 +34,6 @@ public class InboxMessageDTO {
     private String error;
     /** Template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT. */
     private String headerType;
+    /** Actual media URL for an IMAGE/VIDEO/DOCUMENT header, so the UI can display the attachment. */
+    private String headerMediaUrl;
 }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppInboxService.java
@@ -82,6 +82,7 @@ public class WhatsAppInboxService {
                     .deliveryStatus(rm != null ? rm.deliveryStatus : null)
                     .error(rm != null ? rm.error : null)
                     .headerType(rm != null ? rm.headerType : null)
+                    .headerMediaUrl(rm != null ? rm.headerMediaUrl : null)
                     .build();
         }).collect(Collectors.toList());
     }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppTemplateRenderer.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/service/WhatsAppTemplateRenderer.java
@@ -39,6 +39,12 @@ public class WhatsAppTemplateRenderer {
     /** Matches {{1}} / {{ name }} placeholders (token filled in per-call). */
     private static final String PLACEHOLDER_FMT = "\\{\\{\\s*%s\\s*\\}\\}";
 
+    // Used to pull a media URL out of a template's header_sample_url, which is sometimes stored as
+    // raw HTML (e.g. <a href="..."><img src="..."></a>) rather than a plain URL.
+    private static final Pattern IMG_SRC = Pattern.compile("<img[^>]*\\ssrc=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+    private static final Pattern HREF = Pattern.compile("href=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ANY_URL = Pattern.compile("https?://[^\\s\"'<>]+");
+
     /** Result of rebuilding a template message. */
     public static class Rendered {
         /** Rebuilt message text, or {@code null} when the template is no longer on file. */
@@ -51,6 +57,8 @@ public class WhatsAppTemplateRenderer {
         public String error;
         /** Template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT. */
         public String headerType;
+        /** Actual media URL for an IMAGE/VIDEO/DOCUMENT header, so the UI can display it. */
+        public String headerMediaUrl;
     }
 
     /** Create a fresh per-request template cache (institute id → its templates). */
@@ -95,8 +103,22 @@ public class WhatsAppTemplateRenderer {
                     ? nl.getInstituteId() : fallbackInstituteId;
 
             NotificationTemplate tmpl = lookupTemplate(instituteId, rm.templateName, language, cache);
+
+            // Header type: prefer the per-send payload value (WATI/Meta store it lowercase, e.g.
+            // "image"), else the template's header_type. Normalised to upper case for the UI.
+            String headerType = asString(payload.get("headerType"));
+            if ((headerType == null || headerType.isBlank()) && tmpl != null) {
+                headerType = tmpl.getHeaderType();
+            }
+            rm.headerType = (headerType != null && !headerType.isBlank()) ? headerType.toUpperCase() : null;
+
+            // Media header (image/video/document): resolve the real media URL so the UI can render
+            // the actual attachment instead of an "[Image]" placeholder.
+            if (isMediaHeader(rm.headerType)) {
+                rm.headerMediaUrl = resolveHeaderMediaUrl(bodyParams, headerParams, tmpl);
+            }
+
             if (tmpl != null) {
-                rm.headerType = tmpl.getHeaderType();
                 rm.body = composeMessage(tmpl, bodyParams, headerParams);
             }
             return rm;
@@ -120,13 +142,12 @@ public class WhatsAppTemplateRenderer {
                                   Map<String, String> headerParams) {
         StringBuilder sb = new StringBuilder();
 
+        // TEXT header becomes a bold-ish first line; media headers (IMAGE/VIDEO/DOCUMENT) are NOT
+        // inlined as text here — they're surfaced as a real media URL for the UI to render.
         String headerType = tmpl.getHeaderType();
         if ("TEXT".equalsIgnoreCase(headerType) && isNotBlank(tmpl.getHeaderText())) {
             String header = substitute(tmpl.getHeaderText(), null, headerParams).trim();
             if (!header.isEmpty()) sb.append(header).append("\n\n");
-        } else if (isMediaHeader(headerType)) {
-            sb.append("[").append(headerType.substring(0, 1).toUpperCase())
-                    .append(headerType.substring(1).toLowerCase()).append("]\n\n");
         }
 
         String body = substitute(tmpl.getBodyText(), tmpl.getBodyVariableNames(), bodyParams);
@@ -221,6 +242,65 @@ public class WhatsAppTemplateRenderer {
         return "IMAGE".equalsIgnoreCase(headerType)
                 || "VIDEO".equalsIgnoreCase(headerType)
                 || "DOCUMENT".equalsIgnoreCase(headerType);
+    }
+
+    // ==================== Media header URL resolution ====================
+
+    /**
+     * Resolves the real media URL for an image/video/document header. Prefers the per-send dynamic
+     * URL (WATI stores it as {@code bodyParams._headerUrl} / {@code headerParams.link}; Meta passes
+     * it in {@code headerParams}), then falls back to the template's static {@code header_sample_url}
+     * (which is sometimes stored as HTML). Returns {@code null} when no usable URL is found — the UI
+     * then simply shows the message text without a media attachment.
+     */
+    private String resolveHeaderMediaUrl(Map<String, String> bodyParams, Map<String, String> headerParams,
+                                         NotificationTemplate tmpl) {
+        String url = firstUrl(
+                bodyParams.get("_headerUrl"),
+                headerParams.get("link"),
+                headerParams.get("header"),
+                headerParams.get("url"),
+                headerParams.get("image"),
+                headerParams.get("video"),
+                headerParams.get("document"));
+        if (url == null) {
+            // Any header-param value that looks like a URL (covers provider-specific key names).
+            for (String v : headerParams.values()) {
+                if (isUrl(v)) { url = v.trim(); break; }
+            }
+        }
+        if (url == null && tmpl != null) {
+            url = extractUrl(tmpl.getHeaderSampleUrl());
+        }
+        return url;
+    }
+
+    private String firstUrl(String... candidates) {
+        for (String c : candidates) {
+            if (isUrl(c)) return c.trim();
+        }
+        return null;
+    }
+
+    private boolean isUrl(String s) {
+        if (s == null) return false;
+        String t = s.trim();
+        return t.startsWith("http://") || t.startsWith("https://");
+    }
+
+    /** Pulls a media URL out of a header_sample_url that may be a plain URL or raw HTML. */
+    private String extractUrl(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        String s = raw.trim();
+        if (isUrl(s) && !s.contains("<")) return s;
+        // Prefer <img src="..."> (the direct media) over <a href="..."> (a landing page).
+        Matcher img = IMG_SRC.matcher(s);
+        if (img.find()) return img.group(1);
+        Matcher href = HREF.matcher(s);
+        if (href.find()) return href.group(1);
+        Matcher any = ANY_URL.matcher(s);
+        if (any.find()) return any.group();
+        return null;
     }
 
     // ==================== Template lookup (cached per institute) ====================

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/dto/UnifiedCommunicationDTO.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/dto/UnifiedCommunicationDTO.java
@@ -48,6 +48,16 @@ public class UnifiedCommunicationDTO {
     private String templateName;
 
     /**
+     * WhatsApp template header type: NONE, TEXT, IMAGE, VIDEO, DOCUMENT
+     */
+    private String headerType;
+
+    /**
+     * Actual media URL for an IMAGE/VIDEO/DOCUMENT header, so the UI can display the attachment
+     */
+    private String headerMediaUrl;
+
+    /**
      * Current status: PENDING, SENT, DELIVERED, READ, FAILED, BOUNCED
      */
     private String status;

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/service/CommunicationTimelineService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/communication_timeline/service/CommunicationTimelineService.java
@@ -346,6 +346,9 @@ public class CommunicationTimelineService {
             if (rendered.templateName != null) templateName = rendered.templateName;
             if (rendered.body != null) messageBody = rendered.body;
             if ("FAILED".equals(rendered.deliveryStatus)) status = "FAILED";
+            // Surface the header media (image/video/document) so the UI can display the attachment.
+            builder.headerType(rendered.headerType);
+            builder.headerMediaUrl(rendered.headerMediaUrl);
         }
 
         String title = templateName != null ? templateName : truncate(body, 60);


### PR DESCRIPTION
…inbox + student timeline

Media-header templates previously rendered as a bare [Image] text marker. Resolve the actual media URL in WhatsAppTemplateRenderer (per-send bodyParams._headerUrl / headerParams, falling back to the template's header_sample_url incl. HTML-wrapped urls) and expose it as headerType + headerMediaUrl on both InboxMessageDTO and UnifiedCommunicationDTO. The WhatsApp Inbox and the student Notifications timeline now render the real image/video inline or a document link above the message text. Dead/expired image URLs hide themselves. Additive and null-safe; falls back to text-only when no media URL is resolvable.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
