### PR TITLE
feat(support): email the support team when a customer replies

### DIFF
--- a/community_service/src/main/java/vacademy/io/community_service/feature/support/service/SupportAlertService.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/support/service/SupportAlertService.java
@@ -82,6 +82,41 @@ public class SupportAlertService {
     }
 
     /**
+     * The customer replied on an existing ticket: alert Sentry→Slack and email the support
+     * recipients — the same audience as a new ticket (global + institute alert emails + the
+     * institute's assigned engineers), so a reply is never quieter than the ticket it started.
+     */
+    public void onCustomerReply(SupportTicket ticket, String replyBody, String senderName,
+                                List<String> recipientEmails) {
+        try {
+            String summary = String.format("💬 %s replied on %s: %s",
+                    safe(senderName, "Customer"),
+                    safe(ticket.getInstituteName(), ticket.getInstituteId()),
+                    ticket.getSubject());
+
+            Map<String, String> tags = new HashMap<>();
+            tags.put("alert_type", "support_customer_reply");
+            tags.put("priority", String.valueOf(ticket.getPriority()));
+            tags.put("institute_id", String.valueOf(ticket.getInstituteId()));
+            tags.put("ticket_id", String.valueOf(ticket.getId()));
+            SentryLogger.logWarning(summary, tags);
+
+            if (recipientEmails == null || recipientEmails.isEmpty()) {
+                return;
+            }
+            String subject = customerReplySubject(ticket);
+            String body = buildCustomerReplyEmail(ticket, replyBody, senderName);
+            List<EmailUserDto> users = new ArrayList<>();
+            for (String email : recipientEmails) {
+                users.add(recipient(null, email));
+            }
+            sendEmail(subject, body, ticket.getId(), users);
+        } catch (Exception e) {
+            log.error("Failed to dispatch customer-reply alert for {}: {}", ticket.getId(), e.getMessage(), e);
+        }
+    }
+
+    /**
      * A support agent replied: tell the person who raised the ticket, by email and by in-app
      * system alert.
      *
@@ -243,6 +278,32 @@ public class SupportAlertService {
                 + escape(firstMessageBody) + "</div>";
 
         return shell("New support issue", ticket, body,
+                "Open it in the support console to reply.");
+    }
+
+    /**
+     * The team-facing alert when a customer replies. Same triage chrome as the new-ticket mail;
+     * the content is who spoke and what they said, with the ticket's post-reply status — a reply
+     * can silently reopen a resolved ticket, and that is exactly what the reader needs to notice.
+     */
+    private String buildCustomerReplyEmail(SupportTicket ticket, String replyBody, String senderName) {
+        String meta = metaRow("Institute", safe(ticket.getInstituteName(), ticket.getInstituteId()))
+                + metaRow("From", safe(senderName, "Customer"))
+                + metaRow("Status", String.valueOf(ticket.getStatus()))
+                + metaRow("Category", String.valueOf(ticket.getCategory()));
+
+        String body =
+                priorityPill(ticket)
+                + "<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\""
+                + " style=\"width:100%;margin:0 0 16px;font-size:14px;line-height:1.6\">"
+                + meta + "</table>"
+                + "<div style=\"margin:0 0 4px;font-size:13px;font-weight:600;color:#6b7280\">"
+                + "Their reply</div>"
+                + "<div style=\"margin:0;padding:2px 0 2px 14px;border-left:3px solid " + BRAND + ";"
+                + "font-size:15px;line-height:1.6;color:#111827;white-space:pre-wrap\">"
+                + escape(replyBody) + "</div>";
+
+        return shell("Customer replied", ticket, body,
                 "Open it in the support console to reply.");
     }
 
@@ -427,6 +488,14 @@ public class SupportAlertService {
 
     String replySubject(SupportTicket ticket) {
         return "Re: " + ticket.getSubject() + " [" + reference(ticket) + "]";
+    }
+
+    /** Team-facing: who spoke leads, mirroring {@link #newTicketSubject}'s institute-first order. */
+    String customerReplySubject(SupportTicket ticket) {
+        return String.format("Reply · %s · %s [%s]",
+                safe(ticket.getInstituteName(), ticket.getInstituteId()),
+                ticket.getSubject(),
+                reference(ticket));
     }
 
     String resolvedSubject(SupportTicket ticket) {

--- a/community_service/src/main/java/vacademy/io/community_service/feature/support/service/SupportTicketService.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/support/service/SupportTicketService.java
@@ -183,6 +183,9 @@ public class SupportTicketService {
         ticket.setMessageCount(ticket.getMessageCount() + 1);
         ticketRepository.save(ticket);
 
+        alertService.onCustomerReply(ticket, alertBody(body, request.getAttachments()),
+                message.getSenderName(), configService.resolveAlertEmails(instituteId));
+
         return toDetailDto(ticket, false);
     }
 


### PR DESCRIPTION
## Problem

When a client replies on a support ticket, nothing notifies the support team — `addCustomerMessage` saved the message and updated the ticket status, but never called the alert service. Only **new** tickets emailed the team, so client replies sat unseen until someone happened to open the health dashboard.

Real case: on VAC-130 (Shiksha Nation), the client replied on Aug 7 and the team only noticed by opening the board.

## Change

`addCustomerMessage` now fans out through a new `SupportAlertService.onCustomerReply`, mirroring the new-ticket alert:

- **Email** to the same audience as `onNewTicket` — global alert emails + the institute's alert emails + its assigned engineers (via `resolveAlertEmails`).
- **Sentry→Slack** warning tagged `support_customer_reply`.
- Subject follows the team-facing convention: `Reply · <Institute> · <Subject> [VAC-xxx]`.
- The mail shows the ticket's **post-reply status** — a customer reply silently reopens a resolved/closed ticket, and that transition is exactly what the reader needs to notice.
- Best-effort like every other dispatch: an alert failure never breaks the reply itself.

## Notes

- No behavior change for customer-facing mails (support replies / resolution).
- `mvn compile` passes; the module has no test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)