### PR TITLE
Fix duplicate whatsappOtpTemplateName field in LiveSessionStep2Reques…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep2RequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep2RequestDTO.java
@@ -88,12 +88,6 @@ public class LiveSessionStep2RequestDTO {
     private Boolean requirePhoneVerification;
 
     /**
-     * WhatsApp template for the phone-verification OTP. Null = don't touch;
-     * empty string = clear (fall back to the institute default template).
-     */
-    private String whatsappOtpTemplateName;
-
-    /**
      * WhatsApp template for the phone-verification OTP. Null = don't touch
      * (older clients); empty string clears back to the institute default.
      */


### PR DESCRIPTION
…tDTO

Two parallel commits added the same field; the duplicate is an enter-phase javac error that aborts Lombok annotation processing for the whole module, cascading into ~100 cannot-find-symbol builder()/getter/log errors in CI. Local builds passed because the duplicate only existed in the merged state.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
