### PR TITLE
Workflow details: shareable tab URLs + /configuration deep link

### DIFF
--- a/frontend-admin-dashboard/src/routeTree.gen.ts
+++ b/frontend-admin-dashboard/src/routeTree.gen.ts
@@ -150,6 +150,7 @@ import { Route as LoginOauthRedirectRouteImport } from "./routes/login/oauth/red
 import { Route as AutomationChatbotFlowsFlowIdRouteImport } from "./routes/automation/chatbot-flows/$flowId"
 import { Route as AudienceManagerOnboardingFlowIdRouteImport } from "./routes/audience-manager/onboarding/$flowId"
 import { Route as WorkflowWorkflowIdEditIndexRouteImport } from "./routes/workflow/$workflowId/edit/index"
+import { Route as WorkflowWorkflowIdConfigurationIndexRouteImport } from "./routes/workflow/$workflowId/configuration/index"
 import { Route as VimStudioProjectIdIndexRouteImport } from "./routes/vim/studio/$projectId/index"
 import { Route as VimReelsReelIdIndexRouteImport } from "./routes/vim/reels/$reelId/index"
 import { Route as VimEditVideoIdIndexRouteImport } from "./routes/vim/edit/$videoId/index"
@@ -1293,6 +1294,12 @@ const WorkflowWorkflowIdEditIndexRoute =
       (d) => d.Route,
     ),
   )
+const WorkflowWorkflowIdConfigurationIndexRoute =
+  WorkflowWorkflowIdConfigurationIndexRouteImport.update({
+    id: "/workflow/$workflowId/configuration/",
+    path: "/workflow/$workflowId/configuration/",
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const VimStudioProjectIdIndexRoute = VimStudioProjectIdIndexRouteImport.update({
   id: "/vim/studio/$projectId/",
   path: "/vim/studio/$projectId/",
@@ -1903,6 +1910,7 @@ export interface FileRoutesByFullPath {
   "/vim/edit/$videoId/": typeof VimEditVideoIdIndexRoute
   "/vim/reels/$reelId/": typeof VimReelsReelIdIndexRoute
   "/vim/studio/$projectId/": typeof VimStudioProjectIdIndexRoute
+  "/workflow/$workflowId/configuration/": typeof WorkflowWorkflowIdConfigurationIndexRoute
   "/workflow/$workflowId/edit/": typeof WorkflowWorkflowIdEditIndexRoute
   "/study-library/ai-copilot/shared/components/YouTubePlayerSimple": typeof StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute
   "/assessment/assessment-list/offline-entry/$assessmentId/": typeof AssessmentAssessmentListOfflineEntryAssessmentIdIndexRoute
@@ -2099,6 +2107,7 @@ export interface FileRoutesByTo {
   "/vim/edit/$videoId": typeof VimEditVideoIdIndexRoute
   "/vim/reels/$reelId": typeof VimReelsReelIdIndexRoute
   "/vim/studio/$projectId": typeof VimStudioProjectIdIndexRoute
+  "/workflow/$workflowId/configuration": typeof WorkflowWorkflowIdConfigurationIndexRoute
   "/workflow/$workflowId/edit": typeof WorkflowWorkflowIdEditIndexRoute
   "/study-library/ai-copilot/shared/components/YouTubePlayerSimple": typeof StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute
   "/assessment/assessment-list/offline-entry/$assessmentId": typeof AssessmentAssessmentListOfflineEntryAssessmentIdIndexRoute
@@ -2297,6 +2306,7 @@ export interface FileRoutesById {
   "/vim/edit/$videoId/": typeof VimEditVideoIdIndexRoute
   "/vim/reels/$reelId/": typeof VimReelsReelIdIndexRoute
   "/vim/studio/$projectId/": typeof VimStudioProjectIdIndexRoute
+  "/workflow/$workflowId/configuration/": typeof WorkflowWorkflowIdConfigurationIndexRoute
   "/workflow/$workflowId/edit/": typeof WorkflowWorkflowIdEditIndexRoute
   "/study-library/ai-copilot/shared/components/YouTubePlayerSimple": typeof StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute
   "/assessment/assessment-list/offline-entry/$assessmentId/": typeof AssessmentAssessmentListOfflineEntryAssessmentIdIndexRoute
@@ -2496,6 +2506,7 @@ export interface FileRouteTypes {
     | "/vim/edit/$videoId/"
     | "/vim/reels/$reelId/"
     | "/vim/studio/$projectId/"
+    | "/workflow/$workflowId/configuration/"
     | "/workflow/$workflowId/edit/"
     | "/study-library/ai-copilot/shared/components/YouTubePlayerSimple"
     | "/assessment/assessment-list/offline-entry/$assessmentId/"
@@ -2692,6 +2703,7 @@ export interface FileRouteTypes {
     | "/vim/edit/$videoId"
     | "/vim/reels/$reelId"
     | "/vim/studio/$projectId"
+    | "/workflow/$workflowId/configuration"
     | "/workflow/$workflowId/edit"
     | "/study-library/ai-copilot/shared/components/YouTubePlayerSimple"
     | "/assessment/assessment-list/offline-entry/$assessmentId"
@@ -2889,6 +2901,7 @@ export interface FileRouteTypes {
     | "/vim/edit/$videoId/"
     | "/vim/reels/$reelId/"
     | "/vim/studio/$projectId/"
+    | "/workflow/$workflowId/configuration/"
     | "/workflow/$workflowId/edit/"
     | "/study-library/ai-copilot/shared/components/YouTubePlayerSimple"
     | "/assessment/assessment-list/offline-entry/$assessmentId/"
@@ -3086,6 +3099,7 @@ export interface RootRouteChildren {
   VimEditVideoIdIndexRoute: typeof VimEditVideoIdIndexRoute
   VimReelsReelIdIndexRoute: typeof VimReelsReelIdIndexRoute
   VimStudioProjectIdIndexRoute: typeof VimStudioProjectIdIndexRoute
+  WorkflowWorkflowIdConfigurationIndexRoute: typeof WorkflowWorkflowIdConfigurationIndexRoute
   WorkflowWorkflowIdEditIndexRoute: typeof WorkflowWorkflowIdEditIndexRoute
   StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute: typeof StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute
   AssessmentAssessmentListOfflineEntryAssessmentIdIndexRoute: typeof AssessmentAssessmentListOfflineEntryAssessmentIdIndexRoute
@@ -4113,6 +4127,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof WorkflowWorkflowIdEditIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/workflow/$workflowId/configuration/": {
+      id: "/workflow/$workflowId/configuration/"
+      path: "/workflow/$workflowId/configuration"
+      fullPath: "/workflow/$workflowId/configuration/"
+      preLoaderRoute: typeof WorkflowWorkflowIdConfigurationIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/vim/studio/$projectId/": {
       id: "/vim/studio/$projectId/"
       path: "/vim/studio/$projectId"
@@ -4696,6 +4717,8 @@ const rootRouteChildren: RootRouteChildren = {
   VimEditVideoIdIndexRoute: VimEditVideoIdIndexRoute,
   VimReelsReelIdIndexRoute: VimReelsReelIdIndexRoute,
   VimStudioProjectIdIndexRoute: VimStudioProjectIdIndexRoute,
+  WorkflowWorkflowIdConfigurationIndexRoute:
+    WorkflowWorkflowIdConfigurationIndexRoute,
   WorkflowWorkflowIdEditIndexRoute: WorkflowWorkflowIdEditIndexRoute,
   StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute:
     StudyLibraryAiCopilotSharedComponentsYouTubePlayerSimpleRoute,

--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-details-page.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-details-page.tsx
@@ -10,7 +10,7 @@ import { WorkflowConfigTab } from './workflow-config-tab';
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, PencilSimple, Trash, Eye, Play, Warning } from '@phosphor-icons/react';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Calendar, Clock } from '@phosphor-icons/react';
@@ -33,7 +33,27 @@ export function WorkflowDetailsPage({ workflowId }: WorkflowDetailsPageProps) {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { setNavHeading } = useNavHeadingStore();
-    const [activeTab, setActiveTab] = useState('diagram');
+    // ?tab=... deep-links a tab (e.g. /workflow/<id>?tab=configuration, also
+    // reachable via the /workflow/<id>/configuration redirect route).
+    const { tab: tabFromUrl } = useSearch({ from: '/workflow/$workflowId/' });
+    const [activeTab, setActiveTabState] = useState<string>(tabFromUrl ?? 'diagram');
+    const setActiveTab = (tab: string) => {
+        setActiveTabState(tab);
+        // Keep the URL shareable for whichever tab is open.
+        navigate({
+            to: '/workflow/$workflowId',
+            params: { workflowId },
+            search: tab === 'diagram' ? {} : { tab: tab as 'configuration' | 'executions' | 'debug' },
+            replace: true,
+        });
+    };
+    // Follow browser back/forward between tab URLs.
+    useEffect(() => {
+        if (tabFromUrl && tabFromUrl !== activeTab) {
+            setActiveTabState(tabFromUrl);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tabFromUrl]);
     const [debugExecutionId, setDebugExecutionId] = useState<string | null>(null);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);

--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/configuration/index.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/configuration/index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+/**
+ * Shareable deep link to a workflow's Configuration tab:
+ *   /workflow/<id>/configuration  →  /workflow/<id>?tab=configuration
+ * Exists so admins can be sent a direct "edit your workflow here" URL.
+ */
+export const Route = createFileRoute('/workflow/$workflowId/configuration/')({
+    beforeLoad: ({ params }) => {
+        throw redirect({
+            to: '/workflow/$workflowId',
+            params: { workflowId: params.workflowId },
+            search: { tab: 'configuration' },
+        });
+    },
+});

--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/index.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/index.tsx
@@ -1,7 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+const VALID_TABS = ['diagram', 'configuration', 'executions', 'debug'] as const;
+export type WorkflowDetailsTab = (typeof VALID_TABS)[number];
+
 // Route definition only - component is lazy loaded from index.lazy.tsx
 export const Route = createFileRoute('/workflow/$workflowId/')({
+    // ?tab=configuration deep-links straight to a tab (shareable URL).
+    validateSearch: (search: Record<string, unknown>): { tab?: WorkflowDetailsTab } => {
+        const tab = search.tab;
+        return VALID_TABS.includes(tab as WorkflowDetailsTab)
+            ? { tab: tab as WorkflowDetailsTab }
+            : {};
+    },
     // Component is defined in index.lazy.tsx
 });
-


### PR DESCRIPTION
- ?tab=configuration|executions|debug on /workflow/<id> selects the tab (validated search param); switching tabs updates the URL (replace) so the current view is always shareable, and back/forward follow it.
- New /workflow/<id>/configuration route redirects to the Configuration tab - a direct link admins can be handed to edit their workflow.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
