### PR TITLE
Fix leads query 500: no semicolons in native-query SQL comments

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -323,12 +323,16 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                    OR ar.id = ANY(STRING_TO_ARRAY(:customFieldMatchedIdsCsv, ',')))
                               AND (COALESCE(:customFieldExcludedIdsCsv, '') = ''
                                    OR NOT (ar.id = ANY(STRING_TO_ARRAY(:customFieldExcludedIdsCsv, ','))))
+                              -- NOTE never put a semicolon anywhere in this query's comments --
+                              -- Hibernate's limit handler treats the first semicolon as end of
+                              -- statement and injects "fetch first ? rows only" there, which
+                              -- desyncs JDBC parameter binding (column index out of range).
                               -- Call-history matching. A call log links to a lead THREE ways:
                               -- response_id (manual dialer + CDR import), subject_id+LEAD (AI
                               -- campaigns), or just user_id (about a quarter of Airtel CDR rows
-                              -- have no response link; the lead side-panel lists calls by user_id
-                              -- + institute, so the filter must match the same or called leads
-                              -- land in NOT_CALLED).
+                              -- have no response link, while the lead side-panel lists calls by
+                              -- user_id + institute, so the filter must match the same or called
+                              -- leads land in NOT_CALLED).
                               -- Keep each column in its OWN EXISTS block: one EXISTS with an OR
                               -- across columns defeats every index and seq-scans the whole call
                               -- log per candidate lead (statement timeout).
@@ -584,12 +588,16 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                    OR ar.id = ANY(STRING_TO_ARRAY(:customFieldMatchedIdsCsv, ',')))
                               AND (COALESCE(:customFieldExcludedIdsCsv, '') = ''
                                    OR NOT (ar.id = ANY(STRING_TO_ARRAY(:customFieldExcludedIdsCsv, ','))))
+                              -- NOTE never put a semicolon anywhere in this query's comments --
+                              -- Hibernate's limit handler treats the first semicolon as end of
+                              -- statement and injects "fetch first ? rows only" there, which
+                              -- desyncs JDBC parameter binding (column index out of range).
                               -- Call-history matching. A call log links to a lead THREE ways:
                               -- response_id (manual dialer + CDR import), subject_id+LEAD (AI
                               -- campaigns), or just user_id (about a quarter of Airtel CDR rows
-                              -- have no response link; the lead side-panel lists calls by user_id
-                              -- + institute, so the filter must match the same or called leads
-                              -- land in NOT_CALLED).
+                              -- have no response link, while the lead side-panel lists calls by
+                              -- user_id + institute, so the filter must match the same or called
+                              -- leads land in NOT_CALLED).
                               -- Keep each column in its OWN EXISTS block: one EXISTS with an OR
                               -- across columns defeats every index and seq-scans the whole call
                               -- log per candidate lead (statement timeout).
@@ -854,12 +862,16 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                    OR ar.id = ANY(STRING_TO_ARRAY(:customFieldMatchedIdsCsv, ',')))
                               AND (COALESCE(:customFieldExcludedIdsCsv, '') = ''
                                    OR NOT (ar.id = ANY(STRING_TO_ARRAY(:customFieldExcludedIdsCsv, ','))))
+                              -- NOTE never put a semicolon anywhere in this query's comments --
+                              -- Hibernate's limit handler treats the first semicolon as end of
+                              -- statement and injects "fetch first ? rows only" there, which
+                              -- desyncs JDBC parameter binding (column index out of range).
                               -- Call-history matching. A call log links to a lead THREE ways:
                               -- response_id (manual dialer + CDR import), subject_id+LEAD (AI
                               -- campaigns), or just user_id (about a quarter of Airtel CDR rows
-                              -- have no response link; the lead side-panel lists calls by user_id
-                              -- + institute, so the filter must match the same or called leads
-                              -- land in NOT_CALLED).
+                              -- have no response link, while the lead side-panel lists calls by
+                              -- user_id + institute, so the filter must match the same or called
+                              -- leads land in NOT_CALLED).
                               -- Keep each column in its OWN EXISTS block: one EXISTS with an OR
                               -- across columns defeats every index and seq-scans the whole call
                               -- log per candidate lead (statement timeout).
@@ -1111,12 +1123,16 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                                    OR ar.id = ANY(STRING_TO_ARRAY(:customFieldMatchedIdsCsv, ',')))
                               AND (COALESCE(:customFieldExcludedIdsCsv, '') = ''
                                    OR NOT (ar.id = ANY(STRING_TO_ARRAY(:customFieldExcludedIdsCsv, ','))))
+                              -- NOTE never put a semicolon anywhere in this query's comments --
+                              -- Hibernate's limit handler treats the first semicolon as end of
+                              -- statement and injects "fetch first ? rows only" there, which
+                              -- desyncs JDBC parameter binding (column index out of range).
                               -- Call-history matching. A call log links to a lead THREE ways:
                               -- response_id (manual dialer + CDR import), subject_id+LEAD (AI
                               -- campaigns), or just user_id (about a quarter of Airtel CDR rows
-                              -- have no response link; the lead side-panel lists calls by user_id
-                              -- + institute, so the filter must match the same or called leads
-                              -- land in NOT_CALLED).
+                              -- have no response link, while the lead side-panel lists calls by
+                              -- user_id + institute, so the filter must match the same or called
+                              -- leads land in NOT_CALLED).
                               -- Keep each column in its OWN EXISTS block: one EXISTS with an OR
                               -- across columns defeats every index and seq-scans the whole call
                               -- log per candidate lead (statement timeout).


### PR DESCRIPTION
Hibernate's limit handler treats the first semicolon in the SQL as end of statement and injects 'fetch first ? rows only' there. The call-history comment added in f7400fb21 contained one, so the fetch clause landed inside a '--' comment line, its placeholder was never a real parameter, and every paged leads query failed with 'column index out of range: 103, number of columns: 102'.

Reword the comment without semicolons and leave a warning note.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
