### PR TITLE
fix(lexical-convert): stop false 'text would not carry over' warning

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-check/test.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-check/test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeConversion } from '../convert-yoopta';
+
+/** formatHTMLString-style skeleton a stored Yoopta doc actually has, with the
+ *  pretty-printed newlines between block tags that broke the naive
+ *  textContent comparison (regression: "Some text would not carry over" fired
+ *  on plain multi-paragraph docs). */
+const wrap = (inner: string) =>
+    `<html>\n<head></head>\n<body>\n<div>\n${inner}\n</div>\n</body>\n</html>`;
+
+describe('analyzeConversion — text-loss check', () => {
+    it('does not flag a plain multi-paragraph doc (the false-positive case)', () => {
+        const html = wrap('<p>Hello</p>\n<p>tell me this</p>\n<h2>Understanding</h2>');
+        const result = analyzeConversion(html);
+        expect(result.textChanged).toBe(false);
+        expect(result.lostBlocks).toEqual([]);
+        expect(result.safe).toBe(true);
+    });
+
+    it('does not flag inline formatting (bold / italic)', () => {
+        const html = wrap('<p>this is <strong>bold</strong> and <em>italic</em> text</p>');
+        const result = analyzeConversion(html);
+        expect(result.textChanged).toBe(false);
+        expect(result.safe).toBe(true);
+    });
+
+    it('does not flag content split by <br> line breaks', () => {
+        const html = wrap('<p>line one<br>line two<br>line three</p>');
+        const result = analyzeConversion(html);
+        expect(result.textChanged).toBe(false);
+    });
+
+    it('round-trips a plain sentence with no reported loss', () => {
+        const html = wrap('<p>keep this sentence intact please</p>');
+        const result = analyzeConversion(html);
+        expect(result.textChanged).toBe(false);
+        expect(result.safe).toBe(true);
+    });
+});

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-yoopta.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-yoopta.ts
@@ -77,13 +77,28 @@ function mediaUrls(doc: Document): Set<string> {
     return urls;
 }
 
-/** Visible text OUTSIDE custom-block subtrees, whitespace-normalised. Custom
- *  blocks are excluded because the two editors emit different static fallback
- *  bodies for the same payload. */
-function nonBlockText(doc: Document): string {
+/** Word multiset of the visible text OUTSIDE custom-block subtrees.
+ *
+ *  A boundary space is injected at every block edge first, because
+ *  `textContent` concatenates block text with NO separator — so the two
+ *  editors' differing inter-block whitespace (Yoopta pretty-prints with
+ *  newlines; Lexical emits compact HTML) would otherwise make identical text
+ *  look different (`"A B"` vs `"AB"`). Custom blocks are excluded because the
+ *  two editors emit different static fallback bodies for the same payload. */
+const BLOCK_TAGS =
+    'p,div,h1,h2,h3,h4,h5,h6,li,tr,td,th,blockquote,pre,summary,figure,figcaption,section,article,header,footer,ul,ol,table';
+
+function nonBlockWordCounts(doc: Document): Map<string, number> {
     const clone = doc.body.cloneNode(true) as HTMLElement;
     clone.querySelectorAll(CUSTOM_BLOCK_SELECTOR).forEach((el) => el.remove());
-    return (clone.textContent || '').replace(/\s+/g, ' ').trim();
+    // Line breaks and block edges become explicit spaces so words never fuse.
+    clone.querySelectorAll('br').forEach((br) => br.replaceWith(' '));
+    clone.querySelectorAll(BLOCK_TAGS).forEach((el) => el.append(' '));
+    const counts = new Map<string, number>();
+    for (const word of (clone.textContent || '').split(/\s+/)) {
+        if (word) counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+    return counts;
 }
 
 /** Detect inline styling in the source (outside custom blocks) that the new
@@ -166,8 +181,15 @@ export function analyzeConversion(sourceHtml: string): ConversionAnalysis {
         if (!afterUrls.has(u)) lostMedia.push(u);
     });
 
-    // Text loss (outside custom blocks)
-    const textChanged = nonBlockText(srcDoc) !== nonBlockText(convDoc);
+    // Text loss (outside custom blocks): flag only when the source has words
+    // the conversion actually dropped — added words / reflow don't count as
+    // loss, and boundary-aware counting ignores inter-block whitespace diffs.
+    const srcWords = nonBlockWordCounts(srcDoc);
+    const convWords = nonBlockWordCounts(convDoc);
+    let textChanged = false;
+    srcWords.forEach((count, word) => {
+        if ((convWords.get(word) ?? 0) < count) textChanged = true;
+    });
 
     const safe = lostBlocks.length === 0 && lostMedia.length === 0 && !textChanged;
 


### PR DESCRIPTION
## Context
PR #2369 (opt-in "Convert to new editor") shipped with a text-loss check that **false-positives on ordinary multi-paragraph documents** — a plain doc like "Hello / tell me this / Understanding" wrongly showed **"Some text would not carry over"** and pushed users to "Convert anyway".

## Root cause
The check compared the browser's `textContent` of the source vs the Lexical round-trip. `textContent` inserts **no separator between block elements**, and the two editors format HTML differently:
- Old (Yoopta) editor pretty-prints: `<p>A</p>` ⏎ `<p>B</p>` → `"A B"` (newline → space)
- Lexical emits compact HTML: `<p>A</p><p>B</p>` → `"AB"` (no space)

Same words, different strings → every doc with more than one block was flagged.

## Fix
Compare a **boundary-aware word multiset** instead: inject an explicit space at each block edge and `<br>`, then count words and report loss **only when the source has words the conversion actually dropped** (added words / reflow don't count). This removes the whitespace sensitivity while still catching genuine text loss.

Adds `convert-check/test.ts` with regression cases (multi-paragraph — the exact reported scenario — plus inline formatting and `<br>`-split content) that run the real headless conversion pipeline under happy-dom.

## Test plan
- [x] `pnpm test` (the new regression suite — 4/4 pass; multi-paragraph doc now reports safe)
- [x] `pnpm run typecheck`
- [x] per-file `eslint` + `design-lint` (clean)
- [x] `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)