### PR TITLE
Revert "AI drafter: stop bouncing provided values back as clarifying …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowAiDraftService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowAiDraftService.java
@@ -171,19 +171,6 @@ public class WorkflowAiDraftService {
             // If the drafter needs entity resolution, return the questions immediately.
             List<Map<String, Object>> questions = toListOfMaps(root.get("clarifyingQuestions"));
             JsonNode wfNode = root.get("workflow");
-            // Over-asking guard: a burst of questions means the model is bouncing back values the
-            // admin already provided (e.g. per-day template vars) instead of using them. Push it
-            // to self-serve rather than surfacing dozens of free-text boxes.
-            if (questions.size() > 4 && attempt < MAX_ATTEMPTS) {
-                history.add(ConversationSession.ChatMessage.assistant(raw));
-                history.add(ConversationSession.ChatMessage.user(
-                        "You asked " + questions.size() + " clarifying questions. Every value already stated in "
-                                + "the goal (template variable values, times, links, template names, message copy) must be "
-                                + "filled into the workflow config directly — do NOT ask the admin to re-enter it. Re-emit "
-                                + "the full JSON contract with the workflow populated and AT MOST 2 questions, only for "
-                                + "genuinely missing entity ids."));
-                continue;
-            }
             if (!questions.isEmpty() && (wfNode == null || wfNode.isNull())) {
                 return WorkflowAiDraftResponse.builder()
                         .clarifyingQuestions(questions)
@@ -607,12 +594,6 @@ public class WorkflowAiDraftService {
             ENTITY IDS: never invent an audienceId, batchId, inviteId, or templateName. If the goal \
             needs one you were not given (see the user's provided answers), return it as a \
             clarifyingQuestions entry instead and leave workflow null.
-
-            NEVER ask about information already present in the goal. If the admin supplied concrete \
-            values — template variable values (even per-day lists), times, links, message copy, \
-            template names — bake them into the node configs VERBATIM instead of asking the admin \
-            to re-enter them. Clarifying questions are only for genuinely missing entity ids, and \
-            at most 2 total.
 
             OUTPUT: reply with ONLY a JSON object (no markdown, no prose) of this exact shape:
             {


### PR DESCRIPTION
…questions"

This reverts commit f6afefd50. The variable-mapping clarifying questions are intentional product behavior — admins should confirm template variable mappings by default. Auto-filling from the goal remains available on demand: include an explicit instruction in the goal text (e.g. "do not ask me to map the template variables — fill them yourself") and the drafter obeys it.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
