### PR TITLE
Guest identity recovery for paid live-class deep links + OTP on new-d…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/controller/GuestController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/controller/GuestController.java
@@ -46,6 +46,21 @@ public class GuestController {
     @Autowired
     private vacademy.io.admin_core_service.features.live_session.service.LiveSessionPaymentService liveSessionPaymentService;
 
+    /**
+     * Open schedule → session resolution. Lets a guest page that only knows the
+     * scheduleId (embed / waiting-room deep links) find the parent session so it
+     * can bounce an unidentified visitor to the public registration page — the
+     * place that recovers identity (email/phone + OTP) — instead of dead-ending
+     * on the paid-access 403. Returns only the id, no gated details.
+     */
+    @GetMapping("/session-id-by-schedule-id")
+    ResponseEntity<Map<String, String>> getSessionIdByScheduleId(
+            @RequestParam("scheduleId") String scheduleId) {
+        SessionSchedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new VacademyException("Schedule not found: " + scheduleId));
+        return ResponseEntity.ok(Map.of("sessionId", schedule.getSessionId()));
+    }
+
     @GetMapping("/get-session-by-schedule-id")
     ResponseEntity<GetSessionDetailsBySessionIdResponseDTO> getSessionByScheduleIdForGuestUser(
             @RequestParam("scheduleId") String scheduleId,

--- a/frontend-learner-dashboard-app/src/constants/urls.ts
+++ b/frontend-learner-dashboard-app/src/constants/urls.ts
@@ -157,6 +157,9 @@ export const LIVE_SESSION_GET_LIVE_AND_UPCOMING = `${BASE_URL}/admin-core-servic
 export const LIVE_SESSION_GET_PAST = `${BASE_URL}/admin-core-service/get-sessions/learner/past`;
 export const LIVE_SESSION_GET_SESSION_BY_SCHEDULE_ID = `${BASE_URL}/admin-core-service/get-sessions/by-schedule-id`;
 export const LIVE_SESSION_GET_SESSION_BY_SCHEDULE_ID_FOR_GUEST = `${BASE_URL}/admin-core-service/live-session/guest/get-session-by-schedule-id`;
+// Open schedule→session resolution, used to bounce unidentified guests from a
+// 403'd embed/waiting-room deep link back to the registration page.
+export const LIVE_SESSION_GET_SESSION_ID_BY_SCHEDULE_ID = `${BASE_URL}/admin-core-service/live-session/guest/session-id-by-schedule-id`;
 export const LIVE_SESSION_CHECK_EMAIL_REGISTRATION = `${BASE_URL}/admin-core-service/live-session/check-email-registration`;
 export const LIVE_SESSION_REGISTER_GUEST_USER = `${BASE_URL}/admin-core-service/live-session/register-guest-user`;
 // Paid live sessions: registration + fee-invoice creation in one call, and payment state lookup

--- a/frontend-learner-dashboard-app/src/routes/live-class-guest/-hooks/useGuestAccessRecovery.ts
+++ b/frontend-learner-dashboard-app/src/routes/live-class-guest/-hooks/useGuestAccessRecovery.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { type AxiosError } from "axios";
+import { guestAxiosInstance } from "@/lib/auth/axiosInstance";
+import { LIVE_SESSION_GET_SESSION_ID_BY_SCHEDULE_ID } from "@/constants/urls";
+
+/**
+ * Recovery for guest deep links opened without a local registration (new
+ * browser / cleared storage): a paid session's details fetch returns 403
+ * because no registrationId can be presented. Instead of dead-ending on an
+ * error screen, resolve the schedule's parent session and send the visitor to
+ * the public registration page — the one place that can recover their
+ * identity (email/phone, plus OTP when the session requires verification)
+ * and route them back in.
+ */
+export const useGuestAccessRecovery = (
+  scheduleId: string | null | undefined,
+  error: unknown
+) => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const status = (error as AxiosError | undefined)?.response?.status;
+    if (!scheduleId || status !== 403) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await guestAxiosInstance.get(
+          LIVE_SESSION_GET_SESSION_ID_BY_SCHEDULE_ID,
+          { params: { scheduleId } }
+        );
+        const sessionId = response.data?.sessionId;
+        if (!cancelled && sessionId) {
+          navigate({
+            to: "/register/live-class",
+            search: { sessionId },
+          });
+        }
+      } catch (resolveError) {
+        console.error(
+          "Failed to resolve session for guest access recovery:",
+          resolveError
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scheduleId, error, navigate]);
+};

--- a/frontend-learner-dashboard-app/src/routes/live-class-guest/embed/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/live-class-guest/embed/index.tsx
@@ -8,6 +8,7 @@ import { DashboardLoader } from "@/components/core/dashboard-loader";
 import { LinkType } from "@/routes/register/live-class/-types/enum";
 import YouTubePlayerWrapper from "@/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player";
 import { extractYouTubeVideoId, isYouTubeUrl } from "@/utils/youtube";
+import { useGuestAccessRecovery } from "../-hooks/useGuestAccessRecovery";
 import ZoomEmbedPlayer from "@/routes/study-library/live-class/embed/-components/ZoomEmbedPlayer";
 import ZohoEmbedPlayer from "@/routes/study-library/live-class/embed/-components/ZohoEmbedPlayer";
 import { convertSessionTimeToUserTimezone } from "@/utils/timezone";
@@ -36,6 +37,9 @@ function GuestEmbedComponent() {
     isLoading,
     error,
   } = useSessionDetails(sessionId);
+  // Paid session opened without a local registration (new browser): bounce to
+  // the registration page to recover identity instead of showing a 403 error.
+  useGuestAccessRecovery(sessionId, error);
   // If safety modal is disabled, we are "verified" by default.
   const [isSafetyVerified, setIsSafetyVerified] = useState(!ENABLE_LIVE_CLASS_SAFETY_MODAL);
 

--- a/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { useEffect, useState } from "react";
 import { useSessionDetails } from "../-hooks/useSessionDetails";
+import { useGuestAccessRecovery } from "../-hooks/useGuestAccessRecovery";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import { CountdownTimer } from "@/routes/study-library/live-class/waiting-room/-components/CountdownTimer";
 import { getPublicUrl } from "@/services/upload_file";
@@ -33,6 +34,9 @@ function GuestWaitingRoomComponent() {
     isLoading,
     error,
   } = useSessionDetails(sessionId);
+  // Paid session opened without a local registration (new browser): bounce to
+  // the registration page to recover identity instead of showing a 403 error.
+  useGuestAccessRecovery(sessionId, error);
 
   useEffect(() => {
     const fetchThumbnail = async () => {

--- a/frontend-learner-dashboard-app/src/routes/register/live-class/-components/LiveClassRegistrationPage.tsx
+++ b/frontend-learner-dashboard-app/src/routes/register/live-class/-components/LiveClassRegistrationPage.tsx
@@ -89,6 +89,13 @@ export default function LiveClassRegistrationPage() {
   // verified once this page-load are remembered so re-submits skip the OTP.
   const [otpChannels, setOtpChannels] = useState<OtpChannel[]>([]);
   const pendingSubmissionRef = useRef<RegistrationFormValues | null>(null);
+  // New-device resume parked behind OTP: someone typed an already-registered
+  // identity, but this session requires verification — prove ownership before
+  // handing over the registration (a paid one especially).
+  const pendingResumeRef = useRef<{
+    identity: GuestIdentity;
+    info: LiveSessionPaymentInfo;
+  } | null>(null);
   const verifiedIdentitiesRef = useRef<Set<string>>(new Set());
 
   const { mutateAsync: markAttendance } = useMarkAttendance();
@@ -599,10 +606,29 @@ export default function LiveClassRegistrationPage() {
     console.log("Validation errors:", errors);
   };
 
+  // Finishes a typed-identity resume: persist the registration locally and
+  // collapse the form into the registered state.
+  const completeIdentityResume = async (
+    identity: GuestIdentity,
+    info: LiveSessionPaymentInfo
+  ) => {
+    if (!data?.sessionId || !info.registration_id) return;
+    await storeRegistration(data.sessionId, identity, info.registration_id);
+    setRegistrationResponse(info.registration_id);
+    setIsUserAlreadyRegistered(true);
+    setAlreadyRegisteredEmail(identity.email || identity.mobileNumber || "");
+    toast.success("You're already registered for this session");
+    if (!info.payment_required || info.payment_status === "PAID") {
+      fetchSessionDetail(earliestScheduleId || sessionId || "");
+    }
+  };
+
   // Called when the learner types/picks an email or mobile number in the form:
   // silently look up whether that identity is already registered for this
-  // session and, if so, collapse the form into the registered state ("welcome
-  // back") instead of re-asking.
+  // session. On a match, collapse into the registered state — but when the
+  // session requires OTP verification, prove ownership of the typed identity
+  // first (this is the new-device path; without it anyone who knows a payer's
+  // email could take over their seat).
   const checkIdentityRegistration = async (identity: GuestIdentity) => {
     if (!data?.sessionId) return;
     if (!identity.email && !identity.mobileNumber) return;
@@ -614,14 +640,34 @@ export default function LiveClassRegistrationPage() {
       );
       setPaymentInfo(info);
       if (info.registration_id) {
-        await storeRegistration(data.sessionId, identity, info.registration_id);
-        setRegistrationResponse(info.registration_id);
-        setIsUserAlreadyRegistered(true);
-        setAlreadyRegisteredEmail(identity.email || identity.mobileNumber || "");
-        toast.success("You're already registered for this session");
-        if (!info.payment_required || info.payment_status === "PAID") {
-          fetchSessionDetail(earliestScheduleId || sessionId || "");
+        const channelsToVerify: OtpChannel[] = [];
+        if (
+          data?.requireEmailVerification &&
+          identity.email &&
+          !verifiedIdentitiesRef.current.has(
+            `email:${identity.email.toLowerCase()}`
+          )
+        ) {
+          channelsToVerify.push({ type: "email", value: identity.email });
         }
+        if (
+          data?.requirePhoneVerification &&
+          identity.mobileNumber &&
+          !verifiedIdentitiesRef.current.has(
+            `phone:${identity.mobileNumber.replace(/\D/g, "")}`
+          )
+        ) {
+          channelsToVerify.push({
+            type: "phone",
+            value: identity.mobileNumber,
+          });
+        }
+        if (channelsToVerify.length > 0) {
+          pendingResumeRef.current = { identity, info };
+          setOtpChannels(channelsToVerify);
+          return;
+        }
+        await completeIdentityResume(identity, info);
       } else {
         setIsUserAlreadyRegistered(false);
       }
@@ -741,13 +787,20 @@ export default function LiveClassRegistrationPage() {
             verifiedIdentitiesRef.current.add(key);
           });
           setOtpChannels([]);
-          const pending = pendingSubmissionRef.current;
+          const pendingSubmit = pendingSubmissionRef.current;
+          const pendingResume = pendingResumeRef.current;
           pendingSubmissionRef.current = null;
-          if (pending) onSubmit(pending);
+          pendingResumeRef.current = null;
+          if (pendingSubmit) {
+            onSubmit(pendingSubmit);
+          } else if (pendingResume) {
+            completeIdentityResume(pendingResume.identity, pendingResume.info);
+          }
         }}
         onClose={() => {
           setOtpChannels([]);
           pendingSubmissionRef.current = null;
+          pendingResumeRef.current = null;
         }}
       />
     </>


### PR DESCRIPTION
…evice resume

A paid learner opening the embed/waiting-room link in a fresh browser hit a dead-end 403 (no local registrationId to present). Now:

- New open endpoint /live-session/guest/session-id-by-schedule-id resolves the parent session from a scheduleId (covered by the existing /guest/** whitelist).
- Both guest pages (embed, waiting-room) detect the paid-access 403 and bounce the visitor to the registration page, which recovers identity by email/phone.
- Typed-identity resume on the registration page now requires the OTP when the session has verification enabled: pending resume is parked behind the same OtpVerificationDialog, so knowing a payers email is no longer enough to take over their seat from a new device. Same-device resume (localStorage record) stays OTP-free.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
