### PR TITLE
feat(lexical-editor): delete affordance for custom blocks

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/BlockChrome.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/BlockChrome.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useLexicalNodeSelection } from '@lexical/react/useLexicalNodeSelection';
+import { mergeRegister } from '@lexical/utils';
+import {
+    $getNodeByKey,
+    $getSelection,
+    $isRangeSelection,
+    CLICK_COMMAND,
+    COMMAND_PRIORITY_LOW,
+    KEY_BACKSPACE_COMMAND,
+    KEY_DELETE_COMMAND,
+    type NodeKey,
+} from 'lexical';
+import { TrashSimple } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+
+/** Elements inside a block's own editing UI that must keep receiving clicks
+ *  normally (buttons, inputs, links, contentEditable rich-text fields, …) —
+ *  a click landing on any of these must NOT select or delete the block. */
+const INTERACTIVE_SELECTOR =
+    'button, input, textarea, select, a, [contenteditable="true"], [role="option"], [role="tab"]';
+
+/**
+ * Shared delete/selection chrome wrapped around every custom document block
+ * (flashcard, quiz, image, math, …) by the block-node factory. Gives every
+ * block the same two ways to remove it:
+ *  - an always-discoverable hover delete button (top-right corner) — the
+ *    primary, mouse-only affordance, works regardless of selection state.
+ *  - click-to-select (on the chrome border, never on interactive children)
+ *    + Backspace/Delete, matching how native paragraphs/images behave in
+ *    other editors.
+ * Selecting elsewhere in the document (text, another block) clears the
+ * selection automatically via useLexicalNodeSelection.
+ */
+export function BlockChrome({
+    nodeKey,
+    readOnly,
+    children,
+}: {
+    nodeKey: NodeKey;
+    readOnly: boolean;
+    children: React.ReactNode;
+}) {
+    const [editor] = useLexicalComposerContext();
+    const [isSelected, setSelected, clearSelected] = useLexicalNodeSelection(nodeKey);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    const deleteNode = useCallback(() => {
+        editor.update(() => {
+            $getNodeByKey(nodeKey)?.remove();
+        });
+    }, [editor, nodeKey]);
+
+    useEffect(() => {
+        if (readOnly) return undefined;
+        return mergeRegister(
+            editor.registerCommand<MouseEvent>(
+                CLICK_COMMAND,
+                (event) => {
+                    const target = event.target as HTMLElement;
+                    if (!wrapperRef.current?.contains(target)) return false;
+                    // Never hijack clicks meant for the block's own controls.
+                    if (target.closest(INTERACTIVE_SELECTOR)) return false;
+                    event.preventDefault();
+                    setSelected(true);
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                KEY_DELETE_COMMAND,
+                () => {
+                    if (!isSelected) return false;
+                    deleteNode();
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                KEY_BACKSPACE_COMMAND,
+                () => {
+                    if (isSelected) {
+                        deleteNode();
+                        return true;
+                    }
+                    // Backspace with the caret collapsed at the very start of the
+                    // block immediately following this one — select the block
+                    // instead of doing nothing, so a second Backspace (or the
+                    // delete button) removes it. Mirrors how decorator-adjacent
+                    // deletion behaves in other block editors (Notion, etc.).
+                    const selection = $getSelection();
+                    if (
+                        !$isRangeSelection(selection) ||
+                        !selection.isCollapsed() ||
+                        selection.anchor.offset !== 0
+                    ) {
+                        return false;
+                    }
+                    const node = $getNodeByKey(nodeKey);
+                    if (!node) return false;
+                    const topLevel = selection.anchor.getNode().getTopLevelElementOrThrow();
+                    if (!topLevel.getPreviousSibling()?.is(node)) return false;
+                    setSelected(true);
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor, isSelected, setSelected, deleteNode, readOnly, nodeKey]);
+
+    // Clicking anywhere outside this block's chrome (but still inside the
+    // editor) is handled by useLexicalNodeSelection's own selection-change
+    // subscription — isSelected flips to false automatically, no extra code
+    // needed here. clearSelected is exposed for completeness / future use.
+    void clearSelected;
+
+    if (readOnly) return <>{children}</>;
+
+    return (
+        <div
+            ref={wrapperRef}
+            className={cn(
+                'group relative rounded-md',
+                isSelected && 'outline outline-2 outline-offset-2 outline-primary-400'
+            )}
+        >
+            <div className="pointer-events-none absolute -top-3 right-1 z-10 opacity-0 transition-opacity group-hover:opacity-100">
+                <button
+                    type="button"
+                    aria-label="Delete block"
+                    className="pointer-events-auto rounded-md border border-neutral-200 bg-white p-1 text-neutral-500 shadow-sm hover:border-danger-300 hover:text-danger-600"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        deleteNode();
+                    }}
+                >
+                    <TrashSimple size={14} />
+                </button>
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/block-node-factory.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/block-node-factory.tsx
@@ -12,6 +12,7 @@ import {
     type Spread,
 } from 'lexical';
 import type { JSX } from 'react';
+import { BlockChrome } from './BlockChrome';
 
 /**
  * Factory for custom document blocks (flashcard, quiz, tabs, math, …).
@@ -148,6 +149,7 @@ export function createBlockNode<T>(config: BlockNodeConfig<T>): BlockNodeClass<T
         decorate(editor: LexicalEditor): JSX.Element {
             const nodeKey = this.getKey();
             const payload = this.getPayload();
+            const readOnly = !editor.isEditable();
             const setPayload = (next: T) => {
                 editor.update(() => {
                     const self = $getNodeByKey(nodeKey);
@@ -155,12 +157,14 @@ export function createBlockNode<T>(config: BlockNodeConfig<T>): BlockNodeClass<T
                 });
             };
             return (
-                <Component
-                    payload={payload}
-                    setPayload={setPayload}
-                    readOnly={!editor.isEditable()}
-                    nodeKey={nodeKey}
-                />
+                <BlockChrome nodeKey={nodeKey} readOnly={readOnly}>
+                    <Component
+                        payload={payload}
+                        setPayload={setPayload}
+                        readOnly={readOnly}
+                        nodeKey={nodeKey}
+                    />
+                </BlockChrome>
             );
         }
     }


### PR DESCRIPTION
## Summary
- Every custom document block (flashcard, quiz, tabs, timeline, columns, accordion, code, image, video, file, embed, callout, math, mermaid, audio, PDF, fill-blanks, Jupyter, Scratch, TOC) previously had no way to remove it once inserted.
- Adds a shared `BlockChrome` wrapper (used by the block-node factory, so it applies to all block types in one place) providing:
  - An always-visible-on-hover delete button (top-right corner of the block).
  - Click-to-select (never intercepting clicks on a block's own buttons/inputs/rich-text fields) + Backspace/Delete to remove the selected block.
  - Backspace at the start of the paragraph right after a block selects it first (so a second Backspace or the delete button removes it), matching common block-editor behavior.
- Read-only (learner) view is unaffected — no chrome renders there.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (full repo, max-warnings=0)
- [x] `node ../scripts/design-lint.mjs` on changed files (0 errors)
- [x] `pnpm run build`
- [ ] Manual: insert each block type in a document, hover to see the delete button, delete via button and via click+Backspace, confirm learner view renders unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)