### PR TITLE
feat(lexical): open uploaded documents in the new editor when lossless

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-yoopta.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/convert-yoopta.ts
@@ -202,3 +202,21 @@ export function analyzeConversion(sourceHtml: string): ConversionAnalysis {
         formattingWarnings: formattingWarnings(srcDoc, convDoc),
     };
 }
+
+/**
+ * For freshly-created content (docx/doc uploads): return the Lexical-routed
+ * (marker-bearing) HTML when the round-trip is lossless, else null so the
+ * caller keeps the original HTML on the legacy editor. Uploads should open in
+ * the new editor by default, but never at the cost of silently dropping a
+ * table / image / block the uploaded document actually had.
+ */
+export function docHtmlToLexicalIfSafe(sourceHtml: string): string | null {
+    if (!sourceHtml || !sourceHtml.trim()) return null;
+    try {
+        const a = analyzeConversion(sourceHtml);
+        return a.safe && a.convertedHtml ? a.convertedHtml : null;
+    } catch (e) {
+        console.error('[Lexical] upload→lexical pre-flight failed:', e);
+        return null;
+    }
+}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-doc-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slides-sidebar/add-doc-dialog.tsx
@@ -9,6 +9,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { FileType } from '@/types/common/file-upload';
 import { convertDocToHtml } from './utils/doc-to-html';
+import { docHtmlToLexicalIfSafe } from '../lexical-editor/convert-yoopta';
 import { useRouter } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useReplaceBase64ImagesWithNetworkUrls } from '@/utils/helpers/study-library-helpers.ts/slides/replaceBase64ToNetworkUrl';
@@ -17,10 +18,7 @@ import { convertHtmlToPdf } from '../../-helper/helper';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import { useSlidesMutations } from '../../-hooks/use-slides';
 import { getSlideStatusForUser } from '../../non-admin/hooks/useNonAdminSlides';
-import {
-    buildAppendReorderPayload,
-    getNextSlideOrder,
-} from '../../-helper/slide-naming-utils';
+import { buildAppendReorderPayload, getNextSlideOrder } from '../../-helper/slide-naming-utils';
 
 interface FormData {
     docFile: FileList | null;
@@ -194,6 +192,12 @@ export const AddDocDialog = ({
             setUploadProgress(70);
             const { totalPages } = await convertHtmlToPdf(processedHtml);
 
+            // Open uploads in the new (Lexical) editor when the content
+            // round-trips losslessly; otherwise keep the legacy editor so a
+            // complex document never silently loses a table/image/block.
+            const lexicalHtml = docHtmlToLexicalIfSafe(processedHtml);
+            const finalHtml = lexicalHtml ?? processedHtml;
+
             setUploadStage('Saving slide…');
             setUploadProgress(85);
             const slideStatus = getSlideStatusForUser();
@@ -207,11 +211,11 @@ export const AddDocDialog = ({
                 document_slide: {
                     id: documentIdRef.current,
                     type: 'DOC',
-                    data: processedHtml,
+                    data: finalHtml,
                     title,
                     cover_file_id: '',
                     total_pages: totalPages,
-                    published_data: slideStatus === 'PUBLISHED' ? processedHtml : null,
+                    published_data: slideStatus === 'PUBLISHED' ? finalHtml : null,
                     published_document_total_pages: totalPages,
                 },
                 status: slideStatus,
@@ -271,7 +275,7 @@ export const AddDocDialog = ({
                         <div className="text-center">
                             {file ? (
                                 <>
-                                    <p className="text-primary-600 font-medium">{file.name}</p>
+                                    <p className="font-medium text-primary-600">{file.name}</p>
                                     <p className="text-sm text-gray-500">
                                         {(file.size / (1024 * 1024)).toFixed(2)} MB
                                     </p>
@@ -294,7 +298,7 @@ export const AddDocDialog = ({
                     <div className="space-y-3 duration-300 animate-in fade-in slide-in-from-bottom-2">
                         <Progress
                             value={uploadProgress}
-                            className="[&>div]:to-primary-600 h-2 bg-neutral-200 [&>div]:bg-gradient-to-r [&>div]:from-primary-500"
+                            className="h-2 bg-neutral-200 [&>div]:bg-gradient-to-r [&>div]:from-primary-500 [&>div]:to-primary-600"
                         />
                         <div className="text-sm text-neutral-600">
                             {uploadStage || 'This may take a few moments…'}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-quick-add.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-quick-add.tsx
@@ -19,6 +19,7 @@ import { useReplaceBase64ImagesWithNetworkUrls } from '@/utils/helpers/study-lib
 import { convertHtmlToPdf } from './-helper/helper';
 import { formatHTMLString } from './-components/slide-operations/formatHtmlString';
 import { EMPTY_LEXICAL_INNER } from './-components/lexical-editor/lexical-doc-marker';
+import { docHtmlToLexicalIfSafe } from './-components/lexical-editor/convert-yoopta';
 import {
     Plus,
     YoutubeLogo,
@@ -558,6 +559,9 @@ export function QuickAddView({ search }: { search: ChapterSearchParamsForQuickAd
                     const processedHtml = await replaceBase64ImagesWithNetworkUrls(html);
                     const normalized = normalizeHtmlQuotes(processedHtml);
                     const { totalPages } = await convertHtmlToPdf(processedHtml);
+                    // Open uploads in the new (Lexical) editor when lossless;
+                    // else keep the legacy editor (no silent content loss).
+                    const finalHtml = docHtmlToLexicalIfSafe(normalized) ?? normalized;
                     const id = crypto.randomUUID();
                     const resp: string = await addUpdateDocumentSlide({
                         id,
@@ -568,11 +572,11 @@ export function QuickAddView({ search }: { search: ChapterSearchParamsForQuickAd
                         document_slide: {
                             id: crypto.randomUUID(),
                             type: 'DOC',
-                            data: normalized,
+                            data: finalHtml,
                             title: item.title,
                             cover_file_id: '',
                             total_pages: totalPages,
-                            published_data: normalized,
+                            published_data: finalHtml,
                             published_document_total_pages: totalPages,
                         },
                         status,


### PR DESCRIPTION
## Problem
"Upload from device" (and bulk Quick Add) converts docx/doc → HTML and stored it **marker-less**, so every uploaded document opened in the **legacy Yoopta editor** instead of the new Lexical one.

## Fix
The converted HTML is now run through the Lexical import→export round-trip and stored **marker-bearing** (`data-editor="lexical"` → new editor) **when the round-trip is lossless**. If it would drop a table / image / block or text, the upload **keeps the legacy editor** — so an uploaded document is never silently truncated to fit the new editor.

Shared `docHtmlToLexicalIfSafe(html)` helper (in `convert-yoopta.ts`), used by both the "Upload from device" dialog and the bulk Quick-Add DOC path.

## Note on the base
Stacked on #2370 (the text-loss false-positive fix) because this reuses `analyzeConversion().safe`, whose text check #2370 corrects — without it, multi-paragraph uploads would wrongly fall back to the legacy editor. Base is set to that branch; GitHub will retarget to `main` once #2370 merges.

## Behaviour
- Clean docx (text, headings, lists, tables, images, bold/italic) → opens in the **new editor**.
- docx with a construct the new editor can't yet round-trip losslessly → opens in the **legacy editor**, no content lost. (As the importer is hardened, more uploads land in the new editor automatically.)

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (full repo, max-warnings=0)
- [x] `node ../scripts/design-lint.mjs` on changed files (clean)
- [x] `pnpm run build`
- [ ] Manual (needs prod-write to upload → deferred): upload a simple .docx and confirm it opens in the new editor with drag handles / slash menu; upload one with a complex table and confirm it opens in the legacy editor with the table intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)