### PR TITLE
fix(dashboard): keep /dashboard reachable when only the CRM section is hidden

### DIFF
--- a/frontend-admin-dashboard/src/routes/dashboard/index.tsx
+++ b/frontend-admin-dashboard/src/routes/dashboard/index.tsx
@@ -8,13 +8,20 @@ import {
 // Route definition only - component is lazy loaded from index.lazy.tsx
 // This reduces initial bundle size by deferring the Dashboard component loading
 export const Route = createFileRoute('/dashboard/')({
-    // /dashboard belongs to the CRM category. If the role hides CRM, route the
-    // user to their effective landing page so they don't see CRM widgets while
-    // the sidebar shows LMS/AI as the active section.
+    // /dashboard is the universal home page. Its widgets are per-role gated
+    // (e.g. a sub-org admin only sees their own sub-org stats), so landing here
+    // is always role-appropriate — hiding the CRM *section* must NOT make the
+    // dashboard unreachable (that's what blocked sub-org admins, whose custom
+    // role hides CRM but who still need their dashboard).
+    //
+    // Only redirect away when the Dashboard TAB itself is explicitly hidden for
+    // this role. In that case route the user to their effective landing page.
     beforeLoad: () => {
         const roleKey = getActiveRoleDisplaySettingsKey();
         const ds = getDisplaySettingsFromCache(roleKey);
         if (!ds) return;
+        const dashboardTab = ds.sidebar?.find((t) => t.id === 'dashboard');
+        if (dashboardTab?.visible !== false) return; // tab visible (or absent) → reachable
         const target = resolveEffectivePostLoginRoute('/dashboard', ds);
         if (target && target !== '/dashboard') {
             throw redirect({ to: target, replace: true });


### PR DESCRIPTION
## Problem
Sub-org admins couldn't open **/dashboard** — navigating there redirected them away.

The `/dashboard` route guard ([routes/dashboard/index.tsx](../blob/main/frontend-admin-dashboard/src/routes/dashboard/index.tsx)) redirected whenever the role's **CRM category** was hidden, because the Dashboard tab lives in the `CRM` category. A sub-org admin resolves to a **custom role** that hides CRM, so the guard always kicked them out — even though the dashboard is the universal home page and its widgets are already **per-role gated** (a sub-org admin only sees their own `subOrgSelfStats`).

The earlier fix (`5a37fb791`) only helped if `/dashboard` was manually re-added as a custom tab in a visible category, which is fragile.

## Fix
Gate the redirect on the **Dashboard tab's own visibility** instead of the CRM category:
- Only redirect when the Dashboard tab is *explicitly* hidden for the role.
- Hiding the CRM *section* no longer makes the home dashboard unreachable.

```
const dashboardTab = ds.sidebar?.find((t) => t.id === 'dashboard');
if (dashboardTab?.visible !== false) return; // tab visible (or absent) → reachable
```

## Behavior matrix (no regressions)
| Role config | Before | After |
|---|---|---|
| CRM visible | reachable | reachable (unchanged) |
| CRM hidden, Dashboard tab visible | **redirected** | **reachable** ✅ (the fix) |
| Dashboard tab explicitly hidden | redirected | redirected (unchanged) |

`resolveEffectivePostLoginRoute` (post-login landing for every flow) is **untouched** — this only affects direct navigation to `/dashboard`.

## Verification
- `tsc --noEmit`: 0 errors in the changed file (pre-existing `@lexical/*` / `evaluator-ai` baseline untouched).
- `design-lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)