### PR TITLE
fix(live-class): render learner buttons that omit optional fields

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/-types/types.ts
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/-types/types.ts
@@ -39,12 +39,17 @@ export interface RawApiResponse {
   upcoming_sessions?: RawSession[];
 }
 
+/**
+ * One learner-facing action button under the player. Authored by admins in the
+ * workflow config tab, so only text and url are guaranteed; colours and `visible`
+ * may be absent. Missing `visible` means visible.
+ */
 export interface LearnerButtonConfig {
   text: string;
   url: string;
-  background_color: string;
-  text_color: string;
-  visible: boolean;
+  background_color?: string;
+  text_color?: string;
+  visible?: boolean;
 }
 
 export interface SessionDetails {
@@ -65,7 +70,8 @@ export interface SessionDetails {
   session_streaming_service_type: string;
   timezone: string;
   link_type?: string;
-  learner_button_config?: LearnerButtonConfig | null;
+  // Single object (legacy) or a list — see the embed screen's LearnerButtonsSchema.
+  learner_button_config?: LearnerButtonConfig | LearnerButtonConfig[] | null;
   default_class_link?: string | null;
   custom_meeting_link?: string | null;
   provider_meeting_id?: string | null;

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
@@ -27,12 +27,18 @@ import { BASE_URL } from "@/constants/urls";
 import { Capacitor } from "@capacitor/core";
 import { Browser } from "@capacitor/browser";
 
+// Only text and url are required — a button is defined by where it sends the
+// learner. Colours and `visible` are optional because these rows are authored by
+// admins in the workflow config tab: demanding every field made one blank colour
+// (or a row saved without `visible`) fail validation and silently drop EVERY
+// button on the screen. Missing `visible` means visible; only an explicit false
+// hides a button.
 const LearnerButtonConfigSchema = z.object({
   text: z.string(),
   url: z.string(),
-  background_color: z.string(),
-  text_color: z.string(),
-  visible: z.boolean(),
+  background_color: z.string().optional(),
+  text_color: z.string().optional(),
+  visible: z.boolean().optional(),
 });
 
 // A session may carry ONE button (legacy) or a LIST of buttons (e.g. YouTube
@@ -49,7 +55,7 @@ const toVisibleButtons = (config: unknown): LearnerButton[] => {
   const parsed = LearnerButtonsSchema.safeParse(config);
   if (!parsed.success) return [];
   const list = Array.isArray(parsed.data) ? parsed.data : [parsed.data];
-  return list.filter((b) => b.visible && b.url);
+  return list.filter((b) => b.visible !== false && b.url);
 };
 
 /** Right-aligned action buttons row under the player (YouTube/IG/FB etc.). */
@@ -64,11 +70,17 @@ const LearnerActionButtons = ({ config }: { config: unknown }) => {
           variant="default"
           size="sm"
           className="h-9 rounded-full px-6 text-sm font-medium shadow-sm transition-all duration-200 hover:shadow"
-          style={{
-            backgroundColor: button.background_color,
-            color: button.text_color,
-            border: `1px solid ${button.background_color}20`,
-          }}
+          // Admin-chosen brand colours (YouTube red, Instagram pink…) can only be
+          // inline. When a row leaves them blank the Button's own styling stands in.
+          style={
+            button.background_color
+              ? {
+                  backgroundColor: button.background_color,
+                  color: button.text_color,
+                  border: `1px solid ${button.background_color}20`,
+                }
+              : { color: button.text_color }
+          }
           onClick={() => window.open(button.url, "_blank")}
         >
           <span>{button.text}</span>


### PR DESCRIPTION
The schema required `visible: z.boolean()`, but buttons authored by the session-creator workflow carry only text, url and colours. safeParse therefore failed on every real config, toVisibleButtons returned an empty list, and the row rendered as null -- no buttons, no error, nothing in the console.

Only text and url are required now: a button is defined by where it sends the learner. `visible` and both colours are optional, and a missing `visible` means visible, so an explicit false still hides a button as before.

This matters beyond the immediate bug. These rows are edited by admins in the workflow config tab, where one blank colour cell or a row saved without `visible` would have failed validation and silently dropped EVERY button on the screen. The renderer falls back to the Button's own styling when a colour is absent rather than emitting "1px solid undefined20".

Verified against the exact payload the live API serves: the old schema parses to zero buttons, the new one to all three, and a config with visible:false still hides that button.

No data migration -- the stored configs were always valid, the schema was not.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
