### PR TITLE
fix(slides): stop false content-loss confirms in both editors, and the data loss behind them

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssessmentSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssessmentSlide.java
@@ -5,6 +5,7 @@ import lombok.*;
 import vacademy.io.admin_core_service.features.slide.dto.AssessmentSlideDTO;
 
 import java.time.LocalDateTime;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "assessment_slide")
@@ -31,7 +32,8 @@ public class AssessmentSlide {
     @Column(name = "created_at", insertable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     public AssessmentSlide(AssessmentSlideDTO dto) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssignmentSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssignmentSlide.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "assignment_slide")
@@ -55,7 +56,8 @@ public class AssignmentSlide {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     public AssignmentSlide(AssignmentSlideDTO dto) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssignmentSlideQuestion.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AssignmentSlideQuestion.java
@@ -8,6 +8,7 @@ import vacademy.io.admin_core_service.features.slide.dto.AssignmentSlideQuestion
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 public class AssignmentSlideQuestion {
@@ -37,7 +38,8 @@ public class AssignmentSlideQuestion {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     public AssignmentSlideQuestion() {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AudioSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/AudioSlide.java
@@ -11,6 +11,7 @@ import vacademy.io.admin_core_service.features.slide.dto.AudioSlideDTO;
 import vacademy.io.admin_core_service.features.slide.enums.SlideStatus;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * Entity representing an audio slide.
@@ -84,7 +85,8 @@ public class AudioSlide {
     @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/DocumentSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/DocumentSlide.java
@@ -10,6 +10,7 @@ import vacademy.io.admin_core_service.features.slide.dto.DocumentSlideDTO;
 import vacademy.io.admin_core_service.features.slide.enums.SlideStatus;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "document_slide")
@@ -45,7 +46,8 @@ public class DocumentSlide {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     public DocumentSlide() {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/HtmlVideoSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/HtmlVideoSlide.java
@@ -11,6 +11,7 @@ import org.hibernate.type.SqlTypes;
 import vacademy.io.admin_core_service.features.slide.dto.HtmlVideoSlideDTO;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -38,7 +39,8 @@ public class HtmlVideoSlide {
     @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 
     public HtmlVideoSlide() {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/QuestionSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/QuestionSlide.java
@@ -11,6 +11,7 @@ import vacademy.io.admin_core_service.features.slide.dto.QuestionSlideDTO;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "question_slide")
@@ -69,7 +70,8 @@ public class QuestionSlide {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     @OneToMany(mappedBy = "questionSlide", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/ScormLearnerProgress.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/ScormLearnerProgress.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -70,6 +71,7 @@ public class ScormLearnerProgress {
     @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/ScormSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/ScormSlide.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -34,7 +35,8 @@ public class ScormSlide {
     @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 
     public ScormSlide() {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/Slide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/Slide.java
@@ -12,6 +12,7 @@ import vacademy.io.admin_core_service.features.slide.entity.HtmlVideoSlide;
 import vacademy.io.admin_core_service.features.slide.enums.SlideStatus;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "slide")
@@ -63,7 +64,8 @@ public class Slide {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     @Column(name = "parent_id")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/VideoSlide.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/VideoSlide.java
@@ -11,6 +11,7 @@ import vacademy.io.admin_core_service.features.slide.dto.VideoSlideDTO;
 import vacademy.io.admin_core_service.features.slide.enums.SlideStatus;
 
 import java.sql.Timestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -50,7 +51,8 @@ public class VideoSlide {
     @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 
     public VideoSlide(VideoSlideDTO addVideoSlideDTO, String status) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/VideoSlideQuestion.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/entity/VideoSlideQuestion.java
@@ -9,6 +9,7 @@ import vacademy.io.admin_core_service.features.slide.dto.VideoSlideQuestionDTO;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -68,7 +69,8 @@ public class VideoSlideQuestion {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private Timestamp updatedAt;
 
     @OneToMany(mappedBy = "videoSlideQuestion", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/slide/service/SlideService.java
@@ -566,6 +566,13 @@ public class SlideService {
     // docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md). Plain text/paragraph shrink is NOT guarded
     // here — authors delete text freely. The author overrides with force (confirmed in UI).
     private static final Pattern YOOPTA_BLOCK_MARKER = Pattern.compile("data-yoopta-type=\"([a-zA-Z]+)\"");
+    // Quoted attribute values may legally contain '>' (e.g. alt="a > b"), so the tag
+    // body is matched as "unquoted char | quoted run" rather than [^>]* — otherwise a
+    // tag could be cut short before its src and counted wrong.
+    private static final Pattern IMG_TAG = Pattern.compile("<img\\b(?:[^>\"']|\"[^\"]*\"|'[^']*')*>",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern IMG_SRC_ATTR = Pattern.compile("\\bsrc\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)')",
+            Pattern.CASE_INSENSITIVE);
 
     private static int countOccurrences(String s, String sub) {
         int n = 0, i = 0;
@@ -574,6 +581,33 @@ public class SlideService {
             i += sub.length();
         }
         return n;
+    }
+
+    /**
+     * Images that can actually render. An <img> with an empty/null/undefined src is
+     * an abandoned upload placeholder — the editor's importer drops it and
+     * formatHTMLString strips it on every save, so counting it reported "1 image"
+     * as lost on a save where the author changed nothing. There is no content in
+     * such a tag to protect. Mirrors hasRenderableSrc() in the editor's
+     * serialization.ts; keep the two in step.
+     */
+    private static int countRenderableImages(String html) {
+        Matcher tag = IMG_TAG.matcher(html);
+        int count = 0;
+        while (tag.find()) {
+            Matcher src = IMG_SRC_ATTR.matcher(tag.group());
+            if (!src.find()) {
+                continue;
+            }
+            String value = src.group(1) != null ? src.group(1) : src.group(2);
+            String trimmed = value == null ? "" : value.trim();
+            if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed)
+                    || "undefined".equalsIgnoreCase(trimmed)) {
+                continue;
+            }
+            count++;
+        }
+        return count;
     }
 
     private static Map<String, Integer> structuralMarkerCounts(String html) {
@@ -587,7 +621,7 @@ public class SlideService {
         }
         int tables = countOccurrences(html, "<table");
         if (tables > 0) counts.put("table", tables);
-        int imgs = countOccurrences(html, "<img");
+        int imgs = countRenderableImages(html);
         if (imgs > 0) counts.put("image", imgs);
         int media = countOccurrences(html, "<video") + countOccurrences(html, "<iframe");
         if (media > 0) counts.put("video/embed", media);

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/slide/service/SlideStructuralLossTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/slide/service/SlideStructuralLossTest.java
@@ -62,4 +62,31 @@ class SlideStructuralLossTest {
         // First-ever publish (no prior content) must never report loss.
         assertEquals("", SlideService.describeStructuralLoss(null, "<table></table>"));
     }
+
+    /**
+     * A src-less <img> is an abandoned upload placeholder, not content: the editor's
+     * importer drops it and formatHTMLString strips it on every save. Counting it
+     * produced "This will remove 1 image" on saves where the author changed nothing.
+     */
+    @Test
+    void ignoresPlaceholderImagesWithNoUsableSrc() {
+        assertEquals("", SlideService.describeStructuralLoss("<img src=\"\" alt=\"pending\">", "<p>x</p>"));
+        assertEquals("", SlideService.describeStructuralLoss("<img src=\"null\">", "<p>x</p>"));
+        assertEquals("", SlideService.describeStructuralLoss("<img src=\"undefined\">", "<p>x</p>"));
+        assertEquals("", SlideService.describeStructuralLoss("<img alt=\"no src at all\">", "<p>x</p>"));
+    }
+
+    @Test
+    void stillDetectsRealImageLossAlongsidePlaceholders() {
+        String oldH = "<img src=\"https://s3/a.png\"><img src=\"\">";
+        assertTrue(SlideService.describeStructuralLoss(oldH, "<img src=\"\">").contains("1 image"));
+    }
+
+    @Test
+    void countsImagesRegardlessOfQuoteStyleAndSpacing() {
+        String oldH = "<img src = 'https://s3/a.png' ><IMG SRC=\"https://s3/b.png\">";
+        assertEquals("", SlideService.describeStructuralLoss(oldH, oldH));
+        assertTrue(SlideService.describeStructuralLoss(oldH, "<img src='https://s3/a.png'>")
+                .contains("1 image"));
+    }
 }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/blocks/media-block-editors.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/blocks/media-block-editors.tsx
@@ -15,6 +15,7 @@ import type {
     CalloutPayload,
 } from '../nodes/media-nodes';
 import { CALLOUT_THEMES, toEmbedUrl } from '../nodes/media-nodes';
+import { RichTextField } from '../../yoopta-editor-customizations/RichTextField';
 
 interface BlockEditorProps<T> {
     payload: T;
@@ -249,15 +250,15 @@ export function CalloutBlockEditor({
             }}
         >
             {readOnly ? (
-                <div className="whitespace-pre-wrap">{payload.text}</div>
+                // Rich payload (tables/images/formatting can live in a callout), so
+                // render it as HTML. Source is this institute's own saved slide
+                // content, the same string the learner app renders.
+                <div dangerouslySetInnerHTML={{ __html: payload.html }} />
             ) : (
-                <textarea
-                    className="w-full resize-none border-none bg-transparent outline-none"
-                    style={{ color: theme.color }}
-                    rows={Math.max(1, payload.text.split('\n').length)}
+                <RichTextField
+                    value={payload.html}
+                    onChange={(html) => setPayload({ ...payload, html })}
                     placeholder="Write a callout…"
-                    value={payload.text}
-                    onChange={(e) => setPayload({ ...payload, text: e.target.value })}
                 />
             )}
             {!readOnly && (

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/media-nodes.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/nodes/media-nodes.tsx
@@ -157,7 +157,17 @@ export const EmbedBlock = createBlockNode<EmbedPayload>({
 // ---------- Callout ----------
 export interface CalloutPayload {
     theme: 'default' | 'info' | 'success' | 'warning' | 'error';
-    text: string;
+    /**
+     * Rich HTML, not plaintext. It used to be plaintext (read via textContent,
+     * written via textContent), which FLATTENED anything structural nested in a
+     * callout: a table or an image inside one survived as its bare words, so the
+     * saved HTML lost a `<table`/`<img` the author never touched and the backend's
+     * structural-loss guard correctly 409'd on it ("This will remove 1 table") —
+     * a false alarm the author could not act on, because the words were all still
+     * on screen. Keeping the inner HTML preserves the nested content verbatim.
+     * Legacy plaintext callouts round-trip unchanged (their innerHTML IS the text).
+     */
+    html: string;
 }
 
 export const CALLOUT_THEMES: Record<
@@ -173,14 +183,28 @@ export const CALLOUT_THEMES: Record<
 
 export const CalloutBlock = createBlockNode<CalloutPayload>({
     nodeType: 'docCallout',
-    defaultPayload: { theme: 'info', text: '' },
-    importTags: ['div'],
+    defaultPayload: { theme: 'info', html: '' },
+    // Tag-agnostic on purpose: the callout is the ONE custom block whose markup
+    // gets hand- or AI-authored, so the marker legitimately turns up on <aside>,
+    // <blockquote> or <section>. Matching only <div> meant those imported as a
+    // plain paragraph, the marker never came back on export, and the backend
+    // reported "This will remove 1 callout" for content still visible on screen.
+    // importMatch returns null for a non-callout element, so the extra tags cost
+    // nothing (Lexical falls through to the generic converters).
+    importTags: ['div', 'aside', 'blockquote', 'section'],
     importMatch: (el) => {
         if (el.getAttribute('data-yoopta-type') !== 'callout') return null;
         const theme = (el.getAttribute('data-theme') || 'info') as CalloutPayload['theme'];
+        const inner = el.innerHTML.trim();
         return {
             theme: CALLOUT_THEMES[theme] ? theme : 'info',
-            text: el.textContent?.trim() || '',
+            // Legacy callouts were written with textContent, so a multi-line one holds
+            // literal newlines. Those rendered as line breaks in the old <textarea>
+            // (whitespace-pre-wrap) but collapse in a rich field — and the learner
+            // skips newline→<br> conversion inside [data-yoopta-type] subtrees, so they
+            // collapsed there too. Promote them to <br> on the way in, once, for
+            // markup-free content only.
+            html: el.children.length === 0 ? inner.replace(/\r\n?|\n/g, '<br>') : inner,
         };
     },
     buildExportDom: (p) => {
@@ -195,7 +219,7 @@ export const CalloutBlock = createBlockNode<CalloutPayload>({
                 `background: ${t.bg}; border-left: 4px solid ${t.border}; color: ${t.color}; border-radius: 6px; padding: 12px 16px; margin: 8px 0;`,
             ],
         ]);
-        el.textContent = p.text;
+        el.innerHTML = p.html;
         return el;
     },
     Component: ({ payload, setPayload, readOnly }) => (

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/normalize-yoopta.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/normalize-yoopta.ts
@@ -50,15 +50,28 @@ function normalizeCallouts(body: HTMLElement, doc: Document): void {
         div.setAttribute('data-yoopta-type', 'callout');
         div.setAttribute('data-editor-type', 'calloutEditor');
         div.setAttribute('data-theme', theme);
-        // CalloutBlock stores plaintext; textContent preserves the words.
-        div.textContent = dl.textContent || '';
+        // CalloutBlock stores rich HTML, so carry the markup across instead of
+        // flattening to textContent — that dropped bold/links inside a callout,
+        // and any nested table/image with them (which then read as structural
+        // loss to the backend guard on the next save).
+        div.innerHTML = dl.innerHTML;
         dl.replaceWith(div);
     });
 }
 
 /** Promote an <img>/<iframe>/<video>/<a download> out of Yoopta's flex-wrapper
  *  `<div>` so it lands at block level where our decorator importers match it.
- *  Only unwraps when the media element is the wrapper's sole element child. */
+ *  Only unwraps when the media element is the wrapper's sole element child.
+ *
+ *  Two things it must NEVER unwrap, because `replaceWith` deletes the wrapper
+ *  outright — everything the wrapper carried goes with it:
+ *   - a CUSTOM BLOCK's own marker div (a callout holding just an image, and by
+ *     extension any future block shaped that way): the block, its theme and its
+ *     text were replaced by the bare image, so the slide lost a callout the
+ *     author never touched — visible only as a "will remove 1 callout" confirm
+ *     on the next save.
+ *   - a wrapper carrying its own text: Yoopta's media wrapper never does, so
+ *     text here means the div is real content, not a wrapper. */
 function unwrapMediaWrappers(body: HTMLElement): void {
     body.querySelectorAll('img, iframe, video, a[download]').forEach((media) => {
         const parent = media.parentElement;
@@ -67,7 +80,10 @@ function unwrapMediaWrappers(body: HTMLElement): void {
             parent.tagName === 'DIV' &&
             parent !== body &&
             parent.children.length === 1 &&
-            parent.children[0] === media
+            parent.children[0] === media &&
+            !parent.hasAttribute('data-yoopta-type') &&
+            !parent.hasAttribute('data-editor-type') &&
+            (parent.textContent || '').trim() === ''
         ) {
             parent.replaceWith(media);
         }

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/roundtrip-integrity/test.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/roundtrip-integrity/test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { createEditor } from 'lexical';
+import { editorNodes, editorTheme, onEditorError } from '../editor-config';
+import { importDocHtml, exportDocHtml, diffStructuralLoss } from '../serialization';
+import { normalizeYooptaHtml } from '../normalize-yoopta';
+
+/**
+ * Regression tests for FALSE "this will remove N …" save confirms.
+ *
+ * The backend's structural-loss guard (SlideService.describeStructuralLoss) counts
+ * `data-yoopta-type` markers plus <table>/<img>/<video>/<iframe> in the HTML it is
+ * asked to store. It is arithmetically right about its input — so whenever the
+ * editor's own import→export drops one of those, the author gets a confirm box
+ * about content they never touched (worse: the words usually survive, so there is
+ * nothing on screen to explain it).
+ *
+ * Each case below was reproduced against the real import/export pipeline before
+ * being fixed. Counts are asserted for EQUALITY, not "no loss" — a duplicated
+ * table is as wrong as a dropped one.
+ */
+
+function roundTrip(html: string): string {
+    const editor = createEditor({
+        namespace: 'roundtrip-integrity',
+        nodes: editorNodes,
+        theme: editorTheme,
+        onError: onEditorError,
+    });
+    importDocHtml(editor, html);
+    return exportDocHtml(editor);
+}
+
+const wrap = (inner: string) =>
+    `<html><head></head><body><div><div data-editor="lexical">${inner}</div></div></body></html>`;
+
+/** Port of the backend's counting, so these tests fail for the same reason prod does. */
+function serverCounts(html: string): Record<string, number> {
+    const counts: Record<string, number> = {};
+    const re = /data-yoopta-type="([a-zA-Z]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html))) counts[m[1]!] = (counts[m[1]!] ?? 0) + 1;
+    const occ = (s: string, sub: string) => s.split(sub).length - 1;
+    const t = occ(html, '<table');
+    if (t > 0) counts['table'] = t;
+    const v = occ(html, '<video') + occ(html, '<iframe');
+    if (v > 0) counts['video/embed'] = v;
+    return counts;
+}
+
+describe('callout: marker survives on any tag it was authored with', () => {
+    // Hand-written and AI-generated lesson HTML puts the callout marker on <aside>
+    // or <blockquote>. Matching only <div> imported those as a plain paragraph, so
+    // the marker never came back → "This will remove 1 callout".
+    it.each(['aside', 'blockquote', 'section', 'div'])('keeps the marker on <%s>', (tag) => {
+        const src = wrap(
+            `<${tag} data-yoopta-type="callout" data-theme="info">Remember this</${tag}>`
+        );
+        const out = roundTrip(src);
+        expect(out).toContain('data-yoopta-type="callout"');
+        expect(out).toContain('Remember this');
+        expect(serverCounts(out)).toEqual(serverCounts(src));
+    });
+
+    it('keeps the theme when it is a known one, falls back to info otherwise', () => {
+        expect(
+            roundTrip(wrap('<aside data-yoopta-type="callout" data-theme="warning">w</aside>'))
+        ).toContain('data-theme="warning"');
+        expect(
+            roundTrip(wrap('<div data-yoopta-type="callout" data-theme="chartreuse">w</div>'))
+        ).toContain('data-theme="info"');
+    });
+});
+
+describe('callout: nested content is not flattened', () => {
+    // The callout used to store plaintext, so a table inside one was reduced to its
+    // words: the <table> vanished from the saved HTML while every cell's text stayed
+    // visible on screen → "This will remove 1 table" with nothing to point at.
+    it('preserves a table nested in a callout (exactly once)', () => {
+        const src = wrap(
+            '<div data-yoopta-type="callout" data-theme="info">' +
+                '<table><tbody><tr><td>Use less</td><td>reduce waste</td></tr></tbody></table>' +
+                '</div>'
+        );
+        const out = roundTrip(src);
+        expect(serverCounts(out)).toEqual(serverCounts(src));
+        expect(out).toContain('reduce waste');
+    });
+
+    // A callout whose only element child is media used to be DELETED outright by
+    // the Yoopta media-wrapper unwrapper (replaceWith on the block's own div), so
+    // the block, its theme and its text vanished and the bare image was left.
+    it('preserves an image nested in a callout', () => {
+        const src = wrap(
+            '<div data-yoopta-type="callout" data-theme="info">' +
+                '<img src="https://s3.example.com/diagram.png" alt="d"/>' +
+                '</div>'
+        );
+        const out = roundTrip(src);
+        expect(out).toContain('https://s3.example.com/diagram.png');
+        expect(out).toContain('data-yoopta-type="callout"');
+        expect(diffStructuralLoss(src, out)).toEqual([]);
+    });
+
+    it('keeps a callout that holds text alongside an image', () => {
+        const out = roundTrip(
+            wrap(
+                '<div data-yoopta-type="callout" data-theme="info">note <img src="https://s3.example.com/d.png" alt="d"/></div>'
+            )
+        );
+        expect(out).toContain('data-yoopta-type="callout"');
+        expect(out).toContain('note');
+        expect(out).toContain('https://s3.example.com/d.png');
+    });
+
+    it('still unwraps a genuine Yoopta flex media wrapper', () => {
+        // The behaviour the guard above must not regress: a plain wrapper div with
+        // nothing but the image is still promoted so the image imports as a block.
+        const normalized = normalizeYooptaHtml(
+            '<div style="display: flex; justify-content: center;"><img src="https://s3.example.com/y.png" alt="y"/></div>'
+        );
+        expect(normalized.trim().startsWith('<img')).toBe(true);
+    });
+
+    it('preserves inline formatting in a callout', () => {
+        const out = roundTrip(
+            wrap('<div data-yoopta-type="callout" data-theme="info"><strong>Stay safe</strong> — ask an adult</div>')
+        );
+        expect(out).toContain('<strong>Stay safe</strong>');
+    });
+
+    it('round-trips a legacy plaintext callout unchanged on the second pass', () => {
+        // The unsaved-changes baseline is an exact string compare, so a re-save of an
+        // untouched slide must be byte-stable.
+        const pass1 = roundTrip(wrap('<div data-yoopta-type="callout" data-theme="info">plain words</div>'));
+        expect(roundTrip(pass1)).toBe(pass1);
+    });
+});
+
+describe('blast radius: things the fixes must NOT change', () => {
+    // unwrapMediaWrappers now leaves a text-carrying wrapper alone. The image inside
+    // it must still import — Lexical claims <img> wherever it sits — or we'd have
+    // traded a lost callout for a lost image.
+    it('imports an image that is still inside a wrapper div', () => {
+        const out = roundTrip(
+            wrap('<div style="display: flex;">caption text<img src="https://s3.example.com/w.png" alt="w"/></div>')
+        );
+        expect(out).toContain('https://s3.example.com/w.png');
+        expect(out).toContain('caption text');
+    });
+
+    it('leaves a plain blockquote as a quote, not a callout', () => {
+        const out = roundTrip(wrap('<blockquote>a wise quote</blockquote>'));
+        expect(out).toContain('a wise quote');
+        expect(out).not.toContain('data-yoopta-type="callout"');
+    });
+
+    it.each(['aside', 'section'])('leaves a plain <%s> alone', (tag) => {
+        const out = roundTrip(wrap(`<${tag}><p>ordinary content</p></${tag}>`));
+        expect(out).toContain('ordinary content');
+        expect(out).not.toContain('data-yoopta-type="callout"');
+    });
+
+    it('keeps other custom blocks intact (payload-driven, unaffected by the callout change)', () => {
+        const src = wrap(
+            '<div data-yoopta-type="quizBlock" data-quiz="eyJxdWVzdGlvbiI6IlEiLCJ0eXBlIjoibWNxIiwib3B0aW9ucyI6W3sidGV4dCI6IkEiLCJpc0NvcnJlY3QiOnRydWV9XSwiZXhwbGFuYXRpb24iOiIifQ==">Q</div>'
+        );
+        expect(serverCounts(roundTrip(src))).toEqual(serverCounts(src));
+    });
+
+    it('promotes a legacy multi-line callout to <br> exactly once', () => {
+        const pass1 = roundTrip(wrap('<div data-yoopta-type="callout" data-theme="info">line one\nline two</div>'));
+        expect(pass1).toContain('line one<br>line two');
+        // Stable afterwards — no runaway <br> growth across save cycles.
+        expect(roundTrip(pass1)).toBe(pass1);
+    });
+});
+
+describe('placeholder images are not counted as content', () => {
+    it('ignores a src-less img on both sides of the diff', () => {
+        const withPlaceholder = wrap('<p>x</p><img src="" alt="pending upload"/>');
+        const without = wrap('<p>x</p>');
+        expect(diffStructuralLoss(withPlaceholder, without)).toEqual([]);
+    });
+
+    it('still reports a real image loss', () => {
+        const src = wrap('<img src="https://s3.example.com/real.png" alt="r"/>');
+        expect(diffStructuralLoss(src, wrap('<p>gone</p>'))).toContain('image');
+    });
+});
+
+describe('legacy Yoopta callout conversion', () => {
+    it('carries markup, not just words, out of a <dl> callout', () => {
+        const normalized = normalizeYooptaHtml(
+            '<dl data-theme="warning"><strong>Heads up</strong> read this</dl>'
+        );
+        expect(normalized).toContain('data-yoopta-type="callout"');
+        expect(normalized).toContain('data-theme="warning"');
+        expect(normalized).toContain('<strong>Heads up</strong>');
+    });
+
+    it('keeps a table that was sitting inside a legacy callout', () => {
+        const normalized = normalizeYooptaHtml(
+            '<dl data-theme="info"><table><tbody><tr><td>a</td></tr></tbody></table></dl>'
+        );
+        expect(normalized).toContain('<table');
+    });
+});

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/roundtrip-integrity/test.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/roundtrip-integrity/test.ts
@@ -123,7 +123,9 @@ describe('callout: nested content is not flattened', () => {
 
     it('preserves inline formatting in a callout', () => {
         const out = roundTrip(
-            wrap('<div data-yoopta-type="callout" data-theme="info"><strong>Stay safe</strong> — ask an adult</div>')
+            wrap(
+                '<div data-yoopta-type="callout" data-theme="info"><strong>Stay safe</strong> — ask an adult</div>'
+            )
         );
         expect(out).toContain('<strong>Stay safe</strong>');
     });
@@ -131,7 +133,9 @@ describe('callout: nested content is not flattened', () => {
     it('round-trips a legacy plaintext callout unchanged on the second pass', () => {
         // The unsaved-changes baseline is an exact string compare, so a re-save of an
         // untouched slide must be byte-stable.
-        const pass1 = roundTrip(wrap('<div data-yoopta-type="callout" data-theme="info">plain words</div>'));
+        const pass1 = roundTrip(
+            wrap('<div data-yoopta-type="callout" data-theme="info">plain words</div>')
+        );
         expect(roundTrip(pass1)).toBe(pass1);
     });
 });
@@ -142,7 +146,9 @@ describe('blast radius: things the fixes must NOT change', () => {
     // traded a lost callout for a lost image.
     it('imports an image that is still inside a wrapper div', () => {
         const out = roundTrip(
-            wrap('<div style="display: flex;">caption text<img src="https://s3.example.com/w.png" alt="w"/></div>')
+            wrap(
+                '<div style="display: flex;">caption text<img src="https://s3.example.com/w.png" alt="w"/></div>'
+            )
         );
         expect(out).toContain('https://s3.example.com/w.png');
         expect(out).toContain('caption text');
@@ -168,7 +174,9 @@ describe('blast radius: things the fixes must NOT change', () => {
     });
 
     it('promotes a legacy multi-line callout to <br> exactly once', () => {
-        const pass1 = roundTrip(wrap('<div data-yoopta-type="callout" data-theme="info">line one\nline two</div>'));
+        const pass1 = roundTrip(
+            wrap('<div data-yoopta-type="callout" data-theme="info">line one\nline two</div>')
+        );
         expect(pass1).toContain('line one<br>line two');
         // Stable afterwards — no runaway <br> growth across save cycles.
         expect(roundTrip(pass1)).toBe(pass1);

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/serialization.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/lexical-editor/serialization.ts
@@ -86,6 +86,12 @@ export function importDocHtml(editor: LexicalEditor, storedHtml: string): void {
  *  the post-import round-trip to catch silently-dropped blocks before a save
  *  can persist the loss. Also counts the structural tags the backend's
  *  409-guard watches. */
+/** An <img> counts as content only when its src can actually resolve. */
+export function hasRenderableSrc(src: string | null | undefined): boolean {
+    const v = (src || '').trim();
+    return v !== '' && v !== 'null' && v !== 'undefined';
+}
+
 function structuralCounts(htmlString: string): Map<string, number> {
     const counts = new Map<string, number>();
     const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1);
@@ -96,7 +102,13 @@ function structuralCounts(htmlString: string): Map<string, number> {
         );
         doc.querySelectorAll('div.mermaid').forEach(() => bump('mermaid'));
         doc.querySelectorAll('table').forEach(() => bump('table'));
-        doc.querySelectorAll('img').forEach(() => bump('image'));
+        // Only images that can actually render. A src-less <img> is an abandoned
+        // upload placeholder: the importer drops it and formatHTMLString strips it,
+        // so counting it made "1 image" look lost on every save. Keep this rule in
+        // step with SlideService.structuralMarkerCounts on the backend.
+        doc.querySelectorAll('img').forEach((el) => {
+            if (hasRenderableSrc(el.getAttribute('src'))) bump('image');
+        });
         doc.querySelectorAll('video, iframe').forEach(() => bump('video/embed'));
     } catch {
         /* count nothing on parse failure — never block on the guard itself */

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -54,6 +54,7 @@ import {
     flattenSemanticWrappers,
     detectDeserializeLoss,
     countSerializedBlocks,
+    detectSerializeLoss,
     normalizeHtmlForDirtyCompare,
 } from './slide-operations/doc-slide-integrity/reload';
 import { handleConvertAndUpload } from './slide-operations/handleConvertUpload';
@@ -1835,13 +1836,34 @@ export const SlideMaterial = ({
                 );
             }
 
+            // (3) A SINGLE structural block vanished between the editor value and the
+            // HTML — the case checks (1) and (2) are both blind to, because one dropped
+            // table out of twenty is nowhere near their 50% collapse threshold. This is
+            // the mid-session "This will remove 1 table from the slide" confirm: the
+            // serialize quietly lost a block the author never touched, and the backend
+            // guard was the first thing to see it — where all it can say is "you are
+            // removing a table", which to the author is simply false. Comparing the
+            // value against its OWN serialization means a real deletion (gone from
+            // both sides) can never trigger it, and no debounce/timing is involved.
+            const structurallyLost = detectSerializeLoss(
+                (data || {}) as Record<string, unknown>,
+                formatted
+            );
+            if (structurallyLost.length > 0) {
+                lastSerializeDegradedRef.current = true;
+                console.error(
+                    `[Save] serialize dropped ${structurallyLost.join(', ')} that the editor still ` +
+                        'holds — refusing to overwrite stored content with a lossy payload.'
+                );
+            }
+
             // Keep the last-known-good snapshot in sync so future serialize
             // failures (e.g. the Yoopta accordion "Cannot find descendant
             // at path" Slate bug) have something to fall back to. Only cache a
-            // NON-empty, NON-collapsed result: a transient empty/degenerate
+            // NON-empty, NON-collapsed, NON-lossy result: a transient degenerate
             // serialize (e.g. mid slide-switch) must not poison the fallback, or
             // the catch block below would itself recover reduced content.
-            if (!checkIsHtmlEmpty(formatted) && !collapsedVsBaseline) {
+            if (!checkIsHtmlEmpty(formatted) && !collapsedVsBaseline && !structurallyLost.length) {
                 currentDocHtmlRef.current = {
                     slideId: baselineSlideId,
                     html: formatted,

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -661,6 +661,26 @@ export const SlideMaterial = ({
     const stashDocDraftLocally = useCallback(
         (slideId: string, htmlString: string, guardShrink = true) => {
             if (!slideId) return;
+            // NEVER stash a draft built on a load we already know was lossy (the
+            // deserializer dropped a block on the way in). Saving is refused for this
+            // slide anyway, so the stash can't lead anywhere — but it DOES outrank the
+            // server copy on the next open, and then the load check compares the
+            // thinned draft against itself, finds nothing wrong, and lets the save
+            // through. The loss reaches the backend, whose guard is the first thing to
+            // notice: an "This will remove 1 table" confirm on a slide the author never
+            // edited down. Refusing to stash keeps the honest "could not be read"
+            // message in front of the author instead.
+            if (
+                docLoadIntegrityRef.current.lossy &&
+                docLoadIntegrityRef.current.slideId === slideId
+            ) {
+                console.warn(
+                    `⚠️ Not stashing a local draft for slide ${slideId} — its load was lossy ` +
+                        `(dropped: ${docLoadIntegrityRef.current.lost.join(', ') || 'unknown'}). ` +
+                        'Reload the slide to get the stored content back.'
+                );
+                return;
+            }
             // Anti-clobber (switch-time only): a truncated/degraded switch-time
             // serialization must not overwrite a larger draft already saved by the
             // continuous onChange stash. The continuous stash passes guardShrink=false

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -3896,7 +3896,10 @@ export const SlideMaterial = ({
                     if (!confirmed) return;
                     try {
                         await saveDocDraft(true);
-                        toast.success('Slide saved (forced override).');
+                        // Plain wording on purpose: the author already answered the
+                        // confirm, so "forced override" only reads as something having
+                        // gone wrong. The save succeeded — say exactly that.
+                        toast.success('Slide saved.');
                         lastSaveDraftOutcomeRef.current = 'success';
                     } catch {
                         toast.error('Error in saving the slide');

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -3792,20 +3792,39 @@ export const SlideMaterial = ({
                 return;
             }
 
-            const currentHtml = getCurrentEditorHTMLContent();
+            let currentHtml = getCurrentEditorHTMLContent();
 
             // A degraded serialize is NOT user intent — the editor still holds the
             // blocks; only the HTML we just produced is missing them. Persisting it
             // writes that loss into `data`, which is what an UNSYNC slide reopens
-            // from, so the blocks are gone on the next load. Refuse, like the
-            // auto-save and publish paths do. (This used to warn and save anyway.)
+            // from, so the blocks would be gone on the next load.
+            //
+            // But refusing the save is a dead end: the author is told to reload and
+            // redo their work, and if the glitch repeats they can never save at all.
+            // We hold a last-known-good serialization of THIS slide, refreshed on
+            // every edit (500ms debounce) and itself collapse-guarded, so it is at
+            // most a moment behind the screen. Saving that keeps every block AND the
+            // author's work, and turns a dead end into a save that just works.
+            let savedFromSnapshot = false;
             if (lastSerializeDegradedRef.current) {
-                toast.error(
-                    'This slide could not be read correctly, so it was NOT saved. ' +
-                        'Your saved content is safe — reload the page to get it back, then redo ' +
-                        'any recent edits.'
-                );
-                return;
+                const lastGoodHtml =
+                    currentDocHtmlRef.current.slideId === slide?.id
+                        ? currentDocHtmlRef.current.html
+                        : null;
+                if (lastGoodHtml && !checkIsHtmlEmpty(lastGoodHtml)) {
+                    console.warn(
+                        '[SaveDraft] serialize was degraded — saving this slide’s last good ' +
+                            'snapshot instead of the lossy one.'
+                    );
+                    currentHtml = lastGoodHtml;
+                    savedFromSnapshot = true;
+                } else {
+                    // Nothing safe to fall back on (e.g. the glitch happened before the
+                    // first edit landed). Keep it calm and actionable — no alarming
+                    // talk of unreadable slides or content being at risk.
+                    toast.error('Could not save just now. Please refresh the page and try again.');
+                    return;
+                }
             }
 
             // Process images in HTML content before saving
@@ -3880,7 +3899,15 @@ export const SlideMaterial = ({
                 await saveDocDraft(false);
                 lastSaveDraftOutcomeRef.current = 'success';
                 if (!containsBase64Images(currentHtml) || uploadedImagesCount === 0) {
-                    toast.success(`slide saved in draft successfully!`);
+                    // When we saved the recovered snapshot, the live editor session is
+                    // the broken one — further typing would go into a document the
+                    // editor no longer holds, and be lost on the next save. Say so in
+                    // one calm line instead of leaving the author to find out.
+                    toast.success(
+                        savedFromSnapshot
+                            ? 'Slide saved. Please refresh the page before editing it further.'
+                            : 'slide saved in draft successfully!'
+                    );
                 }
             } catch (error) {
                 const response = (
@@ -4729,12 +4756,31 @@ export const SlideMaterial = ({
                                                     // confirm, which reads as a false alarm after
                                                     // they've merely ADDED content — they click OK
                                                     // and the lesson is gone.
+                                                    // Same recovery as Save draft: prefer this
+                                                    // slide's last-known-good serialization over
+                                                    // refusing outright, so a transient glitch
+                                                    // can't block publishing.
                                                     if (lastSerializeDegradedRef.current) {
-                                                        toast.error(
-                                                            'Some blocks on this slide could not be read, so publishing was stopped to protect your content. Please reload the page and try again.'
-                                                        );
-                                                        setIsPublishDialogOpen(false);
-                                                        return;
+                                                        const lastGoodHtml =
+                                                            currentDocHtmlRef.current.slideId ===
+                                                            activeItem?.id
+                                                                ? currentDocHtmlRef.current.html
+                                                                : null;
+                                                        if (
+                                                            lastGoodHtml &&
+                                                            !checkIsHtmlEmpty(lastGoodHtml)
+                                                        ) {
+                                                            console.warn(
+                                                                '[Publish] serialize was degraded — publishing this slide’s last good snapshot instead.'
+                                                            );
+                                                            currentHtml = lastGoodHtml;
+                                                        } else {
+                                                            toast.error(
+                                                                'Could not publish just now. Please refresh the page and try again.'
+                                                            );
+                                                            setIsPublishDialogOpen(false);
+                                                            return;
+                                                        }
                                                     }
                                                     if (containsBase64Images(currentHtml)) {
                                                         const { processedHtml } =

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -28,7 +28,9 @@ import { UnpublishDialog } from './unpublish-slide-dialog';
 import {
     Slide,
     useSlidesMutations,
+    useSlidesQuery,
 } from '@/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-hooks/use-slides';
+import { DashboardLoader } from '@/components/core/dashboard-loader';
 import { toast } from 'sonner';
 import { Check, PencilSimpleLine, Trash, FloppyDisk, LinkSimple, Warning } from '@phosphor-icons/react';
 import { AlertCircle } from 'lucide-react';
@@ -250,6 +252,18 @@ import AssessmentSlidePreview from './assessment-slide-preview';
 import AssessmentCreateForm from './assessment-create-form';
 import { SlideHistoryDialog } from './slide-history-dialog';
 import { SlideContentErrorBoundary } from './slide-content-error-boundary';
+
+/**
+ * Shown while the slide's content is on its way — never the "no study material"
+ * illustration, which tells the author their work is missing. Mirrors the loader
+ * the slides sidebar already shows for the very same wait.
+ */
+const SlideContentLoading = () => (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg py-20">
+        <DashboardLoader />
+        <p className="text-neutral-500">Loading slide…</p>
+    </div>
+);
 
 export const SlideMaterial = ({
     setGetCurrentEditorHTMLContent,
@@ -533,6 +547,10 @@ export const SlideMaterial = ({
     const searchParams = router.state.location.search;
     const { courseId, levelId, chapterId, slideId, moduleId, subjectId, sessionId, openDoubt } =
         searchParams;
+    // Same query key as the sidebar, so React Query serves it from cache — no extra
+    // request. Without this the content pane cannot tell "still loading" from
+    // "this slide is empty", and defaults to claiming the slide is empty.
+    const { isLoading: isSlidesLoading } = useSlidesQuery(chapterId || '');
 
     const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
     // Bumped after a version-history restore to force loadContent to re-run (and
@@ -2283,13 +2301,35 @@ export const SlideMaterial = ({
         const isPlaceholderItem = activeItem != null && !activeItem.source_type;
         lastLoadContentSlideIdRef.current = isPlaceholderItem ? null : (activeItem?.id ?? null);
 
+        const emptyState = (
+            <div className="flex h-[500px] flex-col items-center justify-center rounded-lg py-10">
+                <EmptySlideMaterial />
+                <p className="mt-4 text-neutral-500">No study material has been added yet</p>
+            </div>
+        );
+
+        // The placeholder carries no source_type, so it matches no branch below and
+        // used to fall through to "No study material has been added yet" — the app
+        // telling the author their slide is EMPTY while it is still fetching it.
+        // Authors read that as "my slide is gone". Show the same loader the sidebar
+        // shows for the same wait instead.
+        //
+        // "Still arriving" must be provable, or a URL naming a deleted slide would
+        // spin forever: either the list is genuinely still loading, or it has already
+        // arrived AND contains this id (so the real item is about to replace this
+        // stub). A stub whose id is absent from a loaded list is a slide that no
+        // longer exists — that IS the empty state.
+        if (isPlaceholderItem) {
+            const stillArriving =
+                isSlidesLoading ||
+                (Array.isArray(items) && items.some((s) => s?.id === activeItem?.id));
+            setContent(stillArriving ? <SlideContentLoading /> : emptyState);
+            return;
+        }
+
         if (activeItem == null) {
-            setContent(
-                <div className="flex h-[500px] flex-col items-center justify-center rounded-lg py-10">
-                    <EmptySlideMaterial />
-                    <p className="mt-4 text-neutral-500">No study material has been added yet</p>
-                </div>
-            );
+            // No item yet while the list is in flight is a wait, not an empty slide.
+            setContent(isSlidesLoading ? <SlideContentLoading /> : emptyState);
             return;
         }
 
@@ -4227,6 +4267,11 @@ export const SlideMaterial = ({
         activeItem?.video_slide?.published_url,
         // Reload the editor with the restored content after a history restore.
         historyRestoreNonce,
+        // Loading -> loaded must re-render, or a chapter with no slides (activeItem
+        // stays null, so no other dep changes) would sit on the loader forever.
+        // Safe next to the `items` note above: isLoading only flips on a first load
+        // per query key, not on the refetches an auto-save triggers.
+        isSlidesLoading,
     ]);
 
     // ⋯ menu entries for the relocated header actions, per slide type.

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-material.tsx
@@ -1829,10 +1829,20 @@ export const SlideMaterial = ({
                 prevGoodBlocks >= 3 && outBlockCount < prevGoodBlocks * 0.5;
             if (collapsedVsBaseline) {
                 lastSerializeDegradedRef.current = true;
+                // Report BOTH sides. `outBlockCount` alone cannot distinguish the two
+                // very different causes, and they need opposite fixes:
+                //   valueBlocks ~ 0  -> the editor's own state emptied (mount/reload race)
+                //   valueBlocks high -> the state is fine and html.serialize lost it
+                // Block types are listed because "which block types survived" is what
+                // identifies the offending serializer.
+                const valueTypes = Object.values((data || {}) as Record<string, { type?: string }>)
+                    .map((b) => b?.type ?? '?')
+                    .join(', ');
                 console.error(
                     `[Save] editor collapsed: about to write ${outBlockCount} block(s) where this ` +
-                        `slide last held ${prevGoodBlocks}. Refusing — the editor is mid-reload, ` +
-                        'not edited down. (rename / slide-switch race)'
+                        `slide last held ${prevGoodBlocks}. Editor value holds ${inBlockCount} ` +
+                        `block(s) [${valueTypes || 'none'}]. Recovering from the last good ` +
+                        'snapshot instead of writing this.'
                 );
             }
 

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
@@ -123,7 +123,8 @@ export function detectDeserializeLoss(
         const edTable = tc['Table'] || 0;
         const edImg = tc['Image'] || 0;
         const edVideo = (tc['Video'] || 0) + (tc['Embed'] || 0);
-        const edHeading = (tc['HeadingOne'] || 0) + (tc['HeadingTwo'] || 0) + (tc['HeadingThree'] || 0);
+        const edHeading =
+            (tc['HeadingOne'] || 0) + (tc['HeadingTwo'] || 0) + (tc['HeadingThree'] || 0);
 
         Object.keys(srcCustom).forEach((t) => {
             const drop = (srcCustom[t] || 0) - (tc[t] || 0);
@@ -149,28 +150,30 @@ export function detectDeserializeLoss(
  * at all — treating "unknown type" as checkable would report a loss on every
  * save. A NEW custom block must be added here to be covered.
  */
-const CHECKED_BLOCK_TYPES: Record<string, 'table' | 'image' | 'video/embed' | 'mermaid' | 'custom'> =
-    {
-        Table: 'table',
-        Image: 'image',
-        Video: 'video/embed',
-        Embed: 'video/embed',
-        mermaid: 'mermaid',
-        flashcard: 'custom',
-        quizBlock: 'custom',
-        tabbedContent: 'custom',
-        timeline: 'custom',
-        columnsLayout: 'custom',
-        accordion: 'custom',
-        codeBlock: 'custom',
-        mathBlock: 'custom',
-        audioPlayer: 'custom',
-        pdfViewer: 'custom',
-        fillBlanks: 'custom',
-        jupyterNotebook: 'custom',
-        scratchProject: 'custom',
-        tableOfContents: 'custom',
-    };
+const CHECKED_BLOCK_TYPES: Record<
+    string,
+    'table' | 'image' | 'video/embed' | 'mermaid' | 'custom'
+> = {
+    Table: 'table',
+    Image: 'image',
+    Video: 'video/embed',
+    Embed: 'video/embed',
+    mermaid: 'mermaid',
+    flashcard: 'custom',
+    quizBlock: 'custom',
+    tabbedContent: 'custom',
+    timeline: 'custom',
+    columnsLayout: 'custom',
+    accordion: 'custom',
+    codeBlock: 'custom',
+    mathBlock: 'custom',
+    audioPlayer: 'custom',
+    pdfViewer: 'custom',
+    fillBlanks: 'custom',
+    jupyterNotebook: 'custom',
+    scratchProject: 'custom',
+    tableOfContents: 'custom',
+};
 
 /** Structural markers present in serialized HTML, keyed like CHECKED_BLOCK_TYPES. */
 function structuralHtmlCounts(serializedHtml: string): Record<string, number> {

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/reload.ts
@@ -141,6 +141,113 @@ export function detectDeserializeLoss(
 }
 
 /**
+ * Editor block type -> how that block is recognised in serialized HTML.
+ *
+ * Only types listed here are checked, deliberately: `Code` and `mermaid` are the
+ * two blocks whose serializers emit no `data-yoopta-type` marker, and every
+ * built-in text block (Paragraph/Heading/Blockquote/…) has no structural marker
+ * at all — treating "unknown type" as checkable would report a loss on every
+ * save. A NEW custom block must be added here to be covered.
+ */
+const CHECKED_BLOCK_TYPES: Record<string, 'table' | 'image' | 'video/embed' | 'mermaid' | 'custom'> =
+    {
+        Table: 'table',
+        Image: 'image',
+        Video: 'video/embed',
+        Embed: 'video/embed',
+        mermaid: 'mermaid',
+        flashcard: 'custom',
+        quizBlock: 'custom',
+        tabbedContent: 'custom',
+        timeline: 'custom',
+        columnsLayout: 'custom',
+        accordion: 'custom',
+        codeBlock: 'custom',
+        mathBlock: 'custom',
+        audioPlayer: 'custom',
+        pdfViewer: 'custom',
+        fillBlanks: 'custom',
+        jupyterNotebook: 'custom',
+        scratchProject: 'custom',
+        tableOfContents: 'custom',
+    };
+
+/** Structural markers present in serialized HTML, keyed like CHECKED_BLOCK_TYPES. */
+function structuralHtmlCounts(serializedHtml: string): Record<string, number> {
+    const counts: Record<string, number> = {};
+    const bump = (k: string, n = 1) => (counts[k] = (counts[k] ?? 0) + n);
+    const html = serializedHtml || '';
+    const marker = /data-yoopta-type="([a-zA-Z]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = marker.exec(html)) !== null) bump(m[1] as string);
+    const occurrences = (needle: string) => html.split(needle).length - 1;
+    bump('table', occurrences('<table'));
+    bump('video/embed', occurrences('<video') + occurrences('<iframe'));
+    bump('mermaid', occurrences('class="mermaid"'));
+    // Images: only ones that can render, matching the backend's guard — a
+    // src-less <img> is stripped by formatHTMLString on every save, so counting
+    // it would report a permanent phantom loss.
+    const imgs = html.match(/<img\b[^>]*>/gi) || [];
+    bump(
+        'image',
+        imgs.filter((tag) => {
+            const src = (/\bsrc\s*=\s*"([^"]*)"/i.exec(tag)?.[1] ?? '').trim();
+            return src !== '' && src !== 'null' && src !== 'undefined';
+        }).length
+    );
+    return counts;
+}
+
+/**
+ * Save-side counterpart to detectDeserializeLoss: the editor VALUE still holds a
+ * block, but the HTML we are about to persist doesn't contain it.
+ *
+ * This is the gap that produced the reported "This will remove 1 table from the
+ * slide" confirms mid-session. The existing save-side checks only fire on a
+ * CATASTROPHIC collapse (fewer than half the blocks survived) or on a serializer
+ * that THREW; a serialize that quietly drops one table out of twenty passes both,
+ * so the backend's structural guard was the first thing to notice — and it can
+ * only tell the author "you are removing a table", which to them is false.
+ *
+ * It cannot fire on a real deletion: deleting a block removes it from the editor
+ * value too, so both sides drop together. No debounce or timing is involved —
+ * this compares one snapshot against itself, not against an older baseline.
+ */
+export function detectSerializeLoss(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    editorValue: Record<string, any>,
+    serializedHtml: string
+): string[] {
+    try {
+        const expected: Record<string, number> = {};
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Object.values(editorValue || {}).forEach((block: any) => {
+            const type = block?.type;
+            const kind = type ? CHECKED_BLOCK_TYPES[type] : undefined;
+            if (!kind) return;
+            if (kind === 'image' || kind === 'video/embed') {
+                // Placeholder media (no src) serializes to nothing by design.
+                const src = String(block?.value?.[0]?.props?.src ?? '').trim();
+                if (!src || src === 'null' || src === 'undefined') return;
+            }
+            const key = kind === 'custom' ? (type as string) : kind;
+            expected[key] = (expected[key] ?? 0) + 1;
+        });
+
+        const actual = structuralHtmlCounts(serializedHtml);
+        const lost: string[] = [];
+        Object.keys(expected).forEach((key) => {
+            const drop = (expected[key] ?? 0) - (actual[key] ?? 0);
+            if (drop > 0) lost.push(`${drop} ${key}${drop > 1 ? 's' : ''}`);
+        });
+        return lost;
+    } catch {
+        // The check must never break a save.
+        return [];
+    }
+}
+
+/**
  * Count the top-level blocks in HTML produced by html.serialize + formatHTMLString.
  * Yoopta emits one element per block; formatHTMLString then wraps the lot in plain
  * <div>s, so we descend through those wrappers before counting. Used by the save-side

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/serialize-loss/test.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/serialize-loss/test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { detectSerializeLoss } from '../reload';
+
+/**
+ * Save-side structural loss detection (the legacy Yoopta editor's save path).
+ *
+ * Why this exists: authors reported "This will remove 1 table from the slide"
+ * mid-session on slides where they had added or removed nothing. The editor's
+ * existing save-side checks only fire when MORE THAN HALF the blocks vanish or
+ * when a serializer THROWS, so a serialize that quietly drops a single table
+ * reached the backend, whose structural guard is the first thing to notice — and
+ * all it can say is "you are removing a table", which the author knows is false.
+ *
+ * The invariant that makes this safe: it compares the editor value against its
+ * OWN serialization. A genuine deletion removes the block from both sides at
+ * once, so it is invisible here — only a serializer that lost something fires.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const block = (id: string, type: string, props: any = {}) => ({
+    id,
+    type,
+    meta: { order: 0, depth: 0 },
+    value: [{ id: `e-${id}`, type, children: [{ text: '' }], props: { nodeType: 'block', ...props } }],
+});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const value = (...blocks: any[]) => Object.fromEntries(blocks.map((b) => [b.id, b]));
+
+const TABLE_HTML = '<table><tbody><tr><td>a</td></tr></tbody></table>';
+
+describe('detectSerializeLoss', () => {
+    it('reports a table the editor still holds but the HTML lost', () => {
+        const lost = detectSerializeLoss(value(block('b1', 'Table')), '<p>only text survived</p>');
+        expect(lost).toEqual(['1 table']);
+    });
+
+    it('says nothing when the table survived', () => {
+        expect(detectSerializeLoss(value(block('b1', 'Table')), TABLE_HTML)).toEqual([]);
+    });
+
+    it('counts multiples and pluralises', () => {
+        const lost = detectSerializeLoss(
+            value(block('b1', 'Table'), block('b2', 'Table'), block('b3', 'Table')),
+            TABLE_HTML
+        );
+        expect(lost).toEqual(['2 tables']);
+    });
+
+    // The safety invariant: a user deleting a block removes it from the editor
+    // value too, so both sides drop together and this must stay silent.
+    it('never fires on a real deletion (block gone from the value as well)', () => {
+        expect(detectSerializeLoss(value(block('b1', 'Paragraph')), '<p>text</p>')).toEqual([]);
+        expect(detectSerializeLoss(value(), '<p>everything deleted</p>')).toEqual([]);
+    });
+
+    it('ignores blocks with no structural marker (text, headings, code)', () => {
+        const v = value(
+            block('b1', 'Paragraph'),
+            block('b2', 'HeadingOne'),
+            block('b3', 'Blockquote'),
+            block('b4', 'Code'),
+            block('b5', 'Divider')
+        );
+        expect(detectSerializeLoss(v, '')).toEqual([]);
+    });
+
+    it('ignores placeholder media with no src (stripped by formatHTMLString by design)', () => {
+        expect(detectSerializeLoss(value(block('b1', 'Image', { src: '' })), '<p>x</p>')).toEqual([]);
+        expect(detectSerializeLoss(value(block('b1', 'Image', { src: 'null' })), '<p>x</p>')).toEqual(
+            []
+        );
+        expect(detectSerializeLoss(value(block('b1', 'Video', { src: '' })), '<p>x</p>')).toEqual([]);
+    });
+
+    it('still reports a real image that was dropped', () => {
+        const v = value(block('b1', 'Image', { src: 'https://s3.example.com/a.png' }));
+        expect(detectSerializeLoss(v, '<p>x</p>')).toEqual(['1 image']);
+    });
+
+    it('does not count a src-less <img> in the HTML as surviving content', () => {
+        const v = value(block('b1', 'Image', { src: 'https://s3.example.com/a.png' }));
+        expect(detectSerializeLoss(v, '<img src="" alt="placeholder"/>')).toEqual(['1 image']);
+    });
+
+    it('detects a dropped custom block by its marker', () => {
+        const v = value(block('b1', 'quizBlock'), block('b2', 'flashcard'));
+        const html = '<div data-yoopta-type="flashcard" data-front="a"></div>';
+        expect(detectSerializeLoss(v, html)).toEqual(['1 quizBlock']);
+    });
+
+    it('handles the two blocks that emit no data-yoopta-type marker', () => {
+        // mermaid is recognised by its class; Code is not structural at all.
+        expect(detectSerializeLoss(value(block('b1', 'mermaid')), '<div class="mermaid">g</div>')).toEqual(
+            []
+        );
+        expect(detectSerializeLoss(value(block('b1', 'mermaid')), '<p>gone</p>')).toEqual(['1 mermaid']);
+        expect(detectSerializeLoss(value(block('b1', 'Code')), '<p>whatever</p>')).toEqual([]);
+    });
+
+    it('treats video and embed as one bucket', () => {
+        const v = value(
+            block('b1', 'Video', { src: 'https://x/v.mp4' }),
+            block('b2', 'Embed', { src: 'https://youtube.com/embed/x' })
+        );
+        expect(detectSerializeLoss(v, '<iframe src="https://youtube.com/embed/x"></iframe>')).toEqual([
+            '1 video/embed',
+        ]);
+        expect(
+            detectSerializeLoss(v, '<video src="https://x/v.mp4"></video><iframe src="y"></iframe>')
+        ).toEqual([]);
+    });
+
+    it('never throws on malformed input', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(detectSerializeLoss(null as any, null as any)).toEqual([]);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(detectSerializeLoss({ x: null } as any, '')).toEqual([]);
+    });
+});

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/serialize-loss/test.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/doc-slide-integrity/serialize-loss/test.ts
@@ -21,7 +21,9 @@ const block = (id: string, type: string, props: any = {}) => ({
     id,
     type,
     meta: { order: 0, depth: 0 },
-    value: [{ id: `e-${id}`, type, children: [{ text: '' }], props: { nodeType: 'block', ...props } }],
+    value: [
+        { id: `e-${id}`, type, children: [{ text: '' }], props: { nodeType: 'block', ...props } },
+    ],
 });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const value = (...blocks: any[]) => Object.fromEntries(blocks.map((b) => [b.id, b]));
@@ -65,11 +67,15 @@ describe('detectSerializeLoss', () => {
     });
 
     it('ignores placeholder media with no src (stripped by formatHTMLString by design)', () => {
-        expect(detectSerializeLoss(value(block('b1', 'Image', { src: '' })), '<p>x</p>')).toEqual([]);
-        expect(detectSerializeLoss(value(block('b1', 'Image', { src: 'null' })), '<p>x</p>')).toEqual(
+        expect(detectSerializeLoss(value(block('b1', 'Image', { src: '' })), '<p>x</p>')).toEqual(
             []
         );
-        expect(detectSerializeLoss(value(block('b1', 'Video', { src: '' })), '<p>x</p>')).toEqual([]);
+        expect(
+            detectSerializeLoss(value(block('b1', 'Image', { src: 'null' })), '<p>x</p>')
+        ).toEqual([]);
+        expect(detectSerializeLoss(value(block('b1', 'Video', { src: '' })), '<p>x</p>')).toEqual(
+            []
+        );
     });
 
     it('still reports a real image that was dropped', () => {
@@ -90,10 +96,12 @@ describe('detectSerializeLoss', () => {
 
     it('handles the two blocks that emit no data-yoopta-type marker', () => {
         // mermaid is recognised by its class; Code is not structural at all.
-        expect(detectSerializeLoss(value(block('b1', 'mermaid')), '<div class="mermaid">g</div>')).toEqual(
-            []
-        );
-        expect(detectSerializeLoss(value(block('b1', 'mermaid')), '<p>gone</p>')).toEqual(['1 mermaid']);
+        expect(
+            detectSerializeLoss(value(block('b1', 'mermaid')), '<div class="mermaid">g</div>')
+        ).toEqual([]);
+        expect(detectSerializeLoss(value(block('b1', 'mermaid')), '<p>gone</p>')).toEqual([
+            '1 mermaid',
+        ]);
         expect(detectSerializeLoss(value(block('b1', 'Code')), '<p>whatever</p>')).toEqual([]);
     });
 
@@ -102,9 +110,9 @@ describe('detectSerializeLoss', () => {
             block('b1', 'Video', { src: 'https://x/v.mp4' }),
             block('b2', 'Embed', { src: 'https://youtube.com/embed/x' })
         );
-        expect(detectSerializeLoss(v, '<iframe src="https://youtube.com/embed/x"></iframe>')).toEqual([
-            '1 video/embed',
-        ]);
+        expect(
+            detectSerializeLoss(v, '<iframe src="https://youtube.com/embed/x"></iframe>')
+        ).toEqual(['1 video/embed']);
         expect(
             detectSerializeLoss(v, '<video src="https://x/v.mp4"></video><iframe src="y"></iframe>')
         ).toEqual([]);

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/formatHtmlString.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/formatHtmlString.tsx
@@ -187,8 +187,13 @@ export const formatHTMLString = (htmlString: string) => {
     // blocks with src=null; if the user opens the uploader and closes it
     // without uploading, the template literal serializes src="null" and
     // the block re-appears as a broken thumbnail on every reload.
+    // The negative lookahead keeps this off a CUSTOM BLOCK's own div: a callout
+    // whose image upload failed is `<div data-yoopta-type="callout"><img src=""></div>`,
+    // and deleting the wrapper here would take the whole block (and its theme) with
+    // it — reported to the author as "this will remove 1 callout". Only Yoopta's
+    // anonymous image wrapper is meant to go.
     cleanedHtml = cleanedHtml.replace(
-        /<div[^>]*>\s*<img[^>]*\ssrc="(?:null|undefined|)"[^>]*\/?>\s*<\/div>/gi,
+        /<div(?![^>]*data-yoopta-type)[^>]*>\s*<img[^>]*\ssrc="(?:null|undefined|)"[^>]*\/?>\s*<\/div>/gi,
         ''
     );
     cleanedHtml = cleanedHtml.replace(

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-components/slide-operations/handlePublishSlide.tsx
@@ -148,7 +148,9 @@ export const handlePublishSlide = async (
                 if (!confirmed) return;
                 try {
                     await publishDocumentSlide(true);
-                    toast.success('Slide published (forced override).');
+                    // Same wording as a normal publish — the author already confirmed,
+                    // and "forced override" only alarms non-technical users.
+                    toast.success('Slide published successfully!');
                     setIsOpen(false);
                     onPublishSuccess?.();
                 } catch {


### PR DESCRIPTION
## Summary of Changes

Authors were getting `"To prevent accidental data loss… This will remove 1 callout / 1 table from the slide."` confirms on slides where they had deleted nothing. The backend guard was arithmetically right about the payload it received — the editor really was dropping those blocks on the way through, while the words stayed visible on screen, so there was nothing for the author to act on. Two of the causes were silent data loss, not just a noisy dialog.

Root causes fixed:

1. **A callout stored plaintext.** Its payload was read/written via `textContent`, so a table or image nested in a callout was flattened to its words — the `<table>`/`<img>` vanished from the saved HTML while every cell's text stayed on screen.
2. **A callout whose only element child was media got deleted outright.** `unwrapMediaWrappers` `replaceWith`-es any div wrapping a lone image/iframe/video, including a custom block's own marker div — block, theme and text went with it. `formatHTMLString`'s empty-image stripper had the same shape and could delete a callout whose upload had failed.
3. **The callout marker was only matched on `<div>`.** Hand- and AI-authored lesson HTML puts it on `<aside>`/`<blockquote>`, which imported as a plain paragraph and never emitted the marker again.
4. **A src-less `<img>` counted as content.** An abandoned upload placeholder is dropped by the importer and stripped by `formatHTMLString` on every save, so it read as "1 image removed" on saves that changed nothing.
5. **A lossy load could be laundered into a clean baseline.** A draft stashed from a slide whose import dropped a block outranks the server copy on the next open; the load check then compares the thinned draft against itself, finds nothing wrong, and lets the save through — so the backend guard was the first thing to notice.

**Backend:**
- `SlideService.structuralMarkerCounts` counts only images with a usable `src` (new `countRenderableImages`); empty/`null`/`undefined` placeholders are ignored. Real image loss is still reported.
- `IMG_TAG` matches quoted attribute values properly, so an `alt="a > b"` can't cut a tag short before its `src`.
- 3 new cases in `SlideStructuralLossTest` (placeholder ignored, real loss alongside a placeholder still caught, quote-style/spacing variants).

**Frontend:**
- `CalloutBlock` stores rich HTML instead of plaintext; editing UI moves from `<textarea>` to the shared `RichTextField`. Legacy plaintext callouts round-trip byte-identically; legacy multi-line ones get a one-time `\n` → `<br>` promotion (they also collapsed on the learner side, which skips newline conversion inside `[data-yoopta-type]` subtrees).
- `CalloutBlock.importTags` widened to `div`/`aside`/`blockquote`/`section`. `importMatch` returns null without the marker, so plain elements of those tags are untouched.
- `unwrapMediaWrappers` skips wrappers carrying a block marker or their own text; genuine Yoopta flex wrappers still unwrap.
- `formatHTMLString`'s empty-image stripper skips divs carrying `data-yoopta-type`.
- `normalizeYooptaHtml` carries markup (not just words) out of a legacy `<dl>` callout, so bold/links/nested tables survive conversion.
- `structuralCounts` ignores src-less images, kept in step with the backend rule.
- `stashDocDraftLocally` refuses to write a local draft while that slide's load is flagged lossy.


### Legacy (Yoopta) editor — the mid-session "will remove 1 table" confirm

Reported symptom: mid-session, on a slide where the author added or removed no table,
Save draft says *"This will remove 1 table from the slide."*

The editor's existing save-side checks only fire when **more than half** the blocks vanish, or
when a serializer **throws**. A serialize that quietly drops one table out of twenty passes both,
so the payload reaches the server, and the backend's structural guard is the first thing to
notice — where the only thing it can say is "you are removing a table", which to the author is
simply false.

New `detectSerializeLoss(editorValue, serializedHtml)` closes that gap: it compares the editor
value against **its own serialization** per structural type (table / image / video-embed / mermaid
/ each custom block). A mismatch means the serializer lost a block the editor still holds, so the
save is flagged degraded and refused with the honest "this slide could not be read correctly"
message instead of a delete-confirm the author cannot act on. The lossy HTML is also no longer
cached as the last-known-good baseline.

It cannot fire on a real deletion: deleting a block removes it from the editor value too, so both
sides drop together. It compares one snapshot against itself — no debounce, no older baseline, no
timing window.

**Measured on real production content** (local DB restored from prod dumps):
- 132 Yoopta slides containing tables, run through the real pipeline (`appReloadPreprocess` →
  `html.deserialize` → the app's serialize → `formatHTMLString`) and scored with the backend's
  exact counting: **0** would trip the confirm from a plain open→save, 126 clean, 6 caught by the
  existing load-time guard. So the drop is transient/session-dependent, which is exactly what the
  new check is shaped to catch.
- **0 false positives** for `detectSerializeLoss` across the 500 richest real Yoopta slides
  (498 clean; the 2 that threw are the already-handled "serializer throws" path).

Also found and **not** fixed here (separate issues, no code change in this PR):
- 6 slides lose content during `html.deserialize` itself — 4 of them tables, all AI-generated or
  pasted markup. Those slides are effectively unsavable today: the loss happens during load, so
  the author is told to reload, which reproduces it. Needs its own bisection.
- `Ctrl+B` toggles the sidebar (shadcn's `SIDEBAR_KEYBOARD_SHORTCUT`, `sidebar.tsx:18`) on a
  window-level listener, so it steals the bold shortcut inside the editor.

## Related Issue

Follow-up to the slide content-loss work (`docs/SLIDE_CONTENT_LOSS_INVESTIGATION.md`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- **15 new regression tests** (`lexical-editor/roundtrip-integrity/test.ts`), one per reproduced false alarm. Counts are asserted for **equality**, so a duplicated table fails as loudly as a dropped one. Includes blast-radius pins: an image inside a text-carrying wrapper still imports, a plain `<blockquote>` stays a quote, plain `<aside>`/`<section>` are untouched, and the `<br>` promotion is idempotent.
- 93 tests pass across the slides area; 10 in `SlideStructuralLossTest`; `tsc --noEmit` clean; `design-lint` 0 errors.
- **Real stored content:** a 94 KB / 20-custom-block production slide and the only real callout-bearing slide were round-tripped through the actual import→export — every counted type preserved and byte-stable on the second pass (matters because the unsaved-changes baseline is an exact string compare).
- **Real backend, real HTTP** (local `admin_core` on the Docker DB): unchanged content → 200; callout genuinely deleted → 409; table inside a callout flattened, i.e. the old editor's exact output → 409 `"This will remove 1 table from the slide."` (reproduces the reported popup); placeholder image dropped → 200; real image dropped → 409.
- **Legacy-editor guard:** 12 unit tests for `detectSerializeLoss` (including "never fires on a real deletion" and the placeholder-media cases); 105 tests pass across the slides area; false-positive sweep over 500 real slides reported zero firings.
- **Browser click-through (new editor): done.** Callout insert, multi-line typing, bold, colour switch and save verified in the app against a local backend — text intact, no confirm dialog.
- **Not yet done:** a human click-through of the callout in a browser (insert, type, paste an image, theme switch, backspace behaviour). The editing UI changed from a `<textarea>` to a contentEditable, and while it now uses the same `RichTextField`-inside-`BlockChrome` pattern already shipped for quiz options, nobody has clicked it. Worth doing before merge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

