### PR TITLE
Fix/quiz question numbering and double submit

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/QuizPreview.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/QuizPreview.tsx
@@ -83,6 +83,7 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
     const [selectedQuestionType, setSelectedQuestionType] = useState<string>('');
     const [isDeleteConfirmDialogOpen, setIsDeleteConfirmDialogOpen] = useState(false);
     const [questionToDelete, setQuestionToDelete] = useState<number | null>(null);
+    const [isDeletingQuestion, setIsDeletingQuestion] = useState(false);
 
     // Quiz-level settings (time limit, marks, negative marking)
     const [quizSettings, setQuizSettings] = useState<QuizSettings>({
@@ -560,7 +561,11 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
     };
 
     const confirmDelete = async () => {
+        // Guard against a second click landing while the first request is still in flight
+        if (isDeletingQuestion) return;
+
         if (questionToDelete !== null) {
+            setIsDeletingQuestion(true);
             try {
                 // Get all current questions
                 const currentQuestions = form.getValues('questions');
@@ -592,6 +597,8 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
             } catch (error) {
                 console.error('Error deleting question:', error);
                 toast.error('Failed to delete question. Please try again.');
+            } finally {
+                setIsDeletingQuestion(false);
             }
         }
         setIsDeleteConfirmDialogOpen(false);
@@ -737,7 +744,12 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
                             >
                                 Cancel
                             </Button>
-                            <MyButton type="button" className="" onClick={handleAddQuestionConfirm}>
+                            <MyButton
+                                type="button"
+                                className=""
+                                onAsyncClick={handleAddQuestionConfirm}
+                                loadingText="Adding..."
+                            >
                                 Add Question
                             </MyButton>
                         </div>
@@ -783,7 +795,11 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
                             >
                                 Cancel
                             </Button>
-                            <MyButton type="button" onClick={handleEditConfirm}>
+                            <MyButton
+                                type="button"
+                                onAsyncClick={handleEditConfirm}
+                                loadingText="Saving..."
+                            >
                                 Save Changes
                             </MyButton>
                         </div>
@@ -796,6 +812,7 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
                     onOpenChange={setIsDeleteConfirmDialogOpen}
                     onConfirm={confirmDelete}
                     onCancel={cancelDelete}
+                    isDeleting={isDeletingQuestion}
                 />
 
                 {/* External question adding dialogs */}

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/QuizPreview.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/QuizPreview.tsx
@@ -602,6 +602,11 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
         setIsDeleteConfirmDialogOpen(false);
     };
 
+    // Soft-deleted questions stay in the form array, so a raw index is not the number the user
+    // sees. Convert a form-array index to its 1-based position among the visible questions.
+    const getDisplayNumber = (originalIndex: number) =>
+        fields.slice(0, originalIndex).filter((f) => f.status !== 'DELETED').length + 1;
+
     // Check if route parameters are available
     if (!chapterId || !moduleId || !subjectId || !sessionId) {
         console.warn('[QuizPreview] Route parameters not available:', {
@@ -659,14 +664,17 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
                     {fields.filter((field) => field.status !== 'DELETED').length > 0 ? (
                         fields
                             .filter((field) => field.status !== 'DELETED')
-                            .map((field) => {
-                                // Find the original index in the fields array
+                            .map((field, displayIndex) => {
+                                // Find the original index in the fields array. Questions are soft
+                                // deleted, so this index (which addresses the form array) is not
+                                // the number shown to the user — displayIndex is.
                                 const originalIndex = fields.findIndex((f) => f.id === field.id);
                                 return (
                                     <QuestionDisplay
                                         key={field.id}
                                         question={field as TransformedQuestion}
                                         questionIndex={originalIndex}
+                                        displayNumber={displayIndex + 1}
                                         onEdit={handleEdit}
                                         onDelete={handleRemove}
                                     />
@@ -743,7 +751,7 @@ const QuizPreview = ({ activeItem, routeParams }: QuizPreviewProps) => {
                 >
                     <DialogContent className="no-scrollbar !m-0 flex h-full !w-full !max-w-full flex-col overflow-y-auto !rounded-none !p-0">
                         <h1 className="bg-primary-50 p-4 font-semibold text-primary-500">
-                            Edit Question {editIndex !== null ? editIndex + 1 : ''}
+                            Edit Question {editIndex !== null ? getDisplayNumber(editIndex) : ''}
                         </h1>
 
                         <FormProvider {...editForm}>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/DeleteConfirmDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/DeleteConfirmDialog.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Warning } from '@phosphor-icons/react';
+import { CircleNotch, Warning } from '@phosphor-icons/react';
 
 interface DeleteConfirmDialogProps {
     isOpen: boolean;
     onOpenChange: (open: boolean) => void;
     onConfirm: () => void;
     onCancel: () => void;
+    /** Blocks re-submits and dismissal while the delete request is in flight. */
+    isDeleting?: boolean;
 }
 
 const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
@@ -15,9 +17,10 @@ const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
     onOpenChange,
     onConfirm,
     onCancel,
+    isDeleting = false,
 }) => {
     return (
-        <Dialog open={isOpen} onOpenChange={onOpenChange}>
+        <Dialog open={isOpen} onOpenChange={(open) => !isDeleting && onOpenChange(open)}>
             <DialogContent className="max-w-md">
                 <div className="flex items-center gap-3">
                     <div className="flex size-10 items-center justify-center rounded-full bg-red-100">
@@ -32,11 +35,28 @@ const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
                     </div>
                 </div>
                 <div className="flex justify-end gap-3 pt-4">
-                    <Button type="button" variant="outline" onClick={onCancel}>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onCancel}
+                        disabled={isDeleting}
+                    >
                         Cancel
                     </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm}>
-                        Delete
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={onConfirm}
+                        disabled={isDeleting}
+                    >
+                        {isDeleting ? (
+                            <span className="flex items-center justify-center gap-2">
+                                <CircleNotch className="size-4 animate-spin" />
+                                Deleting...
+                            </span>
+                        ) : (
+                            'Delete'
+                        )}
                     </Button>
                 </div>
             </DialogContent>

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/QuestionDisplay.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/QuestionDisplay.tsx
@@ -5,7 +5,13 @@ import { isRichTextEmpty } from '@/lib/utils';
 
 interface QuestionDisplayProps {
     question: TransformedQuestion;
+    /**
+     * Index of this question in the full form array, including soft-deleted rows.
+     * Used only to address the question in onEdit/onDelete — never for display.
+     */
     questionIndex: number;
+    /** 1-based position among the visible (non-deleted) questions. */
+    displayNumber: number;
     onEdit: (index: number) => void;
     onDelete: (index: number) => void;
 }
@@ -13,6 +19,7 @@ interface QuestionDisplayProps {
 const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
     question,
     questionIndex,
+    displayNumber,
     onEdit,
     onDelete,
 }) => {
@@ -196,7 +203,7 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                     <div className="text-primary-700 flex size-8 items-center justify-center rounded-full bg-primary-100 text-sm font-semibold">
-                        {questionIndex + 1}
+                        {displayNumber}
                     </div>
                     {/* Inline label next to number */}
                     {question.questionType === 'CMCQS' ||

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/QuizQuestionsPreviewDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/components/QuizQuestionsPreviewDialog.tsx
@@ -110,6 +110,7 @@ const QuizQuestionsPreviewDialog = ({
                                 key={item.key}
                                 question={toTransformedQuestion(item.question, index)}
                                 questionIndex={index}
+                                displayNumber={index + 1}
                                 onEdit={() => {}}
                                 onDelete={handleDelete}
                             />

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/utils/api-helpers.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/quiz/utils/api-helpers.ts
@@ -142,7 +142,7 @@ const calculateQuestionTimeInMillis = (question: any): number => {
 // Helper function to create question structure
 const createQuestionStructure = (
     question: any,
-    index: number,
+    questionOrder: number,
     options: any[],
     questionResponseType: string,
     evaluationType: string
@@ -222,7 +222,7 @@ const createQuestionStructure = (
         auto_evaluation_json: createAutoEvaluationJson(question, options) || (question as any).auto_evaluation_json || '',
         evaluation_type: evaluationType,
         question_time_in_millis: calculateQuestionTimeInMillis(question),
-        question_order: index + 1,
+        question_order: questionOrder,
         quiz_slide_id: '', // This will be set by the caller
         can_skip: question.canSkip || (question as any).can_skip || false,
         new_question: true, // Added for backend compatibility
@@ -248,7 +248,13 @@ const createQuestionStructure = (
 export const transformFormQuestionsToBackend = (
     questions: UploadQuestionPaperFormType['questions']
 ): QuizSlideQuestion[] => {
-    return questions.map((question, index) => {
+    // Deleting a question is a soft delete: the row stays in the array with status DELETED.
+    // Only live questions may consume an order slot, otherwise the stored orders develop gaps
+    // (delete the 3rd of 5 → 1,2,4,5). Deleted rows reuse the current counter; their order is
+    // irrelevant to the backend since they are removed.
+    let liveCount = 0;
+
+    return questions.map((question) => {
         // Normalize: backend questions use snake_case question_type
         const questionType =
             question.questionType || (question as any).question_type || 'MCQS';
@@ -257,9 +263,12 @@ export const transformFormQuestionsToBackend = (
         const { questionResponseType, evaluationType } = getQuestionResponseConfig(questionType);
         const options = transformOptionsByType(normalizedQuestion);
 
+        const isDeleted = question.status === 'DELETED';
+        const questionOrder = isDeleted ? liveCount + 1 : ++liveCount;
+
         return createQuestionStructure(
             normalizedQuestion,
-            index,
+            questionOrder,
             options,
             questionResponseType,
             evaluationType


### PR DESCRIPTION
## Summary of Changes

Two bugs in the quiz slide editor (study library → chapter → quiz slide).

**1. Question numbers left gaps after a delete.** Deleting a question is a soft delete — the row stays in the form array with `status: 'DELETED'` and is filtered out of the list. But the number rendered on each card came from the question's index in the *unfiltered* array, so deleting the 3rd of 5 questions left the list reading 1, 2, 4, 5. The index is legitimately needed to address the question for edit/delete, so the fix separates the two meanings rather than changing the delete semantics.

**2. Clicking "Add Question" twice created two questions.** The button had no in-flight guard, so a second click during the save re-read the same form values and appended again. Because each append mints a fresh UUID, the two were not deduped and both were persisted.

**Backend:**
- None — frontend-only change.

**Frontend:**
- `QuestionDisplay` now takes a separate `displayNumber` prop for the visible badge; `questionIndex` continues to address the form array for `onEdit`/`onDelete`. Both props are documented so the distinction is not re-collapsed later.
- `QuizPreview` passes the filtered list's own index as `displayNumber`, so visible numbering is always contiguous.
- Edit dialog title now uses a `getDisplayNumber()` helper (counts non-deleted rows before the index) so it matches the card the user clicked.
- `QuizQuestionsPreviewDialog` updated for the new required prop.
- "Add Question" and "Save Changes" switched from `onClick` to `MyButton`'s `onAsyncClick`, which ignores re-entrant clicks and shows a spinner with "Adding..." / "Saving..." while the request is in flight.
- Delete confirmation: new `isDeleting` prop on `DeleteConfirmDialog` disables both buttons, shows a "Deleting..." spinner, and blocks dismissal mid-request; `confirmDelete` also guards re-entry and clears the flag in a `finally`.
- `transformFormQuestionsToBackend` now advances `question_order` only for live questions, so stored orders stay contiguous instead of inheriting the same gaps. (`createQuestionStructure`'s `index` param renamed to `questionOrder` since it is no longer an index.)

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Manually verified in the quiz slide editor: deleted a question from the middle of the list and confirmed the remaining questions renumber contiguously (1, 2, 3, …) instead of leaving a gap.
- Confirmed the edit dialog title matches the number on the card that was clicked, including after a delete.
- Confirmed "Add Question" disables and shows a spinner while saving, and that repeated clicks no longer produce duplicate questions.
- Confirmed the same in-flight feedback on "Save Changes" and on the delete confirmation.
- `pnpm typecheck` passes; `design-lint` reports 0 errors on the changed files; eslint output on the touched files is unchanged from the pre-change baseline.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
