### PR TITLE
fix(live-session): stop duplicate attendance emails on every re-mark

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepository.java
@@ -11,7 +11,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
-public interface LiveSessionLogsRepository extends JpaRepository<LiveSessionLogs, String> {
+public interface LiveSessionLogsRepository extends JpaRepository<LiveSessionLogs, String>, LiveSessionLogsRepositoryCustom {
 
     @Query("SELECT l FROM LiveSessionLogs l WHERE l.scheduleId = :scheduleId AND l.logType = 'ATTENDANCE_RECORDED'")
     List<LiveSessionLogs> findAllAttendanceByScheduleId(@Param("scheduleId") String scheduleId);
@@ -25,37 +25,13 @@ public interface LiveSessionLogsRepository extends JpaRepository<LiveSessionLogs
         return records.isEmpty() ? Optional.empty() : Optional.of(records.get(0));
     }
 
-    /**
-     * Single-round-trip attendance upsert. During a live class an entire batch
-     * marks attendance on the same schedule concurrently; the previous
-     * check-then-save serialized them (and still produced duplicates under
-     * race). Conflict target is the partial unique index
-     * uq_lsl_attendance_schedule_user (V415). A null details keeps whatever the
-     * existing row already has.
+    /*
+     * The single-round-trip attendance upsert lives in
+     * LiveSessionLogsRepositoryCustomImpl.upsertAttendanceReturningPreviousStatus.
+     * It has to report the pre-existing status so callers can skip re-notifying
+     * on a repeat mark, and @Modifying cannot return a value. Conflict target is
+     * still the partial unique index uq_lsl_attendance_schedule_user (V415).
      */
-    @Modifying
-    @Transactional
-    @Query(value = """
-            INSERT INTO live_session_logs
-                (id, session_id, schedule_id, user_source_type, user_source_id,
-                 log_type, status, status_type, details, updated_at)
-            VALUES (:id, :sessionId, :scheduleId, :userSourceType, :userSourceId,
-                    'ATTENDANCE_RECORDED', :status, :statusType, :details, now())
-            ON CONFLICT (schedule_id, user_source_id) WHERE log_type = 'ATTENDANCE_RECORDED'
-            DO UPDATE SET status      = EXCLUDED.status,
-                          status_type = EXCLUDED.status_type,
-                          details     = COALESCE(EXCLUDED.details, live_session_logs.details),
-                          updated_at  = now()
-            """, nativeQuery = true)
-    void upsertAttendance(
-            @Param("id") String id,
-            @Param("sessionId") String sessionId,
-            @Param("scheduleId") String scheduleId,
-            @Param("userSourceType") String userSourceType,
-            @Param("userSourceId") String userSourceId,
-            @Param("status") String status,
-            @Param("statusType") String statusType,
-            @Param("details") String details);
 
     /**
      * Upsert for the BBB meeting-join path (also a class-start stampede).

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepositoryCustom.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepositoryCustom.java
@@ -1,0 +1,29 @@
+package vacademy.io.admin_core_service.features.live_session.repository;
+
+public interface LiveSessionLogsRepositoryCustom {
+
+    /**
+     * Attendance upsert that also reports what the row looked like before it ran.
+     *
+     * <p>The plain {@code @Modifying} upsert this replaces could not tell a first
+     * mark apart from the fortieth: the learner waiting room re-marks on a 30s
+     * poll, so callers had no way to avoid re-firing the "attendance marked"
+     * notification on every tick. The write itself is byte-for-byte the same
+     * INSERT ... ON CONFLICT DO UPDATE as before — it is only wrapped in a CTE
+     * that captures the pre-existing status in the same round trip, so the
+     * stampede-safety and single-statement properties are preserved.
+     *
+     * @return the status stored before this call, or {@code null} when this call
+     *         created the row. Callers notify only when this differs from the
+     *         status they just wrote.
+     */
+    String upsertAttendanceReturningPreviousStatus(
+            String id,
+            String sessionId,
+            String scheduleId,
+            String userSourceType,
+            String userSourceId,
+            String status,
+            String statusType,
+            String details);
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepositoryCustomImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionLogsRepositoryCustomImpl.java
@@ -1,0 +1,81 @@
+package vacademy.io.admin_core_service.features.live_session.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+public class LiveSessionLogsRepositoryCustomImpl implements LiveSessionLogsRepositoryCustom {
+
+    /**
+     * {@code prev} is evaluated against the pre-statement snapshot, so it still
+     * sees the old row even though {@code ups} overwrites it in the same
+     * statement. The INSERT body, conflict target and SET list are unchanged
+     * from the previous upsert — {@code updated_at} still refreshes on every
+     * mark, {@code details} still falls back to the stored value — so nothing
+     * about the persisted attendance row changes; the statement just also hands
+     * back the status it replaced.
+     */
+    private static final String UPSERT_ATTENDANCE_SQL = """
+            WITH prev AS (
+                SELECT status
+                FROM live_session_logs
+                WHERE schedule_id = :scheduleId
+                  AND user_source_id = :userSourceId
+                  AND log_type = 'ATTENDANCE_RECORDED'
+                LIMIT 1
+            ),
+            ups AS (
+                INSERT INTO live_session_logs
+                    (id, session_id, schedule_id, user_source_type, user_source_id,
+                     log_type, status, status_type, details, updated_at)
+                VALUES (:id, :sessionId, :scheduleId, :userSourceType, :userSourceId,
+                        'ATTENDANCE_RECORDED', :status, :statusType, :details, now())
+                ON CONFLICT (schedule_id, user_source_id) WHERE log_type = 'ATTENDANCE_RECORDED'
+                DO UPDATE SET status      = EXCLUDED.status,
+                              status_type = EXCLUDED.status_type,
+                              details     = COALESCE(EXCLUDED.details, live_session_logs.details),
+                              updated_at  = now()
+                RETURNING id
+            )
+            SELECT (SELECT status FROM prev) AS previous_status
+            FROM ups
+            """;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    @Transactional
+    public String upsertAttendanceReturningPreviousStatus(
+            String id,
+            String sessionId,
+            String scheduleId,
+            String userSourceType,
+            String userSourceId,
+            String status,
+            String statusType,
+            String details) {
+
+        Query query = entityManager.createNativeQuery(UPSERT_ATTENDANCE_SQL)
+                .setParameter("id", id)
+                .setParameter("sessionId", sessionId)
+                .setParameter("scheduleId", scheduleId)
+                .setParameter("userSourceType", userSourceType)
+                .setParameter("userSourceId", userSourceId)
+                .setParameter("status", status)
+                .setParameter("statusType", statusType)
+                .setParameter("details", details);
+
+        List<?> rows = query.getResultList();
+        if (rows.isEmpty() || rows.get(0) == null) {
+            // No prior row: this call created it.
+            return null;
+        }
+        return String.valueOf(rows.get(0));
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
@@ -28,10 +28,15 @@ public class LIveSessionAttendanceService {
     public void markAttendance(MarkAttendanceRequestDTO request , CustomUserDetails user) {
         String userId = request.getUserSourceId().isEmpty() ? user.getUserId() : request.getUserSourceId();
 
-        upsertPresent(request, userId);
+        String previousStatus = upsertPresent(request, userId);
 
-        // Send attendance notification to learner
-        notificationProcessor.sendAttendanceNotification(request.getSessionId(), userId, "PRESENT");
+        // Notify only when the attendance state actually moved. The learner
+        // waiting room re-marks on a 30s poll (and again on every rejoin or
+        // refresh), so an unconditional call here mailed the learner dozens of
+        // times for one class. The row was always idempotent; the mail was not.
+        if (isStatusChange(previousStatus, "PRESENT")) {
+            notificationProcessor.sendAttendanceNotification(request.getSessionId(), userId, "PRESENT");
+        }
     }
 
     public void markGuestAttendance(MarkAttendanceRequestDTO request ) {
@@ -48,8 +53,8 @@ public class LIveSessionAttendanceService {
      * hold a connection across multiple statements or race on the existence
      * check (which historically produced duplicate attendance rows).
      */
-    private void upsertPresent(MarkAttendanceRequestDTO request, String userSourceId) {
-        liveSessionLogRepository.upsertAttendance(
+    private String upsertPresent(MarkAttendanceRequestDTO request, String userSourceId) {
+        return liveSessionLogRepository.upsertAttendanceReturningPreviousStatus(
                 UUID.randomUUID().toString(),
                 request.getSessionId(),
                 request.getScheduleId(),
@@ -58,6 +63,16 @@ public class LIveSessionAttendanceService {
                 "PRESENT",
                 "ONLINE",
                 request.getDetails());
+    }
+
+    /**
+     * True when a mark is worth notifying about: either the first mark for this
+     * schedule+user (no previous status) or a genuine transition such as an
+     * admin-set ABSENT being overwritten by the learner actually joining.
+     * Re-marking the same status is a no-op as far as the learner is concerned.
+     */
+    private static boolean isStatusChange(String previousStatus, String newStatus) {
+        return previousStatus == null || !previousStatus.equalsIgnoreCase(newStatus);
     }
 
     /**
@@ -77,8 +92,14 @@ public class LIveSessionAttendanceService {
                     entry.getUserSourceId()
             );
 
+            // Captured before the overwrite: re-saving an attendance sheet
+            // resubmits every row, so notifying unconditionally re-mailed
+            // learners whose status never moved.
+            boolean statusChanged;
+
             if (existingLog.isPresent()) {
                 LiveSessionLogs log = existingLog.get();
+                statusChanged = isStatusChange(log.getStatus(), entry.getStatus());
                 log.setStatus(entry.getStatus());
                 log.setStatusType("OFFLINE");
                 if (entry.getDetails() != null && !entry.getDetails().isBlank()) {
@@ -88,6 +109,7 @@ public class LIveSessionAttendanceService {
                 liveSessionLogRepository.save(log);
                 updated++;
             } else {
+                statusChanged = true;
                 LiveSessionLogs log = LiveSessionLogs.builder()
                         .sessionId(request.getSessionId())
                         .scheduleId(request.getScheduleId())
@@ -105,8 +127,10 @@ public class LIveSessionAttendanceService {
             }
 
             // Send attendance notification to learner
-            notificationProcessor.sendAttendanceNotification(
-                    request.getSessionId(), entry.getUserSourceId(), entry.getStatus());
+            if (statusChanged) {
+                notificationProcessor.sendAttendanceNotification(
+                        request.getSessionId(), entry.getUserSourceId(), entry.getStatus());
+            }
         }
 
         return Map.of("updated", updated, "created", created);

--- a/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/live-class-guest/waiting-room/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSessionDetails } from "../-hooks/useSessionDetails";
 import { useGuestAccessRecovery } from "../-hooks/useGuestAccessRecovery";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
@@ -42,6 +42,50 @@ function GuestWaitingRoomComponent() {
   // Paid session opened without a local registration (new browser): bounce to
   // the registration page to recover identity instead of showing a 403 error.
   useGuestAccessRecovery(sessionId, error);
+
+  // The session check below runs on a 30s poll and again from the countdown's
+  // onExpire. Without these guards one join re-hit mark-attendance on every
+  // tick and, for redirect sessions, re-opened the meeting link forever —
+  // nothing unmounts this route once window.open takes over.
+  const hasMarkedRef = useRef(false);
+  const hasJoinedRef = useRef(false);
+
+  // One mark per join. Reset on failure so a mark that genuinely did not land
+  // can still be retried by the next tick.
+  const markAttendanceOnce = useCallback(async () => {
+    if (hasMarkedRef.current || !sessionDetails) return;
+    hasMarkedRef.current = true;
+    try {
+      await markAttendance({
+        sessionId: sessionDetails.sessionId,
+        scheduleId: sessionId,
+        userSourceType: "EXTERNAL_USER",
+        userSourceId: guestId,
+        details: "Guest joined live class from waiting room",
+      });
+    } catch (error) {
+      hasMarkedRef.current = false;
+      throw error;
+    }
+  }, [markAttendance, sessionDetails, sessionId, guestId]);
+
+  // Unchanged redirect behaviour, shared by the poll, the countdown's onExpire,
+  // and both the success and failure paths of each.
+  const proceedToJoin = useCallback(async () => {
+    if (!sessionDetails) return;
+    const streamingType = sessionDetails.sessionStreamingServiceType?.toLowerCase();
+    if (streamingType === SessionStreamingServiceType.EMBED.toLowerCase()) {
+      hasJoinedRef.current = true;
+      navigate({
+        to: "/live-class-guest/embed",
+        search: { sessionId },
+      });
+    } else {
+      const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
+      window.open(joinLink, "_blank", "noopener,noreferrer");
+      hasJoinedRef.current = true;
+    }
+  }, [navigate, sessionDetails, sessionId]);
 
   useEffect(() => {
     const fetchThumbnail = async () => {
@@ -90,41 +134,17 @@ function GuestWaitingRoomComponent() {
 
         // Case 1: Session has already started.
         if (isInMainSession) {
-          if (sessionDetails.defaultMeetLink) {
+          if (sessionDetails.defaultMeetLink && !hasJoinedRef.current) {
             try {
               // Mark attendance before redirecting
-              await markAttendance({
-                sessionId: sessionDetails.sessionId,
-                scheduleId: sessionId,
-                userSourceType: "EXTERNAL_USER",
-                userSourceId: guestId,
-                details: "Guest joined live class from waiting room",
-              });
+              await markAttendanceOnce();
 
-              const streamingType = sessionDetails.sessionStreamingServiceType?.toLowerCase();
-              if (streamingType === SessionStreamingServiceType.EMBED.toLowerCase()) {
-                navigate({
-                  to: "/live-class-guest/embed",
-                  search: { sessionId },
-                });
-              } else {
-                const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
-                window.open(joinLink, "_blank", "noopener,noreferrer");
-              }
+              await proceedToJoin();
             } catch (error) {
               console.error("Failed to mark attendance:", error);
               toast.error("Failed to mark attendance");
               // Still proceed with redirection
-              const streamingType = sessionDetails.sessionStreamingServiceType?.toLowerCase();
-              if (streamingType === SessionStreamingServiceType.EMBED.toLowerCase()) {
-                navigate({
-                  to: "/live-class-guest/embed",
-                  search: { sessionId },
-                });
-              } else {
-                const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
-                window.open(joinLink, "_blank", "noopener,noreferrer");
-              }
+              await proceedToJoin();
             }
           }
         } else if (isInWaitingRoom) {
@@ -151,7 +171,14 @@ function GuestWaitingRoomComponent() {
 
       return () => clearInterval(timer);
     }
-  }, [sessionDetails, navigate, markAttendance, sessionId, guestId]);
+  }, [
+    sessionDetails,
+    navigate,
+    markAttendanceOnce,
+    proceedToJoin,
+    sessionId,
+    guestId,
+  ]);
 
   if (isLoading) {
     return <DashboardLoader />;
@@ -202,41 +229,21 @@ function GuestWaitingRoomComponent() {
                   );
                   const isInMainSession = now >= sessionDate;
 
-                  if (isInMainSession && sessionDetails.defaultMeetLink) {
+                  if (
+                    isInMainSession &&
+                    sessionDetails.defaultMeetLink &&
+                    !hasJoinedRef.current
+                  ) {
                     try {
                       // Mark attendance before redirecting
-                      await markAttendance({
-                        sessionId: sessionDetails.sessionId,
-                        scheduleId: sessionId,
-                        userSourceType: "EXTERNAL_USER",
-                        userSourceId: guestId,
-                        details: "Guest joined live class from waiting room",
-                      });
+                      await markAttendanceOnce();
 
-                      const streamingType = sessionDetails.sessionStreamingServiceType?.toLowerCase();
-                      if (streamingType === SessionStreamingServiceType.EMBED.toLowerCase()) {
-                        navigate({
-                          to: "/live-class-guest/embed",
-                          search: { sessionId },
-                        });
-                      } else {
-                        const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
-                        window.open(joinLink, "_blank", "noopener,noreferrer");
-                      }
+                      await proceedToJoin();
                     } catch (error) {
                       console.error("Failed to mark attendance:", error);
                       toast.error("Failed to mark attendance");
                       // Still proceed with redirection
-                      const streamingType = sessionDetails.sessionStreamingServiceType?.toLowerCase();
-                      if (streamingType === SessionStreamingServiceType.EMBED.toLowerCase()) {
-                        navigate({
-                          to: "/live-class-guest/embed",
-                          search: { sessionId },
-                        });
-                      } else {
-                        const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
-                        window.open(joinLink, "_blank", "noopener,noreferrer");
-                      }
+                      await proceedToJoin();
                     }
                   }
                 };

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/waiting-room/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/waiting-room/index.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { useNavHeadingStore } from "@/stores/layout-container/useNavHeadingStore";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useSessionDetails } from "../-hooks/useSessionDetails";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import { CountdownTimer } from "./-components/CountdownTimer";
@@ -44,6 +44,13 @@ function WaitingRoomComponent() {
     error,
   } = useSessionDetails(sessionId);
   const { data: serverTimeData } = useServerTime();
+
+  // checkSessionStart below runs on a 30s poll. Without these guards a single
+  // join re-hit mark-attendance on every tick — harmless for the stored row,
+  // but it re-sent the "attendance marked" mail and, for redirect sessions,
+  // re-opened the meeting link forever because nothing unmounts this route.
+  const hasMarkedRef = useRef(false);
+  const hasJoinedRef = useRef(false);
 
   const fetchThumbnail = useCallback(async () => {
     if (sessionDetails?.thumbnailFileId) {
@@ -90,25 +97,44 @@ function WaitingRoomComponent() {
     // BBB sessions may not have a defaultMeetLink (room is auto-created on join)
     const isBbb = sessionDetails.linkType === LinkType.BBB_MEETING || sessionDetails.linkType === "bbb";
     if (now >= sessionStartInUserTimezone && (sessionDetails.defaultMeetLink || isBbb)) {
-      try {
-        await markAttendance({
-          sessionId: sessionDetails.sessionId,
-          scheduleId: sessionId,
-          userSourceType: "USER",
-          userSourceId: "",
-          details: "Joined live class from waiting room",
-        });
+      // Already sent to the meeting — later ticks only keep watching for the
+      // class-ended redirect above, they must not re-join.
+      if (hasJoinedRef.current) return;
+
+      // One mark per join. Reset on failure so a mark that genuinely did not
+      // land can still be retried by the next tick.
+      const markOnce = async () => {
+        if (hasMarkedRef.current) return;
+        hasMarkedRef.current = true;
+        try {
+          await markAttendance({
+            sessionId: sessionDetails.sessionId,
+            scheduleId: sessionId,
+            userSourceType: "USER",
+            userSourceId: "",
+            details: "Joined live class from waiting room",
+          });
+        } catch (error) {
+          hasMarkedRef.current = false;
+          throw error;
+        }
+      };
+
+      // Unchanged join behaviour, shared by the success and failure paths.
+      const proceedToJoin = async () => {
         if (isBbb) {
           // BBB: open the personalized join URL (real name + userId) directly.
           // Do NOT route to the embed page — its session data can resolve linkType
           // to "other" and fail with "Unsupported session type". The backend
           // /meeting/join is authoritative. Then leave the waiting room.
           await openBbbJoinForLearner(sessionId);
+          hasJoinedRef.current = true;
           navigate({ to: "/study-library/live-class" });
         } else if (
           sessionDetails.sessionStreamingServiceType ===
           SessionStreamingServiceType.EMBED
         ) {
+          hasJoinedRef.current = true;
           navigate({
             to: "/study-library/live-class/embed",
             search: { sessionId },
@@ -116,29 +142,17 @@ function WaitingRoomComponent() {
         } else {
           const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
           window.open(joinLink, "_blank", "noopener,noreferrer");
+          hasJoinedRef.current = true;
         }
+      };
+
+      try {
+        await markOnce();
+        await proceedToJoin();
       } catch (error) {
         console.error("Failed to mark attendance:", error);
         toast.error(t("liveClass.failedToMarkAttendance"));
-        if (isBbb) {
-          // BBB: open the personalized join URL (real name + userId) directly.
-          // Do NOT route to the embed page — its session data can resolve linkType
-          // to "other" and fail with "Unsupported session type". The backend
-          // /meeting/join is authoritative. Then leave the waiting room.
-          await openBbbJoinForLearner(sessionId);
-          navigate({ to: "/study-library/live-class" });
-        } else if (
-          sessionDetails.sessionStreamingServiceType ===
-          SessionStreamingServiceType.EMBED
-        ) {
-          navigate({
-            to: "/study-library/live-class/embed",
-            search: { sessionId },
-          });
-        } else {
-          const joinLink = sessionDetails.customMeetingLink || sessionDetails.defaultMeetLink;
-          window.open(joinLink, "_blank", "noopener,noreferrer");
-        }
+        await proceedToJoin();
       }
     }
   }, [sessionDetails, serverTimeData, markAttendance, navigate, sessionId]);


### PR DESCRIPTION
The learner waiting room re-marks attendance on a 30s poll, and for redirect sessions nothing unmounts the route after window.open, so a single join re-hit mark-attendance every 30s for the whole class (~120 calls/hour). The attendance row was already idempotent via the V415 ON CONFLICT upsert, but sendAttendanceNotification fired unconditionally after it, so learners got one "Attendance Marked" email per call.

Backend: the upsert now reports the status it replaced, so the service notifies only on a genuine transition - the first mark, or ABSENT -> PRESENT when a learner actually joins. @Modifying cannot return a value, so the statement moved to an EntityManager fragment alongside the existing LiveSessionRepositoryCustomImpl; the INSERT body, conflict target and SET list are unchanged, so updated_at still refreshes on every mark and details still falls back to the stored value. The admin bulk path gets the same treatment - re-saving an attendance sheet no longer re-mails learners whose status never moved.

Frontend: both waiting rooms guard the mark with hasMarkedRef (reset on failure so a mark that genuinely did not land still retries) and stop the poll from re-joining with hasJoinedRef. The interval keeps running so the class-ended redirect still works. The guest page's four duplicated copies of the join logic fold into one proceedToJoin.

Verified: javac clean on the changed files, tsc --noEmit clean, eslint 0 errors, and EXPLAIN against the live schema confirms the new statement still arbitrates on uq_lsl_attendance_schedule_user and index-scans the prior-status lookup.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
