### PR TITLE
fix(workflow-ai): unblock Build when a chosen template has no variables

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowAiDraftService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowAiDraftService.java
@@ -372,7 +372,9 @@ public class WorkflowAiDraftService {
                     || (val instanceof List && ((List<Object>) val).isEmpty())
                     || (val instanceof Map && ((Map<Object, Object>) val).isEmpty());
             if (blank) {
-                if (d.isRequired()) unresolvedRequired.add(d.getId());
+                // A TEMPLATE_VAR_MAP whose template is chosen but has no placeholders is complete
+                // with an empty map — the FE derives the placeholders, so don't warn about it.
+                if (d.isRequired() && !isSatisfiedEmptyVarMap(d, answered)) unresolvedRequired.add(d.getId());
                 continue;
             }
             try {
@@ -400,6 +402,22 @@ public class WorkflowAiDraftService {
                 .validationErrors(errors)
                 .warnings(warnings)
                 .build();
+    }
+
+    /**
+     * True for a variable-map decision that legitimately came back empty: its template pick is
+     * answered, and the template simply has no placeholders to map. Warning on these produced a
+     * "fill these in the builder" note for a decision the admin can never fill.
+     */
+    private boolean isSatisfiedEmptyVarMap(WorkflowDecisionDTO d, Map<String, Object> answered) {
+        if (!"TEMPLATE_VAR_MAP".equalsIgnoreCase(String.valueOf(d.getKind()))) return false;
+        List<String> deps = d.getDependsOn();
+        if (deps == null || deps.isEmpty()) return false;
+        for (String dep : deps) {
+            Object v = answered.get(dep);
+            if (v == null || (v instanceof String s && s.isBlank())) return false;
+        }
+        return true;
     }
 
     /** Write a decision's answer onto the skeleton at (nodeId, field dot-path). */

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/ai-draft-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/ai-draft-panel.tsx
@@ -154,6 +154,14 @@ export function AiDraftPanel({
                 .filter((d) => d.required)
                 .filter((d) => {
                     const v = answers[d.id];
+                    if (d.kind === 'TEMPLATE_VAR_MAP') {
+                        // A template with zero placeholders can never be answered — an empty map is
+                        // the complete answer, so it must not block Build.
+                        const { keys } = varMapKeys(d, answers, templatesFor);
+                        if (keys.length === 0) return false;
+                        const map = (v ?? {}) as Record<string, unknown>;
+                        return keys.some((k) => String(map[k] ?? '').trim() === '');
+                    }
                     return (
                         v == null ||
                         (typeof v === 'string' && v.trim() === '') ||
@@ -162,7 +170,18 @@ export function AiDraftPanel({
                     );
                 })
                 .map((d) => d.id),
-        [decisions, answers]
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [decisions, answers, emailTemplates.data, whatsappTemplates.data]
+    );
+
+    /** Prompts of the still-unanswered decisions, so a disabled Build button is never a mystery. */
+    const missingLabels = useMemo(
+        () =>
+            missingRequired
+                .map((id) => decisions.find((d) => d.id === id))
+                .map((d) => d?.prompt ?? d?.id ?? '')
+                .filter(Boolean),
+        [missingRequired, decisions]
     );
 
     const buildWorkflow = async () => {
@@ -363,11 +382,11 @@ export function AiDraftPanel({
                             templatesFor={templatesFor}
                         />
                     ))}
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between gap-3">
                         <span className="text-caption text-neutral-400">
                             {missingRequired.length === 0
                                 ? 'All set'
-                                : `${missingRequired.length} choice(s) still needed`}
+                                : `Still needed: ${missingLabels.join(' • ')}`}
                         </span>
                         <MyButton
                             buttonType="primary"
@@ -449,14 +468,7 @@ function DecisionControl({
 
     if (decision.kind === 'TEMPLATE_VAR_MAP') {
         // Placeholders come from the template chosen in the dependsOn decision.
-        const depId = decision.dependsOn?.[0];
-        const chosenName = depId ? (answers[depId] as string | undefined) : undefined;
-        const tmpl =
-            (chosenName &&
-                (templatesFor('WHATSAPP_TEMPLATE').find((t) => t.name === chosenName) ??
-                    templatesFor('EMAIL_TEMPLATE').find((t) => t.name === chosenName))) ||
-            undefined;
-        const params = parseParams(tmpl?.dynamic_parameters);
+        const { chosenName, params, keys } = varMapKeys(decision, answers, templatesFor);
         const current = (value as Record<string, string>) ?? {};
         if (!chosenName) {
             return (
@@ -466,13 +478,12 @@ function DecisionControl({
                 </div>
             );
         }
-        const keys = Object.keys(params);
         return (
             <div className="flex flex-col gap-2">
                 {label}
                 {keys.length === 0 && (
                     <span className="text-caption text-neutral-400">
-                        This template has no variables to map.
+                        This template has no variables to map — nothing to do here.
                     </span>
                 )}
                 {keys.map((k) => (
@@ -577,6 +588,26 @@ function TemplateSelect({
             )}
         </div>
     );
+}
+
+/**
+ * Placeholders a TEMPLATE_VAR_MAP decision actually needs, derived from the template chosen in its
+ * dependsOn decision. Shared by the control and the completeness check so the panel can never say
+ * "no variables to map" while still blocking Build on that same decision.
+ */
+function varMapKeys(
+    decision: AiDecisionItem,
+    answers: Record<string, unknown>,
+    templatesFor: (kind: string) => TemplateItem[]
+): { chosenName?: string; params: Record<string, string>; keys: string[] } {
+    const depId = decision.dependsOn?.[0];
+    const chosenName = depId ? (answers[depId] as string | undefined) : undefined;
+    if (!chosenName) return { chosenName: undefined, params: {}, keys: [] };
+    const tmpl =
+        templatesFor('WHATSAPP_TEMPLATE').find((t) => t.name === chosenName) ??
+        templatesFor('EMAIL_TEMPLATE').find((t) => t.name === chosenName);
+    const params = parseParams(tmpl?.dynamic_parameters);
+    return { chosenName, params, keys: Object.keys(params) };
 }
 
 function parseParams(dp: unknown): Record<string, string> {


### PR DESCRIPTION
A required TEMPLATE_VAR_MAP decision was counted as unanswered whenever its answer was null/{}. Templates with zero placeholders render "no variables to map" and have no input, so the answer stayed undefined forever and the Build button was permanently disabled.

- extract varMapKeys() so the control and the completeness check resolve the template's placeholders through the same path — the panel can no longer say "nothing to map" while still blocking on that decision
- zero placeholders => satisfied; with placeholders, every key must now be mapped (a partially-filled map used to pass and ship literal placeholders)
- footer names the still-missing decisions instead of showing a bare count
- backend: stop listing an empty var-map whose template pick is answered in "Unanswered required decisions", a note the admin could never act on

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
