### PR TITLE
fix(learner-progress): count SCORM/audio/assessment slides and exclude empty content from progress denominators

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_operation/repository/LearnerOperationRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_operation/repository/LearnerOperationRepository.java
@@ -135,16 +135,25 @@ public interface LearnerOperationRepository extends JpaRepository<LearnerOperati
          * ModuleChapterMappingRepository.getModuleChapterProgress — average
          * over the chapter's slides of the best percentage op, capped at 100,
          * slides without progress counting as 0.
+         *
+         * A chapter appears here only if it has at least one learner-visible
+         * slide; an untouched slide still scores 0, so a chapter that has slides
+         * always produces a row. Callers rely on that: a missing chapter id means
+         * "nothing in it to complete", not "the learner scored zero".
          */
         @Query(value = """
                         SELECT sub.chapter_id AS "chapterId", AVG(sub.slide_pct) AS "percentageCompleted"
                         FROM (
                             SELECT cts.chapter_id, s.id,
+                                -- Must list EVERY slide-level completion operation. A type
+                                -- missing here scores its slides 0 forever and silently caps
+                                -- the chapter, module and subject the learner sees.
                                 COALESCE(MAX(CASE
                                     WHEN lo.operation IN (
                                             'PERCENTAGE_VIDEO_WATCHED', 'PERCENTAGE_DOCUMENT_COMPLETED',
                                             'PERCENTAGE_QUIZ_COMPLETED', 'PERCENTAGE_QUESTION_COMPLETED',
-                                            'PERCENTAGE_ASSIGNMENT_COMPLETED')
+                                            'PERCENTAGE_ASSIGNMENT_COMPLETED', 'PERCENTAGE_AUDIO_LISTENED',
+                                            'PERCENTAGE_SCORM_COMPLETED', 'PERCENTAGE_ASSESSMENT_DONE')
                                          AND lo.value ~ '^[0-9]+(\\.[0-9]+)?$'
                                     THEN LEAST(CAST(lo.value AS FLOAT), 100)
                                     ELSE NULL

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_study_library/service/LearnerStudyLibraryService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_study_library/service/LearnerStudyLibraryService.java
@@ -117,17 +117,33 @@ public class LearnerStudyLibraryService {
         for (LearnerModuleDTOWithDetails module : modules) {
             List<LearnerChapterDetailsDTO> chapters = module.getChapters();
             if (chapters == null || chapters.isEmpty()) {
-                module.setPercentageCompleted(0.0);
+                module.setPercentageCompleted(null);
                 continue;
             }
             double chapterPctSum = 0.0;
+            int countedChapters = 0;
             for (LearnerChapterDetailsDTO chapter : chapters) {
-                Double pct = pctByChapter.getOrDefault(chapter.getId(), 0.0);
-                chapter.setPercentageCompleted(pct);
+                Double pct = pctByChapter.get(chapter.getId());
+                // A chapter with no learner-visible slide never appears in the
+                // progress rows, so pct is null rather than 0. Keep showing it as
+                // 0% (there is nothing in it to complete) but keep it OUT of the
+                // module denominator: a chapter the learner cannot even open must
+                // not count as work they failed to do. Counting it capped the
+                // module below 100% forever, which blocked course certificates and
+                // made every added empty chapter visibly divide the module -- one
+                // empty chapter beside a 41.67% chapter rendered 21%, two rendered
+                // 14%. Mirrors ActivityLogRepository.getModuleCompletionPercentage,
+                // which excludes the same chapters from the stored rollup.
+                chapter.setPercentageCompleted(pct == null ? 0.0 : pct);
                 chapter.setLastSlideViewed(lastSlideByChapter.get(chapter.getId()));
-                chapterPctSum += (pct == null ? 0.0 : pct);
+                if (pct != null) {
+                    chapterPctSum += pct;
+                    countedChapters++;
+                }
             }
-            module.setPercentageCompleted(chapterPctSum / chapters.size());
+            // No countable chapter means the whole module is empty. Null, not 0,
+            // so the subject average can skip it for the same reason.
+            module.setPercentageCompleted(countedChapters == 0 ? null : chapterPctSum / countedChapters);
         }
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
@@ -284,12 +284,39 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
             WHERE
                 smm.subject_id = :subjectId
                 AND m.status IN (:moduleStatusList)
+                -- Same rule as getModuleCompletionPercentage, one level up: a
+                -- module that cannot produce a percentage must not sit in the
+                -- denominator as a 0. A module whose chapters are all empty (or
+                -- which has no chapters at all) never gets a MODULE row written,
+                -- so it would arrive here through the LEFT JOIN as 0 and hold the
+                -- subject down permanently. Count a module only when at least one
+                -- of its chapters could produce a value, which is exactly the
+                -- denominator getModuleCompletionPercentage uses.
+                AND EXISTS (
+                    SELECT 1
+                    FROM module_chapter_mapping mcm2
+                    JOIN chapter c2 ON c2.id = mcm2.chapter_id
+                    JOIN chapter_package_session_mapping cpm2 ON cpm2.chapter_id = c2.id
+                    WHERE mcm2.module_id = m.id
+                      AND c2.status IN (:chapterStatusList)
+                      AND cpm2.status IN (:chapterStatusList)
+                      AND EXISTS (
+                          SELECT 1
+                          FROM chapter_to_slides cts2
+                          JOIN slide s2 ON s2.id = cts2.slide_id
+                          WHERE cts2.chapter_id = c2.id
+                            AND cts2.status IN ('PUBLISHED', 'UNSYNC')
+                            AND s2.source_type IN ('VIDEO', 'DOCUMENT', 'ASSIGNMENT', 'QUESTION',
+                                                   'QUIZ', 'HTML_VIDEO', 'AUDIO', 'SCORM', 'ASSESSMENT')
+                      )
+                )
             """, nativeQuery = true)
     Double getSubjectCompletionPercentage(
             @Param("userId") String userId,
             @Param("subjectId") String subjectId,
             @Param("learnerOperation") List<String> learnerOperation,
-            @Param("moduleStatusList") List<String> moduleStatusList);
+            @Param("moduleStatusList") List<String> moduleStatusList,
+            @Param("chapterStatusList") List<String> chapterStatusList);
 
     @Query(value = """
             SELECT
@@ -306,12 +333,45 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
             WHERE
                 sps.session_id = :packageSessionId
                 AND s.status IN (:subjectStatusList)
+                -- Top of the same chain. A subject with no completable content
+                -- would otherwise land here as 0 and cap the course percentage the
+                -- learner sees, which is also what certificate eligibility is
+                -- gated on. Count a subject only when it has a module that has a
+                -- chapter that has a learner-visible slide, matching the
+                -- denominators used one and two levels below.
+                AND EXISTS (
+                    SELECT 1
+                    FROM subject_module_mapping smm2
+                    JOIN modules m2 ON m2.id = smm2.module_id
+                    WHERE smm2.subject_id = s.id
+                      AND m2.status IN (:moduleStatusList)
+                      AND EXISTS (
+                          SELECT 1
+                          FROM module_chapter_mapping mcm2
+                          JOIN chapter c2 ON c2.id = mcm2.chapter_id
+                          JOIN chapter_package_session_mapping cpm2 ON cpm2.chapter_id = c2.id
+                          WHERE mcm2.module_id = m2.id
+                            AND c2.status IN (:chapterStatusList)
+                            AND cpm2.status IN (:chapterStatusList)
+                            AND EXISTS (
+                                SELECT 1
+                                FROM chapter_to_slides cts2
+                                JOIN slide s2 ON s2.id = cts2.slide_id
+                                WHERE cts2.chapter_id = c2.id
+                                  AND cts2.status IN ('PUBLISHED', 'UNSYNC')
+                                  AND s2.source_type IN ('VIDEO', 'DOCUMENT', 'ASSIGNMENT', 'QUESTION',
+                                                         'QUIZ', 'HTML_VIDEO', 'AUDIO', 'SCORM', 'ASSESSMENT')
+                            )
+                      )
+                )
             """, nativeQuery = true)
     Double getPackageSessionCompletionPercentage(
             @Param("userId") String userId,
             @Param("learnerOperation") List<String> learnerOperation,
             @Param("packageSessionId") String packageSessionId,
-            @Param("subjectStatusList") List<String> subjectStatusList);
+            @Param("subjectStatusList") List<String> subjectStatusList,
+            @Param("moduleStatusList") List<String> moduleStatusList,
+            @Param("chapterStatusList") List<String> chapterStatusList);
 
     /**
      * Resolves the parent chain a chapter rolls up into — module, subject, and the
@@ -1331,10 +1391,16 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
                     GROUP BY cs.subject_id, cs.module_id
                 ),
                 LearnerCompletion AS (
-                    -- Module % = mean over chapters of (mean over that chapter's
-                    -- slides of the slide's completion), computed live from the
-                    -- SLIDE-level operations. Matches the learner app exactly and
-                    -- never drifts, unlike the stored PERCENTAGE_CHAPTER_COMPLETED.
+                    -- Module % = mean over chapters of (mean over the slides in
+                    -- that chapter of the slide completion), computed live from
+                    -- the SLIDE-level operations. Matches the learner app exactly
+                    -- and never drifts, unlike the stored
+                    -- PERCENTAGE_CHAPTER_COMPLETED.
+                    -- NOTE: no apostrophes in a comment inside a @Query block --
+                    -- Spring Data scans for quoted ranges before JPA sees it and
+                    -- does not understand SQL comments, so an odd number of them
+                    -- opens a string literal that never closes and the repository
+                    -- bean fails to build, taking the service down at startup.
                     SELECT cp.subject_id, cp.module_id, AVG(cp.chapter_pct) AS learner_completion
                     FROM (
                         SELECT sp.subject_id, sp.module_id, sp.chapter_id,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/service/LearnerTrackingAsyncService.java
@@ -596,7 +596,8 @@ public class LearnerTrackingAsyncService {
                                 userId,
                                 subjectId,
                                 List.of(LearnerOperationEnum.PERCENTAGE_MODULE_COMPLETED.name()),
-                                List.of(ModuleStatusEnum.ACTIVE.name()));
+                                List.of(ModuleStatusEnum.ACTIVE.name()),
+                                List.of(ChapterStatus.ACTIVE.name()));
 
                 addOrUpdatePercentageOperation(
                                 userId,
@@ -631,7 +632,9 @@ public class LearnerTrackingAsyncService {
                                 userId,
                                 List.of(LearnerOperationEnum.PERCENTAGE_SUBJECT_COMPLETED.name()),
                                 packageSessionId,
-                                List.of(SubjectStatusEnum.ACTIVE.name()));
+                                List.of(SubjectStatusEnum.ACTIVE.name()),
+                                List.of(ModuleStatusEnum.ACTIVE.name()),
+                                List.of(ChapterStatus.ACTIVE.name()));
 
                 if (percentage == null) {
                         log.warn("Course-progress rollup produced no value for user {} / packageSession {} "

--- a/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/courses/course-details/-components/course-structure-details.tsx
@@ -116,8 +116,10 @@ export interface Module {
 export interface ModuleWithChapters {
   module: Module;
   module_order: number | null;
-  // Server-computed module rollup from /modules-with-chapters.
-  percentage_completed?: number;
+  // Server-computed module rollup from /modules-with-chapters. Null when the
+  // module has no learner-visible content at all, which is why the subject
+  // average skips it instead of scoring it 0.
+  percentage_completed?: number | null;
   chapters: Chapter[];
 }
 export type SubjectModulesMap = { [subjectId: string]: ModuleWithChapters[] };
@@ -239,16 +241,26 @@ export const CourseStructureDetails = ({
   const calculateModuleProgress = (mod: ModuleWithChapters): number =>
     Math.round(mod?.percentage_completed ?? 0);
 
+  // Subject progress = mean of its MODULE percentages, skipping modules the
+  // server scored as null.
+  //
+  // Null means "no learner-visible content in here at all" (no chapters, or
+  // every chapter empty), which is different from 0%. Averaging it in as 0
+  // would let an empty module drag the subject down with work the learner
+  // cannot do, the same bug the module denominator has one level lower.
   const calculateSubjectProgress = (subjectId: string): number => {
     const modules = subjectModulesMap[subjectId] ?? [];
-    if (modules.length === 0) return 0;
+    const countedModules = modules.filter(
+      (mod) => mod.percentage_completed !== null && mod.percentage_completed !== undefined,
+    );
+    if (countedModules.length === 0) return 0;
 
-    const totalProgress = modules.reduce(
+    const totalProgress = countedModules.reduce(
       (sum, mod) => sum + (mod.percentage_completed ?? 0),
       0,
     );
 
-    return Math.round(totalProgress / modules.length);
+    return Math.round(totalProgress / countedModules.length);
   };
 
   // Helper: render progress bar


### PR DESCRIPTION
## Summary of Changes

Learner course progress was showing wrong numbers in two independent ways, both on the same read path.

A chapter with no learner-visible slides was counted in the module denominator as 0%. A module with one 41.67% chapter plus one empty chapter rendered **21%**; adding a second empty chapter made it **14%**. Because the course percentage comes from a *different* source (the stored `learner_operation` rollup, which already excluded empty chapters), the course number could legitimately read higher than every subject beneath it — the reported "course 37% but subjects are 33% and 21%".

Separately, the query feeding that same tree listed only 5 of the 8 slide-completion operations, so completed **SCORM, audio and assessment** slides scored 0% — the "SCORM marked complete but not counted in progress" report.

Both defects existed because `e3f9eb634` (study-library caching) moved this endpoint onto a new query and Java overlay a few hours before the two earlier fixes (`1b5571a79`, `b53896771`) landed on the repository queries the endpoint no longer calls. This PR applies both rules to the path that is actually live, and extends the empty-content rule up the stored chain, which had it at module level only.

No data migration. Existing stored rows correct themselves as each learner's rollup next recomputes.

**Backend:**
- `LearnerStudyLibraryService#overlayModuleChapterProgress`: count only chapters that can produce a value (absent from the progress rows ⇔ no learner-visible slide; an untouched slide still scores 0, so the distinction is exact). Empty chapters still render 0% but leave the denominator. A module with no countable chapters is now `null` rather than `0.0`.
- `LearnerOperationRepository#findChapterSlideProgressForPackageSession`: added the three missing operations (`PERCENTAGE_AUDIO_LISTENED`, `PERCENTAGE_SCORM_COMPLETED`, `PERCENTAGE_ASSESSMENT_DONE`).
- `ActivityLogRepository#getSubjectCompletionPercentage` / `#getPackageSessionCompletionPercentage`: `EXISTS` guards so a module with no countable chapter, and a subject with no countable module, leave the denominator — mirroring the module-level rule one and two levels up. New `chapterStatusList` / `moduleStatusList` params; `LearnerTrackingAsyncService` callers updated.
- Removed two apostrophes from a SQL comment inside a `@Query` block. They balanced each other so nothing was breaking, but an odd count there is what took the service down at startup in `d58463057`.

**Frontend:**
- `course-structure-details.tsx`: subject progress skips modules the server scored `null` instead of averaging them in as 0%; `percentage_completed` widened to `number | null`.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Ran the full stack locally (admin_core against a restored prod dump, learner app, admin dashboard) with two empty chapters seeded into a module holding one 41.67% chapter. Tree rendered **module 42% / subject 42%**, against **14%** under the old formula, with the course number sitting between the two subjects instead of above both.
- Verified the SCORM path against a real learner in the dump who had completed SCORM slides: the module computes **0.00%** with the 5-operation list and **43.50%** with the corrected 8-operation list.
- Audited all 18 sites in `admin_core_service` that enumerate slide-completion operations. Every aggregate list now carries all 8; the only remaining 5-operation list is `V410`, which is already applied and is superseded by `V423`, so it must not be edited.
- Both rewritten `ActivityLogRepository` queries executed against Postgres to confirm syntax and alias resolution.
- Measured the stored-rollup blast radius read-only on production before choosing not to backfill: 455 `SUBJECT` rows across 263 learners would change, up to +75 percentage points.
- `mvnw compile` clean, `tsc --noEmit` clean, `design-lint` 0 errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly

---

**Note for reviewers:** after this ships, the subject and course percentages for roughly 263 learners will **rise** as their rollups recompute naturally. That is the fix landing, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
