### PR TITLE
fix(course-cards): size the preview band to the artwork so nothing is cropped or padded

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentPreviews.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentPreviews.tsx
@@ -130,7 +130,9 @@ const ProductPageOfferPreview: React.FC<P> = ({ props }) => {
                         style={isCarousel ? { flex: `0 0 calc((100% - ${(cols - 1) * 24}px) / ${cols})`, minWidth: 250 } : undefined}
                     >
                         {props.showImage !== false && (
-                            <div className="mb-4 aspect-[16/9] w-full rounded-catalogue-lg bg-catalogue-bg-muted" />
+                            // 2:1, matching the live offer card — the builder
+                            // preview must reserve the same band the learner sees.
+                            <div className="mb-4 aspect-[2/1] w-full rounded-catalogue-lg bg-catalogue-bg-muted" />
                         )}
                         {props.showChips !== false && chips.length > 0 && (
                             <div className="mb-2 flex flex-wrap gap-1.5">

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseCatalogComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseCatalogComponent.tsx
@@ -86,8 +86,11 @@ interface CourseImageProps {
   className?: string;
 }
 
+// Fills whatever band it is dropped into — the card owns the ratio (2:1, the
+// ratio admins crop preview images to), so the fallback never disagrees with
+// the real artwork about how tall the header band is.
 const CoursePlaceholder: React.FC<{ title: string }> = ({ title }) => (
-  <div className="aspect-video w-full flex flex-col items-center justify-center gap-2 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent">
+  <div className="size-full flex flex-col items-center justify-center gap-2 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent">
     <BookOpen size={40} className="text-primary/60" />
     <span className="text-xs font-medium text-primary/70 px-3 text-center line-clamp-1">
       {title}
@@ -176,7 +179,7 @@ const CourseImageWithState: React.FC<CourseImageProps> = ({
   // Show loading placeholder while loading
   if (loadingImage && !courseImageUrl) {
     return (
-      <div className="aspect-video">
+      <div className="size-full">
         <div className="w-full h-full bg-catalogue-bg-muted animate-pulse rounded-md flex items-center justify-center">
           <div className="text-catalogue-text-muted text-xs">
             Loading...
@@ -187,7 +190,7 @@ const CourseImageWithState: React.FC<CourseImageProps> = ({
   }
 
   return (
-    <div className="aspect-video">
+    <div className="size-full">
       <img
         src={courseImageUrl}
         alt={alt}
@@ -1081,7 +1084,7 @@ export const CourseCatalogComponent: React.FC<CourseCatalogComponentProps> = ({
                 key={i}
                 className="catalogue-card-elevated overflow-hidden"
               >
-                <div className="catalogue-skeleton-shimmer h-44 w-full rounded-none"></div>
+                <div className="catalogue-skeleton-shimmer aspect-[2/1] w-full rounded-none"></div>
                 <div className="flex flex-col gap-2.5 p-4">
                   <div className="catalogue-skeleton-shimmer h-4 w-3/4"></div>
                   <div className="catalogue-skeleton-shimmer h-3 w-full"></div>
@@ -1403,7 +1406,10 @@ export const CourseCatalogComponent: React.FC<CourseCatalogComponentProps> = ({
                     {displayImage && (
                       <div
                         className={cn(
-                          "relative h-44 overflow-hidden flex-shrink-0",
+                          // 2:1 — the ratio the admin cropper enforces on course
+                          // preview images, so a correct upload fills the band
+                          // exactly and nothing is cropped away.
+                          "relative aspect-[2/1] w-full overflow-hidden flex-shrink-0",
                           // `contain` letterboxes, so give the band a surface
                           // rather than leaving a bare gap beside the artwork.
                           imageFit === "contain" && "bg-catalogue-bg-subtle",

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseRecommendationsComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseRecommendationsComponent.tsx
@@ -133,7 +133,8 @@ export const CourseRecommendationsComponent: React.FC<CourseRecommendationsCompo
             >
               {/* Thumbnail */}
               {course.thumbnail && (
-                <div className="aspect-video">
+                // 2:1 — the ratio course preview images are cropped to in admin.
+                <div className="aspect-[2/1]">
                   <img
                     src={course.thumbnail}
                     alt={course.title}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/ProductPageOfferComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/ProductPageOfferComponent.tsx
@@ -213,7 +213,7 @@ const CoursePlaceholder: React.FC<{ title: string }> = ({ title }) => (
   // renders directly under the tile, so printing it inside the tile too made
   // every imageless card read its own name twice. A big two-letter monogram
   // gives each tile identity without the echo.
-  <div className="relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden rounded-catalogue-lg bg-gradient-to-br from-primary-200 via-primary-100 to-primary-50">
+  <div className="relative flex aspect-[2/1] w-full items-center justify-center overflow-hidden rounded-catalogue-lg bg-gradient-to-br from-primary-200 via-primary-100 to-primary-50">
     <span className="catalogue-h2 select-none font-bold tracking-wide-08 text-catalogue-brand-ink opacity-90" aria-hidden="true">
       {initialsOf(title)}
     </span>
@@ -225,14 +225,37 @@ const CoursePlaceholder: React.FC<{ title: string }> = ({ title }) => (
   </div>
 );
 
+/**
+ * Band ratio for an upload we have not measured yet — the ratio the admin
+ * cropper enforces on course previews, so correctly cropped art never reflows.
+ */
+const DEFAULT_BAND_RATIO = 2;
+/**
+ * A wildly off-ratio upload (a portrait phone photo, a long banner strip) would
+ * otherwise hand one card a band twice its neighbours' height and wreck the
+ * row, so the measured ratio is clamped to what still reads as a card header.
+ */
+const MIN_BAND_RATIO = 1.4;
+const MAX_BAND_RATIO = 3;
+
 const CourseImage: React.FC<{ mediaId?: string; alt: string }> = ({ mediaId, alt }) => {
   const [url, setUrl] = useState("");
   const [failed, setFailed] = useState(false);
+  // The band takes the artwork's OWN ratio once the file reports it. `cover`
+  // into a fixed band cropped the logo and class label off the corners;
+  // `contain` kept them but padded the band with dead space, because these
+  // tiles carry their own margins. Matching the ratio means the image fills
+  // the band edge to edge with nothing cropped and nothing padded — the two
+  // fits become identical. Uploads reach us off ratio routinely (bulk create
+  // and the course-details editor both skip the 2:1 cropper), so this is
+  // measured per image rather than assumed.
+  const [bandRatio, setBandRatio] = useState(DEFAULT_BAND_RATIO);
 
   useEffect(() => {
     let alive = true;
     setFailed(false);
     setUrl("");
+    setBandRatio(DEFAULT_BAND_RATIO);
     if (!mediaId) return;
     if (mediaId.startsWith("http")) {
       setUrl(mediaId);
@@ -248,7 +271,11 @@ const CourseImage: React.FC<{ mediaId?: string; alt: string }> = ({ mediaId, alt
 
   // Reserve the band either way so cards don't reflow when images resolve.
   return (
-    <div className="catalogue-img-zoom aspect-[16/9] w-full overflow-hidden rounded-catalogue-lg bg-catalogue-bg-muted">
+    <div
+      className="catalogue-img-zoom w-full overflow-hidden rounded-catalogue-lg bg-catalogue-bg-muted"
+      // Dynamic: the uploaded artwork's own ratio, known only at load.
+      style={{ aspectRatio: bandRatio }}
+    >
       {url && (
         <img
           src={url}
@@ -256,6 +283,11 @@ const CourseImage: React.FC<{ mediaId?: string; alt: string }> = ({ mediaId, alt
           loading="lazy"
           decoding="async"
           className="size-full object-cover"
+          onLoad={(e) => {
+            const { naturalWidth: w, naturalHeight: h } = e.currentTarget;
+            if (!w || !h) return;
+            setBandRatio(Math.min(Math.max(w / h, MIN_BAND_RATIO), MAX_BAND_RATIO));
+          }}
           onError={() => setFailed(true)}
         />
       )}
@@ -468,7 +500,7 @@ export const ProductPageOfferComponent: React.FC<ProductPageOfferProps> = ({
       <div className={gridCols} aria-busy="true">
         {Array.from({ length: cols }, (_, i) => (
           <div key={i} className="catalogue-card-elevated p-5">
-            {showImage && <div className="catalogue-skeleton-shimmer mb-4 aspect-[16/9] w-full rounded-catalogue-lg" />}
+            {showImage && <div className="catalogue-skeleton-shimmer mb-4 aspect-[2/1] w-full rounded-catalogue-lg" />}
             <div className="catalogue-skeleton-shimmer mb-2 h-5 w-3/4 rounded" />
             <div className="catalogue-skeleton-shimmer mb-4 h-4 w-full rounded" />
             <div className="catalogue-skeleton-shimmer h-9 w-full rounded-catalogue-md" />

--- a/frontend-learner-dashboard-app/src/routes/product-pages/$productPageCode/-components/PageRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/routes/product-pages/$productPageCode/-components/PageRenderer.tsx
@@ -494,9 +494,9 @@ const CourseDetailSheet = ({
 
         {/* Banner */}
         {resolvedBannerUrl ? (
-          <img src={resolvedBannerUrl} alt={title} className="w-full aspect-video object-cover" />
+          <img src={resolvedBannerUrl} alt={title} className="w-full aspect-[2/1] object-cover" />
         ) : (
-          <div className="flex aspect-video w-full items-center justify-center" style={{ backgroundColor: `${primaryColor}22` }}>
+          <div className="flex aspect-[2/1] w-full items-center justify-center" style={{ backgroundColor: `${primaryColor}22` }}>
             <span className="text-5xl font-bold" style={{ color: primaryColor }}>{getInitials(title)}</span>
           </div>
         )}
@@ -705,6 +705,8 @@ const CourseCard = ({
   productPageCode?: string;
 }) => {
   const [showDetail, setShowDetail] = useState(false);
+  // 2:1 until the artwork reports its own ratio — see the thumbnail band below.
+  const [bandRatio, setBandRatio] = useState(2);
   const { title } = getDisplayParts(mapping);
   const plan = mapping.payment_plan;
   const isFree = !plan?.actual_price || plan.actual_price === 0;
@@ -750,13 +752,27 @@ const CourseCard = ({
         )}
         style={selected ? { borderColor: primaryColor, boxShadow: `0 0 0 2px ${primaryColor}40, 0 4px 16px ${primaryColor}18` } : {}}
       >
-        {/* Thumbnail */}
+        {/* Thumbnail. The band takes the artwork's own ratio once the file
+            reports it (2:1 until then — the ratio the admin cropper enforces),
+            so the image fills it with nothing cropped off the corners and no
+            dead padding around it. Clamped so one odd upload can't hand a card
+            a band twice its neighbours' height. */}
         <div
-          className="relative flex h-40 w-full items-center justify-center overflow-hidden"
-          style={{ backgroundColor: `${primaryColor}12` }}
+          className="relative flex w-full items-center justify-center overflow-hidden"
+          // Dynamic: brand tint, and the uploaded artwork's own ratio.
+          style={{ backgroundColor: `${primaryColor}12`, aspectRatio: bandRatio }}
         >
           {imageUrl ? (
-            <img src={imageUrl} alt={title} className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" />
+            <img
+              src={imageUrl}
+              alt={title}
+              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              onLoad={(e) => {
+                const { naturalWidth: w, naturalHeight: h } = e.currentTarget;
+                if (!w || !h) return;
+                setBandRatio(Math.min(Math.max(w / h, 1.4), 3));
+              }}
+            />
           ) : (
             <BookOpen className="size-10 transition-transform duration-200 group-hover:scale-110" style={{ color: primaryColor, opacity: 0.75 }} />
           )}


### PR DESCRIPTION
## Summary of Changes

Course preview images were being cropped on catalogue and product-page cards. The cards rendered every upload into a fixed band (16:9, or a fixed pixel height) with `object-cover`, which crops whenever the file's ratio differs from the box — and these are marketing tiles whose corners carry the logo, the class label and the headline, so the crop was destructive.

Two things made it worse than a simple ratio mismatch:

- The catalogue card had **two conflicting ratio sources**: a fixed `h-44` band with `overflow-hidden`, and inside it `CourseImage` wrapping the `<img>` in its own `aspect-video` div. At a ~430px column the inner box wants ~242px while the band clips at 176px, so roughly the bottom quarter was cut on top of the side-crop.
- Uploads reach us off-ratio routinely. Only the Create/Edit Course preview field runs the 2:1 cropper; bulk create and the course-details editor write the media id straight through.

Neither fit works against a fixed band — `cover` crops the corners, `contain` letterboxes and leaves dead space (these tiles carry their own margins). So the product-page cards now measure the artwork and give the band the image's own ratio, at which point the image fills it edge to edge with nothing cropped and nothing padded.

**Frontend:**
- `ProductPageOfferComponent` — `CourseImage` reads `naturalWidth/naturalHeight` on load and sets the band's `aspectRatio`; defaults to 2:1 before load so correctly cropped uploads never reflow, clamped to 1.4–3 so one odd file can't hand a card twice its neighbours' height.
- `PageRenderer` — same measured-ratio band in the product-page checkout `CourseCard`; detail-sheet banner moved from `aspect-video` to 2:1.
- `CourseCatalogComponent` — band `h-44` → `aspect-[2/1] w-full`; the nested `aspect-video` wrappers (image + loading) and `CoursePlaceholder` → `size-full`, so the band is the single ratio source instead of fighting an inner box; skeleton matched. The admin-authored `imageFit: contain` option is untouched and still works.
- `CourseRecommendationsComponent` — thumbnail band → 2:1.
- `ComponentPreviews` (admin page builder) — offer-card preview → 2:1, so the builder reserves the band the learner actually sees.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- Reproduced on `sn.localhost:8100/course-collect` against the Shiksha Nation product page — cards visibly cut the Achievo tile artwork (logo and class label clipped).
- Iterated on the live page through three states: 16:9 `cover` (cropped), 2:1 `cover` (still cropped — proving the uploads match neither ratio), 2:1 `contain` (whole artwork visible but heavily letterboxed), and finally the measured-ratio band (fills the band, nothing cropped, no padding).
- Verified the `Free PDF Notes` and `Free Memory Maps` carousels keep even card heights, and that the CTA rows stay aligned.
- `node scripts/design-lint.mjs` on all five files: no new errors. The inline `aspectRatio` is a warning under the rule's explicitly sanctioned dynamic-value case (isolated and commented).
- All five files parse clean through esbuild.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
