### PR TITLE
feat(lexical-editor): drag-to-reorder blocks (Notion-style)

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/LexicalDocumentEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/LexicalDocumentEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
@@ -19,6 +19,7 @@ import { AutosaveBridgePlugin } from './plugins/AutosaveBridgePlugin';
 import { SlashMenuPlugin } from './plugins/SlashMenuPlugin';
 import { buildCustomBlockOptions } from './plugins/custom-block-options';
 import { FloatingToolbarPlugin } from './plugins/FloatingToolbarPlugin';
+import { DragHandlePlugin } from './plugins/DragHandlePlugin';
 import './lexical-editor.css';
 
 export interface LexicalDocumentEditorProps {
@@ -104,13 +105,26 @@ export default function LexicalDocumentEditor({
         onError: onEditorError,
     }));
 
+    // The drag-handle plugin portals its grip + drop line into this anchor and
+    // positions them relative to it; hover detection runs on the anchor's
+    // parent (.lexical-doc-editor). Captured post-mount so the plugin only
+    // mounts once the wrapper DOM exists.
+    const [anchorElem, setAnchorElem] = useState<HTMLDivElement | null>(null);
+    const onAnchorRef = useCallback((el: HTMLDivElement | null) => {
+        if (el) setAnchorElem(el);
+    }, []);
+
     return (
         <div className="lexical-doc-editor" data-slide-id={slideId}>
             <LexicalComposer initialConfig={initialConfig}>
                 <RichTextPlugin
-                    contentEditable={<ContentEditable className="lexical-content-editable" />}
+                    contentEditable={
+                        <div className="lexical-editor-anchor" ref={onAnchorRef}>
+                            <ContentEditable className="lexical-content-editable" />
+                        </div>
+                    }
                     placeholder={
-                        <div className="pointer-events-none absolute left-0 top-1 text-lg text-gray-400">
+                        <div className="pointer-events-none absolute left-7 top-1 text-lg text-gray-400">
                             Click to start writing here...
                         </div>
                     }
@@ -126,6 +140,7 @@ export default function LexicalDocumentEditor({
                 <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
                 {!readOnly && <SlashMenuPlugin extraOptions={buildCustomBlockOptions()} />}
                 {!readOnly && <FloatingToolbarPlugin />}
+                {!readOnly && anchorElem && <DragHandlePlugin anchorElem={anchorElem} />}
                 <EditablePlugin readOnly={readOnly} />
                 <EditorLifecyclePlugin
                     initialHtml={initialHtml}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/lexical-editor.css
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/lexical-editor.css
@@ -6,10 +6,58 @@
     width: 100%;
 }
 
+/* Positioned wrapper the drag-handle plugin portals its grip + drop line into
+   and measures block offsets against. Must stay position:relative. */
+.lexical-doc-editor .lexical-editor-anchor {
+    position: relative;
+    width: 100%;
+}
+
 .lexical-doc-editor .lexical-content-editable {
     min-height: 200px;
     outline: none;
-    padding: 4px 0 120px;
+    /* left padding = drag-handle gutter (matches the plugin's 28px text-box
+       padding assumption so the grip sits left of the text, not over it). */
+    padding: 4px 0 120px 28px;
+}
+
+/* ---- Drag-to-reorder (DragHandlePlugin) ---- */
+/* The plugin toggles display/opacity and sets transform inline; these rules
+   provide the resting appearance. */
+.lexical-doc-editor .lex-drag-handle-floating {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 24px;
+    padding: 0;
+    opacity: 0;
+    color: #9ca3af;
+    border-radius: 4px;
+    cursor: grab;
+    will-change: transform;
+    transition: background-color 0.12s ease, color 0.12s ease;
+}
+.lexical-doc-editor .lex-drag-handle-floating:hover {
+    background-color: #f3f4f6;
+    color: #4b5563;
+}
+.lexical-doc-editor .lex-drag-handle-floating:active {
+    cursor: grabbing;
+}
+.lexical-doc-editor .lex-drag-target-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 4px;
+    background-color: hsl(var(--primary-500));
+    border-radius: 2px;
+    opacity: 0;
+    pointer-events: none;
+    will-change: transform;
 }
 
 /* Check-list items (CheckListPlugin toggles via the theme classes) */

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/plugins/DragHandlePlugin.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/plugins/DragHandlePlugin.tsx
@@ -1,0 +1,49 @@
+import { useRef } from 'react';
+import { DraggableBlockPlugin_EXPERIMENTAL } from '@lexical/react/LexicalDraggableBlockPlugin';
+import { DotsSixVertical } from '@phosphor-icons/react';
+
+/** Class the plugin's `isOnMenu` predicate keys on to recognise handle
+ *  interactions (so a mousedown on the grip starts a drag rather than a
+ *  caret placement / block select). */
+const DRAG_HANDLE_CLASS = 'lex-drag-handle';
+
+function isOnHandle(element: HTMLElement): boolean {
+    return !!element.closest(`.${DRAG_HANDLE_CLASS}`);
+}
+
+/**
+ * Notion-style reordering of top-level blocks. On hover, a grip handle appears
+ * in the left gutter of the block under the cursor; dragging it shows a drop
+ * line and moves the whole block (paragraph, heading, list, table, or any
+ * custom block) to the new position. Reordering mutates the editor state, so
+ * autosave + serialization pick it up with no extra wiring.
+ *
+ * The handle and drop line are portaled into `anchorElem` (the positioned
+ * wrapper around the ContentEditable); hover detection runs on the anchor's
+ * parent (`.lexical-doc-editor`). Only mounted for the editable (admin) view.
+ */
+export function DragHandlePlugin({ anchorElem }: { anchorElem: HTMLElement }) {
+    const menuRef = useRef<HTMLDivElement>(null);
+    const targetLineRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <DraggableBlockPlugin_EXPERIMENTAL
+            anchorElem={anchorElem}
+            menuRef={menuRef}
+            targetLineRef={targetLineRef}
+            menuComponent={
+                <div
+                    ref={menuRef}
+                    className={`${DRAG_HANDLE_CLASS} lex-drag-handle-floating`}
+                    role="button"
+                    aria-label="Drag to reorder block"
+                    title="Drag to reorder"
+                >
+                    <DotsSixVertical size={16} weight="bold" />
+                </div>
+            }
+            targetLineComponent={<div ref={targetLineRef} className="lex-drag-target-line" />}
+            isOnMenu={isOnHandle}
+        />
+    );
+}


### PR DESCRIPTION
## Summary
Adds Notion-style drag-to-reorder for the new Lexical document editor. On hover, a grip handle (`⠿`) appears in the left gutter of the block under the cursor; dragging it shows a drop line and moves the whole block — paragraph, heading, list, table, or **any** custom block (flashcard, quiz, tabs, image, …) — to a new position.

## How it works
- Built on Lexical's own `DraggableBlockPlugin_EXPERIMENTAL` (`@lexical/react`), the same primitive the Lexical playground uses.
- The grip + drop line are portaled into a positioned `.lexical-editor-anchor` wrapping the `ContentEditable`; hover detection runs on the anchor's parent (`.lexical-doc-editor`).
- The content editable gets a 28px left gutter (matching the plugin's text-box padding assumption) so the handle sits left of the text, not over it. Placeholder shifted to match.
- Reordering mutates the editor state → existing autosave + serialization pick it up with **no extra persistence wiring**.
- Editable (admin) view only — never mounted in the read-only learner-preview.

## Scope / limitations
- Reorders **top-level blocks** in the main document flow (what people mostly want from Notion-style DnD). Dragging a block *into* a nested container (table cell, tab, column) is out of scope for this pass.
- Sits symmetrically with the existing block chrome: drag grip on the left gutter, delete button on the right.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (full repo, max-warnings=0)
- [x] `node ../scripts/design-lint.mjs` on changed files (clean)
- [x] `pnpm run build`
- [ ] Manual (needs a Lexical doc, which creates a slide → prod write, so deferred to reviewer): hover a block to see the grip, drag it up/down, confirm the drop line + reorder, confirm reorder persists after Save Draft + reload, and that custom blocks reorder too

🤖 Generated with [Claude Code](https://claude.com/claude-code)