### PR TITLE
ci(notification): set SES_SENDER_SMTP_* from AWS_MAIL secrets so cust…

### DIFF
--- a/.github/workflows/maven-publish-notification-service.yml
+++ b/.github/workflows/maven-publish-notification-service.yml
@@ -132,6 +132,8 @@ jobs:
             MAIL_PORT=${{ secrets.MAIL_PORT }} \
             AWS_MAIL_USERNAME=${{ secrets.AWS_MAIL_USERNAME }} \
             AWS_MAIL_PASSWORD=${{ secrets.AWS_MAIL_PASSWORD }} \
+            SES_SENDER_SMTP_USERNAME=${{ secrets.AWS_MAIL_USERNAME }} \
+            SES_SENDER_SMTP_PASSWORD=${{ secrets.AWS_MAIL_PASSWORD }} \
             SES_SENDER_EMAIL=${{ secrets.SES_SENDER_EMAIL }} \
             WHATSAPP_ACCESS_TOKEN=${{ secrets.WHATSAPP_ACCESS_TOKEN }} \
             WHATSAPP_ACCESS_TOKEN_VIDYAYATAN=${{ secrets.WHATSAPP_ACCESS_TOKEN_VIDYAYATAN }} \

--- a/.github/workflows/vet-deploy-notification-service.yml
+++ b/.github/workflows/vet-deploy-notification-service.yml
@@ -122,6 +122,8 @@ jobs:
             "MAIL_PORT=${{ secrets.MAIL_PORT }}" \
             "AWS_MAIL_USERNAME=${{ secrets.AWS_MAIL_USERNAME }}" \
             "AWS_MAIL_PASSWORD=${{ secrets.AWS_MAIL_PASSWORD }}" \
+            "SES_SENDER_SMTP_USERNAME=${{ secrets.AWS_MAIL_USERNAME }}" \
+            "SES_SENDER_SMTP_PASSWORD=${{ secrets.AWS_MAIL_PASSWORD }}" \
             "SES_SENDER_EMAIL=${{ secrets.SES_SENDER_EMAIL }}" \
             "WHATSAPP_ACCESS_TOKEN=${{ secrets.WHATSAPP_ACCESS_TOKEN }}" \
             "WHATSAPP_ACCESS_TOKEN_VIDYAYATAN=${{ secrets.WHATSAPP_ACCESS_TOKEN_VIDYAYATAN }}" \


### PR DESCRIPTION
## Summary of Changes

Sets `SES_SENDER_SMTP_USERNAME` / `SES_SENDER_SMTP_PASSWORD` from the same `AWS_MAIL_*` secrets that already feed the default mail path, in both notification_service deploy workflows.

The custom-sender path (`app.ses.sender.smtp.*` in `application-stage.properties`) falls back to `AWS_MAIL_*` only when those two variables are unset. On the prod Deployment they appear to have been set by hand at some point, pinning that path to a separate SES SMTP credential that no longer matched the default path. Because `kubectl set env` only adds or overwrites the variables it names, that override survived every deploy and was invisible in the repo — so rotating the `AWS_MAIL_*` secrets alone would have moved only half the outbound traffic onto the new credential, leaving all custom-sender tenant mail on the old one.

Setting both explicitly makes the deploy authoritative: one secret pair drives both paths, and future credential rotations are a single change with nothing hidden on the cluster.

Part of rotating the SES SMTP credential compromised in the 2026-07-30 incident.

**Backend:**
- `.github/workflows/maven-publish-notification-service.yml` — add `SES_SENDER_SMTP_USERNAME` / `SES_SENDER_SMTP_PASSWORD` to the `kubectl set env` block, sourced from `secrets.AWS_MAIL_USERNAME` / `secrets.AWS_MAIL_PASSWORD`
- `.github/workflows/vet-deploy-notification-service.yml` — same two variables added to the VET EKS deploy block, matching that file's quoted style
- No application code changes; the properties fallback in `application-stage.properties` is unchanged

**Frontend:**
- None

## Related Issue

<!-- SES credential compromise, 2026-07-30 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- New SES SMTP credentials created on a dedicated least-privilege IAM user (`vacademy-ses-2026-07`) and verified by a direct SMTP send to `email-smtp.ap-south-1.amazonaws.com:587` — authenticated on first attempt, message delivered and confirmed received
- Both workflow files validated as parseable YAML after the edit
- Verified from SES metrics that the two mail paths were using different credentials: custom-sender traffic (`support@shikshanation.com`, `info@veteducation.com.au`) was authenticating with a key that had no reference anywhere in the repo, while the `AWS_MAIL_*` key had been idle for 12 hours
- Post-merge verification plan: deploy with the rotated secrets, trigger a custom-sender tenant email, and confirm the new key's `last-used` advances while the old key goes stale before deactivating the old credentials

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
