### PR TITLE
Atomic attendance upsert: kill the class-start lock convoy

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
@@ -780,38 +780,16 @@ public class LiveSessionProviderController {
 
     private void markBbbAttendance(String sessionId, String scheduleId, String userId,
                                     String fullName, String role, String providerMeetingId) {
-        Optional<LiveSessionLogs> existing = liveSessionLogsRepository
-                .findExistingAttendanceRecord(scheduleId, userId);
-
-        String joinTimeIso = java.time.Instant.now().toString();
-
-        if (existing.isPresent()) {
-            // User already has an attendance record for this schedule.
-            // Update join time and provider meeting ID (handles retry/recreate scenario).
-            LiveSessionLogs log = existing.get();
-            log.setProviderJoinTime(joinTimeIso);
-            log.setProviderMeetingId(providerMeetingId);
-            log.setStatus("PRESENT");
-            log.setStatusType("ONLINE");
-            log.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
-            liveSessionLogsRepository.save(log);
-        } else {
-            LiveSessionLogs logEntry = LiveSessionLogs.builder()
-                    .sessionId(sessionId)
-                    .scheduleId(scheduleId)
-                    .userSourceType("USER")
-                    .userSourceId(userId)
-                    .logType(SessionLog.ATTENDANCE_RECORDED.name())
-                    .status("PRESENT")
-                    .statusType("ONLINE")
-                    .details(fullName + " | role=" + role)
-                    .providerJoinTime(joinTimeIso)
-                    .providerMeetingId(providerMeetingId)
-                    .createdAt(new Timestamp(System.currentTimeMillis()))
-                    .updatedAt(new Timestamp(System.currentTimeMillis()))
-                    .build();
-            liveSessionLogsRepository.save(logEntry);
-        }
+        // Atomic upsert (V415 unique index) — the join endpoint takes the whole
+        // class concurrently at start time, so no check-then-save here.
+        liveSessionLogsRepository.upsertBbbJoinAttendance(
+                java.util.UUID.randomUUID().toString(),
+                sessionId,
+                scheduleId,
+                userId,
+                fullName + " | role=" + role,
+                java.time.Instant.now().toString(),
+                providerMeetingId);
     }
 
     // ───────────────────────────── Feedback endpoints ─────────────────────────────

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepository.java
@@ -1,8 +1,10 @@
 package vacademy.io.admin_core_service.features.live_session.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import vacademy.io.admin_core_service.features.live_session.entity.LiveSessionLogs;
 
 import java.sql.Timestamp;
@@ -22,6 +24,70 @@ public interface LiveSessionLogsRepository extends JpaRepository<LiveSessionLogs
         List<LiveSessionLogs> records = findAllAttendanceRecords(scheduleId, userSourceId);
         return records.isEmpty() ? Optional.empty() : Optional.of(records.get(0));
     }
+
+    /**
+     * Single-round-trip attendance upsert. During a live class an entire batch
+     * marks attendance on the same schedule concurrently; the previous
+     * check-then-save serialized them (and still produced duplicates under
+     * race). Conflict target is the partial unique index
+     * uq_lsl_attendance_schedule_user (V415). A null details keeps whatever the
+     * existing row already has.
+     */
+    @Modifying
+    @Transactional
+    @Query(value = """
+            INSERT INTO live_session_logs
+                (id, session_id, schedule_id, user_source_type, user_source_id,
+                 log_type, status, status_type, details, updated_at)
+            VALUES (:id, :sessionId, :scheduleId, :userSourceType, :userSourceId,
+                    'ATTENDANCE_RECORDED', :status, :statusType, :details, now())
+            ON CONFLICT (schedule_id, user_source_id) WHERE log_type = 'ATTENDANCE_RECORDED'
+            DO UPDATE SET status      = EXCLUDED.status,
+                          status_type = EXCLUDED.status_type,
+                          details     = COALESCE(EXCLUDED.details, live_session_logs.details),
+                          updated_at  = now()
+            """, nativeQuery = true)
+    void upsertAttendance(
+            @Param("id") String id,
+            @Param("sessionId") String sessionId,
+            @Param("scheduleId") String scheduleId,
+            @Param("userSourceType") String userSourceType,
+            @Param("userSourceId") String userSourceId,
+            @Param("status") String status,
+            @Param("statusType") String statusType,
+            @Param("details") String details);
+
+    /**
+     * Upsert for the BBB meeting-join path (also a class-start stampede).
+     * Carries provider join metadata; on conflict it refreshes join
+     * time/meeting id and forces PRESENT but leaves details untouched,
+     * matching the previous update branch of markBbbAttendance.
+     */
+    @Modifying
+    @Transactional
+    @Query(value = """
+            INSERT INTO live_session_logs
+                (id, session_id, schedule_id, user_source_type, user_source_id,
+                 log_type, status, status_type, details, provider_join_time,
+                 provider_meeting_id, updated_at)
+            VALUES (:id, :sessionId, :scheduleId, 'USER', :userSourceId,
+                    'ATTENDANCE_RECORDED', 'PRESENT', 'ONLINE', :details,
+                    :providerJoinTime, :providerMeetingId, now())
+            ON CONFLICT (schedule_id, user_source_id) WHERE log_type = 'ATTENDANCE_RECORDED'
+            DO UPDATE SET status              = 'PRESENT',
+                          status_type         = 'ONLINE',
+                          provider_join_time  = EXCLUDED.provider_join_time,
+                          provider_meeting_id = EXCLUDED.provider_meeting_id,
+                          updated_at          = now()
+            """, nativeQuery = true)
+    void upsertBbbJoinAttendance(
+            @Param("id") String id,
+            @Param("sessionId") String sessionId,
+            @Param("scheduleId") String scheduleId,
+            @Param("userSourceId") String userSourceId,
+            @Param("details") String details,
+            @Param("providerJoinTime") String providerJoinTime,
+            @Param("providerMeetingId") String providerMeetingId);
 
     /**
      * Used by the provider sync scheduler to upsert provider-sourced attendance.

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
@@ -14,6 +14,7 @@ import vacademy.io.common.auth.model.CustomUserDetails;
 import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class LIveSessionAttendanceService {
@@ -27,111 +28,44 @@ public class LIveSessionAttendanceService {
     public void markAttendance(MarkAttendanceRequestDTO request , CustomUserDetails user) {
         String userId = request.getUserSourceId().isEmpty() ? user.getUserId() : request.getUserSourceId();
 
-        // Check if attendance record already exists for this schedule and user
-        Optional<LiveSessionLogs> existingLog = liveSessionLogRepository.findExistingAttendanceRecord(
-            request.getScheduleId(),
-            userId
-        );
-
-        if (existingLog.isPresent()) {
-            // Update existing record
-            LiveSessionLogs log = existingLog.get();
-            log.setStatus("PRESENT");
-            log.setStatusType("ONLINE");
-            log.setDetails(request.getDetails());
-            log.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
-            liveSessionLogRepository.save(log);
-        } else {
-            // Create new record
-            LiveSessionLogs log = LiveSessionLogs.builder()
-                    .sessionId(request.getSessionId())
-                    .scheduleId(request.getScheduleId())
-                    .userSourceType(request.getUserSourceType())
-                    .userSourceId(userId)
-                    .logType(SessionLog.ATTENDANCE_RECORDED.name())
-                    .status("PRESENT")
-                    .statusType("ONLINE")
-                    .details(request.getDetails())
-                    .createdAt(new Timestamp(System.currentTimeMillis()))
-                    .updatedAt(new Timestamp(System.currentTimeMillis()))
-                    .build();
-
-            liveSessionLogRepository.save(log);
-        }
+        upsertPresent(request, userId);
 
         // Send attendance notification to learner
         notificationProcessor.sendAttendanceNotification(request.getSessionId(), userId, "PRESENT");
     }
+
     public void markGuestAttendance(MarkAttendanceRequestDTO request ) {
-        // Check if attendance record already exists for this schedule and user
-        Optional<LiveSessionLogs> existingLog = liveSessionLogRepository.findExistingAttendanceRecord(
-            request.getScheduleId(),
-            request.getUserSourceId()
-        );
-
-        if (existingLog.isPresent()) {
-            // Update existing record
-            LiveSessionLogs log = existingLog.get();
-            log.setStatus("PRESENT");
-            log.setStatusType("ONLINE");
-            log.setDetails(request.getDetails());
-            log.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
-            liveSessionLogRepository.save(log);
-        } else {
-            // Create new record
-            LiveSessionLogs log = LiveSessionLogs.builder()
-                    .sessionId(request.getSessionId())
-                    .scheduleId(request.getScheduleId())
-                    .userSourceType(request.getUserSourceType())
-                    .userSourceId(request.getUserSourceId())
-                    .logType(SessionLog.ATTENDANCE_RECORDED.name())
-                    .status("PRESENT")
-                    .statusType("ONLINE")
-                    .details(request.getDetails())
-                    .createdAt(new Timestamp(System.currentTimeMillis()))
-                    .updatedAt(new Timestamp(System.currentTimeMillis()))
-                    .build();
-
-            liveSessionLogRepository.save(log);
-        }
+        upsertPresent(request, request.getUserSourceId());
     }
+
     public void markAttendanceForGuest(MarkAttendanceRequestDTO request ) {
-        // Check if attendance record already exists for this schedule and user
-        Optional<LiveSessionLogs> existingLog = liveSessionLogRepository.findExistingAttendanceRecord(
-            request.getScheduleId(),
-            request.getUserSourceId()
-        );
+        upsertPresent(request, request.getUserSourceId());
+    }
 
-        if (existingLog.isPresent()) {
-            // Update existing record
-            LiveSessionLogs log = existingLog.get();
-            log.setStatus("PRESENT");
-            log.setStatusType("ONLINE");
-            log.setDetails(request.getDetails());
-            log.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
-            liveSessionLogRepository.save(log);
-        } else {
-            // Create new record
-            LiveSessionLogs log = LiveSessionLogs.builder()
-                    .sessionId(request.getSessionId())
-                    .scheduleId(request.getScheduleId())
-                    .userSourceType(request.getUserSourceType())
-                    .userSourceId( request.getUserSourceId() )
-                    .logType(SessionLog.ATTENDANCE_RECORDED.name())
-                    .status("PRESENT")
-                    .statusType("ONLINE")
-                    .details(request.getDetails())
-                    .createdAt(new Timestamp(System.currentTimeMillis()))
-                    .updatedAt(new Timestamp(System.currentTimeMillis()))
-                    .build();
-
-            liveSessionLogRepository.save(log);
-        }
+    /**
+     * One atomic INSERT ... ON CONFLICT round trip instead of check-then-save.
+     * A whole batch hits this concurrently at class start, so the flow must not
+     * hold a connection across multiple statements or race on the existence
+     * check (which historically produced duplicate attendance rows).
+     */
+    private void upsertPresent(MarkAttendanceRequestDTO request, String userSourceId) {
+        liveSessionLogRepository.upsertAttendance(
+                UUID.randomUUID().toString(),
+                request.getSessionId(),
+                request.getScheduleId(),
+                request.getUserSourceType(),
+                userSourceId,
+                "PRESENT",
+                "ONLINE",
+                request.getDetails());
     }
 
     /**
      * Admin batch marking — sets statusType=OFFLINE since admin is marking manually.
-     * Returns a map with "updated" and "created" counts.
+     * Returns a map with "updated" and "created" counts. Stays on check-then-save
+     * because the response shape needs per-row created/updated attribution and this
+     * path is a single admin request, not a concurrent stampede; the V415 unique
+     * index still backstops it against duplicates.
      */
     public Map<String, Integer> adminMarkAttendance(AdminMarkAttendanceRequestDTO request) {
         int updated = 0;

--- a/admin_core_service/src/main/resources/db/migration/V415__Attendance_unique_index_for_upsert.sql
+++ b/admin_core_service/src/main/resources/db/migration/V415__Attendance_unique_index_for_upsert.sql
@@ -1,0 +1,21 @@
+-- Attendance marking used read-check-then-save, so concurrent requests from a
+-- class joining at once created duplicate ATTENDANCE_RECORDED rows (2,487 excess
+-- rows across 1,622 schedule+user pairs at the time of writing). Reads pick the
+-- earliest row (ORDER BY created_at ASC, first), so keep that one and drop the rest.
+DELETE FROM live_session_logs del
+USING live_session_logs keep
+WHERE del.log_type = 'ATTENDANCE_RECORDED'
+  AND keep.log_type = 'ATTENDANCE_RECORDED'
+  AND del.schedule_id = keep.schedule_id
+  AND del.user_source_id = keep.user_source_id
+  AND del.id <> keep.id
+  AND (keep.created_at < del.created_at
+       OR (keep.created_at = del.created_at AND keep.id < del.id));
+
+-- Partial unique index scoped to attendance rows only: other log types
+-- (FEEDBACK_SUBMITTED etc.) may legitimately repeat per schedule+user.
+-- This is the conflict target for the INSERT ... ON CONFLICT upsert in
+-- LiveSessionLogsRepository.upsertAttendance.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lsl_attendance_schedule_user
+    ON live_session_logs (schedule_id, user_source_id)
+    WHERE log_type = 'ATTENDANCE_RECORDED';


### PR DESCRIPTION
Attendance marking (learner mark-attendance and BBB join) used read-check-then-save, so a class joining at once serialized behind row locks while holding pool connections, and races still created duplicate ATTENDANCE_RECORDED rows (2,487 excess rows across 1,622 schedule+user pairs in prod).

- V415: dedupe existing duplicates (keep earliest row, matching the current read path) and add partial unique index on (schedule_id, user_source_id) WHERE log_type = ATTENDANCE_RECORDED
- Replace check-then-save with single INSERT .. ON CONFLICT upserts in markAttendance/markGuestAttendance/markAttendanceForGuest and the BBB join path (upsertBbbJoinAttendance preserves provider join metadata and leaves details untouched on update)
- Admin batch marking keeps check-then-save for created/updated counts; the unique index backstops it

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
