### PR TITLE
Guest waiting room: fetch media via the no-login URL endpoint

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
@@ -5,7 +5,9 @@ import { useSessionDetails } from "../-hooks/useSessionDetails";
 import { useGuestAccessRecovery } from "../-hooks/useGuestAccessRecovery";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import { CountdownTimer } from "@/routes/study-library/live-class/waiting-room/-components/CountdownTimer";
-import { getPublicUrl } from "@/services/upload_file";
+// No-login variant: guests have no auth token, so the authenticated
+// getPublicUrl silently 401s and the thumbnail/hero never render.
+import { getPublicUrlWithoutLogin } from "@/services/upload_file";
 import { BackgroundMusic } from "@/routes/study-library/live-class/waiting-room/-components/BackgroundMusic";
 import { SessionStreamingServiceType } from "@/routes/register/live-class/-types/enum";
 import { useMarkAttendance } from "../-hooks/useMarkAttendance";
@@ -44,7 +46,7 @@ function GuestWaitingRoomComponent() {
   useEffect(() => {
     const fetchThumbnail = async () => {
       if (sessionDetails?.thumbnailFileId) {
-        const thumbnailUrl = await getPublicUrl(sessionDetails.thumbnailFileId);
+        const thumbnailUrl = await getPublicUrlWithoutLogin(sessionDetails.thumbnailFileId);
         setThumbnail(thumbnailUrl);
       }
     };
@@ -56,7 +58,7 @@ function GuestWaitingRoomComponent() {
     const heroFileId =
       sessionDetails?.customWaitingRoomMediaId || sessionDetails?.coverFileId;
     if (heroFileId) {
-      getPublicUrl(heroFileId)
+      getPublicUrlWithoutLogin(heroFileId)
         .then((url) => setHeroUrl(url))
         .catch(() => setHeroUrl(null));
     }

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/waiting-room/-components/BackgroundMusic.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/waiting-room/-components/BackgroundMusic.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from "react";
-import { getPublicUrl } from "@/services/upload_file";
+// No-login variant: this component also renders on the GUEST waiting room,
+// where the authenticated getPublicUrl silently fails (no token) and music
+// never plays. The public endpoint works for logged-in learners too.
+import { getPublicUrlWithoutLogin } from "@/services/upload_file";
 
 interface BackgroundMusicProps {
   backgroundScoreFileId: string | null;
@@ -14,7 +17,7 @@ export function BackgroundMusic({
     const fetchAndPlayAudio = async () => {
       if (backgroundScoreFileId) {
         try {
-          const url = await getPublicUrl(backgroundScoreFileId);
+          const url = await getPublicUrlWithoutLogin(backgroundScoreFileId);
           if (audioRef.current) {
             audioRef.current.src = url;
             audioRef.current.volume = 0.3; // Set volume to 30%


### PR DESCRIPTION
The guest waiting room (and the shared BackgroundMusic component) resolved file URLs through the authenticated getPublicUrl - a guest has no token, so the call silently failed and the hero background, thumbnail and background music never rendered for public-session visitors. Switched to getPublicUrlWithoutLogin (public endpoint, works for logged-in learners too).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
