### PR TITLE
Config tab: simple view (default) + developer view toggle

### DIFF
--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-config-tab.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-config-tab.tsx
@@ -58,6 +58,37 @@ type OutputDataPoint = {
     [key: string]: unknown;
 };
 
+/**
+ * What the simple (non-developer) view can edit on a node: plain-text settings
+ * rows and/or literal message variables. Nodes with neither are hidden there.
+ */
+function normalEditableSections(configText: string): { settings: boolean; message: boolean } {
+    try {
+        const p: unknown = JSON.parse(configText);
+        if (!p || typeof p !== 'object' || Array.isArray(p)) {
+            return { settings: false, message: false };
+        }
+        const cfg = p as Record<string, unknown>;
+        const points = Array.isArray(cfg.outputDataPoints)
+            ? (cfg.outputDataPoints as OutputDataPoint[])
+            : [];
+        const settings = points.some(
+            (row) =>
+                row.compute === undefined &&
+                (typeof row.value === 'string' || isNestedStringMap(row.value))
+        );
+        const vars =
+            cfg.templateVars && typeof cfg.templateVars === 'object' && !Array.isArray(cfg.templateVars)
+                ? (cfg.templateVars as Record<string, string>)
+                : null;
+        const message =
+            !!vars && Object.values(vars).some((v) => !String(v ?? '').trim().startsWith('#'));
+        return { settings, message };
+    } catch {
+        return { settings: false, message: false };
+    }
+}
+
 /** True for a two-level map of strings: { day1: { "05:30": "url", ... }, ... } */
 function isNestedStringMap(value: unknown): boolean {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
@@ -153,9 +184,11 @@ function NestedMapGridEditor({
 function OutputDataPointsEditor({
     configText,
     onChange,
+    devMode,
 }: {
     configText: string;
     onChange: (next: string) => void;
+    devMode: boolean;
 }) {
     let parsed: Record<string, unknown> | null = null;
     try {
@@ -206,6 +239,8 @@ function OutputDataPointsEditor({
             );
         }
         if (!isCompute && point.value !== undefined && typeof point.value !== 'string') {
+            // Other structured values: dev-only pointer to the raw editor.
+            if (!devMode) return null;
             return (
                 <div key={index} className="flex items-center gap-2">
                     <Input
@@ -222,13 +257,19 @@ function OutputDataPointsEditor({
         const text = isCompute ? (point.compute ?? '') : ((point.value as string | undefined) ?? '');
         return (
             <div key={index} className="flex items-start gap-2">
-                <Input
-                    value={point.fieldName ?? ''}
-                    onChange={(e) => updateRow(index, { fieldName: e.target.value })}
-                    placeholder="fieldName"
-                    spellCheck={false}
-                    className="h-8 w-44 shrink-0 font-mono text-xs"
-                />
+                {devMode ? (
+                    <Input
+                        value={point.fieldName ?? ''}
+                        onChange={(e) => updateRow(index, { fieldName: e.target.value })}
+                        placeholder="fieldName"
+                        spellCheck={false}
+                        className="h-8 w-44 shrink-0 font-mono text-xs"
+                    />
+                ) : (
+                    <span className="mt-2 w-44 shrink-0 truncate text-right text-xs text-neutral-500">
+                        {point.fieldName}
+                    </span>
+                )}
                 <Textarea
                     value={text}
                     onChange={(e) =>
@@ -239,30 +280,34 @@ function OutputDataPointsEditor({
                     }
                     spellCheck={false}
                     rows={Math.min(6, Math.max(1, Math.ceil(text.length / 80)))}
-                    className="min-h-8 flex-1 font-mono text-xs"
+                    className={`min-h-8 flex-1 text-xs ${devMode ? 'font-mono' : ''}`}
                 />
-                <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 shrink-0 px-2 text-caption"
-                    onClick={() => toggleMode(index)}
-                    title={
-                        isCompute
-                            ? 'SpEL expression — click to treat as plain text'
-                            : 'Plain text — click to treat as SpEL expression'
-                    }
-                >
-                    {isCompute ? 'SpEL' : 'Text'}
-                </Button>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 shrink-0 px-2 text-neutral-400 hover:text-red-600"
-                    onClick={() => removeRow(index)}
-                    title="Remove setting"
-                >
-                    <Trash size={14} />
-                </Button>
+                {devMode && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8 shrink-0 px-2 text-caption"
+                        onClick={() => toggleMode(index)}
+                        title={
+                            isCompute
+                                ? 'SpEL expression — click to treat as plain text'
+                                : 'Plain text — click to treat as SpEL expression'
+                        }
+                    >
+                        {isCompute ? 'SpEL' : 'Text'}
+                    </Button>
+                )}
+                {devMode && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 shrink-0 px-2 text-neutral-400 hover:text-red-600"
+                        onClick={() => removeRow(index)}
+                        title="Remove setting"
+                    >
+                        <Trash size={14} />
+                    </Button>
+                )}
             </div>
         );
     };
@@ -276,6 +321,13 @@ function OutputDataPointsEditor({
         .map((p, i) => ({ p, i }))
         .filter(({ p }) => p.compute !== undefined);
 
+    // In the simple view, hide the panel entirely when there is nothing a
+    // non-technical admin can safely change here.
+    const normalEditable = textEntries.filter(
+        ({ p }) => typeof p.value === 'string' || isNestedStringMap(p.value)
+    );
+    if (!devMode && normalEditable.length === 0) return null;
+
     return (
         <div className="rounded-md border border-neutral-200 bg-neutral-50 p-3">
             <div className="mb-2 flex items-center justify-between">
@@ -285,24 +337,26 @@ function OutputDataPointsEditor({
                         template text, links &amp; audience values
                     </span>
                 </Label>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 gap-1 text-caption text-neutral-500"
-                    onClick={() => write([...points, { fieldName: '', value: '' }])}
-                >
-                    <Plus size={12} /> Add setting
-                </Button>
+                {devMode && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 gap-1 text-caption text-neutral-500"
+                        onClick={() => write([...points, { fieldName: '', value: '' }])}
+                    >
+                        <Plus size={12} /> Add setting
+                    </Button>
+                )}
             </div>
             <div className="space-y-2">
-                {textEntries.length === 0 && (
+                {devMode && textEntries.length === 0 && (
                     <p className="text-caption text-neutral-400">
                         No editable text settings on this node.
                     </p>
                 )}
                 {textEntries.map(({ p, i }) => renderRow(p, i))}
             </div>
-            {formulaEntries.length > 0 && (
+            {devMode && formulaEntries.length > 0 && (
                 <details className="mt-2">
                     <summary className="cursor-pointer text-caption text-neutral-400">
                         Advanced formulas ({formulaEntries.length}) — edit only if you know SpEL
@@ -325,9 +379,11 @@ function OutputDataPointsEditor({
 function TemplateVarsEditor({
     configText,
     onChange,
+    devMode,
 }: {
     configText: string;
     onChange: (next: string) => void;
+    devMode: boolean;
 }) {
     let parsed: Record<string, unknown> | null = null;
     try {
@@ -361,6 +417,8 @@ function TemplateVarsEditor({
     const textVars = entries.filter(([, v]) => !String(v ?? '').trim().startsWith('#'));
     const formulaVars = entries.filter(([, v]) => String(v ?? '').trim().startsWith('#'));
 
+    if (!devMode && textVars.length === 0) return null;
+
     const renderVar = ([key, value]: [string, string]) => (
         <div key={key} className="flex items-start gap-2">
             <span className="mt-1.5 w-12 shrink-0 text-right font-mono text-xs text-neutral-500">
@@ -391,16 +449,20 @@ function TemplateVarsEditor({
                     <span className="w-12 shrink-0 text-right text-caption text-neutral-500">
                         Template
                     </span>
-                    <Input
-                        value={cfg.templateName}
-                        onChange={(e) => writeField('templateName', e.target.value)}
-                        spellCheck={false}
-                        className="h-8 flex-1 font-mono text-xs"
-                    />
+                    {devMode ? (
+                        <Input
+                            value={cfg.templateName}
+                            onChange={(e) => writeField('templateName', e.target.value)}
+                            spellCheck={false}
+                            className="h-8 flex-1 font-mono text-xs"
+                        />
+                    ) : (
+                        <span className="text-xs text-neutral-600">{cfg.templateName}</span>
+                    )}
                 </div>
             )}
             <div className="space-y-2">{textVars.map(renderVar)}</div>
-            {formulaVars.length > 0 && (
+            {devMode && formulaVars.length > 0 && (
                 <details className="mt-2">
                     <summary className="cursor-pointer text-caption text-neutral-400">
                         Auto-filled variables ({formulaVars.length}) — name, links, dates
@@ -415,9 +477,11 @@ function TemplateVarsEditor({
 function NodeConfigEditorCard({
     workflowId,
     node,
+    devMode,
 }: {
     workflowId: string;
     node: WorkflowRawNode;
+    devMode: boolean;
 }) {
     const queryClient = useQueryClient();
 
@@ -508,6 +572,10 @@ function NodeConfigEditorCard({
 
     const nodeMeta = WORKFLOW_NODE_TYPES.find((t) => t.type === node.node_type);
 
+    // Simple view: only show nodes a non-technical admin can act on.
+    const editable = normalEditableSections(configText);
+    if (!devMode && !editable.settings && !editable.message) return null;
+
     return (
         <div className="rounded-lg border border-neutral-200 bg-white">
             {/* Card header */}
@@ -517,24 +585,28 @@ function NodeConfigEditorCard({
                 </span>
                 <span className="text-lg">{nodeMeta?.icon ?? '⚙️'}</span>
                 <span className="font-medium text-neutral-800">{node.node_name}</span>
-                <Badge variant="outline" className="text-[10px] font-medium text-neutral-600">
-                    {nodeMeta?.label ?? node.node_type}
-                </Badge>
-                {isStart && (
+                {devMode && (
+                    <Badge variant="outline" className="text-[10px] font-medium text-neutral-600">
+                        {nodeMeta?.label ?? node.node_type}
+                    </Badge>
+                )}
+                {devMode && isStart && (
                     <Badge className="bg-green-100 text-[10px] text-green-700 hover:bg-green-100">Start</Badge>
                 )}
-                {isEnd && (
+                {devMode && isEnd && (
                     <Badge className="bg-neutral-100 text-[10px] text-neutral-600 hover:bg-neutral-100">End</Badge>
                 )}
-                <code className="ml-auto hidden text-[10px] text-neutral-400 sm:block">
-                    {node.node_template_id}
-                </code>
+                {devMode && (
+                    <code className="ml-auto hidden text-[10px] text-neutral-400 sm:block">
+                        {node.node_template_id}
+                    </code>
+                )}
             </div>
 
             {/* Card body */}
             <div className="space-y-4 p-4">
                 {/* Node metadata row */}
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div className={devMode ? 'grid grid-cols-1 gap-3 sm:grid-cols-3' : 'hidden'}>
                     <div>
                         <Label className="text-xs text-neutral-600">Node name</Label>
                         <Input
@@ -582,7 +654,7 @@ function NodeConfigEditorCard({
                 </div>
 
                 {/* Start / end toggles */}
-                <div className="flex flex-wrap items-center gap-6">
+                <div className={devMode ? 'flex flex-wrap items-center gap-6' : 'hidden'}>
                     <label className="flex cursor-pointer items-center gap-2">
                         <Switch checked={isStart} onCheckedChange={setIsStart} />
                         <span className="text-xs text-neutral-600">Start node</span>
@@ -594,11 +666,11 @@ function NodeConfigEditorCard({
                 </div>
 
                 {/* Friendly settings editors — each shows only when the config has its section */}
-                <OutputDataPointsEditor configText={configText} onChange={setConfigText} />
-                <TemplateVarsEditor configText={configText} onChange={setConfigText} />
+                <OutputDataPointsEditor configText={configText} onChange={setConfigText} devMode={devMode} />
+                <TemplateVarsEditor configText={configText} onChange={setConfigText} devMode={devMode} />
 
                 {/* config_json editor */}
-                <div>
+                <div className={devMode ? '' : 'hidden'}>
                     <div className="mb-1 flex items-center justify-between">
                         <Label className="text-xs text-neutral-600">
                             config_json
@@ -633,7 +705,7 @@ function NodeConfigEditorCard({
                 </div>
 
                 {/* retry_config editor (optional) */}
-                <div>
+                <div className={devMode ? '' : 'hidden'}>
                     <Label className="text-xs text-neutral-600">
                         retry_config
                         <span className="ml-1.5 text-[10px] text-neutral-400">
@@ -700,6 +772,15 @@ function NodeConfigEditorCard({
 
 export function WorkflowConfigTab({ workflowId }: { workflowId: string }) {
     const { data, isLoading, error } = useQuery(getWorkflowRawQuery(workflowId));
+    // Simple view by default; the developer toggle persists across visits.
+    const [devMode, setDevMode] = useState(
+        () => localStorage.getItem('workflow-config-dev-mode') === 'true'
+    );
+    const toggleDevMode = () => {
+        const next = !devMode;
+        setDevMode(next);
+        localStorage.setItem('workflow-config-dev-mode', String(next));
+    };
 
     if (isLoading) {
         return (
@@ -730,22 +811,48 @@ export function WorkflowConfigTab({ workflowId }: { workflowId: string }) {
 
     return (
         <div className="space-y-4">
-            {/* Intro / guidance */}
+            {/* Intro / guidance + view toggle */}
             <div className="flex items-start gap-2 rounded-lg border border-primary-100 bg-primary-50 px-4 py-3">
                 <Info size={16} weight="fill" className="mt-0.5 shrink-0 text-primary-500" />
-                <div className="text-xs text-primary-600">
-                    <p className="font-medium">Advanced node configuration</p>
-                    <p className="mt-0.5 text-primary-500">
-                        Edit each node&apos;s raw <code>config_json</code> (including its{' '}
-                        <code>routing</code>) in place. Changes are validated and saved directly to the
-                        node template — the running workflow picks them up on its next execution. This is
-                        the loss-less alternative to the visual editor for complex workflows.
-                    </p>
+                <div className="flex-1 text-xs text-primary-600">
+                    {devMode ? (
+                        <>
+                            <p className="font-medium">Developer view — full node configuration</p>
+                            <p className="mt-0.5 text-primary-500">
+                                Edit each node&apos;s raw <code>config_json</code> (including its{' '}
+                                <code>routing</code>) in place. Changes are validated and saved directly
+                                to the node template — the running workflow picks them up on its next
+                                execution.
+                            </p>
+                        </>
+                    ) : (
+                        <>
+                            <p className="font-medium">Workflow settings</p>
+                            <p className="mt-0.5 text-primary-500">
+                                Edit your messages, links and settings below, then save each card.
+                                Changes apply automatically from the workflow&apos;s next run.
+                            </p>
+                        </>
+                    )}
                 </div>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 gap-1.5"
+                    onClick={toggleDevMode}
+                >
+                    <BracketsCurly size={14} />
+                    {devMode ? 'Simple view' : 'Developer view'}
+                </Button>
             </div>
 
             {data.nodes.map((node) => (
-                <NodeConfigEditorCard key={node.node_template_id} workflowId={workflowId} node={node} />
+                <NodeConfigEditorCard
+                    key={node.node_template_id}
+                    workflowId={workflowId}
+                    node={node}
+                    devMode={devMode}
+                />
             ))}
         </div>
     );


### PR DESCRIPTION
Simple view is what a non-technical institute admin sees: only nodes with editable content (settings text/links, link grid, message text boxes), setting names as read-only labels, template name read-only, no raw config_json, no retry_config, no node type/status/start-end controls, no SpEL anywhere, no add/remove row buttons. Logic nodes are hidden entirely.

Developer view (top-right toggle, persisted in localStorage) restores the full editor exactly as before.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
