### PR TITLE
hotfix(admin-core): remove apostrophe in SQL comment crashing service startup

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
@@ -236,7 +236,13 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
                       -- Count a chapter only when it could actually produce a value.
                       -- Slide statuses are pinned rather than parameterised because
                       -- every caller passes exactly PUBLISHED + UNSYNC, matching
-                      -- getChapterCompletionPercentage's own denominator.
+                      -- the denominator used by getChapterCompletionPercentage.
+                      -- NOTE: never write an apostrophe in a comment inside a
+                      -- @Query block. Spring Data scans the query for quoted
+                      -- ranges before JPA sees it and does not understand SQL
+                      -- comments, so a lone apostrophe opens a string literal
+                      -- that never closes and the repository bean fails to
+                      -- build -- taking the whole service down at startup.
                       AND EXISTS (
                           SELECT 1
                           FROM chapter_to_slides cts


### PR DESCRIPTION
## Summary of Changes

**Hotfix — `admin-core-service` fails to start on `main`.** New pods are in `CrashLoopBackOff`; the LKE rollout for #2438 timed out at "1 out of 4 new replicas". The four previous pods are still serving, so there is no outage, but no admin-core deploy can succeed until this lands.

I introduced the bug in #2438. A comment I added inside a `@Query` block contained an apostrophe:

```
-- getChapterCompletionPercentage's own denominator.
```

Spring Data scans the query string for quoted ranges (`SpelQueryContext$QuotationMap`) **before** JPA parses it, and it does not understand `--` SQL comments. That lone apostrophe opens a string literal that never closes, so building the `ActivityLogRepository` bean throws:

```
starts a quoted range at 1961, but never ends it
  at SpelQueryContext$QuotationMap.<init>(SpelQueryContext.java:341)
  ...
  at JpaQueryMethod.assertParameterNamesInAnnotatedQuery(JpaQueryMethod.java:166)
```

and the whole application context fails.

The pre-existing comments in the same file survive only because they happen to contain an even number of apostrophes (`chapter's` … `slide's`), which the scanner pairs up.

**Backend:**
- Reworded the comment to drop the apostrophe — no SQL or logic change whatsoever
- Added a warning at that spot so the next person does not reintroduce it

**Frontend:**
- None

## Related Issue

Regression from #2438. Failing run: `Deploy Admin to LKE` #2192 on commit `95504be`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

Booted the service locally against the Docker database, with and without the fix — an A/B against the same environment:

| | `main` today (broken) | this branch |
|---|---|---|
| `starts a quoted range at 1961, but never ends it` | **14 occurrences** | 0 |
| startup | **fails** | `Started AdminCoreServiceApplication` |

Offset **1961** is the exact position production reported, so the local reproduction matches the failing pod.

Note a compile passes either way — this class of bug only surfaces when the Spring context builds, which is why it reached production.

Also scanned all **445** text-block `@Query` definitions in `admin_core_service` for an odd number of single quotes. After this fix, `ActivityLogRepository` is clean. One other pre-existing hit worth a separate look: `PaymentLogRepository.java:315`, which contains the comment `-- *** SYNTAX FIX: Removed apostrophe from "it's" ***` — the fix-comment itself reintroduced an apostrophe. It is not currently breaking startup, so it is out of scope here.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

> `admin_core_service` has no test infrastructure. A cheap guard for this class of bug would be a build-time check that every `@Query` block contains an even number of single quotes — happy to add it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
