### PR TITLE
Fix/learner course progress rollup

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/ActivityLogService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/ActivityLogService.java
@@ -12,7 +12,7 @@ import vacademy.io.admin_core_service.features.learner_tracking.dto.LearnerActiv
 import vacademy.io.admin_core_service.features.learner_tracking.entity.ActivityLog;
 import vacademy.io.admin_core_service.features.learner_tracking.repository.ActivityLogRepository;
 import vacademy.io.common.auth.model.CustomUserDetails;
-import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -41,7 +41,8 @@ public class ActivityLogService {
 
     public ActivityLog updateActivityLog(ActivityLogDTO activityLogDTO) {
         ActivityLog activityLog = activityLogRepository.findById(activityLogDTO.getId())
-                .orElseThrow(() -> new VacademyException("Activity Log not found"));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Activity log " + activityLogDTO.getId() + " not found"));
         updateActivityFields(activityLog, activityLogDTO);
         return activityLogRepository.save(activityLog);
     }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/AssignmentSlideActivityLogService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/AssignmentSlideActivityLogService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.learner_tracking.dto.ActivityLogDTO;
 import vacademy.io.admin_core_service.features.learner_tracking.dto.AssignmentSlideActivityLogDTO;
@@ -21,7 +20,8 @@ import vacademy.io.admin_core_service.features.slide.entity.Slide;
 import vacademy.io.admin_core_service.features.slide.repository.AssignmentSlideRepository;
 import vacademy.io.admin_core_service.features.slide.repository.SlideRepository;
 import vacademy.io.common.auth.model.CustomUserDetails;
-import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.common.exceptions.ForbiddenException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -75,14 +75,12 @@ public class AssignmentSlideActivityLogService {
         // referenced via slide.sourceId. (Don't trust DTO.source_id — client
         // could spoof to point at a different, still-open assignment.)
         Slide parentSlide = slideRepository.findById(slideId)
-                .orElseThrow(() -> new VacademyException(HttpStatus.NOT_FOUND,
-                        "Slide not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Slide " + slideId + " not found"));
         AssignmentSlide slide = assignmentSlideRepository.findById(parentSlide.getSourceId())
-                .orElseThrow(() -> new VacademyException(HttpStatus.NOT_FOUND,
-                        "Assignment slide not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Assignment slide not found for slide " + slideId));
         Instant now = Instant.now();
         if (slide.getLiveDate() != null && now.isBefore(slide.getLiveDate())) {
-            throw new VacademyException(HttpStatus.FORBIDDEN,
+            throw new ForbiddenException(
                     "Assignment opens on " + HUMAN_DATE_TIME.format(slide.getLiveDate()));
         }
         boolean late = slide.getEndDate() != null && now.isAfter(slide.getEndDate());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.chapter.enums.ChapterStatus;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.institute_learner.enums.LearnerSessionStatusEnum;
@@ -456,8 +457,26 @@ public class LearnerTrackingAsyncService {
 
         // ==== Chapter-Level Tracking ====
 
+        // Every id here arrives from the client request. A missing one used to
+        // mean the corresponding rollup quietly computed null and was dropped,
+        // so the learner's slide went to 100% while the chapter (and everything
+        // above it) kept its old value — indistinguishable, in the data, from
+        // "nothing has happened yet". The assignment submit path sent none of
+        // them at all. Log what's missing so a stuck percentage is diagnosable
+        // from the service logs instead of a database forensics session.
         public void updateLearnerOperationsForChapter(String userId, String chapterId, String moduleId,
                         String subjectId, String packageSessionId) {
+                if (!StringUtils.hasText(chapterId) || !StringUtils.hasText(moduleId)
+                                || !StringUtils.hasText(subjectId) || !StringUtils.hasText(packageSessionId)) {
+                        log.warn("Progress rollup for user {} is missing ids (chapterId={}, moduleId={}, "
+                                        + "subjectId={}, packageSessionId={}). Levels without an id keep their "
+                                        + "previous percentage.",
+                                        userId, chapterId, moduleId, subjectId, packageSessionId);
+                }
+                if (!StringUtils.hasText(chapterId)) {
+                        return;
+                }
+
                 learnerOperationService.deleteLearnerOperationByUserIdSourceAndSourceIdAndOperation(userId,
                                 LearnerOperationSourceEnum.CHAPTER.name(), chapterId,
                                 LearnerOperationEnum.LAST_SLIDE_VIEWED.name());
@@ -539,12 +558,37 @@ public class LearnerTrackingAsyncService {
 
         // ==== Package Session-Level Tracking ====
 
+        // This is the number the learner's home page shows for the course, so a
+        // silent no-op here is the most visible failure in the whole cascade:
+        // the chapter/module/subject percentages move, the course percentage
+        // doesn't, and the learner reports "I finished the chapter but my
+        // progress is stuck". Two ways that happened before the guards below:
+        // a blank packageSessionId (client couldn't resolve the batch), or a
+        // batch the learner isn't studying (multi-batch learners sent the one
+        // id cached at login). Either way the query matches no subject_session
+        // rows, returns null, and addOrUpdatePercentageOperation drops it —
+        // leaving the previous value in place with nothing logged. Now it's
+        // logged loudly enough to find in support triage.
         public void updatePackageSessionCompletionPercentage(String userId, String packageSessionId) {
+                if (!StringUtils.hasText(packageSessionId)) {
+                        log.warn("Skipping course-progress rollup for user {}: no packageSessionId supplied. "
+                                        + "The course percentage on the learner home page will keep its previous value.",
+                                        userId);
+                        return;
+                }
+
                 Double percentage = activityLogRepository.getPackageSessionCompletionPercentage(
                                 userId,
                                 List.of(LearnerOperationEnum.PERCENTAGE_SUBJECT_COMPLETED.name()),
                                 packageSessionId,
                                 List.of(SubjectStatusEnum.ACTIVE.name()));
+
+                if (percentage == null) {
+                        log.warn("Course-progress rollup produced no value for user {} / packageSession {} "
+                                        + "(no active subject_session rows matched). Previous course percentage retained.",
+                                        userId, packageSessionId);
+                        return;
+                }
 
                 addOrUpdatePercentageOperation(
                                 userId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
@@ -473,10 +473,21 @@ public class LearnerTrackingAsyncService {
                                         + "previous percentage.",
                                         userId, chapterId, moduleId, subjectId, packageSessionId);
                 }
-                if (!StringUtils.hasText(chapterId)) {
-                        return;
+                // Skip only the chapter-level work when there's no chapterId; the
+                // module / subject / package rollups below still run off whatever
+                // ids WERE supplied. They recompute from stored chapter values, so
+                // they remain useful without a chapterId — and returning early here
+                // would silently drop a refresh the caller used to get.
+                if (StringUtils.hasText(chapterId)) {
+                        updateChapterCompletionPercentage(userId, chapterId);
                 }
 
+                updateModuleCompletionPercentage(userId, moduleId);
+                updateSubjectCompletionPercentage(userId, subjectId);
+                updatePackageSessionCompletionPercentage(userId, packageSessionId);
+        }
+
+        private void updateChapterCompletionPercentage(String userId, String chapterId) {
                 learnerOperationService.deleteLearnerOperationByUserIdSourceAndSourceIdAndOperation(userId,
                                 LearnerOperationSourceEnum.CHAPTER.name(), chapterId,
                                 LearnerOperationEnum.LAST_SLIDE_VIEWED.name());
@@ -516,10 +527,6 @@ public class LearnerTrackingAsyncService {
                                                 chapterId,
                                                 LearnerOperationEnum.LAST_SLIDE_VIEWED.name(),
                                                 slideId));
-
-                updateModuleCompletionPercentage(userId, moduleId);
-                updateSubjectCompletionPercentage(userId, subjectId);
-                updatePackageSessionCompletionPercentage(userId, packageSessionId);
         }
 
         // ==== Module-Level Tracking ====

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -66,7 +67,7 @@ public class LearnerTrackingService {
                 // update threw "Activity Log not found". Latent only because the
                 // web viewer always sends new_activity=true; any client that
                 // doesn't would lose its page tracking entirely.
-                : updateActivityLog(activityLogDTO, activityLogDTO.getId());
+                : updateActivityLog(activityLogDTO, activityLogDTO.getId(), user.getUserId());
         saveDocumentTracking(activityLogDTO, activityLog);
         recomputeEngagedMsFromBreadcrumbs(activityLog);
         learnerTrackingAsyncService.updateLearnerOperationsForDocument(user.getUserId(), slideId, chapterId, moduleId,
@@ -81,7 +82,7 @@ public class LearnerTrackingService {
         validateActivityLogDTO(activityLogDTO, false); // Validate for videos
         ActivityLog activityLog = activityLogDTO.isNewActivity()
                 ? saveActivityLog(activityLogDTO, slideId, user.getUserId())
-                : updateActivityLog(activityLogDTO, activityLogDTO.getId());
+                : updateActivityLog(activityLogDTO, activityLogDTO.getId(), user.getUserId());
 
         saveVideoTracking(activityLogDTO, activityLog);
         recomputeEngagedMsFromBreadcrumbs(activityLog);
@@ -97,7 +98,7 @@ public class LearnerTrackingService {
         validateActivityLogDTO(activityLogDTO, false); // Reuse validation for videos
         ActivityLog activityLog = activityLogDTO.isNewActivity()
                 ? saveActivityLog(activityLogDTO, slideId, user.getUserId())
-                : updateActivityLog(activityLogDTO, activityLogDTO.getId());
+                : updateActivityLog(activityLogDTO, activityLogDTO.getId(), user.getUserId());
 
         saveVideoTracking(activityLogDTO, activityLog); // Reuse VideoTracking entity
         recomputeEngagedMsFromBreadcrumbs(activityLog);
@@ -121,6 +122,15 @@ public class LearnerTrackingService {
     private ActivityLog saveActivityLog(ActivityLogDTO activityLogDTO, String slideId, String userId) {
         if (StringUtils.hasText(activityLogDTO.getId())) {
             ActivityLog existing = activityLogRepository.findById(activityLogDTO.getId()).orElse(null);
+            // Same reasoning as updateActivityLog: because this save() merges on a
+            // client-supplied id, an id belonging to another learner would be
+            // rewritten here — and the merge would set user_id to the caller,
+            // silently transferring ownership of the row.
+            if (existing != null && !Objects.equals(existing.getUserId(), userId)) {
+                log.warn("User {} attempted to write activity {} owned by {}", userId, existing.getId(),
+                        existing.getUserId());
+                throw new VacademyException(HttpStatus.FORBIDDEN, "Activity Log does not belong to this user");
+            }
             if (existing != null && StringUtils.hasText(existing.getSlideId())
                     && !existing.getSlideId().equals(slideId)) {
                 log.warn("Refusing to re-parent activity {} from slide {} to slide {} (user {}). "
@@ -133,9 +143,21 @@ public class LearnerTrackingService {
         return activityLogRepository.save(new ActivityLog(activityLogDTO, userId, slideId));
     }
 
-    private ActivityLog updateActivityLog(ActivityLogDTO activityLogDTO, String activityId) {
+    // activityId is client-supplied, so the row it resolves to must be checked
+    // against the caller before it is mutated — otherwise any authenticated
+    // learner can rewrite another learner's start/end time and percentage
+    // watched (which feed engaged time and the leaderboard) just by sending
+    // their activity id. The document path could not reach this before because
+    // it passed the user id as the activity id and always threw; the video and
+    // audio paths always could.
+    private ActivityLog updateActivityLog(ActivityLogDTO activityLogDTO, String activityId, String userId) {
         ActivityLog activityLog = activityLogRepository.findById(activityId)
-                .orElseThrow(() -> new VacademyException("Activity Log not found"));
+                .orElseThrow(() -> new VacademyException(HttpStatus.NOT_FOUND, "Activity Log not found"));
+        if (!Objects.equals(activityLog.getUserId(), userId)) {
+            log.warn("User {} attempted to update activity {} owned by {}", userId, activityId,
+                    activityLog.getUserId());
+            throw new VacademyException(HttpStatus.FORBIDDEN, "Activity Log does not belong to this user");
+        }
         updateActivityFields(activityLog, activityLogDTO);
         return activityLogRepository.save(activityLog);
     }
@@ -226,7 +248,7 @@ public class LearnerTrackingService {
         validateAudioActivityLogDTO(activityLogDTO);
         ActivityLog activityLog = activityLogDTO.isNewActivity()
                 ? saveActivityLog(activityLogDTO, slideId, user.getUserId())
-                : updateActivityLog(activityLogDTO, activityLogDTO.getId());
+                : updateActivityLog(activityLogDTO, activityLogDTO.getId(), user.getUserId());
 
         saveAudioTracking(activityLogDTO, activityLog);
         recomputeEngagedMsFromBreadcrumbs(activityLog);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -19,7 +18,9 @@ import vacademy.io.admin_core_service.features.learner_tracking.repository.Docum
 import vacademy.io.admin_core_service.features.learner_tracking.repository.VideoTrackedRepository;
 import vacademy.io.admin_core_service.features.learner_tracking.repository.AudioTrackedRepository;
 import vacademy.io.common.auth.model.CustomUserDetails;
-import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.common.exceptions.ActivityLogAccessDeniedException;
+import vacademy.io.common.exceptions.InvalidRequestException;
+import vacademy.io.common.exceptions.ResourceNotFoundException;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -129,7 +130,7 @@ public class LearnerTrackingService {
             if (existing != null && !Objects.equals(existing.getUserId(), userId)) {
                 log.warn("User {} attempted to write activity {} owned by {}", userId, existing.getId(),
                         existing.getUserId());
-                throw new VacademyException(HttpStatus.FORBIDDEN, "Activity Log does not belong to this user");
+                throw new ActivityLogAccessDeniedException(existing.getId());
             }
             if (existing != null && StringUtils.hasText(existing.getSlideId())
                     && !existing.getSlideId().equals(slideId)) {
@@ -152,11 +153,11 @@ public class LearnerTrackingService {
     // audio paths always could.
     private ActivityLog updateActivityLog(ActivityLogDTO activityLogDTO, String activityId, String userId) {
         ActivityLog activityLog = activityLogRepository.findById(activityId)
-                .orElseThrow(() -> new VacademyException(HttpStatus.NOT_FOUND, "Activity Log not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Activity log " + activityId + " not found"));
         if (!Objects.equals(activityLog.getUserId(), userId)) {
             log.warn("User {} attempted to update activity {} owned by {}", userId, activityId,
                     activityLog.getUserId());
-            throw new VacademyException(HttpStatus.FORBIDDEN, "Activity Log does not belong to this user");
+            throw new ActivityLogAccessDeniedException(activityId);
         }
         updateActivityFields(activityLog, activityLogDTO);
         return activityLogRepository.save(activityLog);
@@ -219,13 +220,13 @@ public class LearnerTrackingService {
 
     private void validateActivityLogDTO(ActivityLogDTO dto, boolean isDocument) {
         if (Objects.isNull(dto)) {
-            throw new VacademyException("Invalid request. Activity Log cannot be null.");
+            throw new InvalidRequestException("Activity log payload cannot be null.");
         }
         if (isDocument && Objects.isNull(dto.getDocuments())) {
-            throw new VacademyException("Invalid request. Documents cannot be null.");
+            throw new InvalidRequestException("Documents cannot be null for a document activity.");
         }
         if (!isDocument && Objects.isNull(dto.getVideos())) {
-            throw new VacademyException("Invalid request. Videos cannot be null.");
+            throw new InvalidRequestException("Videos cannot be null for a video activity.");
         }
     }
 
@@ -270,10 +271,10 @@ public class LearnerTrackingService {
 
     private void validateAudioActivityLogDTO(ActivityLogDTO dto) {
         if (Objects.isNull(dto)) {
-            throw new VacademyException("Invalid request. Activity Log cannot be null.");
+            throw new InvalidRequestException("Activity log payload cannot be null.");
         }
         if (Objects.isNull(dto.getAudios())) {
-            throw new VacademyException("Invalid request. Audios cannot be null.");
+            throw new InvalidRequestException("Audios cannot be null for an audio activity.");
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingService.java
@@ -1,10 +1,12 @@
 package vacademy.io.admin_core_service.features.learner_tracking.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.learner_operation.service.LearnerOperationService;
 import vacademy.io.admin_core_service.features.learner_tracking.dto.ActivityLogDTO;
 import vacademy.io.admin_core_service.features.learner_tracking.dto.DocumentActivityLogDTO;
@@ -22,6 +24,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 public class LearnerTrackingService {
 
@@ -58,7 +61,12 @@ public class LearnerTrackingService {
         validateActivityLogDTO(activityLogDTO, true); // Validate for documents
         ActivityLog activityLog = activityLogDTO.isNewActivity()
                 ? saveActivityLog(activityLogDTO, slideId, user.getUserId())
-                : updateActivityLog(activityLogDTO, activityLogDTO.getUserId());
+                // getId(), not getUserId() — the latter looked up an activity by
+                // the user's id, which never matches, so every non-new document
+                // update threw "Activity Log not found". Latent only because the
+                // web viewer always sends new_activity=true; any client that
+                // doesn't would lose its page tracking entirely.
+                : updateActivityLog(activityLogDTO, activityLogDTO.getId());
         saveDocumentTracking(activityLogDTO, activityLog);
         recomputeEngagedMsFromBreadcrumbs(activityLog);
         learnerTrackingAsyncService.updateLearnerOperationsForDocument(user.getUserId(), slideId, chapterId, moduleId,
@@ -99,7 +107,29 @@ public class LearnerTrackingService {
         return activityLog.toActivityLogDTO();
     }
 
+    // Clients send new_activity=true with an id they generated, so this save()
+    // is an upsert: an id that already exists is merged, not inserted. That is
+    // intended (it lets a viewer extend one activity as the learner reads), but
+    // it also means a request carrying the wrong slideId would silently move an
+    // existing row to another slide — taking its document_tracked page views
+    // with it, since those hang off activity_id. The victim slide is then left
+    // with no evidence to recompute from while the receiving slide is credited
+    // with pages it never had.
+    //
+    // An activity belongs to the slide it was opened on. If a later request
+    // disagrees, keep the original binding rather than re-parenting the row.
     private ActivityLog saveActivityLog(ActivityLogDTO activityLogDTO, String slideId, String userId) {
+        if (StringUtils.hasText(activityLogDTO.getId())) {
+            ActivityLog existing = activityLogRepository.findById(activityLogDTO.getId()).orElse(null);
+            if (existing != null && StringUtils.hasText(existing.getSlideId())
+                    && !existing.getSlideId().equals(slideId)) {
+                log.warn("Refusing to re-parent activity {} from slide {} to slide {} (user {}). "
+                        + "Keeping the original slide; the client sent a stale slideId.",
+                        existing.getId(), existing.getSlideId(), slideId, userId);
+                updateActivityFields(existing, activityLogDTO);
+                return activityLogRepository.save(existing);
+            }
+        }
         return activityLogRepository.save(new ActivityLog(activityLogDTO, userId, slideId));
     }
 

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingSlideBindingTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingSlideBindingTest.java
@@ -1,0 +1,147 @@
+package vacademy.io.admin_core_service.features.learner_tracking.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import vacademy.io.admin_core_service.features.learner_operation.service.LearnerOperationService;
+import vacademy.io.admin_core_service.features.learner_tracking.dto.ActivityLogDTO;
+import vacademy.io.admin_core_service.features.learner_tracking.dto.DocumentActivityLogDTO;
+import vacademy.io.admin_core_service.features.learner_tracking.entity.ActivityLog;
+import vacademy.io.admin_core_service.features.learner_tracking.repository.ActivityLogRepository;
+import vacademy.io.admin_core_service.features.learner_tracking.repository.AudioTrackedRepository;
+import vacademy.io.admin_core_service.features.learner_tracking.repository.DocumentTrackedRepository;
+import vacademy.io.admin_core_service.features.learner_tracking.repository.VideoTrackedRepository;
+import vacademy.io.common.auth.model.CustomUserDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Locks the slide binding of an activity log.
+ *
+ * Clients generate the activity id themselves and send new_activity=true on every
+ * flush, so the save is an upsert. Before the guard under test, a flush carrying a
+ * stale slideId re-parented the existing row to a different slide — and because
+ * document_tracked rows hang off activity_id, that slide's page views moved with
+ * it. Observed in production: a 2-page reading note holding 14 distinct tracked
+ * pages (capped to 100%) next to a 14-page PDF left below 100% with no evidence
+ * left to recompute from.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LearnerTrackingSlideBindingTest {
+
+    private static final String USER = "learner-1";
+    private static final String ACTIVITY = "activity-1";
+    private static final String ORIGINAL_SLIDE = "slide-pdf";
+    private static final String OTHER_SLIDE = "slide-reading-note";
+
+    @Mock private ActivityLogRepository activityLogRepository;
+    @Mock private DocumentTrackedRepository documentTrackedRepository;
+    @Mock private VideoTrackedRepository videoTrackedRepository;
+    @Mock private AudioTrackedRepository audioTrackedRepository;
+    @Mock private LearnerOperationService learnerOperationService;
+    @Mock private LearnerTrackingAsyncService learnerTrackingAsyncService;
+    @Mock private ConcentrationScoreService concentrationScoreService;
+
+    @InjectMocks private LearnerTrackingService service;
+
+    private ActivityLogDTO flush(String activityId) {
+        ActivityLogDTO dto = new ActivityLogDTO();
+        dto.setId(activityId);
+        dto.setNewActivity(true);
+        dto.setStartTimeInMillis(1_753_000_000_000L);
+        dto.setEndTimeInMillis(1_753_000_060_000L);
+        DocumentActivityLogDTO page = new DocumentActivityLogDTO();
+        page.setId("page-view-1");
+        page.setPageNumber(7);
+        dto.setDocuments(List.of(page));
+        return dto;
+    }
+
+    private CustomUserDetails user() {
+        CustomUserDetails user = mock(CustomUserDetails.class);
+        when(user.getUserId()).thenReturn(USER);
+        return user;
+    }
+
+    @Test
+    @DisplayName("a flush carrying a stale slideId does not move the activity to the new slide")
+    void staleSlideIdDoesNotReParentActivity() {
+        ActivityLog existing = new ActivityLog();
+        existing.setId(ACTIVITY);
+        existing.setUserId(USER);
+        existing.setSlideId(ORIGINAL_SLIDE);
+
+        when(activityLogRepository.findById(ACTIVITY)).thenReturn(Optional.of(existing));
+        when(activityLogRepository.save(any(ActivityLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // Same activity id, but the client now claims a different slide.
+        service.addOrUpdateDocumentActivityLog(
+                flush(ACTIVITY), OTHER_SLIDE, "chapter-1", "ps-1", "module-1", "subject-1", user());
+
+        // The request saves more than once (bind, then the engaged-ms recompute);
+        // the invariant is that no save ever moves the row off its slide.
+        ArgumentCaptor<ActivityLog> saved = ArgumentCaptor.forClass(ActivityLog.class);
+        verify(activityLogRepository, atLeastOnce()).save(saved.capture());
+
+        assertTrue(saved.getAllValues().stream()
+                        .allMatch(a -> ORIGINAL_SLIDE.equals(a.getSlideId())),
+                "activity must stay bound to the slide it was opened on, got: "
+                        + saved.getAllValues().stream().map(ActivityLog::getSlideId).toList());
+        assertTrue(saved.getAllValues().stream().allMatch(a -> ACTIVITY.equals(a.getId())));
+    }
+
+    @Test
+    @DisplayName("a first flush for an unseen activity binds to the slide it was opened on")
+    void newActivityBindsToRequestSlide() {
+        when(activityLogRepository.findById(ACTIVITY)).thenReturn(Optional.empty());
+        when(activityLogRepository.save(any(ActivityLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        service.addOrUpdateDocumentActivityLog(
+                flush(ACTIVITY), ORIGINAL_SLIDE, "chapter-1", "ps-1", "module-1", "subject-1", user());
+
+        ArgumentCaptor<ActivityLog> saved = ArgumentCaptor.forClass(ActivityLog.class);
+        verify(activityLogRepository, atLeastOnce()).save(saved.capture());
+
+        assertEquals(ORIGINAL_SLIDE, saved.getAllValues().get(0).getSlideId());
+    }
+
+    @Test
+    @DisplayName("repeat flushes on the same slide still extend the same activity row")
+    void sameSlideFlushKeepsExtendingTheSameActivity() {
+        ActivityLog existing = new ActivityLog();
+        existing.setId(ACTIVITY);
+        existing.setUserId(USER);
+        existing.setSlideId(ORIGINAL_SLIDE);
+
+        when(activityLogRepository.findById(ACTIVITY)).thenReturn(Optional.of(existing));
+        when(activityLogRepository.save(any(ActivityLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        service.addOrUpdateDocumentActivityLog(
+                flush(ACTIVITY), ORIGINAL_SLIDE, "chapter-1", "ps-1", "module-1", "subject-1", user());
+
+        ArgumentCaptor<ActivityLog> saved = ArgumentCaptor.forClass(ActivityLog.class);
+        verify(activityLogRepository, atLeastOnce()).save(saved.capture());
+
+        assertEquals(ACTIVITY, saved.getAllValues().get(0).getId());
+        assertEquals(ORIGINAL_SLIDE, saved.getAllValues().get(0).getSlideId());
+    }
+}

--- a/common_service/src/main/java/vacademy/io/common/exceptions/ActivityLogAccessDeniedException.java
+++ b/common_service/src/main/java/vacademy/io/common/exceptions/ActivityLogAccessDeniedException.java
@@ -1,0 +1,19 @@
+package vacademy.io.common.exceptions;
+
+/**
+ * Thrown when a caller sends an activity-log id that resolves to a row owned by
+ * a different learner.
+ *
+ * Activity ids are generated client-side and sent back on every flush, so the
+ * id in a request is untrusted input: without this check a learner could pass
+ * someone else's id and rewrite their start/end time and percentage watched,
+ * which feed engaged time and the leaderboard. Extends {@link ForbiddenException}
+ * so it maps to HTTP 403 through the existing handler while still naming the
+ * specific failure in logs and responses.
+ */
+public class ActivityLogAccessDeniedException extends ForbiddenException {
+
+    public ActivityLogAccessDeniedException(String activityId) {
+        super("Activity log " + activityId + " does not belong to this user");
+    }
+}

--- a/docs/runbooks/learner-progress-rollup-backfill.sql
+++ b/docs/runbooks/learner-progress-rollup-backfill.sql
@@ -1,0 +1,253 @@
+-- Backfill: repair stale learner course-progress rollups (admin_core_service)
+--
+-- WHY
+-- The learner home page reads learner_operation(source='PACKAGE_SESSION',
+-- operation='PERCENTAGE_PACKAGE_SESSION_COMPLETED'). That row is only rewritten
+-- when an activity request arrives carrying the right packageSessionId. The
+-- learner clients used to resolve that id from a single value cached in device
+-- Preferences at login, so a learner enrolled in more than one batch sent the
+-- wrong id whenever they studied any other course. The rollup then matched no
+-- subject_session rows, produced null, and was silently dropped -- leaving the
+-- course percentage frozen while the chapter/module/subject percentages (whose
+-- ids come from the route) kept moving. That is the "I finished the chapter but
+-- my course progress won't move" report.
+--
+-- The client fix (useResolvedPackageSessionId) stops new drift. This script
+-- repairs rows already stranded.
+--
+-- SCOPE / SAFETY
+--  * Touches ONLY the three rollup levels. Never invents slide-level data and
+--    never lowers a slide percentage.
+--  * Recomputes with exactly the formulas the service uses
+--    (ActivityLogRepository#getModule/Subject/PackageSessionCompletionPercentage),
+--    so it converges on what the app would have written itself.
+--  * Idempotent -- re-running after convergence updates 0 rows.
+--  * Order matters: module -> subject -> package_session, each level reads the
+--    level below.
+--  * Wrapped in a single transaction. Review the row counts psql prints for each
+--    UPDATE before committing; ROLLBACK is safe at any point.
+--
+-- HOW TO RUN
+--   psql -v ON_ERROR_STOP=1 -f learner-progress-rollup-backfill.sql
+--   Section 0 prints the audit (keep it -- it is the rollback reference), then
+--   sections 1-3 apply. Re-run section 0 afterwards; drift should be empty.
+--
+-- NOTE learner_operation maps created_at/updated_at insertable=false,
+-- updatable=false and the table has no trigger, so updated_at is effectively
+-- created_at. Do not use it to judge freshness before or after this run.
+
+\echo '=== 0. AUDIT: course percentages that disagree with their own subjects ==='
+
+WITH stored AS (
+    SELECT user_id, source_id AS package_session_id, CAST(value AS numeric) AS stored_pct
+    FROM learner_operation
+    WHERE source = 'PACKAGE_SESSION'
+      AND operation = 'PERCENTAGE_PACKAGE_SESSION_COMPLETED'
+      AND value ~ '^-?[0-9]+(\.[0-9]+)?$'
+),
+recomputed AS (
+    SELECT st.user_id,
+           st.package_session_id,
+           st.stored_pct,
+           COALESCE(SUM(CAST(lo.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT ss.subject_id), 0) AS correct_pct
+    FROM stored st
+    JOIN subject_session ss ON ss.session_id = st.package_session_id
+    JOIN subject s ON s.id = ss.subject_id AND s.status = 'ACTIVE'
+    LEFT JOIN learner_operation lo
+           ON lo.source_id = s.id
+          AND lo.user_id = st.user_id
+          AND lo.operation = 'PERCENTAGE_SUBJECT_COMPLETED'
+          AND lo.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    GROUP BY st.user_id, st.package_session_id, st.stored_pct
+)
+SELECT user_id,
+       package_session_id,
+       ROUND(stored_pct, 2)               AS shows_now,
+       ROUND(correct_pct, 2)              AS should_show,
+       ROUND(correct_pct - stored_pct, 2) AS drift
+FROM recomputed
+WHERE ABS(correct_pct - stored_pct) > 0.01
+ORDER BY correct_pct - stored_pct DESC;
+
+BEGIN;
+
+\echo '=== 0b. CHAPTER <- mean of its slides ==='
+-- The cascade starts here, so this level drifts too and every level above
+-- inherits the error. The assignment submit path was the worst offender: it sent
+-- no chapterId at all, so a submitted assignment set its slide to 100% and the
+-- chapter kept its old value. Denominator is every slide of a tracked type in
+-- the chapter, so untouched slides correctly count as 0.
+UPDATE learner_operation lo
+SET value = calc.correct_pct::text
+FROM (
+    SELECT existing.user_id,
+           existing.source_id AS chapter_id,
+           COALESCE(SUM(CAST(sv.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT cs.slide_id), 0) AS correct_pct
+    FROM learner_operation existing
+    JOIN chapter_to_slides cs ON cs.chapter_id = existing.source_id
+                             AND cs.status IN ('PUBLISHED', 'UNSYNC')
+    JOIN slide s ON s.id = cs.slide_id
+                AND s.source_type IN ('VIDEO','DOCUMENT','ASSIGNMENT','QUESTION','QUIZ',
+                                      'HTML_VIDEO','AUDIO','SCORM','ASSESSMENT')
+    LEFT JOIN learner_operation sv
+           ON sv.source_id = cs.slide_id
+          AND sv.source = 'SLIDE'
+          AND sv.user_id = existing.user_id
+          AND sv.operation IN ('PERCENTAGE_VIDEO_WATCHED','PERCENTAGE_DOCUMENT_COMPLETED',
+                               'PERCENTAGE_ASSIGNMENT_COMPLETED','PERCENTAGE_QUESTION_COMPLETED',
+                               'PERCENTAGE_QUIZ_COMPLETED','PERCENTAGE_AUDIO_LISTENED',
+                               'PERCENTAGE_SCORM_COMPLETED','PERCENTAGE_ASSESSMENT_DONE')
+          AND sv.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    WHERE existing.source = 'CHAPTER'
+      AND existing.operation = 'PERCENTAGE_CHAPTER_COMPLETED'
+    GROUP BY existing.user_id, existing.source_id
+) calc
+WHERE lo.source = 'CHAPTER'
+  AND lo.operation = 'PERCENTAGE_CHAPTER_COMPLETED'
+  AND lo.user_id = calc.user_id
+  AND lo.source_id = calc.chapter_id
+  AND calc.correct_pct IS NOT NULL
+  AND (lo.value !~ '^-?[0-9]+(\.[0-9]+)?$'
+       OR ABS(CAST(lo.value AS numeric) - calc.correct_pct) > 0.01);
+
+\echo '=== 1. MODULE <- mean of its ACTIVE chapters ==='
+-- Denominator is every ACTIVE chapter mapped into the module, so chapters the
+-- learner has not opened correctly count as 0.
+UPDATE learner_operation lo
+SET value = calc.correct_pct::text
+FROM (
+    SELECT existing.user_id,
+           existing.source_id AS module_id,
+           COALESCE(SUM(CAST(cv.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT dc.chapter_id), 0) AS correct_pct
+    FROM learner_operation existing
+    JOIN LATERAL (
+        SELECT DISTINCT mcm.chapter_id
+        FROM module_chapter_mapping mcm
+        JOIN chapter c ON c.id = mcm.chapter_id
+        JOIN chapter_package_session_mapping cpm ON cpm.chapter_id = c.id
+        WHERE mcm.module_id = existing.source_id
+          AND cpm.status = 'ACTIVE'
+          AND c.status = 'ACTIVE'
+    ) dc ON TRUE
+    LEFT JOIN learner_operation cv
+           ON cv.source_id = dc.chapter_id
+          AND cv.user_id = existing.user_id
+          AND cv.operation = 'PERCENTAGE_CHAPTER_COMPLETED'
+          AND cv.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    WHERE existing.source = 'MODULE'
+      AND existing.operation = 'PERCENTAGE_MODULE_COMPLETED'
+    GROUP BY existing.user_id, existing.source_id
+) calc
+WHERE lo.source = 'MODULE'
+  AND lo.operation = 'PERCENTAGE_MODULE_COMPLETED'
+  AND lo.user_id = calc.user_id
+  AND lo.source_id = calc.module_id
+  AND calc.correct_pct IS NOT NULL
+  AND (lo.value !~ '^-?[0-9]+(\.[0-9]+)?$'
+       OR ABS(CAST(lo.value AS numeric) - calc.correct_pct) > 0.01);
+
+\echo '=== 2. SUBJECT <- mean of its ACTIVE modules ==='
+UPDATE learner_operation lo
+SET value = calc.correct_pct::text
+FROM (
+    SELECT existing.user_id,
+           existing.source_id AS subject_id,
+           COALESCE(SUM(CAST(mv.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT smm.module_id), 0) AS correct_pct
+    FROM learner_operation existing
+    JOIN subject_module_mapping smm ON smm.subject_id = existing.source_id
+    JOIN modules m ON m.id = smm.module_id AND m.status = 'ACTIVE'
+    LEFT JOIN learner_operation mv
+           ON mv.source_id = m.id
+          AND mv.user_id = existing.user_id
+          AND mv.operation = 'PERCENTAGE_MODULE_COMPLETED'
+          AND mv.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    WHERE existing.source = 'SUBJECT'
+      AND existing.operation = 'PERCENTAGE_SUBJECT_COMPLETED'
+    GROUP BY existing.user_id, existing.source_id
+) calc
+WHERE lo.source = 'SUBJECT'
+  AND lo.operation = 'PERCENTAGE_SUBJECT_COMPLETED'
+  AND lo.user_id = calc.user_id
+  AND lo.source_id = calc.subject_id
+  AND calc.correct_pct IS NOT NULL
+  AND (lo.value !~ '^-?[0-9]+(\.[0-9]+)?$'
+       OR ABS(CAST(lo.value AS numeric) - calc.correct_pct) > 0.01);
+
+\echo '=== 3. PACKAGE_SESSION <- mean of its ACTIVE subjects (the home page number) ==='
+UPDATE learner_operation lo
+SET value = calc.correct_pct::text
+FROM (
+    SELECT existing.user_id,
+           existing.source_id AS package_session_id,
+           COALESCE(SUM(CAST(sv.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT ss.subject_id), 0) AS correct_pct
+    FROM learner_operation existing
+    JOIN subject_session ss ON ss.session_id = existing.source_id
+    JOIN subject s ON s.id = ss.subject_id AND s.status = 'ACTIVE'
+    LEFT JOIN learner_operation sv
+           ON sv.source_id = s.id
+          AND sv.user_id = existing.user_id
+          AND sv.operation = 'PERCENTAGE_SUBJECT_COMPLETED'
+          AND sv.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    WHERE existing.source = 'PACKAGE_SESSION'
+      AND existing.operation = 'PERCENTAGE_PACKAGE_SESSION_COMPLETED'
+    GROUP BY existing.user_id, existing.source_id
+) calc
+WHERE lo.source = 'PACKAGE_SESSION'
+  AND lo.operation = 'PERCENTAGE_PACKAGE_SESSION_COMPLETED'
+  AND lo.user_id = calc.user_id
+  AND lo.source_id = calc.package_session_id
+  AND calc.correct_pct IS NOT NULL
+  AND (lo.value !~ '^-?[0-9]+(\.[0-9]+)?$'
+       OR ABS(CAST(lo.value AS numeric) - calc.correct_pct) > 0.01);
+
+COMMIT;
+
+\echo '=== 4. VERIFY: this should return no rows ==='
+
+WITH stored AS (
+    SELECT user_id, source_id AS package_session_id, CAST(value AS numeric) AS stored_pct
+    FROM learner_operation
+    WHERE source = 'PACKAGE_SESSION'
+      AND operation = 'PERCENTAGE_PACKAGE_SESSION_COMPLETED'
+      AND value ~ '^-?[0-9]+(\.[0-9]+)?$'
+),
+recomputed AS (
+    SELECT st.user_id, st.package_session_id, st.stored_pct,
+           COALESCE(SUM(CAST(lo.value AS numeric)), 0)
+               / NULLIF(COUNT(DISTINCT ss.subject_id), 0) AS correct_pct
+    FROM stored st
+    JOIN subject_session ss ON ss.session_id = st.package_session_id
+    JOIN subject s ON s.id = ss.subject_id AND s.status = 'ACTIVE'
+    LEFT JOIN learner_operation lo
+           ON lo.source_id = s.id
+          AND lo.user_id = st.user_id
+          AND lo.operation = 'PERCENTAGE_SUBJECT_COMPLETED'
+          AND lo.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+    GROUP BY st.user_id, st.package_session_id, st.stored_pct
+)
+SELECT user_id, package_session_id,
+       ROUND(stored_pct, 2) AS shows_now,
+       ROUND(correct_pct, 2) AS should_show
+FROM recomputed
+WHERE ABS(correct_pct - stored_pct) > 0.01;
+
+-- =====================================================================
+-- NOT DONE HERE, ON PURPOSE: slide percentages
+-- =====================================================================
+-- Slides that lost page views to the activity re-parenting bug cannot be
+-- repaired by recomputation -- the evidence moved to a neighbouring slide and
+-- there is no reliable way to attribute historical document_tracked rows back.
+-- Recomputing would LOWER real learners (a 14-page PDF read end to end now
+-- recomputes to 50% because 12 of its pages sit on the reading note beside it),
+-- which the slide-level monotonic guard in addOrUpdatePercentageOperation
+-- deliberately prevents. Those rows are left alone.
+--
+-- If a deliberate repair is wanted later, the defensible rule is: credit a
+-- document slide 100% where DOCUMENT_LAST_PAGE shows the learner reached the
+-- final page. That is a product decision, not a data-integrity fix, so it is
+-- not bundled here.

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/assignment-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/assignment-slide.tsx
@@ -18,6 +18,7 @@ import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refre
 import { MyInput } from "@/components/design-system/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
+import { useResolvedPackageSessionId } from "@/hooks/study-library/useResolvedPackageSessionId";
 import { getTerminology } from "@/components/common/layout-container/sidebar/utils";
 import { RoleTerms, SystemTerms } from "@/types/naming-settings";
 import { useSlideDownloadPermission } from "@/hooks/useSlideDownloadPermission";
@@ -776,6 +777,7 @@ const AssignmentSlide = ({
   isUploading,
 }: AssignmentSlideProps) => {
   const { activeItem } = useContentStore();
+  const resolvePackageSessionId = useResolvedPackageSessionId();
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
   const [uploadedFileIds, setUploadedFileIds] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -1040,12 +1042,27 @@ const AssignmentSlide = ({
       // a drifted DOCUMENT id makes it 404 "Assignment slide not found".
       const slideId = activeItem?.id || urlParams.get("slideId") || "";
       const userId = await getUserId();
+      // The backend cascades slide -> chapter -> module -> subject -> course
+      // progress from these ids. Omitting them (as this call used to) still set
+      // the slide to 100% but rolled nothing up, so submitting an assignment as
+      // the last action in a chapter left the course percentage untouched until
+      // the learner happened to open some other slide. `sessionId` is the URL's
+      // name for packageSessionId.
+      const chapterId = urlParams.get("chapterId") || "";
+      const moduleId = urlParams.get("moduleId") || "";
+      const subjectId = urlParams.get("subjectId") || "";
+      const packageSessionId =
+        urlParams.get("sessionId") || (await resolvePackageSessionId());
       return authenticatedAxiosInstance.post(
         SUBMIT_ASSIGNMENT_SLIDE_ANSWERS,
         payload,
         {
           params: {
             slideId,
+            chapterId,
+            moduleId,
+            subjectId,
+            packageSessionId,
             userId,
           },
         }

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/pdf-viewer.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/pdf-viewer.tsx
@@ -54,6 +54,33 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ documentId, pdfUrl }) => {
   const updateIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const { activeItem } = useContentStore();
+
+  // The slide this viewer's activity buffer belongs to.
+  //
+  // `activityId` and `pageViews` used to be created once per mount and the
+  // buffered activity's slide_id was read from `activeItem` at flush time. When
+  // the learner moved to the next slide, the still-mounted viewer rewrote the
+  // buffer's slide_id to the new slide while keeping the *previous* slide's
+  // page views. The sync then POSTed them under the new slide, and because the
+  // backend merges an activity row by its client-supplied id, the whole row was
+  // re-parented — the previous slide lost its tracking outright and the new one
+  // absorbed page numbers it never had. That is how a 2-page reading note ended
+  // up with 14 tracked pages (capped to 100%) while the 14-page PDF next to it
+  // sat below 100% with no evidence left to recompute from.
+  //
+  // Binding the buffer to a slide and resetting it on change keeps each slide's
+  // page views its own. Reset happens during render (refs only, no state) so the
+  // effect below can never observe a buffer from the previous slide.
+  const trackedSlideIdRef = useRef<string | null>(null);
+  if (activeItem?.id && trackedSlideIdRef.current !== activeItem.id) {
+    trackedSlideIdRef.current = activeItem.id;
+    activityId.current = uuidv4();
+    pageViews.current = [];
+    totalPagesReadRef.current = 0;
+    startTime.current = getISTTime();
+    startTimeInMillis.current = getEpochTimeInMillis();
+    pageStartTime.current = new Date();
+  }
   // const { pdfRef } = useMediaRefs();
   // Verification state
   const [showVerification, setShowVerification] = useState(false);
@@ -438,13 +465,19 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ documentId, pdfUrl }) => {
 
   // Update activity in real-time when elapsedTime changes
   useEffect(() => {
+    // Only track the slide this buffer belongs to. Without this the viewer
+    // would attribute the buffered page views to whatever slide happens to be
+    // active at flush time — see trackedSlideIdRef above.
+    const trackedSlideId = trackedSlideIdRef.current;
+    if (!trackedSlideId || trackedSlideId !== activeItem?.id) return;
+
     totalPagesReadRef.current = new Set(
       pageViews.current.map((v) => v.page)
     ).size;
 
     addActivity(
       {
-        slide_id: activeItem?.id || "",
+        slide_id: trackedSlideId,
         activity_id: activityId.current,
         source: "DOCUMENT" as const,
         source_id: documentId || "",

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/question-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/question-slide.tsx
@@ -16,7 +16,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getUserId } from "@/constants/getUserId";
 import { Textarea } from "@/components/ui/textarea";
 import { useRouter } from "@tanstack/react-router";
-import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
+import { useResolvedPackageSessionId } from "@/hooks/study-library/useResolvedPackageSessionId";
 import { refreshProgressAfterSubmit } from "@/utils/study-library/tracking/refreshProgressAfterSubmit";
 
 interface Option {
@@ -74,6 +74,10 @@ const QuestionSlide = ({ questionData, onSubmit }: QuestionSlideProps) => {
     const router = useRouter();
     const queryClient = useQueryClient();
     const { chapterId, moduleId, subjectId } = router.state.location.search;
+    // Resolve the batch from the course being studied, not the single id cached
+    // at login — otherwise a multi-batch learner's submission updates the wrong
+    // package_session and their course progress never moves.
+    const resolvePackageSessionId = useResolvedPackageSessionId();
     // const { activeItem } = useContentStore();
     const [selectedOptionsMap, setSelectedOptionsMap] = useState<
         Record<string, SelectedOption | null>
@@ -189,7 +193,7 @@ const QuestionSlide = ({ questionData, onSubmit }: QuestionSlideProps) => {
         }) => {
             const userId = await getUserId();
 
-            const packageSessionId = await getPackageSessionId();
+            const packageSessionId = await resolvePackageSessionId();
 
             if (!slideId || !userId || !packageSessionId) {
                 throw new Error(

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/scorm-slide.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/scorm-slide.tsx
@@ -5,7 +5,7 @@ import { useFileUpload } from '@/hooks/use-file-upload';
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { BASE_URL } from '@/constants/urls';
 import { Slide, ScormSlide } from '@/hooks/study-library/use-slides';
-import { getPackageSessionId } from '@/utils/study-library/get-list-from-stores/getPackageSessionId';
+import { useResolvedPackageSessionId } from '@/hooks/study-library/useResolvedPackageSessionId';
 import { refreshProgressAfterSubmit } from '@/utils/study-library/tracking/refreshProgressAfterSubmit';
 
 // SCORM Tracking endpoints
@@ -72,14 +72,19 @@ const ScormSlideComponent = ({
 
     const scormSlide = slide.scorm_slide as ScormSlide | undefined;
 
-    // Fetch packageSessionId if not provided
+    // Resolve the batch if the parent didn't pass one (slide-material doesn't).
+    // Must come from the course being studied, not the single id cached at
+    // login — a multi-batch learner would otherwise report SCORM completion
+    // against the wrong package_session and their course progress would sit
+    // still. See useResolvedPackageSessionId.
+    const resolvePackageSessionId = useResolvedPackageSessionId();
     useEffect(() => {
         if (!propPackageSessionId) {
-            getPackageSessionId().then((id) => {
+            resolvePackageSessionId().then((id) => {
                 if (id) setResolvedPackageSessionId(id);
             });
         }
-    }, [propPackageSessionId]);
+    }, [propPackageSessionId, resolvePackageSessionId]);
 
     // Reset state when switching slides
     useEffect(() => {

--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/slide-material.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/slide-material.tsx
@@ -787,7 +787,10 @@ export const SlideMaterial = ({
             setContent(
               <div className="h-full w-full animate-in fade-in slide-in-from-bottom-4 duration-700">
                 <div className="h-full w-full bg-white rounded-lg overflow-hidden border border-neutral-200">
-                  <PDFViewer pdfUrl={url} />
+                  {/* Keyed by slide so moving between two PDF slides mounts a
+                      fresh viewer instead of reusing one carrying the previous
+                      slide's activity id and page-view buffer. */}
+                  <PDFViewer key={activeItem.id} pdfUrl={url} />
                 </div>
               </div>
             );

--- a/frontend-learner-dashboard-app/src/hooks/study-library/usePdfSync.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/usePdfSync.ts
@@ -3,11 +3,11 @@ import { ActivitySchema } from "@/schemas/study-library/pdf-tracking-schema";
 import { useAddDocumentActivity } from "@/services/study-library/tracking-api/add-document-activity";
 import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
 import { TrackingDataType } from "@/types/tracking-data-type";
-import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
 import { calculateAndUpdatePageViews } from "@/utils/study-library/tracking/calculateAndUpdatePageViews";
 import { Preferences } from "@capacitor/preferences";
 import { useRouter } from "@tanstack/react-router";
 import { z } from "zod";
+import { useResolvedPackageSessionId } from "./useResolvedPackageSessionId";
 import { useSlidesRefresh } from "./useSlidesRefresh";
 
 const STORAGE_KEY = "pdf_tracking_data";
@@ -25,6 +25,7 @@ export const usePDFSync = () => {
     const { activeItem } = useContentStore();
     const router = useRouter();
     const { chapterId, moduleId, subjectId } = router.state.location.search;
+    const resolvePackageSessionId = useResolvedPackageSessionId();
 
     const { refreshSlides } = useSlidesRefresh();
 
@@ -35,7 +36,7 @@ export const usePDFSync = () => {
                 ? JSON.parse(userDetailsStr.value)
                 : null;
             const userId = userDetails?.user_id;
-            const packageSessionId = await getPackageSessionId();
+            const packageSessionId = await resolvePackageSessionId();
 
             if (!userId) {
                 throw new Error("User ID not found in storage");

--- a/frontend-learner-dashboard-app/src/hooks/study-library/usePresentationSync.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/usePresentationSync.ts
@@ -2,10 +2,10 @@ import { ActivitySchema } from "@/schemas/study-library/presentation-tracking-sc
 import { useAddDocumentActivity } from "@/services/study-library/tracking-api/add-document-activity";
 import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
 import { TrackingDataType } from "@/types/tracking-data-type";
-import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
 import { Preferences } from "@capacitor/preferences";
 import { useRouter } from "@tanstack/react-router";
 import { z } from "zod";
+import { useResolvedPackageSessionId } from "./useResolvedPackageSessionId";
 import { useSlidesRefresh } from "./useSlidesRefresh";
 const STORAGE_KEY = "presentation_tracking_data";
 const USER_ID_KEY = "StudentDetails";
@@ -22,6 +22,7 @@ export const usePresentationSync = () => {
     const { activeItem } = useContentStore();
     const router = useRouter();
     const { chapterId, moduleId, subjectId } = router.state.location.search;
+    const resolvePackageSessionId = useResolvedPackageSessionId();
 
     const { refreshSlides } = useSlidesRefresh();
 
@@ -36,7 +37,7 @@ export const usePresentationSync = () => {
                 : null;
             const userId = userDetails?.user_id;
 
-            const packageSessionId = await getPackageSessionId();
+            const packageSessionId = await resolvePackageSessionId();
 
             console.log("👤 [usePresentationSync] User ID found:", userId);
 

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useResolvedPackageSessionId.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useResolvedPackageSessionId.ts
@@ -1,0 +1,43 @@
+import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
+import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
+import { useRouter } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+/**
+ * Resolves the package_session_id (a.k.a. "batch") of the course the learner is
+ * *currently studying*.
+ *
+ * Why this exists: the tracking hooks used to read the batch straight from
+ * `getPackageSessionId()`, which returns the single `package_session_id` cached
+ * in device Preferences at login. A learner enrolled in more than one batch has
+ * exactly one value cached, so studying any *other* course sent the wrong batch
+ * to the activity endpoints. The backend's rollup cascade then updated the
+ * chapter/module/subject percentages correctly (those ids come from the route)
+ * but computed the package-session percentage against a batch the learner
+ * wasn't studying — finding no rows, yielding null, and silently leaving the
+ * old course percentage in place. That is the "my chapter is done but my
+ * course progress won't move" report.
+ *
+ * Resolution order, most authoritative first:
+ *  1. `sessionId` route search param — the URL's name for this value, and the
+ *     only source guaranteed to describe the page the learner is on right now.
+ *     Checked before the store because the store is written by a route effect
+ *     and can still hold the previous course for a render after a switch.
+ *  2. `currentPackageSessionId` — set by the slides route; covers routes whose
+ *     URL doesn't carry sessionId.
+ *  3. the cached Preferences value — correct for single-batch learners, and the
+ *     only thing available outside the course-details routes.
+ */
+export const useResolvedPackageSessionId = () => {
+    const { currentPackageSessionId } = useContentStore();
+    const router = useRouter();
+    const { sessionId } = router.state.location.search as {
+        sessionId?: string;
+    };
+
+    return useCallback(async (): Promise<string> => {
+        if (sessionId) return sessionId;
+        if (currentPackageSessionId) return currentPackageSessionId;
+        return (await getPackageSessionId()) || "";
+    }, [currentPackageSessionId, sessionId]);
+};

--- a/frontend-learner-dashboard-app/src/hooks/study-library/useVideoSync.ts
+++ b/frontend-learner-dashboard-app/src/hooks/study-library/useVideoSync.ts
@@ -3,12 +3,12 @@ import { ActivitySchema } from "@/schemas/study-library/youtube-video-tracking-s
 import { useAddVideoActivity } from "@/services/study-library/tracking-api/add-video-activity";
 import { useContentStore } from "@/stores/study-library/chapter-sidebar-store";
 import { TrackingDataType } from "@/types/tracking-data-type";
-import { getPackageSessionId } from "@/utils/study-library/get-list-from-stores/getPackageSessionId";
 import { calculateAndUpdateTimestamps } from "@/utils/study-library/tracking/calculateAndUpdateTimestamps";
 import { Preferences } from "@capacitor/preferences";
 import { useRouter } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { z } from "zod";
+import { useResolvedPackageSessionId } from "./useResolvedPackageSessionId";
 import { useSlidesRefresh } from "./useSlidesRefresh";
 import { ADD_UPDATE_VIDEO_ACTIVITY } from "@/constants/urls";
 
@@ -27,16 +27,8 @@ export const useVideoSync = () => {
   const { activeItem } = useContentStore();
   const router = useRouter();
   const { chapterId, moduleId, subjectId } = router.state.location.search;
-  const [packageSessionId, setPackageSessionId] = useState<string | null>(null);
+  const resolvePackageSessionId = useResolvedPackageSessionId();
   const { refreshSlides } = useSlidesRefresh();
-
-  useEffect(() => {
-    const fetchPackageSessionId = async () => {
-      const id = await getPackageSessionId();
-      setPackageSessionId(id);
-    };
-    fetchPackageSessionId();
-  }, []);
 
   // Tab-close safety net. The periodic 60s sync covers the "user keeps the
   // tab open" case; this covers "user pauses then closes the tab". We use
@@ -212,6 +204,8 @@ export const useVideoSync = () => {
       if (!userId) {
         throw new Error("User ID not found in storage");
       }
+
+      const packageSessionId = await resolvePackageSessionId();
 
       const { value } = await Preferences.get({ key: STORAGE_KEY });
       if (!value) return;

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
@@ -235,12 +235,26 @@ export const CourseStructureDetails = ({
     return Math.round(totalProgress / moduleChapters.length);
   };
 
-  // Helper: subject progress aggregated across all its chapters
+  // Helper: subject progress = mean of its MODULE percentages.
+  //
+  // Deliberately mean-of-module-means, not a flat average over every chapter in
+  // the subject. The backend computes it the same way
+  // (ActivityLogRepository#getSubjectCompletionPercentage sums the module
+  // percentages and divides by the module count), and the course percentage is
+  // in turn the mean of these subject values. Flattening the chapters instead
+  // silently weights modules by how many chapters they contain, so a subject
+  // with a 1-chapter module and a 10-chapter module would render a number that
+  // contradicts the course bar directly beneath it.
   const calculateSubjectProgress = (subjectId: string): number => {
-    const chapters = (subjectModulesMap[subjectId] ?? []).flatMap(
-      (mod) => mod.chapters ?? []
+    const modules = subjectModulesMap[subjectId] ?? [];
+    if (modules.length === 0) return 0;
+
+    const totalProgress = modules.reduce(
+      (sum, mod) => sum + calculateModuleProgress(mod.chapters ?? []),
+      0
     );
-    return calculateModuleProgress(chapters);
+
+    return Math.round(totalProgress / modules.length);
   };
 
   // Helper: render progress bar
@@ -1234,6 +1248,25 @@ export const CourseStructureDetails = ({
                       >
                         {toTitleCase(subject.subject_name)}
                       </span>
+                      {/* Subject Progress Indicator — same treatment modules and
+                          chapters get, so every level of the outline reads the
+                          same way. onDark: the subject row sits on the navy
+                          surface in the Play theme. */}
+                      <div className="flex items-center gap-2 ms-auto shrink-0 min-w-20">
+                        {(() => {
+                          const progress = calculateSubjectProgress(subject.id);
+                          return (
+                            <>
+                              <div className="w-14 sm:w-16 hidden sm:block">
+                                {renderProgressBar(progress, "sm")}
+                              </div>
+                              {renderCompletionBadge(progress, {
+                                onDark: true,
+                              })}
+                            </>
+                          );
+                        })()}
+                      </div>
                     </div>
                   </CollapsibleTrigger>
                   <CollapsibleContent
@@ -2165,6 +2198,23 @@ export const CourseStructureDetails = ({
                       <span className="break-words font-medium" title={toTitleCase(subject.subject_name)}>
                         {toTitleCase(subject.subject_name)}
                       </span>
+                      {/* Subject Progress Indicator — matches the module and
+                          chapter rows below so every outline level reads the
+                          same way. onDark: this row sits on the navy surface in
+                          the Play theme. */}
+                      <div className="flex items-center gap-2 ms-auto shrink-0 min-w-20">
+                        {(() => {
+                          const progress = calculateSubjectProgress(subject.id);
+                          return (
+                            <>
+                              <div className="w-14 sm:w-16 hidden sm:block">
+                                {renderProgressBar(progress, "sm")}
+                              </div>
+                              {renderCompletionBadge(progress, { onDark: true })}
+                            </>
+                          );
+                        })()}
+                      </div>
                     </div>
                   </CollapsibleTrigger>
                   <CollapsibleContent className={`pb-1 pt-2 `}>


### PR DESCRIPTION
## Summary of Changes

Learners reported that finishing a chapter didn't move their course progress. Root-caused to two independent defects, plus a display gap.

**1. The course rollup was silently skipped.** The learner clients resolved the batch (`packageSessionId`) from a single value cached in device Preferences at login, while chapter/module/subject ids came from the route. A learner enrolled in more than one batch therefore sent the wrong batch whenever they studied any other course. The backend matched no rows, produced `null`, and dropped it — leaving the course percentage frozen while every level below it moved. The assignment submit path was worse: it sent no cascade ids at all, so a submitted assignment set its slide to 100% and rolled up nothing.

Prod data: multi-batch learners were 7x more likely to have an understated course percentage than single-batch learners (3.4% vs 0.5%), worst case understated by 80 points.

**2. PDF page-views migrated to the neighbouring slide.** `pdf-viewer` created its activity id and page-view buffer once per mount and read `slide_id` from `activeItem` at flush time, so moving to the next slide re-tagged the buffered views. Because the backend merges an activity row by its client-supplied id, the whole row was re-parented and its `document_tracked` rows went with it. Observed in prod: a 2-page reading note holding 14 distinct tracked pages (capped to 100%) beside a 14-page PDF stuck below 100% with no evidence left to recompute from. `doc-viewer` already guarded this; `pdf-viewer` never got the guard.

**Backend:**
- `LearnerTrackingService`: refuse to re-parent an activity log to a different slide; keep the original binding and warn.
- `LearnerTrackingService`: pass `getId()` rather than `getUserId()` when updating a document activity — every sibling method already did (latent, since the web client always sends `new_activity: true`).
- `LearnerTrackingAsyncService`: log which ids are missing at the chapter cascade and bail on a blank `chapterId`; warn instead of silently discarding a null course rollup.

**Frontend:**
- New `useResolvedPackageSessionId` — resolves the batch from the course being studied (route `sessionId` → content store → cached value). Wired into the pdf, presentation, video, question, SCORM and assignment paths. The correct pattern already existed in the quiz and coding paths; these six hadn't been updated.
- `assignment-slide`: send `chapterId` / `moduleId` / `subjectId` / `packageSessionId` on submit.
- `pdf-viewer`: bind the activity buffer to a slide and reset it on change; freeze `slide_id` at creation. `slide-material`: `key={activeItem.id}` so PDF→PDF navigation remounts.
- `course-structure-details`: show subject progress in the outline (subjects had only a status icon while modules and chapters had a bar and a percentage), and correct `calculateSubjectProgress` to mean-of-module-means so it matches the backend rather than flat-averaging every chapter.

**Docs:**
- `docs/runbooks/learner-progress-rollup-backfill.sql` — idempotent repair for rollups already stranded. Recomputes chapter → module → subject → package_session with the service's own formulas. Deliberately does not touch slide percentages (see the footer for why recomputing them would lower real learners).

## Related Issue

Progress status for Ariz Ali Tejani 082774 — edustream

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Reproduced end to end against a local `admin_core_service` on a same-day production dump, with only the tracking endpoints pointed at localhost and everything else on the remote backend.
- Progressed a chapter as a learner enrolled in two batches: chapter 12.22 → 70.56, module/subject 33.24 → 52.69, course 47.87 → 57.59, matching `(52.69 + 62.50) / 2` exactly. Before the fix the course value did not move.
- Verified the tracking requests carry the batch of the course actually open rather than the login-cached one.
- 3 new unit tests in `LearnerTrackingSlideBindingTest` cover the slide-binding guard; confirmed they fail with the guard disabled and pass with it.
- Backfill validated on a local copy: 3,091 chapter, 2,460 module, 1,830 subject, 691 package_session rows corrected; second run updates 0; the verify section returns no rows.
- `tsc --noEmit` clean; `design-lint` 0 errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
