### PR TITLE
Leads: exclude deleted from status matrix + RBAC on campaign-users list

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -2525,6 +2525,19 @@ public class AudienceService {
                 ? String.join(",", filterDTO.getOverallStatuses())
                 : null;
 
+        // SECURITY: the campaign-users client sends only audienceId (no instituteId),
+        // and every RBAC block below gates on a non-blank instituteId — so the
+        // per-campaign list used to skip counsellor-hierarchy and sub-org scoping
+        // entirely (institute-wide visibility for scoped callers), while the
+        // institute_id-carrying Recent Leads request was scoped. Derive the institute
+        // from the audience up-front so scoping applies no matter what the client sends.
+        if ((filterDTO.getInstituteId() == null || filterDTO.getInstituteId().isBlank())
+                && filterDTO.getAudienceId() != null && !filterDTO.getAudienceId().isBlank()) {
+            audienceRepository.findById(filterDTO.getAudienceId())
+                    .map(Audience::getInstituteId)
+                    .ifPresent(filterDTO::setInstituteId);
+        }
+
         // Caller-level access scoping driven by the institute's
         // AUDIENCE_ROLE_ACCESS setting. Admin / root resolve to DEFAULT;
         // pure counselors are auto-scoped; AUDIENCE_LIST roles are restricted

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
@@ -306,7 +306,9 @@ public class PipelineReportService {
      * COALESCE(lu.user_id, assigned_counselor_id) convention; NULL collapses into a synthetic
      * UNASSIGNED row, which — like SYSTEM — only appears for unscoped callers (NULL never matches
      * a scope CSV). DISTINCT on the lead's user id so a multi-response lead counts once per
-     * status, not once per response.
+     * status, not once per response. Soft-deleted leads are excluded (audience_status = 'ACTIVE')
+     * to match the Recent Leads list default (EXCLUDE_DELETED) — without this the matrix counts
+     * deleted leads the list can't show, and the two screens disagree.
      */
     private static final String CURRENT_STATUS_BY_COUNSELLOR_SQL = """
             SELECT COALESCE(lu.user_id, ulp.assigned_counselor_id, 'UNASSIGNED') AS actor_id,
@@ -317,6 +319,7 @@ public class PipelineReportService {
             WHERE a.institute_id = :instituteId
               AND ar.submitted_at >= :fromTs
               AND ar.submitted_at <  :toTs
+              AND ar.audience_status = 'ACTIVE'
             """ + LEAD_SCOPE_PREDICATES + """
             GROUP BY 1, 2
             """;


### PR DESCRIPTION
Two mismatches against the Recent Leads list, both verified on prod:

1. Current-status-by-counsellour matrix counted soft-deleted leads (audience_status INACTIVE) that Recent Leads hides by default - e.g. a counsellor showing New: 8 while the list showed 0 (all 8 were deleted). The matrix now filters audience_status = 'ACTIVE', matching the list's EXCLUDE_DELETED default.

2. The per-campaign users list (audience-manager/list) had NO RBAC: its client sends only audience_id, and every scoping block in AudienceService.getLeads gates on a non-blank instituteId - so counsellor-hierarchy and sub-org scoping silently skipped while the institute_id-carrying Recent Leads request was scoped. getLeads now derives the institute from the audience up-front so scoping applies regardless of what the client sends.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
