### PR TITLE
feat(mentorship): branded, per-institute DB email templates with DEFA…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/mentorship/service/MentorshipNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/mentorship/service/MentorshipNotificationService.java
@@ -4,6 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.domain_routing.repository.InstituteDomainRoutingRepository;
+import vacademy.io.admin_core_service.features.institute.entity.Template;
+import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
+import vacademy.io.admin_core_service.features.institute.repository.TemplateRepository;
 import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
 import vacademy.io.admin_core_service.features.mentorship.entity.Mentor;
 import vacademy.io.admin_core_service.features.mentorship.enums.MentorStatus;
@@ -14,6 +18,7 @@ import vacademy.io.admin_core_service.features.notification.dto.UnifiedSendReque
 import vacademy.io.admin_core_service.features.notification.util.PhoneCountryUtil;
 import vacademy.io.admin_core_service.features.notification_service.service.NotificationService;
 import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.institute.entity.Institute;
 
 import java.util.HashMap;
 import java.util.List;
@@ -55,14 +60,29 @@ public class MentorshipNotificationService {
 
     public static final String SETTING_KEY = "MENTORSHIP_SETTING";
 
+    /** Global-default templates live under this pseudo institute (see V424 seed). */
+    private static final String DEFAULT_INSTITUTE_ID = "DEFAULT";
+    private static final String FALLBACK_THEME_COLOR = "#FF9800";
+    private static final String FALLBACK_SUPPORT_EMAIL = "support@vacademy.io";
+    private static final String FALLBACK_LEARNER_URL = "https://learner.vacademy.io";
+
     private final NotificationService notificationService;
     private final InstituteSettingService instituteSettingService;
     private final MentorRepository mentorRepository;
     private final AuthService authService;
+    private final InstituteRepository instituteRepository;
+    private final TemplateRepository templateRepository;
+    private final InstituteDomainRoutingRepository domainRoutingRepository;
 
-    /** Immutable code-default text for a trigger (used when the admin hasn't customised a field). */
+    /**
+     * Immutable code-default text for a trigger. {@code templateName} is the name of the DB
+     * email template (in the {@code templates} table) preferred over this inline body — resolved
+     * per-institute with a DEFAULT fallback (V424 seed); the inline body is only used when no
+     * template row exists at all.
+     */
     private record Defaults(String type, boolean emailDefault, String emailSubject, String emailBody,
-                            String alertTitle, String alertBody, String pushTitle, String pushBody) {}
+                            String alertTitle, String alertBody, String pushTitle, String pushBody,
+                            String templateName) {}
 
     private static final Defaults ASSIGNMENT_STUDENT = new Defaults(
             "MENTOR_ASSIGNED", true,
@@ -72,7 +92,8 @@ public class MentorshipNotificationService {
             "You have a new mentor",
             "You've been assigned a mentor: {{mentor_name}}. Open My Mentors to book a session or message them.",
             "You have a new mentor",
-            "You've been assigned a mentor: {{mentor_name}}. Open My Mentors to book or message.");
+            "You've been assigned a mentor: {{mentor_name}}. Open My Mentors to book or message.",
+            "Mentor Assigned - Student");
 
     private static final Defaults BOOKING = new Defaults(
             "MENTOR_BOOKING", false, // booking-page confirmation email already covers email
@@ -82,7 +103,8 @@ public class MentorshipNotificationService {
             "Mentor session booked",
             "Your session \"{{session_title}}\" is confirmed for {{session_datetime}}.",
             "Mentor session booked",
-            "Your session \"{{session_title}}\" is confirmed for {{session_datetime}}.");
+            "Your session \"{{session_title}}\" is confirmed for {{session_datetime}}.",
+            "Mentor Session Booked");
 
     private static final Defaults CANCELLATION = new Defaults(
             "MENTOR_BOOKING", true,
@@ -92,7 +114,8 @@ public class MentorshipNotificationService {
             "Mentor session cancelled",
             "Your session \"{{session_title}}\" was cancelled.",
             "Mentor session cancelled",
-            "Your session \"{{session_title}}\" was cancelled.");
+            "Your session \"{{session_title}}\" was cancelled.",
+            "Mentor Session Cancelled");
 
     // ---------------------------------------------------------------- triggers
 
@@ -176,9 +199,14 @@ public class MentorshipNotificationService {
                                   Map<String, String> vars, Defaults d) {
         Map<String, Object> em = channel(trigger, "email");
         if (channelEnabled(em, d.emailDefault()) && email != null && !email.isBlank()) {
-            sendEmail(instituteId, email, userId,
-                    applyPlaceholders(orDefault(str(em, "subject"), d.emailSubject()), vars),
-                    applyPlaceholders(orDefault(str(em, "body"), d.emailBody()), vars), d.type());
+            // Prefer the branded DB template (institute override -> DEFAULT seed); fall back to
+            // the admin's inline subject/body, then the code default.
+            if (!sendTemplatedEmail(instituteId, email, vars.getOrDefault("name", "there"),
+                    d.templateName(), vars)) {
+                sendEmail(instituteId, email, userId,
+                        applyPlaceholders(orDefault(str(em, "subject"), d.emailSubject()), vars),
+                        applyPlaceholders(orDefault(str(em, "body"), d.emailBody()), vars), d.type());
+            }
         }
         Map<String, Object> al = channel(trigger, "system_alert");
         if (channelEnabled(al, true) && userId != null) {
@@ -214,11 +242,100 @@ public class MentorshipNotificationService {
                         + "Open My Mentorship to view them.", vars);
         if (channelEnabled(channel(trigger, "email"), true)
                 && user != null && user.getEmail() != null && !user.getEmail().isBlank()) {
-            sendEmail(instituteId, user.getEmail(), userId, title,
-                    "<p>Hi " + applyPlaceholders("{{name}}", vars) + ",</p><p>" + body + "</p>", "MENTEE_ASSIGNED");
+            if (!sendTemplatedEmail(instituteId, user.getEmail(),
+                    vars.getOrDefault("name", nameOf(user, "there")), "New Mentee - Mentor", vars)) {
+                sendEmail(instituteId, user.getEmail(), userId, title,
+                        "<p>Hi " + applyPlaceholders("{{name}}", vars) + ",</p><p>" + body + "</p>", "MENTEE_ASSIGNED");
+            }
         }
         if (channelEnabled(channel(trigger, "system_alert"), true)) systemAlert(instituteId, userId, title, body);
         if (channelEnabled(channel(trigger, "push"), true)) push(instituteId, userId, title, body);
+    }
+
+    // ----------------------------------------------------------- DB templates
+
+    /**
+     * Send a branded HTML email from the DB template store. Resolves by
+     * (institute, name, EMAIL) with a DEFAULT fallback (V424 seed) and renders the
+     * subject/content with the mentorship vars + institute branding. Returns false when
+     * no template row exists so the caller can fall back to the inline body.
+     */
+    private boolean sendTemplatedEmail(String instituteId, String email, String recipientName,
+                                       String templateName, Map<String, String> vars) {
+        if (templateName == null || templateName.isBlank() || email == null || email.isBlank()) return false;
+        Template template = resolveTemplate(instituteId, templateName);
+        if (template == null) return false;
+        try {
+            InstituteContext ctx = loadInstituteContext(instituteId);
+            Map<String, String> v = new HashMap<>(vars);
+            v.put("recipient_name", recipientName != null && !recipientName.isBlank() ? recipientName : "there");
+            v.put("institute_name", ctx.name());
+            v.put("institute_theme_color", ctx.themeColor());
+            v.put("support_email", ctx.supportEmail());
+            v.put("cta_url", ctx.ctaUrl());
+            String subject = applyPlaceholders(template.getSubject(), v);
+            String body = applyPlaceholders(template.getContent(), v);
+            notificationService.sendHtmlEmailViaUnified(email, subject, body, instituteId,
+                    null, ctx.fromName(), "TRANSACTIONAL");
+            return true;
+        } catch (Exception e) {
+            log.warn("mentorship templated email failed ({}): {}", templateName, e.getMessage());
+            return false;
+        }
+    }
+
+    /** Institute's own EMAIL template row for this name, else the shared DEFAULT seed. */
+    private Template resolveTemplate(String instituteId, String templateName) {
+        try {
+            Optional<Template> institute =
+                    templateRepository.findByInstituteIdAndNameAndType(instituteId, templateName, "EMAIL");
+            if (institute.isPresent()) return institute.get();
+            return templateRepository.findByInstituteIdAndNameAndType(
+                    DEFAULT_INSTITUTE_ID, templateName, "EMAIL").orElse(null);
+        } catch (Exception e) {
+            log.warn("mentorship template lookup failed ({}): {}", templateName, e.getMessage());
+            return null;
+        }
+    }
+
+    private record InstituteContext(String name, String themeColor, String supportEmail,
+                                    String ctaUrl, String fromName) {}
+
+    /** Institute branding for email rendering: name, theme colour, learner CTA link. */
+    private InstituteContext loadInstituteContext(String instituteId) {
+        String name = "";
+        String themeColor = FALLBACK_THEME_COLOR;
+        String cta = FALLBACK_LEARNER_URL;
+        try {
+            Institute inst = instituteRepository.findById(instituteId).orElse(null);
+            if (inst != null) {
+                if (inst.getInstituteName() != null && !inst.getInstituteName().isBlank()) {
+                    name = inst.getInstituteName();
+                }
+                themeColor = normalizeThemeColor(inst.getInstituteThemeCode());
+            }
+        } catch (Exception ignore) {
+            // fall back to defaults
+        }
+        try {
+            cta = domainRoutingRepository.findByInstituteIdAndRole(instituteId, "LEARNER")
+                    .map(r -> r.getSubdomain())
+                    .filter(s -> s != null && s.contains("."))
+                    .map(s -> "https://" + s)
+                    .orElse(FALLBACK_LEARNER_URL);
+        } catch (Exception ignore) {
+            // fall back to the default learner URL
+        }
+        return new InstituteContext(name, themeColor, FALLBACK_SUPPORT_EMAIL, cta,
+                name.isBlank() ? null : name);
+    }
+
+    /** Accept a raw hex (with/without '#') or CSS keyword; blank -> fallback. Mirrors doubt emails. */
+    private static String normalizeThemeColor(String themeCode) {
+        if (themeCode == null || themeCode.trim().isEmpty()) return FALLBACK_THEME_COLOR;
+        String t = themeCode.trim();
+        if (t.matches("^[0-9A-Fa-f]{6}$")) return "#" + t;
+        return t;
     }
 
     // --------------------------------------------------------------- channels

--- a/admin_core_service/src/main/resources/db/migration/V424__Seed_mentorship_email_templates.sql
+++ b/admin_core_service/src/main/resources/db/migration/V424__Seed_mentorship_email_templates.sql
@@ -1,0 +1,162 @@
+-- ============================================================================
+--  Seed DEFAULT EMAIL templates for mentorship notifications.
+--
+--  One shared global-default row per trigger (institute_id = 'DEFAULT').
+--  MentorshipNotificationService resolves the email body by (institute_id, name,
+--  type='EMAIL') with a 2-layer fallback: the institute's own same-named row
+--  (an admin override) -> this DEFAULT row. If neither exists it falls back to
+--  a plain inline body, so a deleted row never breaks sends.
+--
+--  Branding is NOT hardcoded — runtime placeholders are substituted per-send:
+--    {{institute_name}}         -> institute.institute_name
+--    {{institute_theme_color}}  -> institute.institute_theme_code (normalized #RRGGBB)
+--    {{recipient_name}}         -> the email recipient's name
+--    {{mentor_name}}            -> the mentor's display name
+--    {{student_name}}           -> the student's name
+--    {{session_title}}          -> booking/session title
+--    {{session_datetime}}       -> human-readable session time
+--    {{cta_url}}                -> deep link (learner portal), resolved from domain routing
+--    {{support_email}}          -> institute support/from email
+--
+--  Idempotent: guarded by (institute_id='DEFAULT', name) NOT EXISTS.
+-- ============================================================================
+
+-- Shared branded shell is inlined per template so an admin can override one trigger
+-- without affecting the others.
+
+-- ---- 1) Mentor Assigned -> Student ----------------------------------------
+INSERT INTO templates (id, type, institute_id, name, subject, content, content_type,
+                       setting_json, can_delete, status, template_category, created_by, updated_by)
+SELECT gen_random_uuid()::text, 'EMAIL', 'DEFAULT', 'Mentor Assigned - Student',
+ 'You have a new mentor on {{institute_name}}',
+ $html$<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>New mentor</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+ <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f8;padding:24px 0;"><tr><td align="center">
+  <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+   <tr><td style="background:{{institute_theme_color}};padding:22px 28px;">
+     <p style="margin:0;font-size:12px;font-weight:700;letter-spacing:.6px;text-transform:uppercase;color:#ffffff;opacity:.9;">{{institute_name}}</p>
+   </td></tr>
+   <tr><td style="padding:32px 28px 8px;">
+     <h1 style="margin:0 0 6px;font-size:22px;line-height:1.3;color:#111827;">You have a new mentor 🎉</h1>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">Hi {{recipient_name}},</p>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">
+       <strong>{{mentor_name}}</strong> is now your mentor. You can book 1:1 sessions and message them anytime from your dashboard.</p>
+     <table cellpadding="0" cellspacing="0" style="margin:6px 0 22px;"><tr><td style="border-radius:8px;background:{{institute_theme_color}};">
+       <a href="{{cta_url}}" style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">Open My Mentors</a>
+     </td></tr></table>
+   </td></tr>
+   <tr><td style="padding:0 28px 30px;">
+     <hr style="border:none;border-top:1px solid #eef1f4;margin:14px 0;">
+     <p style="margin:0;font-size:12px;line-height:1.6;color:#9ca3af;">Sent by {{institute_name}}. Questions? Reply to <a href="mailto:{{support_email}}" style="color:#6b7280;">{{support_email}}</a>.</p>
+   </td></tr>
+  </table>
+ </td></tr></table>
+</body></html>$html$,
+ 'text/html', NULL, TRUE, 'ACTIVE', 'TRANSACTIONAL', 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM templates WHERE institute_id='DEFAULT' AND name='Mentor Assigned - Student');
+
+-- ---- 2) New Mentee -> Mentor ----------------------------------------------
+INSERT INTO templates (id, type, institute_id, name, subject, content, content_type,
+                       setting_json, can_delete, status, template_category, created_by, updated_by)
+SELECT gen_random_uuid()::text, 'EMAIL', 'DEFAULT', 'New Mentee - Mentor',
+ 'A new mentee was assigned to you on {{institute_name}}',
+ $html$<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>New mentee</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+ <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f8;padding:24px 0;"><tr><td align="center">
+  <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+   <tr><td style="background:{{institute_theme_color}};padding:22px 28px;">
+     <p style="margin:0;font-size:12px;font-weight:700;letter-spacing:.6px;text-transform:uppercase;color:#ffffff;opacity:.9;">{{institute_name}}</p>
+   </td></tr>
+   <tr><td style="padding:32px 28px 8px;">
+     <h1 style="margin:0 0 6px;font-size:22px;line-height:1.3;color:#111827;">New mentee assigned</h1>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">Hi {{recipient_name}},</p>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">
+       <strong>{{student_name}}</strong> has been assigned to you for mentorship. Open your mentee list to view their progress and start a conversation.</p>
+     <table cellpadding="0" cellspacing="0" style="margin:6px 0 22px;"><tr><td style="border-radius:8px;background:{{institute_theme_color}};">
+       <a href="{{cta_url}}" style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">Open My Mentorship</a>
+     </td></tr></table>
+   </td></tr>
+   <tr><td style="padding:0 28px 30px;">
+     <hr style="border:none;border-top:1px solid #eef1f4;margin:14px 0;">
+     <p style="margin:0;font-size:12px;line-height:1.6;color:#9ca3af;">Sent by {{institute_name}}. Questions? Reply to <a href="mailto:{{support_email}}" style="color:#6b7280;">{{support_email}}</a>.</p>
+   </td></tr>
+  </table>
+ </td></tr></table>
+</body></html>$html$,
+ 'text/html', NULL, TRUE, 'ACTIVE', 'TRANSACTIONAL', 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM templates WHERE institute_id='DEFAULT' AND name='New Mentee - Mentor');
+
+-- ---- 3) Session Booked ----------------------------------------------------
+INSERT INTO templates (id, type, institute_id, name, subject, content, content_type,
+                       setting_json, can_delete, status, template_category, created_by, updated_by)
+SELECT gen_random_uuid()::text, 'EMAIL', 'DEFAULT', 'Mentor Session Booked',
+ 'Your mentor session is confirmed - {{institute_name}}',
+ $html$<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Session confirmed</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+ <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f8;padding:24px 0;"><tr><td align="center">
+  <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+   <tr><td style="background:{{institute_theme_color}};padding:22px 28px;">
+     <p style="margin:0;font-size:12px;font-weight:700;letter-spacing:.6px;text-transform:uppercase;color:#ffffff;opacity:.9;">{{institute_name}}</p>
+   </td></tr>
+   <tr><td style="padding:32px 28px 8px;">
+     <h1 style="margin:0 0 6px;font-size:22px;line-height:1.3;color:#111827;">Your session is confirmed ✅</h1>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">Hi {{recipient_name}}, your mentor session is booked. Here are the details:</p>
+     <table cellpadding="0" cellspacing="0" width="100%" style="margin:0 0 22px;background:#f9fafb;border:1px solid #eef1f4;border-radius:8px;">
+       <tr><td style="padding:14px 18px;font-size:14px;color:#374151;line-height:1.6;">
+         <strong style="color:#111827;">{{session_title}}</strong><br>
+         🗓️ {{session_datetime}}
+       </td></tr>
+     </table>
+     <table cellpadding="0" cellspacing="0" style="margin:0 0 22px;"><tr><td style="border-radius:8px;background:{{institute_theme_color}};">
+       <a href="{{cta_url}}" style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">View booking</a>
+     </td></tr></table>
+   </td></tr>
+   <tr><td style="padding:0 28px 30px;">
+     <hr style="border:none;border-top:1px solid #eef1f4;margin:14px 0;">
+     <p style="margin:0;font-size:12px;line-height:1.6;color:#9ca3af;">Sent by {{institute_name}}. Questions? Reply to <a href="mailto:{{support_email}}" style="color:#6b7280;">{{support_email}}</a>.</p>
+   </td></tr>
+  </table>
+ </td></tr></table>
+</body></html>$html$,
+ 'text/html', NULL, TRUE, 'ACTIVE', 'TRANSACTIONAL', 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM templates WHERE institute_id='DEFAULT' AND name='Mentor Session Booked');
+
+-- ---- 4) Session Cancelled -------------------------------------------------
+INSERT INTO templates (id, type, institute_id, name, subject, content, content_type,
+                       setting_json, can_delete, status, template_category, created_by, updated_by)
+SELECT gen_random_uuid()::text, 'EMAIL', 'DEFAULT', 'Mentor Session Cancelled',
+ 'Your mentor session was cancelled - {{institute_name}}',
+ $html$<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Session cancelled</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+ <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f8;padding:24px 0;"><tr><td align="center">
+  <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+   <tr><td style="background:{{institute_theme_color}};padding:22px 28px;">
+     <p style="margin:0;font-size:12px;font-weight:700;letter-spacing:.6px;text-transform:uppercase;color:#ffffff;opacity:.9;">{{institute_name}}</p>
+   </td></tr>
+   <tr><td style="padding:32px 28px 8px;">
+     <h1 style="margin:0 0 6px;font-size:22px;line-height:1.3;color:#111827;">Session cancelled</h1>
+     <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#374151;">Hi {{recipient_name}}, your mentor session has been cancelled:</p>
+     <table cellpadding="0" cellspacing="0" width="100%" style="margin:0 0 22px;background:#f9fafb;border:1px solid #eef1f4;border-radius:8px;">
+       <tr><td style="padding:14px 18px;font-size:14px;color:#374151;line-height:1.6;">
+         <strong style="color:#111827;">{{session_title}}</strong><br>
+         🗓️ {{session_datetime}}
+       </td></tr>
+     </table>
+     <p style="margin:0 0 22px;font-size:15px;line-height:1.6;color:#374151;">You can book another time whenever you're ready.</p>
+     <table cellpadding="0" cellspacing="0" style="margin:0 0 22px;"><tr><td style="border-radius:8px;background:{{institute_theme_color}};">
+       <a href="{{cta_url}}" style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">Book again</a>
+     </td></tr></table>
+   </td></tr>
+   <tr><td style="padding:0 28px 30px;">
+     <hr style="border:none;border-top:1px solid #eef1f4;margin:14px 0;">
+     <p style="margin:0;font-size:12px;line-height:1.6;color:#9ca3af;">Sent by {{institute_name}}. Questions? Reply to <a href="mailto:{{support_email}}" style="color:#6b7280;">{{support_email}}</a>.</p>
+   </td></tr>
+  </table>
+ </td></tr></table>
+</body></html>$html$,
+ 'text/html', NULL, TRUE, 'ACTIVE', 'TRANSACTIONAL', 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM templates WHERE institute_id='DEFAULT' AND name='Mentor Session Cancelled');


### PR DESCRIPTION
…ULT fallback

Move mentorship notification emails off hardcoded inline HTML onto proper, professional, theme-branded templates stored in the DB (templates table).

- V424 seeds DEFAULT (institute_id='DEFAULT') EMAIL templates for each trigger: 'Mentor Assigned - Student', 'New Mentee - Mentor', 'Mentor Session Booked', 'Mentor Session Cancelled'. Responsive 600px card, themed header, CTA button, footer — all branding via placeholders, nothing hardcoded.
- MentorshipNotificationService resolves the email body by (institute, name, EMAIL) with a 2-layer fallback: institute's own same-named row (admin override) -> DEFAULT seed -> inline code default (only if a row was deleted). Renders subject/content via applyPlaceholders with institute branding (name, theme colour, learner CTA link from domain routing, support email) + the mentorship vars, sent via sendHtmlEmailViaUnified. Mirrors the proven DoubtNotificationService pattern.

Placeholders: {{recipient_name}} {{mentor_name}} {{student_name}} {{session_title}} {{session_datetime}} {{institute_name}} {{institute_theme_color}} {{cta_url}} {{support_email}}. Institutes customise per-trigger by creating a same-named EMAIL template row. Compiles.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
