### PR TITLE
SEND_WHATSAPP: resolve templateVars per item instead of passing them …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
@@ -118,8 +118,10 @@ public class WorkflowAiCatalogController {
                 "{\"templateName\":\"...\",\"on\":\"#ctx['students']\",\"forEach\":{\"operation\":\"SEND_EMAIL\",\"eval\":\"#ctx['item']\"},\"recipientField\":\"email\",\"templateVars\":{\"fullName\":\"fullName\"},\"routing\":[{\"type\":\"end\"}]}",
                 "'on' must be a List. Recipient resolved from recipientField then to/email/... Rate-limited."));
         nodes.add(node("SEND_WHATSAPP", "Like SEND_EMAIL for WhatsApp; mobile-based recipients.", true, false,
-                "{\"templateName\":\"...\",\"on\":\"#ctx['leads']\",\"forEach\":{\"operation\":\"SEND_WHATSAPP\",\"eval\":\"#ctx['item']\"},\"templateVars\":{},\"routing\":[{\"type\":\"end\"}]}",
-                "'on' must be a List. Mobile from mobileNumber/mobile/phone/to. Rate-limited."));
+                "{\"templateName\":\"...\",\"on\":\"#ctx['leads']\",\"forEach\":{\"operation\":\"SEND_WHATSAPP\",\"eval\":\"#ctx['item']\"},\"templateVars\":{\"1\":\"full_name\"},\"routing\":[{\"type\":\"end\"}]}",
+                "'on' must be a List. Mobile from mobileNumber/mobile_number/mobile/phone/to. Rate-limited. "
+                        + "templateVars values resolve per item: '#'-prefixed SpEL (both #ctx and #item bound, e.g. \"#item['full_name']\"), "
+                        + "else an item field name (preferred — e.g. \"full_name\"), else sent as a literal. Keys are the Meta template's positional placeholders (\"1\", \"2\", ...)."));
         nodes.add(node("HTTP_REQUEST", "Generic HTTP call; response namespaced under resultKey.", true, false,
                 "{\"resultKey\":\"httpResult\",\"config\":{\"requestType\":\"EXTERNAL\",\"method\":\"POST\",\"url\":\"...\",\"body\":{}},\"routing\":[{\"type\":\"end\"}]}",
                 "Response at #ctx['<resultKey>']['body']. Optional SpEL 'condition' to skip."));

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/SendWhatsAppNodeHandler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/SendWhatsAppNodeHandler.java
@@ -299,6 +299,20 @@ public class SendWhatsAppNodeHandler implements NodeHandler {
                         }
                     }
                     
+                    // Resolve dynamic templateVars values the same way SEND_EMAIL does:
+                    // '#...' → SpEL against the item context (with #item bound), plain
+                    // string that matches an item field → that field's value, else literal.
+                    // Previously values were passed through VERBATIM, so an AI-drafted
+                    // "#item['full_name']" reached Meta as literal text in the message.
+                    if (templateVars != null && !templateVars.isEmpty()) {
+                        Map<String, String> resolvedVars = new HashMap<>();
+                        for (Map.Entry<String, String> varEntry : templateVars.entrySet()) {
+                            resolvedVars.put(varEntry.getKey(),
+                                    resolveTemplateVarValue(varEntry.getValue(), messageData, itemContext));
+                        }
+                        templateVars = resolvedVars;
+                    }
+
                     // NEW: Extract COMBOT-specific fields
                     log.debug("messageData keys for template {}: {}", templateName, messageData.keySet());
                     String headerImage = (String) messageData.get("headerImage");
@@ -671,6 +685,35 @@ public class SendWhatsAppNodeHandler implements NodeHandler {
      * Used to handle both camelCase and snake_case shapes (e.g. mobileNumber vs mobile_number)
      * when the iteration item came from a bean serialized via a SnakeCase ObjectMapper.
      */
+    /**
+     * Resolve one templateVars value for the current item. Mirrors SEND_EMAIL's
+     * substitution order: SpEL (value starts with '#', evaluated with both
+     * {@code #ctx} and {@code #item} bound) → item-field lookup by name → literal.
+     * A failed SpEL evaluation resolves to "" (and logs) rather than leaking the
+     * raw expression text into the outbound message.
+     */
+    private String resolveTemplateVarValue(String value, Map<String, Object> item,
+                                           Map<String, Object> itemContext) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("#")) {
+            try {
+                Object out = spelEvaluator.evaluate(trimmed, itemContext, Map.of("item", item));
+                return out != null ? String.valueOf(out) : "";
+            } catch (Exception e) {
+                log.warn("templateVars SpEL '{}' failed to resolve: {} — sending empty value", trimmed, e.getMessage());
+                return "";
+            }
+        }
+        Object fieldValue = item.get(trimmed);
+        if (fieldValue != null) {
+            return String.valueOf(fieldValue);
+        }
+        return value;
+    }
+
     private static String firstNonBlank(Map<String, Object> messageData, String... keys) {
         for (String key : keys) {
             Object value = messageData.get(key);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/SpelEvaluator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/SpelEvaluator.java
@@ -32,6 +32,15 @@ public class SpelEvaluator {
      * @throws SpelEvaluationError if evaluation fails (for error tracking)
      */
     public Object evaluate(String expressionString, Map<String, Object> contextVars) {
+        return evaluate(expressionString, contextVars, null);
+    }
+
+    /**
+     * Evaluate with additional named SpEL variables (e.g. {@code item} so per-item
+     * expressions can use {@code #item['field']} in addition to {@code #ctx['item']}).
+     */
+    public Object evaluate(String expressionString, Map<String, Object> contextVars,
+                           Map<String, Object> extraVars) {
         if (expressionString == null || expressionString.isBlank()) {
             return null;
         }
@@ -47,6 +56,9 @@ public class SpelEvaluator {
         // in a node AFTER a multi-day delay would throw EL1008 and drop/abort the run.
         context.addPropertyAccessor(new MapAccessor());
         context.setVariable("ctx", contextVars);
+        if (extraVars != null) {
+            extraVars.forEach(context::setVariable);
+        }
 
         try {
             Expression expr = parser.parseExpression(exprStr);


### PR DESCRIPTION
…verbatim

Live-fire test of the SuchBliss trial drip showed Meta receiving the literal text "#item['full_name']" as the template parameter — SendWhatsAppNodeHandler SpEL-evaluated only 'on' and forEach.eval, never templateVars, unlike SEND_EMAIL's substitution pipeline.

Values now resolve per item in SEND_EMAIL's order: '#'-prefixed SpEL (evaluated with both #ctx and #item bound — SpelEvaluator gains an extraVars overload), else item-field lookup by name, else literal. Failed SpEL resolves to "" with a warning rather than leaking expression text into the outbound message. ai-catalog documents the resolution rules so drafts emit valid vars.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
