### PR TITLE
Config tab: message-content editor + fold SpEL under Advanced

### DIFF
--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-config-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-config-tab.tsx
@@ -106,13 +106,72 @@ function OutputDataPointsEditor({
         );
     };
 
+    const renderRow = (point: OutputDataPoint, index: number) => {
+        const isCompute = point.compute !== undefined;
+        const text = isCompute ? (point.compute ?? '') : (point.value ?? '');
+        return (
+            <div key={index} className="flex items-start gap-2">
+                <Input
+                    value={point.fieldName ?? ''}
+                    onChange={(e) => updateRow(index, { fieldName: e.target.value })}
+                    placeholder="fieldName"
+                    spellCheck={false}
+                    className="h-8 w-44 shrink-0 font-mono text-xs"
+                />
+                <Textarea
+                    value={text}
+                    onChange={(e) =>
+                        updateRow(
+                            index,
+                            isCompute ? { compute: e.target.value } : { value: e.target.value }
+                        )
+                    }
+                    spellCheck={false}
+                    rows={Math.min(6, Math.max(1, Math.ceil(text.length / 80)))}
+                    className="min-h-8 flex-1 font-mono text-xs"
+                />
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 shrink-0 px-2 text-caption"
+                    onClick={() => toggleMode(index)}
+                    title={
+                        isCompute
+                            ? 'SpEL expression — click to treat as plain text'
+                            : 'Plain text — click to treat as SpEL expression'
+                    }
+                >
+                    {isCompute ? 'SpEL' : 'Text'}
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 shrink-0 px-2 text-neutral-400 hover:text-red-600"
+                    onClick={() => removeRow(index)}
+                    title="Remove setting"
+                >
+                    <Trash size={14} />
+                </Button>
+            </div>
+        );
+    };
+
+    // Editable text rows front and center; formula (SpEL) rows folded away so
+    // non-technical admins only see what's safe to change.
+    const textEntries = points
+        .map((p, i) => ({ p, i }))
+        .filter(({ p }) => p.compute === undefined);
+    const formulaEntries = points
+        .map((p, i) => ({ p, i }))
+        .filter(({ p }) => p.compute !== undefined);
+
     return (
         <div className="rounded-md border border-neutral-200 bg-neutral-50 p-3">
             <div className="mb-2 flex items-center justify-between">
                 <Label className="text-xs text-neutral-600">
                     Workflow settings
                     <span className="ml-1.5 text-caption text-neutral-400">
-                        outputDataPoints — template text, links &amp; audience values
+                        template text, links &amp; audience values
                     </span>
                 </Label>
                 <Button
@@ -125,61 +184,119 @@ function OutputDataPointsEditor({
                 </Button>
             </div>
             <div className="space-y-2">
-                {points.length === 0 && (
-                    <p className="text-caption text-neutral-400">No settings yet — add one above.</p>
+                {textEntries.length === 0 && (
+                    <p className="text-caption text-neutral-400">
+                        No editable text settings on this node.
+                    </p>
                 )}
-                {points.map((point, index) => {
-                    const isCompute = point.compute !== undefined;
-                    const text = isCompute ? (point.compute ?? '') : (point.value ?? '');
-                    return (
-                        <div key={index} className="flex items-start gap-2">
-                            <Input
-                                value={point.fieldName ?? ''}
-                                onChange={(e) => updateRow(index, { fieldName: e.target.value })}
-                                placeholder="fieldName"
-                                spellCheck={false}
-                                className="h-8 w-44 shrink-0 font-mono text-xs"
-                            />
-                            <Textarea
-                                value={text}
-                                onChange={(e) =>
-                                    updateRow(
-                                        index,
-                                        isCompute
-                                            ? { compute: e.target.value }
-                                            : { value: e.target.value }
-                                    )
-                                }
-                                spellCheck={false}
-                                rows={Math.min(6, Math.max(1, Math.ceil(text.length / 80)))}
-                                className="min-h-8 flex-1 font-mono text-xs"
-                            />
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-8 shrink-0 px-2 text-caption"
-                                onClick={() => toggleMode(index)}
-                                title={
-                                    isCompute
-                                        ? 'SpEL expression — click to treat as plain text'
-                                        : 'Plain text — click to treat as SpEL expression'
-                                }
-                            >
-                                {isCompute ? 'SpEL' : 'Text'}
-                            </Button>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 shrink-0 px-2 text-neutral-400 hover:text-red-600"
-                                onClick={() => removeRow(index)}
-                                title="Remove setting"
-                            >
-                                <Trash size={14} />
-                            </Button>
-                        </div>
-                    );
-                })}
+                {textEntries.map(({ p, i }) => renderRow(p, i))}
             </div>
+            {formulaEntries.length > 0 && (
+                <details className="mt-2">
+                    <summary className="cursor-pointer text-caption text-neutral-400">
+                        Advanced formulas ({formulaEntries.length}) — edit only if you know SpEL
+                    </summary>
+                    <div className="mt-2 space-y-2">
+                        {formulaEntries.map(({ p, i }) => renderRow(p, i))}
+                    </div>
+                </details>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Friendly editor for a send node's message: template name + per-variable rows
+ * ({{1}}, {{2}}, ...). Plain-text variables (a day's message line) are editable
+ * up front; values starting with '#' are SpEL formulas and live in the advanced
+ * fold. Writes into the same config text as the raw JSON editor.
+ */
+function TemplateVarsEditor({
+    configText,
+    onChange,
+}: {
+    configText: string;
+    onChange: (next: string) => void;
+}) {
+    let parsed: Record<string, unknown> | null = null;
+    try {
+        const p: unknown = JSON.parse(configText);
+        if (p && typeof p === 'object' && !Array.isArray(p)) {
+            parsed = p as Record<string, unknown>;
+        }
+    } catch {
+        // Invalid JSON — the raw editor is already showing the error; hide this panel.
+    }
+    const vars =
+        parsed &&
+        parsed.templateVars &&
+        typeof parsed.templateVars === 'object' &&
+        !Array.isArray(parsed.templateVars)
+            ? (parsed.templateVars as Record<string, string>)
+            : null;
+    if (!parsed || !vars) return null;
+
+    const cfg = parsed;
+    const writeVar = (key: string, value: string) =>
+        onChange(
+            JSON.stringify({ ...cfg, templateVars: { ...vars, [key]: value } }, null, 2)
+        );
+    const writeField = (field: string, value: string) =>
+        onChange(JSON.stringify({ ...cfg, [field]: value }, null, 2));
+
+    const entries = Object.entries(vars).sort(([a], [b]) =>
+        a.localeCompare(b, undefined, { numeric: true })
+    );
+    const textVars = entries.filter(([, v]) => !String(v ?? '').trim().startsWith('#'));
+    const formulaVars = entries.filter(([, v]) => String(v ?? '').trim().startsWith('#'));
+
+    const renderVar = ([key, value]: [string, string]) => (
+        <div key={key} className="flex items-start gap-2">
+            <span className="mt-1.5 w-12 shrink-0 text-right font-mono text-xs text-neutral-500">
+                {'{{'}
+                {key}
+                {'}}'}
+            </span>
+            <Textarea
+                value={value ?? ''}
+                onChange={(e) => writeVar(key, e.target.value)}
+                spellCheck={false}
+                rows={Math.min(6, Math.max(1, Math.ceil(String(value ?? '').length / 80)))}
+                className="min-h-8 flex-1 text-xs"
+            />
+        </div>
+    );
+
+    return (
+        <div className="rounded-md border border-neutral-200 bg-neutral-50 p-3">
+            <Label className="mb-2 block text-xs text-neutral-600">
+                Message content
+                <span className="ml-1.5 text-caption text-neutral-400">
+                    what this node sends — edit the text freely
+                </span>
+            </Label>
+            {typeof cfg.templateName === 'string' && (
+                <div className="mb-2 flex items-center gap-2">
+                    <span className="w-12 shrink-0 text-right text-caption text-neutral-500">
+                        Template
+                    </span>
+                    <Input
+                        value={cfg.templateName}
+                        onChange={(e) => writeField('templateName', e.target.value)}
+                        spellCheck={false}
+                        className="h-8 flex-1 font-mono text-xs"
+                    />
+                </div>
+            )}
+            <div className="space-y-2">{textVars.map(renderVar)}</div>
+            {formulaVars.length > 0 && (
+                <details className="mt-2">
+                    <summary className="cursor-pointer text-caption text-neutral-400">
+                        Auto-filled variables ({formulaVars.length}) — name, links, dates
+                    </summary>
+                    <div className="mt-2 space-y-2">{formulaVars.map(renderVar)}</div>
+                </details>
+            )}
         </div>
     );
 }
@@ -365,8 +482,9 @@ function NodeConfigEditorCard({
                     </label>
                 </div>
 
-                {/* Friendly settings editor — only shows when config has outputDataPoints */}
+                {/* Friendly settings editors — each shows only when the config has its section */}
                 <OutputDataPointsEditor configText={configText} onChange={setConfigText} />
+                <TemplateVarsEditor configText={configText} onChange={setConfigText} />
 
                 {/* config_json editor */}
                 <div>


### PR DESCRIPTION
For non-technical admins editing workflows:
- New TemplateVarsEditor: send nodes with node-level templateVars show "Message content" — template name + {{n}} variables as plain text boxes; '#'-prefixed (SpEL) variables fold under "Auto-filled variables".
- OutputDataPointsEditor: plain-text rows stay front and center; compute (SpEL) rows fold under "Advanced formulas".

Pairs with the per-day SuchBliss workflow restructure (one SEND_WHATSAPP node per day holding only that day's text as literals).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
