### PR TITLE
fix(side-view): don't brand superseded duplicate plans as Cancelled M…

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-side-view.tsx
@@ -176,9 +176,27 @@ export const StudentSidebar = ({
     // NOTE: the /user-plan/all endpoint ignores the requested status filter and
     // returns plans of every status, so we must match CANCELED client-side rather
     // than trust the response to be pre-filtered.
-    const isCancelledMember = (learnerPlans?.content ?? []).some(
-        (p) => (p.status || '').toUpperCase() === 'CANCELED'
-    );
+    //
+    // A CANCELED plan only means "cancelled membership" when the learner has no
+    // live plan for the SAME product (enroll invite). Failed/retried checkouts and
+    // superseded duplicates are also parked as CANCELED (e.g. by
+    // supersedeAbandonedSubOrgSiblings and the payment-data repair) while the
+    // learner's real plan stays ACTIVE — those must not brand a paying learner as
+    // a Cancelled Member.
+    const isCancelledMember = (() => {
+        const plans = learnerPlans?.content ?? [];
+        const LIVE_STATUSES = new Set(['ACTIVE', 'PENDING', 'PENDING_FOR_PAYMENT']);
+        return plans.some((p) => {
+            if ((p.status || '').toUpperCase() !== 'CANCELED') return false;
+            const supersededByLiveSibling = plans.some(
+                (s) =>
+                    s.id !== p.id &&
+                    s.enroll_invite_id === p.enroll_invite_id &&
+                    LIVE_STATUSES.has((s.status || '').toUpperCase())
+            );
+            return !supersededByLiveSibling;
+        });
+    })();
 
     // Membership courses this learner is enrolled in — resolved from the institute
     // details store (no extra network call) by matching each of their package


### PR DESCRIPTION
…ember

The Cancelled Member badge fired on ANY CANCELED user_plan. But CANCELED is also the parking status for superseded duplicate plans (failed/retried checkouts, the Razorpay phase-2 artifacts cleaned up by the payment data repair, supersedeAbandonedSubOrgSiblings) - so paying learners with a fully ACTIVE membership were shown as cancelled.

A CANCELED plan now only produces the badge when the learner has no live plan (ACTIVE / PENDING / PENDING_FOR_PAYMENT) for the same enroll invite:
- discarded duplicate next to an active paid plan -> no badge
- genuine "Remove from product" soft-cancel -> badge unchanged
- one product cancelled while another stays active -> badge unchanged

No extra API call; the badge query already receives plans of every status.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
