### PR TITLE
fix(live-session): stop dropping multi-button learner configs

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GetSessionByIdResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GetSessionByIdResponseDTO.java
@@ -25,7 +25,8 @@ public class GetSessionByIdResponseDTO {
     private String defaultClassLink;
     private String defaultClassName;
     private String defaultClassLinkType;
-    private LearnerButtonConfigDTO learnerButtonConfig;
+    // Single object or list of objects — see LiveSessionStep1RequestDTO#learnerButtonConfig.
+    private Object learnerButtonConfig;
     private LocalDateTime startTime;
     private LocalDateTime lastEntryTime;
     private String linkType;
@@ -59,7 +60,7 @@ public class GetSessionByIdResponseDTO {
         private String link;
         private String defaultClassLink;
         private String defaultClassName;
-        private LearnerButtonConfigDTO learnerButtonConfig;
+        private Object learnerButtonConfig;
         private LocalDate meetingDate;
         private String timezone;
         private Boolean dailyAttendance;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GetSessionDetailsBySessionIdResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GetSessionDetailsBySessionIdResponseDTO.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import vacademy.io.admin_core_service.features.live_session.dto.GetSessionByIdResponseDTO.LearnerButtonConfigDTO;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -29,7 +28,8 @@ public class GetSessionDetailsBySessionIdResponseDTO {
     private String defaultClassLink;
     private String defaultClassName;
     private String defaultClassLinkType;
-    private LearnerButtonConfigDTO learnerButtonConfig;
+    // Single object or list of objects — see LiveSessionStep1RequestDTO#learnerButtonConfig.
+    private Object learnerButtonConfig;
     private String waitingRoomLink;
     private Integer waitingRoomTime;
     private String registrationFormLinkForPublicSessions;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GroupedSessionsByDateDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GroupedSessionsByDateDTO.java
@@ -22,7 +22,7 @@ public class GroupedSessionsByDateDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Kolkata")
     private Date date;
     private List<LiveSessionListDTO> sessions;
-    private LiveSessionStep1RequestDTO.LearnerButtonConfigDTO learnerButtonConfig;
+    private Object learnerButtonConfig;
     private String defaultClassLink;
     private String defaultClassName;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionListDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionListDTO.java
@@ -38,7 +38,8 @@ public class LiveSessionListDTO {
     private String meetingLink;
     private String registrationFormLinkForPublicSessions;
     private String timezone;
-    private LiveSessionStep1RequestDTO.LearnerButtonConfigDTO learnerButtonConfig;
+    // Single object or list of objects — see LiveSessionStep1RequestDTO#learnerButtonConfig.
+    private Object learnerButtonConfig;
     private String defaultClassLink;
     private String defaultClassName;
     private String linkType;
@@ -52,7 +53,7 @@ public class LiveSessionListDTO {
             Date meetingDate, Time startTime, Time lastEntryTime, String recurrenceType,
             String accessLevel, String title, String subject, String meetingLink,
             String registrationFormLinkForPublicSessions, String timezone,
-            LiveSessionStep1RequestDTO.LearnerButtonConfigDTO learnerButtonConfig,
+            Object learnerButtonConfig,
             String defaultClassLink, String defaultClassName, String linkType) {
         this.sessionId = sessionId;
         this.waitingRoomTime = waitingRoomTime;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep1RequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep1RequestDTO.java
@@ -49,7 +49,10 @@ public class LiveSessionStep1RequestDTO {
     private List<ScheduleDTO> updatedSchedules;
     private List<String> deletedScheduleIds;
 
-    private LearnerButtonConfigDTO learnerButtonConfig;
+    // Either a single LearnerButtonConfigDTO-shaped object (legacy) or a list of
+    // them. Kept untyped so both shapes round-trip untouched; see
+    // LearnerButtonConfigDTO for the field names.
+    private Object learnerButtonConfig;
 
     private BbbConfigDTO bbbConfig;
 
@@ -102,7 +105,7 @@ public class LiveSessionStep1RequestDTO {
         private boolean dailyAttendance;
         private String defaultClassLink;
         private String defaultClassName;
-        private LearnerButtonConfigDTO learnerButtonConfig;
+        private Object learnerButtonConfig;
     }
 
     @Data

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/GetLiveSessionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/GetLiveSessionService.java
@@ -582,13 +582,16 @@ public class GetLiveSessionService {
         }
     }
 
-        private vacademy.io.admin_core_service.features.live_session.dto.LiveSessionStep1RequestDTO.LearnerButtonConfigDTO deserializeLearnerButtonConfig(
-                        String json) {
-                if (json == null)
+        /**
+         * Deserialized untyped: the column holds either a single button object or a
+         * list of them. Binding to the single-object DTO made every multi-button
+         * session fall into the catch block and silently return no buttons at all.
+         */
+        private Object deserializeLearnerButtonConfig(String json) {
+                if (json == null || json.isBlank())
                         return null;
                 try {
-                        return new com.fasterxml.jackson.databind.ObjectMapper().readValue(json,
-                                        vacademy.io.admin_core_service.features.live_session.dto.LiveSessionStep1RequestDTO.LearnerButtonConfigDTO.class);
+                        return new com.fasterxml.jackson.databind.ObjectMapper().readValue(json, Object.class);
                 } catch (Exception e) {
                         System.err.println("Error deserializing LearnerButtonConfig: " + e.getMessage());
                         return null;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/GetSessionByIdService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/GetSessionByIdService.java
@@ -150,14 +150,7 @@ public class GetSessionByIdService {
             dto.setDefaultClassLinkType(first.getDefaultClassLinkType());
             dto.setLinkType(first.getLinkType());
 
-            if (first.getLearnerButtonConfig() != null) {
-                try {
-                    dto.setLearnerButtonConfig(new com.fasterxml.jackson.databind.ObjectMapper().readValue(
-                            first.getLearnerButtonConfig(), GetSessionByIdResponseDTO.LearnerButtonConfigDTO.class));
-                } catch (Exception e) {
-                    System.err.println("Error deserializing LearnerButtonConfig: " + e.getMessage());
-                }
-            }
+            dto.setLearnerButtonConfig(deserializeLearnerButtonConfig(first.getLearnerButtonConfig()));
 
             dto.setJoinLink(first.getRegistrationFormLinkForPublicSessions());
             dto.setRecurrenceType(first.getRecurrenceType());
@@ -376,12 +369,16 @@ public class GetSessionByIdService {
         return scheduleRepository.findEarliestScheduleIdBySessionId(sessionId);
     }
 
-    private GetSessionByIdResponseDTO.LearnerButtonConfigDTO deserializeLearnerButtonConfig(String json) {
-        if (json == null)
+    /**
+     * Untyped on purpose — the column holds either a single button object or a
+     * list of them, and binding to the single-object DTO dropped every
+     * multi-button session's config.
+     */
+    private Object deserializeLearnerButtonConfig(String json) {
+        if (json == null || json.isBlank())
             return null;
         try {
-            return new com.fasterxml.jackson.databind.ObjectMapper().readValue(json,
-                    GetSessionByIdResponseDTO.LearnerButtonConfigDTO.class);
+            return new com.fasterxml.jackson.databind.ObjectMapper().readValue(json, Object.class);
         } catch (Exception e) {
             System.err.println("Error deserializing LearnerButtonConfig: " + e.getMessage());
             return null;


### PR DESCRIPTION
learner_button_config holds either a single button object (legacy) or a list of them, but every read path bound it to the single-object LearnerButtonConfigDTO. A list threw inside the deserializer, the catch block returned null, and @JsonInclude(NON_NULL) then omitted the field from the response entirely -- so sessions carrying YouTube/Instagram/ Facebook buttons reached the learner app with no button data at all and silently rendered nothing.

The write path had the same flaw: LiveSessionStep1RequestDTO also typed the field as a single object, so saving more than one button from the admin config tab could not bind.

Type the field as an untyped JSON passthrough on both paths so both shapes round-trip unchanged. No migration needed -- the stored rows were already correct.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
