### PR TITLE
Dispositions: exclude deleted/opted-out leads from the pending count

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/PipelineReportService.java
@@ -251,7 +251,10 @@ public class PipelineReportService {
      * Leads assigned to each counsellor that have never had a status change recorded — i.e.
      * zero rows in lead_status_history across any of their audience_responses in this institute.
      * Scoped to the report window via ar2.submitted_at, matching Recent Leads and the other
-     * disposition metrics — a lead only counts as "pending" here if it was submitted in-window.
+     * disposition metrics — a lead only counts as "pending" here if it was submitted in-window,
+     * on a NON-deleted, non-opted-out response (same ACTIVE + OPTED_OUT guards as the leads
+     * list and the current-status matrix — without them a deleted lead kept counting as
+     * "pending" while every other surface hid it, and the columns didn't reconcile).
      * audienceId filter is honoured so the count scopes to a single campaign when selected.
      */
     private static final String PENDING_LEADS_SQL = """
@@ -265,6 +268,8 @@ public class PipelineReportService {
                   SELECT 1 FROM audience_response ar2
                   WHERE (ar2.user_id = ulp.user_id OR ar2.student_user_id = ulp.user_id)
                     AND ar2.submitted_at >= :fromTs AND ar2.submitted_at < :toTs
+                    AND ar2.audience_status = 'ACTIVE'
+                    AND (ar2.overall_status IS NULL OR ar2.overall_status != 'OPTED_OUT')
                     AND (:audienceId IS NULL OR ar2.audience_id = :audienceId)
               )
               AND NOT EXISTS (


### PR DESCRIPTION
Pending counted assigned in-window leads with no status history, but its cohort check lacked the ACTIVE + OPTED_OUT guards every other lead surface applies - so soft-deleted leads kept counting as pending while being hidden everywhere else (verified: a counsellor showing Pending 17 vs New 10 had exactly 7 deleted leads in the window; both read 10 after this).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
