### PR TITLE
fix(workflow): make DRAFT and INACTIVE workflows visible in the UI

### DIFF
--- a/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-details-page.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/$workflowId/-components/workflow-details-page.tsx
@@ -1,6 +1,6 @@
 import { useSuspenseQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { getWorkflowDiagramQuery, getActiveWorkflowsQuery, deleteWorkflow, triggerWorkflowNow } from '@/services/workflow-service';
+import { getWorkflowDiagramQuery, getWorkflowsByStatusQuery, WORKFLOW_STATUSES, deleteWorkflow, triggerWorkflowNow } from '@/services/workflow-service';
 import { useInstituteQuery } from '@/services/student-list-section/getInstituteDetails';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
 import { WorkflowDiagramSimple } from './workflow-diagram-simple';
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft, PencilSimple, Trash, Eye, Play, Warning } from '@phosphor-icons/react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { Badge } from '@/components/ui/badge';
+import { WorkflowStatusBadge } from '@/routes/workflow/-components/workflow-status-badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Calendar, Clock } from '@phosphor-icons/react';
 import { formatDistanceToNow } from 'date-fns';
@@ -61,8 +62,10 @@ export function WorkflowDetailsPage({ workflowId }: WorkflowDetailsPageProps) {
     const [isRunning, setIsRunning] = useState(false);
     const [runResult, setRunResult] = useState<{ ok: boolean; message: string } | null>(null);
     const { data: instituteDetails } = useSuspenseQuery(useInstituteQuery());
+    // Every status, not just ACTIVE — otherwise opening a DRAFT or INACTIVE workflow renders
+    // "Workflow not found" even though the workflow exists and the diagram loads fine.
     const { data: workflows } = useSuspenseQuery(
-        getActiveWorkflowsQuery(instituteDetails?.id || '')
+        getWorkflowsByStatusQuery(instituteDetails?.id || '', WORKFLOW_STATUSES)
     );
     const {
         data: diagram,
@@ -129,12 +132,7 @@ export function WorkflowDetailsPage({ workflowId }: WorkflowDetailsPageProps) {
                     <div className="flex-1">
                         <div className="flex items-center gap-3">
                             <h1 className="text-3xl font-bold text-neutral-800">{workflow.name}</h1>
-                            <Badge
-                                variant={workflow.status === 'ACTIVE' ? 'default' : 'secondary'}
-                                className="bg-green-100 text-green-800 hover:bg-green-100"
-                            >
-                                {workflow.status}
-                            </Badge>
+                            <WorkflowStatusBadge status={workflow.status} />
                             <Button
                                 variant="outline"
                                 size="sm"

--- a/frontend-admin-dashboard/src/routes/workflow/-components/workflow-status-badge.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/-components/workflow-status-badge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * Lifecycle badge for a workflow. Both the list card and the detail header used to hard-code
+ * green here, so a DRAFT (which never fires) looked identical to a live ACTIVE workflow.
+ */
+const STATUS_STYLES: Record<string, string> = {
+    ACTIVE: 'bg-success-100 text-success-600 hover:bg-success-100',
+    DRAFT: 'bg-warning-100 text-warning-600 hover:bg-warning-100',
+    INACTIVE: 'bg-neutral-100 text-neutral-600 hover:bg-neutral-100',
+};
+
+export function WorkflowStatusBadge({
+    status,
+    className,
+}: {
+    status: string;
+    className?: string;
+}) {
+    const style = STATUS_STYLES[status?.toUpperCase()] ?? STATUS_STYLES.INACTIVE;
+    return (
+        <Badge variant="secondary" className={cn('shrink-0', style, className)}>
+            {status}
+        </Badge>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/workflow/list/-components/workflow-card.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/list/-components/workflow-card.tsx
@@ -1,6 +1,7 @@
 import { Workflow } from '@/types/workflow/workflow-types';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { WorkflowStatusBadge } from '@/routes/workflow/-components/workflow-status-badge';
 import { formatDistanceToNow } from 'date-fns';
 import { useNavigate } from '@tanstack/react-router';
 import { Calendar, Clock, Tag } from '@phosphor-icons/react';
@@ -132,12 +133,7 @@ export function WorkflowCard({ workflow }: WorkflowCardProps) {
                     <h3 className="line-clamp-2 text-lg font-semibold text-neutral-900 transition-colors group-hover:text-primary-600">
                         {workflow.name}
                     </h3>
-                    <Badge
-                        variant={workflow.status === 'ACTIVE' ? 'default' : 'secondary'}
-                        className="shrink-0 bg-green-100 text-green-800 hover:bg-green-100"
-                    >
-                        {workflow.status}
-                    </Badge>
+                    <WorkflowStatusBadge status={workflow.status} />
                 </div>
             </CardHeader>
 

--- a/frontend-admin-dashboard/src/routes/workflow/list/-components/workflow-list-page.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/list/-components/workflow-list-page.tsx
@@ -1,6 +1,10 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { getActiveWorkflowsQuery } from '@/services/workflow-service';
+import {
+    getWorkflowsByStatusQuery,
+    WORKFLOW_STATUSES,
+    type WorkflowStatus,
+} from '@/services/workflow-service';
 import { useInstituteQuery } from '@/services/student-list-section/getInstituteDetails';
 import { DashboardLoader } from '@/components/core/dashboard-loader';
 import { WorkflowCard } from './workflow-card';
@@ -12,18 +16,36 @@ import { Plus } from '@phosphor-icons/react';
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { useNavigate } from '@tanstack/react-router';
 
+/** `null` = no status filter, i.e. show every lifecycle status. */
+type StatusFilter = WorkflowStatus | null;
+
+const STATUS_LABELS: Record<WorkflowStatus, string> = {
+    ACTIVE: 'Active',
+    DRAFT: 'Draft',
+    INACTIVE: 'Inactive',
+};
+
 export function WorkflowListPage() {
     const navigate = useNavigate();
     const { setNavHeading } = useNavHeadingStore();
     const { data: instituteDetails } = useSuspenseQuery(useInstituteQuery());
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [selectedType, setSelectedType] = useState<string | null>(null);
+    const [selectedStatus, setSelectedStatus] = useState<StatusFilter>(null);
+
+    // Status is filtered server-side (the list endpoint only returns workflows whose status is
+    // in the payload), so this drives the request rather than a client-side .filter().
     const {
         data: workflows,
         isLoading,
         error,
-    } = useSuspenseQuery(getActiveWorkflowsQuery(instituteDetails?.id || ''));
-
-    const [searchTerm, setSearchTerm] = useState('');
-    const [selectedType, setSelectedType] = useState<string | null>(null);
+    } = useQuery(
+        getWorkflowsByStatusQuery(
+            instituteDetails?.id || '',
+            selectedStatus ? [selectedStatus] : WORKFLOW_STATUSES
+        )
+    );
 
     useEffect(() => {
         setNavHeading(
@@ -33,7 +55,9 @@ export function WorkflowListPage() {
         );
     }, [setNavHeading]);
 
-    if (isLoading) {
+    // Only take over the whole page on the first load — switching the status filter refetches,
+    // and swapping the filter chips out for a full-page loader would make them jump.
+    if (isLoading && !workflows) {
         return <DashboardLoader />;
     }
 
@@ -53,9 +77,10 @@ export function WorkflowListPage() {
 
     // Filter workflows based on search term and selected type
     const filteredWorkflows = workflows?.filter((workflow: Workflow) => {
+        // description is nullable on the wire (drafts often have none) — guard both.
         const matchesSearch =
-            workflow.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            workflow.description.toLowerCase().includes(searchTerm.toLowerCase());
+            (workflow.name ?? '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (workflow.description ?? '').toLowerCase().includes(searchTerm.toLowerCase());
         const matchesType = !selectedType || workflow.workflow_type === selectedType;
         return matchesSearch && matchesType;
     });
@@ -79,7 +104,9 @@ export function WorkflowListPage() {
             <div className="mb-8 flex flex-col gap-6">
                 <div className="flex items-center justify-between">
                     <div>
-                        <h1 className="text-3xl font-bold text-neutral-800">Active Workflows</h1>
+                        <h1 className="text-3xl font-bold text-neutral-800">
+                            {selectedStatus ? `${STATUS_LABELS[selectedStatus]} Workflows` : 'Workflows'}
+                        </h1>
                         <p className="mt-1 text-neutral-600">
                             {filteredWorkflows?.length || 0} workflow
                             {filteredWorkflows?.length !== 1 ? 's' : ''} found
@@ -97,7 +124,7 @@ export function WorkflowListPage() {
                 </div>
 
                 {/* Search and Filter Section */}
-                <div className="flex items-center gap-4">
+                <div className="flex flex-wrap items-center gap-4">
                     <div className="relative max-w-md flex-1">
                         <MagnifyingGlass
                             className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
@@ -110,6 +137,30 @@ export function WorkflowListPage() {
                             onChange={(e) => setSearchTerm(e.target.value)}
                             className="pl-10"
                         />
+                    </div>
+
+                    {/* Status Filter */}
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-neutral-600">Status:</span>
+                        <div className="flex gap-2">
+                            <Button
+                                variant={selectedStatus === null ? 'default' : 'outline'}
+                                size="sm"
+                                onClick={() => setSelectedStatus(null)}
+                            >
+                                All
+                            </Button>
+                            {WORKFLOW_STATUSES.map((status) => (
+                                <Button
+                                    key={status}
+                                    variant={selectedStatus === status ? 'default' : 'outline'}
+                                    size="sm"
+                                    onClick={() => setSelectedStatus(status)}
+                                >
+                                    {STATUS_LABELS[status]}
+                                </Button>
+                            ))}
+                        </div>
                     </div>
 
                     {/* Type Filter */}
@@ -145,16 +196,16 @@ export function WorkflowListPage() {
                 <div className="flex h-[50vh] flex-col items-center justify-center rounded-lg border-2 border-dashed border-neutral-300 bg-neutral-50">
                     <div className="max-w-md text-center">
                         <p className="mb-2 text-lg font-medium text-neutral-500">
-                            {searchTerm || selectedType
+                            {searchTerm || selectedType || selectedStatus
                                 ? 'No workflows found'
-                                : 'No active workflows'}
+                                : 'No workflows yet'}
                         </p>
                         <p className="text-sm text-neutral-400">
-                            {searchTerm || selectedType
+                            {searchTerm || selectedType || selectedStatus
                                 ? 'Try adjusting your search or filter criteria'
                                 : 'Create your first workflow to automate your institute processes'}
                         </p>
-                        {!searchTerm && !selectedType && (
+                        {!searchTerm && !selectedType && !selectedStatus && (
                             <Button
                                 onClick={() => {
                                     navigate({ to: '/workflow/create' });

--- a/frontend-admin-dashboard/src/services/workflow-service.ts
+++ b/frontend-admin-dashboard/src/services/workflow-service.ts
@@ -67,7 +67,25 @@ interface WorkflowsWithSchedulesResponse {
     first: boolean;
 }
 
-export const fetchActiveWorkflows = async (instituteId: string): Promise<Workflow[]> => {
+/** Workflow lifecycle statuses. A workflow only fires when it is ACTIVE. */
+export const WORKFLOW_STATUSES = ['ACTIVE', 'DRAFT', 'INACTIVE'] as const;
+export type WorkflowStatus = (typeof WORKFLOW_STATUSES)[number];
+
+export const fetchWorkflows = async (
+    instituteId: string,
+    statuses: readonly WorkflowStatus[] = ['ACTIVE']
+): Promise<Workflow[]> => {
+    // Anything not listed here is invisible to the caller — the backend filters on
+    // workflow.status, so omitting DRAFT is why "Save Draft" workflows used to disappear.
+    const workflowStatuses = statuses.length > 0 ? [...statuses] : [...WORKFLOW_STATUSES];
+    // schedule_statuses / trigger_statuses gate the LEFT JOINs. Constraining them to ACTIVE
+    // makes sense when we're only showing live workflows, but a DRAFT workflow's schedule or
+    // trigger rows are usually non-ACTIVE too — keeping the filter would join them to null
+    // and the card would claim "No schedule added" / "No trigger details". So drop the
+    // filter (backend reads an absent list as "no constraint") whenever we ask for more
+    // than just ACTIVE.
+    const activeOnly = workflowStatuses.length === 1 && workflowStatuses[0] === 'ACTIVE';
+
     // Use new POST endpoint that returns workflows along with schedules (paginated)
     const response = await authenticatedAxiosInstance<WorkflowsWithSchedulesResponse>({
         method: 'POST',
@@ -78,8 +96,8 @@ export const fetchActiveWorkflows = async (instituteId: string): Promise<Workflo
         },
         data: {
             institute_id: instituteId,
-            workflow_statuses: ['ACTIVE'],
-            schedule_statuses: ['ACTIVE'],
+            workflow_statuses: workflowStatuses,
+            ...(activeOnly ? { schedule_statuses: ['ACTIVE'] } : {}),
         },
     });
 
@@ -161,13 +179,39 @@ export const fetchActiveWorkflows = async (instituteId: string): Promise<Workflo
     return Object.values(workflowIdToWorkflow);
 };
 
-export const getActiveWorkflowsQuery = (instituteId: string) =>
+/**
+ * Shared cache-key prefix for every workflow-list query, whatever statuses it asks for.
+ * Callers that save/delete a workflow invalidate on this prefix alone, so each status
+ * variant must hang off it — TanStack matches query keys by prefix.
+ */
+export const WORKFLOWS_WITH_SCHEDULES_QUERY_KEY = 'GET_ACTIVE_WORKFLOWS_WITH_SCHEDULES';
+
+/**
+ * Workflows in the given lifecycle statuses — for management surfaces (the list page and the
+ * detail page) that must be able to reach DRAFT and INACTIVE workflows, not just live ones.
+ */
+export const getWorkflowsByStatusQuery = (
+    instituteId: string,
+    statuses: readonly WorkflowStatus[]
+) =>
     queryOptions({
-        queryKey: ['GET_ACTIVE_WORKFLOWS_WITH_SCHEDULES', instituteId],
-        queryFn: () => fetchActiveWorkflows(instituteId),
+        queryKey: [
+            WORKFLOWS_WITH_SCHEDULES_QUERY_KEY,
+            instituteId,
+            [...statuses].sort().join(','),
+        ],
+        queryFn: () => fetchWorkflows(instituteId, statuses),
         staleTime: 300000, // 5 minutes
         enabled: !!instituteId,
     });
+
+/**
+ * ACTIVE workflows only — for pickers that link a workflow to an audience, batch or
+ * enrollment, where offering a DRAFT would silently do nothing (a DRAFT workflow's triggers
+ * are skipped by findSpecificTriggers/findGlobalTriggers, which require workflow.status='ACTIVE').
+ */
+export const getActiveWorkflowsQuery = (instituteId: string) =>
+    getWorkflowsByStatusQuery(instituteId, ['ACTIVE']);
 
 export const fetchWorkflowDiagram = async (workflowId: string): Promise<AutomationDiagram> => {
     const response = await authenticatedAxiosInstance<AutomationDiagram>({


### PR DESCRIPTION
The Workflows list hardcoded workflow_statuses: ['ACTIVE'] in its request payload, so a workflow saved via "Save Draft" vanished from the UI with no route back to it — the backend was never the problem, it treats an omitted status list as "no filter".

- workflow-service: fetchActiveWorkflows -> fetchWorkflows(instituteId, statuses); add WORKFLOW_STATUSES + getWorkflowsByStatusQuery. Both query factories share one cache-key prefix so the six existing invalidations on 'GET_ACTIVE_WORKFLOWS_WITH_SCHEDULES' keep hitting every status variant. Drop the schedule/trigger status filters when asking for more than ACTIVE, otherwise a draft's non-ACTIVE schedule and trigger rows join to null.
- list page: All / Active / Draft / Inactive filter chips (default All), filtered server-side; useQuery instead of useSuspenseQuery so switching the filter doesn't swap the chips out for a full-page loader.
- detail page: query all statuses — it resolves the workflow out of the same list, so opening a draft rendered "Workflow not found".
- status badge: extract WorkflowStatusBadge. Both surfaces hardcoded green, which showed a DRAFT (which never fires) as if it were live.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
