### PR TITLE
fix(enroll-learner): sub-org "staff" role must write LEARNER, not ADM…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -1106,12 +1106,21 @@ public class BulkAssignmentService {
     }
 
     /**
-     * Falls back to ADMIN,LEARNER (the same default {@code InstituteCustomFieldMapper} applies when
-     * the "admin only access" answer is absent) and normalises casing/spacing of an explicit value.
+     * Normalises casing/spacing of an explicit roles CSV, falling back to LEARNER.
+     *
+     * <p>The fallback is deliberately LEARNER and NOT {@code ADMIN,LEARNER}: anything containing
+     * ADMIN makes the member an organization admin (see
+     * {@code findAdminsBySubOrg}'s {@code LIKE '%ADMIN%'}), which would silently hand every
+     * ordinary member admin rights over their organization. An ordinary member is the
+     * overwhelmingly common case, so the safe default is the least-privileged one.
+     *
+     * <p>Note this differs from {@code InstituteCustomFieldMapper.determineRolesAsString}, whose
+     * fallback IS {@code ADMIN,LEARNER} — that mapper models an "admin only access?" yes/no
+     * question and so can never express a non-admin member at all.
      */
     private String normalizeSubOrgRoles(String roles) {
         if (!StringUtils.hasText(roles)) {
-            return SubOrgRoles.ADMIN.name() + "," + SubOrgRoles.LEARNER.name();
+            return SubOrgRoles.LEARNER.name();
         }
         return Arrays.stream(roles.split(","))
                 .map(String::trim)

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4Preview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4Preview.tsx
@@ -108,7 +108,11 @@ export const Step4Preview = ({ previewResponse, selectedPackageSessions }: Props
                                                 : 'Not selected')}
                                     </span>
                                     <span className="rounded-full bg-white px-2 py-0.5 text-caption font-medium text-neutral-600 ring-1 ring-inset ring-neutral-200">
-                                        {ps.subOrgRole === 'ADMIN' ? 'Admin only' : learnerTerm}
+                                        {ps.subOrgRole === 'ADMIN_ONLY'
+                                            ? 'Admin only'
+                                            : ps.subOrgRole === 'ADMIN'
+                                              ? `Admin + ${learnerTerm}`
+                                              : `Staff — ${learnerTerm}`}
                                     </span>
                                 </li>
                             ))}

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4SubOrg.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/bulk-assign-dialog/steps/Step4SubOrg.tsx
@@ -88,7 +88,7 @@ const SubOrgConfigRow = ({ ps, onUpdate }: RowProps) => {
     const isCreatingNew = !ps.subOrgId && !!ps.newSubOrg;
     const pickerValue = ps.subOrgId ?? (isCreatingNew ? CREATE_NEW : '');
     const selectedSubOrg = subOrgs.find((s) => s.sub_org_id === ps.subOrgId);
-    const role: SubOrgRoleChoice = ps.subOrgRole ?? 'LEARNER';
+    const role: SubOrgRoleChoice = ps.subOrgRole ?? 'STAFF';
 
     const handlePick = (value: string) => {
         if (value === CREATE_NEW) {
@@ -233,16 +233,17 @@ const SubOrgConfigRow = ({ ps, onUpdate }: RowProps) => {
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="z-popover-above-modal">
-                            <SelectItem value="LEARNER">
-                                {learnerTerm} (default)
-                            </SelectItem>
-                            <SelectItem value="ADMIN">Admin only</SelectItem>
+                            <SelectItem value="STAFF">Staff — {learnerTerm} (default)</SelectItem>
+                            <SelectItem value="ADMIN">Admin + {learnerTerm}</SelectItem>
+                            <SelectItem value="ADMIN_ONLY">Admin only</SelectItem>
                         </SelectContent>
                     </Select>
                     <p className="mt-1 text-xs text-neutral-400">
-                        {role === 'ADMIN'
+                        {role === 'ADMIN_ONLY'
                             ? 'Manages the organisation’s roster without course access. Member-enrollment automations do not run for admin-only members.'
-                            : `Gets course access and can manage the organisation’s roster. Runs the sub-org member enrollment automations.`}
+                            : role === 'ADMIN'
+                              ? 'Gets course access AND manages the organisation’s roster — they will show as an organisation admin.'
+                              : 'Course access only. No admin rights over the organisation.'}
                     </p>
                 </div>
             </div>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-types/bulk-assign-types.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-types/bulk-assign-types.ts
@@ -363,12 +363,18 @@ export interface SelectedPackageSession {
 }
 
 /**
- * Role the enrolled member holds inside the sub-org.
- * - 'LEARNER' → `ADMIN,LEARNER` (the default a learner-side enrollment produces): consumes the
- *   course and can administer their organization's roster.
- * - 'ADMIN' → `ADMIN` only: manages the organization without learner access.
+ * Role the enrolled member holds inside the sub-org. These map onto the three CSV values
+ * actually stored on `ssigm.comma_separated_org_roles`:
+ * - 'STAFF' → `LEARNER` — ordinary member: course access only, no admin rights. The default,
+ *   and by far the most common value in practice.
+ * - 'ADMIN' → `ADMIN,LEARNER` — runs the organization's roster AND takes the course.
+ * - 'ADMIN_ONLY' → `ADMIN` — manages the roster without any course access.
+ *
+ * Note `ADMIN,LEARNER` grants BOTH — anything containing ADMIN makes the member an
+ * organization admin (see findAdminsBySubOrg's `LIKE '%ADMIN%'`). Picking 'STAFF' must
+ * therefore emit `LEARNER` alone, never `ADMIN,LEARNER`.
  */
-export type SubOrgRoleChoice = 'LEARNER' | 'ADMIN';
+export type SubOrgRoleChoice = 'STAFF' | 'ADMIN' | 'ADMIN_ONLY';
 
 export interface NewSubOrgInput {
     name: string;
@@ -377,8 +383,11 @@ export interface NewSubOrgInput {
 }
 
 /** Serialises a role choice to the CSV the backend stores on the SSIGM. */
-export const subOrgRolesCsv = (role: SubOrgRoleChoice | undefined): string =>
-    role === 'ADMIN' ? 'ADMIN' : 'ADMIN,LEARNER';
+export const subOrgRolesCsv = (role: SubOrgRoleChoice | undefined): string => {
+    if (role === 'ADMIN') return 'ADMIN,LEARNER';
+    if (role === 'ADMIN_ONLY') return 'ADMIN';
+    return 'LEARNER';
+};
 
 /** A sub-org already present in a package session, from /sub-org/v1/by-package-session. */
 export interface PackageSessionSubOrg {


### PR DESCRIPTION
…IN,LEARNER

Picking the default role in the sub-org step enrolled the member as BOTH Practice Admin and Practice Staff. Anything containing ADMIN makes the member an organization admin (findAdminsBySubOrg matches LIKE '%ADMIN%'), so ADMIN,LEARNER handed every ordinary member the management portal.

The mapping was copied from InstituteCustomFieldMapper's fallback, which was the wrong thing to match: that mapper models an "admin only access?" yes/no question and so can never express a non-admin member at all. The stored data says otherwise — LEARNER alone is the dominant value in practice (7924 rows vs 668 ADMIN,LEARNER vs 59 ROOT_ADMIN on Vet Education).

The picker now offers the three values actually in use and defaults to the least-privileged one:

  Staff — Learner (default) -> LEARNER        course access, no admin rights
  Admin + Learner           -> ADMIN,LEARNER  runs the roster and takes the course
  Admin only                -> ADMIN          roster management, no course access

normalizeSubOrgRoles' blank fallback moves from ADMIN,LEARNER to LEARNER for the same reason: a missing role must never silently confer admin.

Not fixed here: InstituteCustomFieldMapper.determineRolesAsString still cannot produce LEARNER, so the learner-side custom-field enrollment path keeps making every member an admin. Changing it affects public enrollment and needs a call on who legitimately keeps admin.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
