### PR TITLE
feat(display-settings): add sub-org / course learner-invite auto butt…

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-list-section/student-list-header.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-list-section/student-list-header.tsx
@@ -16,6 +16,12 @@ import { UserPlus, ArrowRight, Users, GraduationCap, Calendar, LinkSimple } from
 import { getDisplaySettingsFromCache } from '@/services/display-settings';
 import { getActiveRoleDisplaySettingsKey } from '@/lib/auth/instituteUtils';
 import type { StudentHeaderCustomButton } from '@/types/display-settings';
+import { useQuery } from '@tanstack/react-query';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { getInstituteId } from '@/constants/helper';
+import { GET_INVITE_LINKS, GET_DEFAULT_INVITE } from '@/constants/urls';
+import createInviteLink from '@/routes/manage-students/invite/-utils/createInviteLink';
+import { getValidSelectedSubOrgId } from '@/lib/auth/facultyAccessUtils';
 import { getTerminology, getTerminologyPlural } from '@/components/common/layout-container/sidebar/utils';
 import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
 import CreateInvite from '@/routes/manage-students/invite/-components/create-invite/CreateInvite';
@@ -222,23 +228,97 @@ export const StudentListHeader = ({
     const { isCompact } = useCompactMode();
 
     // Per-role Display Settings → "Learner Management Buttons": hide the built-in
-    // Enroll / Invite buttons and surface custom link buttons (invite link or
-    // sub-org learner registration link) in this header.
+    // Enroll / Invite buttons and surface custom link buttons (manual URL, the
+    // sub-org learner invite link, or the course learner invite link) in this header.
     const actionSettings = getDisplaySettingsFromCache(
         getActiveRoleDisplaySettingsKey()
     )?.studentManagementActions;
     const showEnrollButton = actionSettings?.showEnrollButton !== false;
     const showInviteButton = actionSettings?.showInviteButton !== false;
-    const customButtons = (actionSettings?.customButtons ?? []).filter(
-        (b) => b.url?.trim() && b.label?.trim()
-    );
+    const rawButtons = actionSettings?.customButtons ?? [];
 
-    const openCustomLink = (button: StudentHeaderCustomButton) => {
-        if (!button.url) return;
-        if (button.openInNewTab === false) {
-            window.location.href = button.url;
+    const needsSubOrgInvite = rawButtons.some((b) => b.kind === 'suborg_learner_invite');
+    const needsCourseInvite = rawButtons.some((b) => b.kind === 'course_invite');
+
+    // Sub-org context signal — same one the navbar/sidebar/Students tab use. Null
+    // for the parent institute admin, so sub-org invite buttons stay hidden there.
+    const selectedSubOrgId = getValidSelectedSubOrgId();
+    const instituteId = getInstituteId();
+    const learnerBase = instituteDetails?.learner_portal_base_url;
+
+    // The sub-org's SUBORG_LEARNER invite for the viewed course. get-enroll-invite
+    // is FSPSSM-scoped to the caller, so for a sub-org admin `tags:['SUBORG_LEARNER']`
+    // returns only THEIR sub-org's learner invite for this package session — a
+    // learner who enrolls through it lands in the sub-org admin's learner list.
+    const { data: subOrgInviteCode } = useQuery({
+        queryKey: ['suborg-learner-invite-code', packageSessionId, selectedSubOrgId, instituteId],
+        queryFn: async (): Promise<string | null> => {
+            const res = await authenticatedAxiosInstance.post(
+                `${GET_INVITE_LINKS}?instituteId=${instituteId}&pageNo=0&pageSize=20`,
+                {
+                    search_name: '',
+                    package_session_ids: [packageSessionId],
+                    payment_option_ids: [],
+                    sort_columns: {},
+                    tags: ['SUBORG_LEARNER'],
+                }
+            );
+            const row = (res.data?.content ?? [])[0] as
+                | { invite_code?: string; inviteCode?: string }
+                | undefined;
+            return row?.invite_code ?? row?.inviteCode ?? null;
+        },
+        enabled: needsSubOrgInvite && !!packageSessionId && !!selectedSubOrgId && !!instituteId,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    // The course's DEFAULT learner invite for the viewed package session.
+    const { data: courseInviteCode } = useQuery({
+        queryKey: ['course-default-invite-code', packageSessionId, instituteId],
+        queryFn: async (): Promise<string | null> => {
+            const res = await authenticatedAxiosInstance.get(
+                GET_DEFAULT_INVITE(instituteId ?? '', packageSessionId ?? '')
+            );
+            const d = (res.data ?? {}) as { invite_code?: string; inviteCode?: string };
+            return d.invite_code ?? d.inviteCode ?? null;
+        },
+        enabled: needsCourseInvite && !!packageSessionId && !!instituteId,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+    // Resolve each configured button to a concrete href; drop the ones that can't
+    // resolve in this context (missing label/URL, or an auto invite that has no
+    // sub-org / package session / matching invite here).
+    const resolveHref = (button: StudentHeaderCustomButton): string | null => {
+        const kind = button.kind ?? 'url';
+        if (kind === 'url') return button.url?.trim() || null;
+        if (kind === 'suborg_learner_invite') {
+            if (!selectedSubOrgId || !packageSessionId || !subOrgInviteCode) return null;
+            return createInviteLink(subOrgInviteCode, learnerBase);
+        }
+        if (kind === 'course_invite') {
+            if (!packageSessionId || !courseInviteCode) return null;
+            return createInviteLink(courseInviteCode, learnerBase);
+        }
+        return null;
+    };
+
+    type ResolvedButton = { id: string; label: string; href: string; openInNewTab?: boolean };
+    const resolvedButtons: ResolvedButton[] = rawButtons
+        .map((button): ResolvedButton | null => {
+            const label = button.label?.trim();
+            const href = resolveHref(button);
+            if (!label || !href) return null;
+            return { id: button.id, label, href, openInNewTab: button.openInNewTab };
+        })
+        .filter((b): b is ResolvedButton => b !== null);
+
+    const openCustomLink = (href: string, openInNewTab?: boolean) => {
+        if (openInNewTab === false) {
+            window.location.href = href;
         } else {
-            window.open(button.url, '_blank', 'noopener,noreferrer');
+            window.open(href, '_blank', 'noopener,noreferrer');
         }
     };
 
@@ -281,10 +361,10 @@ export const StudentListHeader = ({
 
             {/* Compact professional action buttons */}
             <div className="flex flex-wrap items-center gap-1.5">
-                {customButtons.map((button) => (
+                {resolvedButtons.map((button) => (
                     <MyButton
                         key={button.id}
-                        onClick={() => openCustomLink(button)}
+                        onClick={() => openCustomLink(button.href, button.openInNewTab)}
                         scale="small"
                         buttonType="secondary"
                         className={cn(

--- a/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/StudentManagementActionsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/StudentManagementActionsCard.tsx
@@ -1,17 +1,44 @@
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { MyButton } from '@/components/design-system/button';
 import { MyInput } from '@/components/design-system/input';
 import { Plus, TrashSimple } from '@phosphor-icons/react';
 import type {
     StudentManagementActionSettings,
     StudentHeaderCustomButton,
+    StudentHeaderButtonKind,
 } from '@/types/display-settings';
 
 interface StudentManagementActionsCardProps {
     settings: StudentManagementActionSettings | undefined;
     onChange: (next: StudentManagementActionSettings) => void;
 }
+
+const BUTTON_KIND_OPTIONS: {
+    value: StudentHeaderButtonKind;
+    label: string;
+    hint: string;
+}[] = [
+    { value: 'url', label: 'Custom URL', hint: 'Opens the link you enter below.' },
+    {
+        value: 'suborg_learner_invite',
+        label: 'Sub-org learner invite link',
+        hint: 'Auto-fills the sub-org learner invite for the course being viewed. Shows only for a sub-org admin on a course’s Learner tab — learners who enroll through it appear in the sub-org admin’s learner list.',
+    },
+    {
+        value: 'course_invite',
+        label: 'Course learner invite link',
+        hint: 'Auto-fills the course’s default learner invite link for the course being viewed.',
+    },
+];
 
 // Stable id for a new custom button. crypto.randomUUID where available, with a
 // timestamp fallback for older runtimes.
@@ -46,7 +73,7 @@ export const StudentManagementActionsCard = ({
         patch({
             customButtons: [
                 ...customButtons,
-                { id: genButtonId(), label: '', url: '', openInNewTab: true },
+                { id: genButtonId(), label: '', kind: 'url', url: '', openInNewTab: true },
             ],
         });
 
@@ -101,47 +128,83 @@ export const StudentManagementActionsCard = ({
                         </div>
                     ) : (
                         <div className="space-y-3">
-                            {customButtons.map((btn) => (
-                                <div
-                                    key={btn.id}
-                                    className="flex flex-col gap-2 rounded-md border border-neutral-200 p-3 sm:flex-row sm:items-end"
-                                >
-                                    <div className="flex-1">
+                            {customButtons.map((btn) => {
+                                const kind: StudentHeaderButtonKind = btn.kind ?? 'url';
+                                const kindMeta =
+                                    BUTTON_KIND_OPTIONS.find((o) => o.value === kind) ??
+                                    BUTTON_KIND_OPTIONS[0]!;
+                                return (
+                                    <div
+                                        key={btn.id}
+                                        className="flex flex-col gap-3 rounded-md border border-neutral-200 p-3"
+                                    >
+                                        <div className="flex items-end gap-2">
+                                            <div className="flex flex-1 flex-col gap-1">
+                                                <Label className="text-subtitle font-regular">
+                                                    Button type
+                                                </Label>
+                                                <Select
+                                                    value={kind}
+                                                    onValueChange={(v) =>
+                                                        updateButton(btn.id, {
+                                                            kind: v as StudentHeaderButtonKind,
+                                                        })
+                                                    }
+                                                >
+                                                    <SelectTrigger className="h-9">
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {BUTTON_KIND_OPTIONS.map((o) => (
+                                                            <SelectItem key={o.value} value={o.value}>
+                                                                {o.label}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                            <MyButton
+                                                type="button"
+                                                layoutVariant="icon"
+                                                buttonType="secondary"
+                                                scale="small"
+                                                onClick={() => removeButton(btn.id)}
+                                                className="shrink-0 text-danger-600 hover:border-danger-400"
+                                            >
+                                                <TrashSimple className="size-4" />
+                                            </MyButton>
+                                        </div>
+
                                         <MyInput
                                             label="Button label"
                                             inputType="text"
-                                            inputPlaceholder="e.g. Register learners"
+                                            inputPlaceholder="e.g. Invite learners"
                                             input={btn.label}
                                             onChangeFunction={(e) =>
                                                 updateButton(btn.id, { label: e.target.value })
                                             }
                                             className="sm:w-full"
                                         />
+
+                                        {kind === 'url' ? (
+                                            <MyInput
+                                                label="Link (URL)"
+                                                inputType="text"
+                                                inputPlaceholder="https://..."
+                                                input={btn.url ?? ''}
+                                                onChangeFunction={(e) =>
+                                                    updateButton(btn.id, { url: e.target.value })
+                                                }
+                                                className="sm:w-full"
+                                            />
+                                        ) : (
+                                            <p className="text-xs text-neutral-500">
+                                                {kindMeta.hint}
+                                            </p>
+                                        )}
                                     </div>
-                                    <div className="flex-1">
-                                        <MyInput
-                                            label="Link (URL)"
-                                            inputType="text"
-                                            inputPlaceholder="https://..."
-                                            input={btn.url}
-                                            onChangeFunction={(e) =>
-                                                updateButton(btn.id, { url: e.target.value })
-                                            }
-                                            className="sm:w-full"
-                                        />
-                                    </div>
-                                    <MyButton
-                                        type="button"
-                                        layoutVariant="icon"
-                                        buttonType="secondary"
-                                        scale="small"
-                                        onClick={() => removeButton(btn.id)}
-                                        className="shrink-0 text-danger-600 hover:border-danger-400"
-                                    >
-                                        <TrashSimple className="size-4" />
-                                    </MyButton>
-                                </div>
-                            ))}
+                                );
+                            })}
                         </div>
                     )}
                 </div>

--- a/frontend-admin-dashboard/src/types/display-settings.ts
+++ b/frontend-admin-dashboard/src/types/display-settings.ts
@@ -251,13 +251,29 @@ export interface LearnerManagementSettings {
     showApprovalToggle: boolean;
 }
 
+// What a custom header button links to.
+//  - 'url' (default): opens the manually-entered `url`.
+//  - 'suborg_learner_invite': auto-resolves the VIEWER's sub-org SUBORG_LEARNER
+//     invite link for the course being viewed. Only renders for a sub-org admin
+//     on a course Student tab (needs a selected sub-org + a package session).
+//     Learners who enrol through it appear in the sub-org admin's learner list.
+//  - 'course_invite': auto-resolves the course's DEFAULT learner invite link for
+//     the package session being viewed.
+export type StudentHeaderButtonKind = 'url' | 'suborg_learner_invite' | 'course_invite';
+
 // A custom link button rendered in the Learner Management header (the Student
 // tab on Course Details + the standalone learner lists). Lets an admin surface
-// an invite link or a sub-org learner registration link as a one-click action.
+// a manual link, the sub-org learner invite link, or the course invite link as
+// a one-click action.
 export interface StudentHeaderCustomButton {
     id: string;
     label: string;
-    url: string;
+    // Link source. Missing/undefined = 'url' (backwards-compatible with buttons
+    // saved before kinds existed).
+    kind?: StudentHeaderButtonKind;
+    // Manual URL — used only when kind is 'url'/undefined; ignored for the auto
+    // (invite-resolving) kinds.
+    url?: string;
     // Open the URL in a new browser tab. Default (undefined/true) = new tab.
     openInNewTab?: boolean;
 }


### PR DESCRIPTION
…on types

Extends the custom header buttons with a "type" selector:
- Custom URL (existing) — manual label + URL.
- Sub-org learner invite link — auto-resolves the viewing sub-org admin's SUBORG_LEARNER invite for the course being viewed (no URL to paste). Learners who enroll through it land in the sub-org admin's learner list.
- Course learner invite link — auto-resolves the course's DEFAULT invite.

Frontend-only. The auto types resolve at render time in StudentListHeader via the FSPSSM-scoped get-enroll-invite endpoint (tags:[SUBORG_LEARNER]) and the default-invite endpoint, gated on a selected sub-org + package session — so they appear only for a sub-org admin on a course's Learner tab and stay hidden for parent admins / non-course headers. No backend change, no migration.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
