### PR TITLE
fix(reports): project engaged_ms in activity CTEs so learner-report queries resolve

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
@@ -442,7 +442,7 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
 
     @Query(value = """
                 WITH filtered_activity_log AS (
-                    SELECT DISTINCT al.id, al.user_id, al.start_time, al.end_time
+                    SELECT DISTINCT al.id, al.user_id, al.start_time, al.end_time, al.engaged_ms
                     FROM activity_log al
                     JOIN slide s ON s.id = al.slide_id
                     JOIN chapter_to_slides cs ON cs.slide_id = s.id
@@ -1307,6 +1307,7 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
                     al.slide_id,
                     al.start_time,
                     al.end_time,
+                    al.engaged_ms,
                     al.user_id
                 FROM activity_log al
                 JOIN Slides s ON al.slide_id = s.slide_id
@@ -1634,6 +1635,7 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
                     al.slide_id,
                     al.start_time,
                     al.end_time,
+                    al.engaged_ms,
                     al.user_id
                 FROM activity_log al
                 JOIN Slides s ON al.slide_id = s.slide_id

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/module/service/LearnerModuleDetailsService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/module/service/LearnerModuleDetailsService.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.module.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.learner_operation.enums.LearnerOperationEnum;
 import vacademy.io.admin_core_service.features.learner_study_library.dto.LearnerModuleDTOWithDetails;
 import vacademy.io.admin_core_service.features.module.enums.ModuleStatusEnum;
@@ -22,10 +23,13 @@ public class LearnerModuleDetailsService {
     @org.springframework.transaction.annotation.Transactional(readOnly = true)
     public List<LearnerModuleDTOWithDetails> getModulesDetailsWithChapters(String subjectId, String packageSessionId,
             String userId, CustomUserDetails user) {
+        // Admins view a learner's progress, so the requested userId wins; fall back to the
+        // caller only when it is omitted (learner fetching their own progress).
+        String progressUserId = StringUtils.hasText(userId) ? userId : user.getUserId();
         String rawResponse = moduleChapterMappingRepository.getModuleChapterProgress(
                 subjectId,
                 packageSessionId,
-                user.getUserId(),
+                progressUserId,
                 LearnerOperationEnum.PERCENTAGE_MODULE_COMPLETED.name(),
                 LearnerOperationEnum.PERCENTAGE_CHAPTER_COMPLETED.name(),
                 List.of(SlideStatus.PUBLISHED.name(), SlideStatus.UNSYNC.name()),


### PR DESCRIPTION
## Summary of Changes

`POST /admin-core-service/learner-management/learner-report` was returning a 500 (`column al.engaged_ms does not exist`). The column exists on `activity_log` (V360) — the bug is CTE scoping: PR #2124 swapped the time expressions from `end_time - start_time` to `engaged_ms`, but three CTEs still projected only `id, slide_id, start_time, end_time, user_id`, so the downstream reference had nothing to resolve against.

Since these are `nativeQuery = true` strings, Hibernate never parses them at startup — there is no compile-time or schema check, so the failure only surfaces when the endpoint is actually called.

**Backend:**
- `filtered_activity_log` CTE now projects `al.engaged_ms` — fixes `findAverageTimeSpentByBatch` (the reported 500)
- Both `ActivityLogs` CTEs now project `al.engaged_ms` — fixes `getChapterSlideProgressForLearner` and `getChapterSlideProgress`, broken the same way and not yet reported
- No expression, filter, or grouping logic changed — only the CTE select lists

**Frontend:**
- None

## Related Issue

Regression from #2124 (`fix/leaderboard-engaged-time-v2`, merged 2026-07-06)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Extracted every native query in `ActivityLogRepository` and ran `EXPLAIN` against a local Postgres restored from a prod dump: all three previously-failing queries now plan successfully, with every column reference resolved
- Confirmed `activity_log.id` is the primary key, so adding `engaged_ms` to `SELECT DISTINCT` cannot change the row count — the dedup that guards against join fan-out behaves identically and the sums are unchanged
- Verified the reported query's only CTE consumer is `activity_duration`; nothing else reads these column lists
- Confirmed the fix preserves #2124's intent: the queries still compute real engaged time, not wall-clock

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly


---

## Additional fix: admin-side learner progress always showed 0%

Found while investigating the 500 above — a second, independent bug that surfaces on the same screen, which is why the two were being conflated.

In Manage Students → learner sidebar → **Progress**, every learner rendered as `0% Complete` with every unit chipped `Behind`, regardless of actual progress.

That panel is fed by `GET /admin-core-service/subject/learner/v1/subjects?userId=…&packageSessionId=…`, and the hero percentage is just an average of `chapter.percentage_completed` (`calculateLearningPercentage.ts`). The frontend sends the correct learner id; the backend discarded it:

```java
public List<LearnerModuleDTOWithDetails> getModulesDetailsWithChapters(String subjectId, String packageSessionId,
        String userId, CustomUserDetails user) {          // userId = the learner being viewed
    String rawResponse = moduleChapterMappingRepository.getModuleChapterProgress(
            subjectId,
            packageSessionId,
            user.getUserId(),                              // ...but the caller's id was passed
```

The `userId` parameter was declared and never used. `user` is the JWT-derived caller, i.e. the admin — and that id is what `getModuleChapterProgress` joins `learner_operation` on, for both module and chapter percentages. Admins have no `PERCENTAGE_CHAPTER_COMPLETED` rows, so every chapter came back `0`.

This is why it never showed up on the learner dashboard: `LearnerStudyLibraryService` takes no `userId` at all, so `user.getUserId()` *is* the learner there and is correct. The admin path is the only caller that needs the override, and it was the broken one. Long-standing — not a regression from #2124.

**Backend:**
- `LearnerModuleDetailsService.getModulesDetailsWithChapters` now passes the requested `userId` through to the progress query
- Falls back to `user.getUserId()` when `userId` is blank, rather than swapping outright: the controller's `userId` param is unannotated, so Spring resolves it as `@RequestParam(required = false)` and it can arrive null. Blank → previous self-only behaviour; present → the learner being viewed

**Frontend:**
- None

### Testing (both fixes, end-to-end)

Ran `admin_core_service` + `auth_service` locally against a Docker Postgres restored from a **fresh prod dump** taken for this test (316 tables, 279,357 `learner_operation` rows — exact row-count match with prod).

- **Progress endpoint, live over HTTP (200):** for a real learner with 42 chapters of recorded progress, the sidebar hero now computes **73% Complete** — the same account renders `0%` on the deployed build. Per-module: `88.33 / 87.42 / 76.85 / 58.01 / 47.16 / 66.11`. Re-running the same query with any other caller id still returns all zeros, reproducing the pre-fix behaviour.
- **`learner-report`, live over HTTP:** now **200** where it was 500. `batch_progress_report.avg_time_spent_in_minutes = 6.979370945945946`, matching to the digit the value the fixed CTE returns when run directly in psql.
- **Pre-fix vs post-fix SQL side by side:** the original CTE still fails with `ERROR: column al.engaged_ms does not exist`; the fixed one returns a value.

### Note for a follow-up (not addressed here)

Two things surfaced that are out of scope for this PR:

1. **No authorization check** on `/subject/learner/v1/subjects` — now that `userId` is honoured, any authenticated caller can pass an arbitrary learner id and read that person's course progress. It was effectively self-only before, so this fix widens the surface. Worth an institute/role guard.
2. **`engaged_ms` is sparsely populated in prod** — only 10,347 of 75,332 `activity_log` rows have it set, so `backfill_engaged_ms.sql` appears never to have run against prod. Time-spent metrics will under-report for older rows until it does. `COALESCE(…, 0)` means this degrades quietly rather than erroring.
