### PR TITLE
Add BBB participant restriction settings to live classes

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep1RequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/LiveSessionStep1RequestDTO.java
@@ -89,6 +89,13 @@ public class LiveSessionStep1RequestDTO {
         private Boolean muteOnStart;
         private Boolean webcamsOnlyForModerator;
         private String guestPolicy;
+        // Lock settings — restrict viewers (students) only; moderators are unaffected
+        private Boolean disablePrivateChat;
+        private Boolean disablePublicChat;
+        private Boolean disableSharedNotes;
+        private Boolean hideUserList;
+        // Auto-end the meeting shortly after the last moderator leaves
+        private Boolean endWhenNoModerator;
     }
 
     @Data

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/manager/BbbMeetingManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/manager/BbbMeetingManager.java
@@ -211,6 +211,13 @@ public class BbbMeetingManager implements LiveSessionProviderStrategy {
         // via the provider config keys below.
         int meetingCameraCap = intOrDefault(bbbCfg, "meeting_camera_cap", 20);
         int userCameraCap = intOrDefault(bbbCfg, "user_camera_cap", 3);
+        // Lock settings restrict VIEWERS (students) only — moderators keep full
+        // access, e.g. a teacher can still private-message a locked student.
+        boolean disablePrivateChat = boolOrDefault(bbbCfg, "disable_private_chat", false);
+        boolean disablePublicChat = boolOrDefault(bbbCfg, "disable_public_chat", false);
+        boolean disableSharedNotes = boolOrDefault(bbbCfg, "disable_shared_notes", false);
+        boolean hideUserList = boolOrDefault(bbbCfg, "hide_user_list", false);
+        boolean endWhenNoModerator = boolOrDefault(bbbCfg, "end_when_no_moderator", false);
 
         Map<String, String> params = new LinkedHashMap<>();
         params.put("name", request.getTopic() != null ? request.getTopic() : instituteName + " Live Class");
@@ -223,6 +230,18 @@ public class BbbMeetingManager implements LiveSessionProviderStrategy {
         params.put("meetingCameraCap", String.valueOf(meetingCameraCap));
         params.put("userCameraCap", String.valueOf(userCameraCap));
         params.put("guestPolicy", guestPolicy);
+        params.put("lockSettingsDisablePrivateChat", String.valueOf(disablePrivateChat));
+        params.put("lockSettingsDisablePublicChat", String.valueOf(disablePublicChat));
+        params.put("lockSettingsDisableNotes", String.valueOf(disableSharedNotes));
+        params.put("lockSettingsHideUserList", String.valueOf(hideUserList));
+        // Auto-end after the last moderator leaves — saves server capacity when a
+        // teacher forgets to end the class. Delay gives them room to rejoin after
+        // a network drop without killing the meeting for everyone.
+        if (endWhenNoModerator) {
+            params.put("endWhenNoModerator", "true");
+            params.put("endWhenNoModeratorDelayInMinutes",
+                    String.valueOf(intOrDefault(bbbCfg, "end_when_no_moderator_delay_minutes", 10)));
+        }
         params.put("welcome", "");
 
         // Institute branding

--- a/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
@@ -640,8 +640,8 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                     />
                     <Separator />
                     <SettingRow
-                        title="Mute participants on join"
-                        description="Learners join muted by default."
+                        title="Mute participants when they join"
+                        description="Everyone except the host joins muted."
                         checked={settings.defaultBbbMuteOnStart}
                         onChange={(v) => togglePrimitive('defaultBbbMuteOnStart', v)}
                     />
@@ -677,12 +677,47 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                             <SelectContent>
                                 <SelectItem value="ALWAYS_ACCEPT">Always accept</SelectItem>
                                 <SelectItem value="ASK_MODERATOR">
-                                    Ask moderator to approve
+                                    Ask host to approve
                                 </SelectItem>
                                 <SelectItem value="ALWAYS_DENY">Always deny guests</SelectItem>
                             </SelectContent>
                         </Select>
                     </div>
+                    <Separator />
+                    <SettingRow
+                        title="Participants can't private message each other"
+                        description="Blocks private chat between participants. The host can still message anyone."
+                        checked={settings.defaultBbbDisablePrivateChat}
+                        onChange={(v) => togglePrimitive('defaultBbbDisablePrivateChat', v)}
+                    />
+                    <Separator />
+                    <SettingRow
+                        title="Participants can't send messages in class chat"
+                        description="Participants can read the class chat but not type in it. The host can still send messages."
+                        checked={settings.defaultBbbDisablePublicChat}
+                        onChange={(v) => togglePrimitive('defaultBbbDisablePublicChat', v)}
+                    />
+                    <Separator />
+                    <SettingRow
+                        title="Participants can't edit shared notes"
+                        description="Participants can view the shared notes but not change them."
+                        checked={settings.defaultBbbDisableSharedNotes}
+                        onChange={(v) => togglePrimitive('defaultBbbDisableSharedNotes', v)}
+                    />
+                    <Separator />
+                    <SettingRow
+                        title="Participants can't see who else is in the class"
+                        description="Hides the participant list from everyone except the host."
+                        checked={settings.defaultBbbHideUserList}
+                        onChange={(v) => togglePrimitive('defaultBbbHideUserList', v)}
+                    />
+                    <Separator />
+                    <SettingRow
+                        title="End class automatically after the host leaves"
+                        description="The class ends about 10 minutes after the last host leaves, so it never runs unattended."
+                        checked={settings.defaultBbbEndWhenNoModerator}
+                        onChange={(v) => togglePrimitive('defaultBbbEndWhenNoModerator', v)}
+                    />
                 </CardContent>
             </Card>
 

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/-constants/helper.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/-constants/helper.ts
@@ -56,6 +56,12 @@ export interface BbbMeetingConfig {
     mute_on_start?: boolean;
     webcams_only_for_moderator?: boolean;
     guest_policy?: string;
+    // Lock settings — restrict students only; the host keeps full access
+    disable_private_chat?: boolean;
+    disable_public_chat?: boolean;
+    disable_shared_notes?: boolean;
+    hide_user_list?: boolean;
+    end_when_no_moderator?: boolean;
 }
 
 export interface FeedbackQuestionConfig {
@@ -339,6 +345,11 @@ export function transformFormToDTOStep1(
         bbbMuteOnStart,
         bbbWebcamsOnlyForModerator,
         bbbGuestPolicy,
+        bbbDisablePrivateChat,
+        bbbDisablePublicChat,
+        bbbDisableSharedNotes,
+        bbbHideUserList,
+        bbbEndWhenNoModerator,
         feedbackEnabled,
         feedbackCompulsory,
         feedbackQuestions,
@@ -422,6 +433,11 @@ export function transformFormToDTOStep1(
             mute_on_start: bbbMuteOnStart ?? true,
             webcams_only_for_moderator: bbbWebcamsOnlyForModerator ?? false,
             guest_policy: bbbGuestPolicy ?? 'ALWAYS_ACCEPT',
+            disable_private_chat: bbbDisablePrivateChat ?? false,
+            disable_public_chat: bbbDisablePublicChat ?? false,
+            disable_shared_notes: bbbDisableSharedNotes ?? false,
+            hide_user_list: bbbHideUserList ?? false,
+            end_when_no_moderator: bbbEndWhenNoModerator ?? false,
         } : null,
         feedback_config: feedbackEnabled ? {
             enabled: true,

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/-services/utils.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/-services/utils.ts
@@ -118,6 +118,11 @@ export interface Schedule {
         mute_on_start?: boolean;
         webcams_only_for_moderator?: boolean;
         guest_policy?: string;
+        disable_private_chat?: boolean;
+        disable_public_chat?: boolean;
+        disable_shared_notes?: boolean;
+        hide_user_list?: boolean;
+        end_when_no_moderator?: boolean;
     } | null;
     feedback_config?: {
         enabled?: boolean;

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/BulkScheduleGrid.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/BulkScheduleGrid.tsx
@@ -335,6 +335,11 @@ export function BulkScheduleGrid() {
                 webcamsOnlyForModerator:
                     liveSessionSettings.defaultBbbWebcamsOnlyForModerator ?? false,
                 guestPolicy: liveSessionSettings.defaultBbbGuestPolicy ?? 'ALWAYS_ACCEPT',
+                disablePrivateChat: liveSessionSettings.defaultBbbDisablePrivateChat ?? false,
+                disablePublicChat: liveSessionSettings.defaultBbbDisablePublicChat ?? false,
+                disableSharedNotes: liveSessionSettings.defaultBbbDisableSharedNotes ?? false,
+                hideUserList: liveSessionSettings.defaultBbbHideUserList ?? false,
+                endWhenNoModerator: liveSessionSettings.defaultBbbEndWhenNoModerator ?? false,
                 defaultPlatform: initialPlatform,
                 defaultDescription: '',
             },
@@ -794,6 +799,39 @@ export function BulkScheduleGrid() {
         ) {
             form.setValue('sharedOptions.guestPolicy', bbbGuestDefault);
         }
+        const snapBbbLockBool = (
+            name:
+                | 'sharedOptions.disablePrivateChat'
+                | 'sharedOptions.disablePublicChat'
+                | 'sharedOptions.disableSharedNotes'
+                | 'sharedOptions.hideUserList'
+                | 'sharedOptions.endWhenNoModerator',
+            def: boolean
+        ) => {
+            if (!form.getFieldState(name).isDirty && form.getValues(name) !== def) {
+                form.setValue(name, def);
+            }
+        };
+        snapBbbLockBool(
+            'sharedOptions.disablePrivateChat',
+            liveSessionSettings.defaultBbbDisablePrivateChat ?? false
+        );
+        snapBbbLockBool(
+            'sharedOptions.disablePublicChat',
+            liveSessionSettings.defaultBbbDisablePublicChat ?? false
+        );
+        snapBbbLockBool(
+            'sharedOptions.disableSharedNotes',
+            liveSessionSettings.defaultBbbDisableSharedNotes ?? false
+        );
+        snapBbbLockBool(
+            'sharedOptions.hideUserList',
+            liveSessionSettings.defaultBbbHideUserList ?? false
+        );
+        snapBbbLockBool(
+            'sharedOptions.endWhenNoModerator',
+            liveSessionSettings.defaultBbbEndWhenNoModerator ?? false
+        );
     }, [
         liveSessionSettings.feedbackEnabled,
         liveSessionSettings.defaultFeedbackEnabled,
@@ -808,6 +846,11 @@ export function BulkScheduleGrid() {
         liveSessionSettings.defaultBbbMuteOnStart,
         liveSessionSettings.defaultBbbWebcamsOnlyForModerator,
         liveSessionSettings.defaultBbbGuestPolicy,
+        liveSessionSettings.defaultBbbDisablePrivateChat,
+        liveSessionSettings.defaultBbbDisablePublicChat,
+        liveSessionSettings.defaultBbbDisableSharedNotes,
+        liveSessionSettings.defaultBbbHideUserList,
+        liveSessionSettings.defaultBbbEndWhenNoModerator,
         form,
     ]);
 
@@ -968,6 +1011,11 @@ export function BulkScheduleGrid() {
                         ? shared.webcamsOnlyForModerator
                         : undefined,
                     bbbGuestPolicy: isBbb ? shared.guestPolicy : undefined,
+                    bbbDisablePrivateChat: isBbb ? shared.disablePrivateChat : undefined,
+                    bbbDisablePublicChat: isBbb ? shared.disablePublicChat : undefined,
+                    bbbDisableSharedNotes: isBbb ? shared.disableSharedNotes : undefined,
+                    bbbHideUserList: isBbb ? shared.hideUserList : undefined,
+                    bbbEndWhenNoModerator: isBbb ? shared.endWhenNoModerator : undefined,
                 };
                 const dto = transformFormToDTOStep1(
                     synthetic,
@@ -1703,7 +1751,7 @@ export function BulkScheduleGrid() {
                                     name="sharedOptions.muteOnStart"
                                     render={({ field }) => (
                                         <label className="flex items-center justify-between text-sm">
-                                            <span>Mute participants on join</span>
+                                            <span>Mute participants when they join</span>
                                             <Switch
                                                 checked={field.value}
                                                 onCheckedChange={field.onChange}
@@ -1742,7 +1790,7 @@ export function BulkScheduleGrid() {
                                                         Always accept
                                                     </SelectItem>
                                                     <SelectItem value="ASK_MODERATOR">
-                                                        Ask moderator to approve
+                                                        Ask host to approve
                                                     </SelectItem>
                                                     <SelectItem value="ALWAYS_DENY">
                                                         Always deny guests
@@ -1754,6 +1802,80 @@ export function BulkScheduleGrid() {
                                 </div>
                             </div>
                         )}
+                        {/* Lock settings apply regardless of recording, so they sit
+                            outside the recordSession conditional above. */}
+                        <div className="mt-3 border-t border-neutral-200 pt-3">
+                            <div className="text-xs font-medium text-neutral-600">
+                                Participant restrictions — the host always keeps full access
+                            </div>
+                            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                                <Controller
+                                    control={form.control}
+                                    name="sharedOptions.disablePrivateChat"
+                                    render={({ field }) => (
+                                        <label className="flex items-center justify-between text-sm">
+                                            <span>Participants can&apos;t private message each other</span>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </label>
+                                    )}
+                                />
+                                <Controller
+                                    control={form.control}
+                                    name="sharedOptions.disablePublicChat"
+                                    render={({ field }) => (
+                                        <label className="flex items-center justify-between text-sm">
+                                            <span>Participants can&apos;t send messages in class chat</span>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </label>
+                                    )}
+                                />
+                                <Controller
+                                    control={form.control}
+                                    name="sharedOptions.disableSharedNotes"
+                                    render={({ field }) => (
+                                        <label className="flex items-center justify-between text-sm">
+                                            <span>Participants can&apos;t edit shared notes</span>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </label>
+                                    )}
+                                />
+                                <Controller
+                                    control={form.control}
+                                    name="sharedOptions.hideUserList"
+                                    render={({ field }) => (
+                                        <label className="flex items-center justify-between text-sm">
+                                            <span>Participants can&apos;t see who else is in the class</span>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </label>
+                                    )}
+                                />
+                                <Controller
+                                    control={form.control}
+                                    name="sharedOptions.endWhenNoModerator"
+                                    render={({ field }) => (
+                                        <label className="flex items-center justify-between text-sm">
+                                            <span>End class after the host leaves</span>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </label>
+                                    )}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </SectionCard>

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/scheduleStep1.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-components/scheduleStep1.tsx
@@ -293,6 +293,11 @@ export default function ScheduleStep1() {
             bbbWebcamsOnlyForModerator:
                 liveSessionSettings.defaultBbbWebcamsOnlyForModerator ?? false,
             bbbGuestPolicy: liveSessionSettings.defaultBbbGuestPolicy ?? 'ALWAYS_ACCEPT',
+            bbbDisablePrivateChat: liveSessionSettings.defaultBbbDisablePrivateChat ?? false,
+            bbbDisablePublicChat: liveSessionSettings.defaultBbbDisablePublicChat ?? false,
+            bbbDisableSharedNotes: liveSessionSettings.defaultBbbDisableSharedNotes ?? false,
+            bbbHideUserList: liveSessionSettings.defaultBbbHideUserList ?? false,
+            bbbEndWhenNoModerator: liveSessionSettings.defaultBbbEndWhenNoModerator ?? false,
             // Zoom meeting defaults (only used when platform = Zoom with an account).
             // Seeding them here means the Zoom settings panel and the step-2 DTO
             // builder both read the institute defaults without extra wiring.
@@ -432,6 +437,36 @@ export default function ScheduleStep1() {
         ) {
             form.setValue('bbbGuestPolicy', bbbGuestDefault);
         }
+        const snapBbbLockBool = (
+            name:
+                | 'bbbDisablePrivateChat'
+                | 'bbbDisablePublicChat'
+                | 'bbbDisableSharedNotes'
+                | 'bbbHideUserList'
+                | 'bbbEndWhenNoModerator',
+            def: boolean
+        ) => {
+            if (!form.getFieldState(name).isDirty && form.getValues(name) !== def) {
+                form.setValue(name, def);
+            }
+        };
+        snapBbbLockBool(
+            'bbbDisablePrivateChat',
+            liveSessionSettings.defaultBbbDisablePrivateChat ?? false
+        );
+        snapBbbLockBool(
+            'bbbDisablePublicChat',
+            liveSessionSettings.defaultBbbDisablePublicChat ?? false
+        );
+        snapBbbLockBool(
+            'bbbDisableSharedNotes',
+            liveSessionSettings.defaultBbbDisableSharedNotes ?? false
+        );
+        snapBbbLockBool('bbbHideUserList', liveSessionSettings.defaultBbbHideUserList ?? false);
+        snapBbbLockBool(
+            'bbbEndWhenNoModerator',
+            liveSessionSettings.defaultBbbEndWhenNoModerator ?? false
+        );
     }, [
         liveSessionSettings.feedbackEnabled,
         liveSessionSettings.defaultFeedbackEnabled,
@@ -446,6 +481,11 @@ export default function ScheduleStep1() {
         liveSessionSettings.defaultBbbMuteOnStart,
         liveSessionSettings.defaultBbbWebcamsOnlyForModerator,
         liveSessionSettings.defaultBbbGuestPolicy,
+        liveSessionSettings.defaultBbbDisablePrivateChat,
+        liveSessionSettings.defaultBbbDisablePublicChat,
+        liveSessionSettings.defaultBbbDisableSharedNotes,
+        liveSessionSettings.defaultBbbHideUserList,
+        liveSessionSettings.defaultBbbEndWhenNoModerator,
         isEdit,
         form,
     ]);
@@ -863,6 +903,11 @@ export default function ScheduleStep1() {
             bbbMuteOnStart: schedule.bbb_config?.mute_on_start ?? true,
             bbbWebcamsOnlyForModerator: schedule.bbb_config?.webcams_only_for_moderator ?? false,
             bbbGuestPolicy: (schedule.bbb_config?.guest_policy as 'ALWAYS_ACCEPT' | 'ASK_MODERATOR' | 'ALWAYS_DENY') ?? 'ALWAYS_ACCEPT',
+            bbbDisablePrivateChat: schedule.bbb_config?.disable_private_chat ?? false,
+            bbbDisablePublicChat: schedule.bbb_config?.disable_public_chat ?? false,
+            bbbDisableSharedNotes: schedule.bbb_config?.disable_shared_notes ?? false,
+            bbbHideUserList: schedule.bbb_config?.hide_user_list ?? false,
+            bbbEndWhenNoModerator: schedule.bbb_config?.end_when_no_moderator ?? false,
             feedbackEnabled: schedule.feedback_config?.enabled ?? false,
             feedbackCompulsory: schedule.feedback_config?.allow_skip === false,
             feedbackQuestions: schedule.feedback_config?.questions ?? DEFAULT_FEEDBACK_QUESTIONS,
@@ -2387,7 +2432,11 @@ export default function ScheduleStep1() {
             {/* BBB Meeting Configuration */}
             {isBbbPlatform && (
                 <div className="rounded-lg border border-primary-200 bg-primary-50/30 p-4">
-                    <h4 className="mb-3 text-sm font-semibold">Vacademy Meet Settings</h4>
+                    <h4 className="text-sm font-semibold">Vacademy Meet Settings</h4>
+                    <p className="mb-3 mt-0.5 text-xs text-neutral-500">
+                        Restrictions apply to participants only — the host always keeps full
+                        access.
+                    </p>
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <FormField
                             control={control}
@@ -2436,7 +2485,7 @@ export default function ScheduleStep1() {
                                             className="size-4 rounded border-gray-300"
                                         />
                                     </FormControl>
-                                    <FormLabel className="text-sm font-normal">Mute participants on join</FormLabel>
+                                    <FormLabel className="text-sm font-normal">Mute participants when they join</FormLabel>
                                 </FormItem>
                             )}
                         />
@@ -2457,6 +2506,91 @@ export default function ScheduleStep1() {
                                 </FormItem>
                             )}
                         />
+                        <FormField
+                            control={control}
+                            name="bbbDisablePrivateChat"
+                            render={({ field }) => (
+                                <FormItem className="flex items-center gap-2 space-y-0">
+                                    <FormControl>
+                                        <input
+                                            type="checkbox"
+                                            checked={field.value ?? false}
+                                            onChange={(e) => field.onChange(e.target.checked)}
+                                            className="size-4 rounded border-gray-300"
+                                        />
+                                    </FormControl>
+                                    <FormLabel className="text-sm font-normal">Participants can&apos;t private message each other</FormLabel>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={control}
+                            name="bbbDisablePublicChat"
+                            render={({ field }) => (
+                                <FormItem className="flex items-center gap-2 space-y-0">
+                                    <FormControl>
+                                        <input
+                                            type="checkbox"
+                                            checked={field.value ?? false}
+                                            onChange={(e) => field.onChange(e.target.checked)}
+                                            className="size-4 rounded border-gray-300"
+                                        />
+                                    </FormControl>
+                                    <FormLabel className="text-sm font-normal">Participants can&apos;t send messages in class chat</FormLabel>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={control}
+                            name="bbbDisableSharedNotes"
+                            render={({ field }) => (
+                                <FormItem className="flex items-center gap-2 space-y-0">
+                                    <FormControl>
+                                        <input
+                                            type="checkbox"
+                                            checked={field.value ?? false}
+                                            onChange={(e) => field.onChange(e.target.checked)}
+                                            className="size-4 rounded border-gray-300"
+                                        />
+                                    </FormControl>
+                                    <FormLabel className="text-sm font-normal">Participants can&apos;t edit shared notes</FormLabel>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={control}
+                            name="bbbHideUserList"
+                            render={({ field }) => (
+                                <FormItem className="flex items-center gap-2 space-y-0">
+                                    <FormControl>
+                                        <input
+                                            type="checkbox"
+                                            checked={field.value ?? false}
+                                            onChange={(e) => field.onChange(e.target.checked)}
+                                            className="size-4 rounded border-gray-300"
+                                        />
+                                    </FormControl>
+                                    <FormLabel className="text-sm font-normal">Participants can&apos;t see who else is in the class</FormLabel>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={control}
+                            name="bbbEndWhenNoModerator"
+                            render={({ field }) => (
+                                <FormItem className="flex items-center gap-2 space-y-0">
+                                    <FormControl>
+                                        <input
+                                            type="checkbox"
+                                            checked={field.value ?? false}
+                                            onChange={(e) => field.onChange(e.target.checked)}
+                                            className="size-4 rounded border-gray-300"
+                                        />
+                                    </FormControl>
+                                    <FormLabel className="text-sm font-normal">End class automatically after the host leaves</FormLabel>
+                                </FormItem>
+                            )}
+                        />
                     </div>
                     <div className="mt-3">
                         <FormField
@@ -2472,7 +2606,7 @@ export default function ScheduleStep1() {
                                             className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 sm:w-64"
                                         >
                                             <option value="ALWAYS_ACCEPT">Always accept</option>
-                                            <option value="ASK_MODERATOR">Ask moderator to approve</option>
+                                            <option value="ASK_MODERATOR">Ask host to approve</option>
                                             <option value="ALWAYS_DENY">Always deny guests</option>
                                         </select>
                                     </FormControl>

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-schema/bulkSchema.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-schema/bulkSchema.ts
@@ -142,6 +142,16 @@ export const bulkSharedOptionsSchema = z.object({
     guestPolicy: z
         .enum(['ALWAYS_ACCEPT', 'ASK_MODERATOR', 'ALWAYS_DENY'])
         .default('ALWAYS_ACCEPT'),
+    /** Students cannot start private chats (the host still can message them). */
+    disablePrivateChat: z.boolean().default(false),
+    /** Students cannot type in the public chat. */
+    disablePublicChat: z.boolean().default(false),
+    /** Students cannot edit the shared notes. */
+    disableSharedNotes: z.boolean().default(false),
+    /** Students cannot see the participant list. */
+    hideUserList: z.boolean().default(false),
+    /** Auto-end the meeting shortly after the last moderator leaves. */
+    endWhenNoModerator: z.boolean().default(false),
     /**
      * Default streaming platform for new rows. The "Add row" button stamps
      * each new row's platform with this value so admins don't have to set it

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-schema/schema.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/schedule/-schema/schema.ts
@@ -103,6 +103,12 @@ export const sessionFormSchema = z
         bbbMuteOnStart: z.boolean().optional(),
         bbbWebcamsOnlyForModerator: z.boolean().optional(),
         bbbGuestPolicy: z.enum(['ALWAYS_ACCEPT', 'ASK_MODERATOR', 'ALWAYS_DENY']).optional(),
+        // Lock settings — restrict students only; the host keeps full access
+        bbbDisablePrivateChat: z.boolean().optional(),
+        bbbDisablePublicChat: z.boolean().optional(),
+        bbbDisableSharedNotes: z.boolean().optional(),
+        bbbHideUserList: z.boolean().optional(),
+        bbbEndWhenNoModerator: z.boolean().optional(),
         // Zoom meeting configuration (only used when sessionPlatform = 'zoom' and an
         // account is selected). When no account is chosen, Zoom falls back to the
         // manual defaultLink paste just like YouTube/Meet/Other.

--- a/frontend-admin-dashboard/src/services/live-session-settings.ts
+++ b/frontend-admin-dashboard/src/services/live-session-settings.ts
@@ -174,6 +174,16 @@ export interface LiveSessionSettings {
     defaultBbbWebcamsOnlyForModerator: boolean;
     /** Default guest admission policy. */
     defaultBbbGuestPolicy: LiveSessionGuestPolicy;
+    /** Default "disable private chat for students" toggle (host is unaffected). */
+    defaultBbbDisablePrivateChat: boolean;
+    /** Default "disable public chat for students" toggle (host is unaffected). */
+    defaultBbbDisablePublicChat: boolean;
+    /** Default "disable shared notes for students" toggle (host is unaffected). */
+    defaultBbbDisableSharedNotes: boolean;
+    /** Default "hide participant list from students" toggle (host is unaffected). */
+    defaultBbbHideUserList: boolean;
+    /** Default "end class when host leaves" toggle. */
+    defaultBbbEndWhenNoModerator: boolean;
     /**
      * Defaults for the "Notifications" block (channels + triggers) applied to
      * new live classes in both single-class step 2 and the bulk grid. Admins
@@ -271,6 +281,11 @@ export const DEFAULT_LIVE_SESSION_SETTINGS: LiveSessionSettings = {
     defaultBbbMuteOnStart: true,
     defaultBbbWebcamsOnlyForModerator: false,
     defaultBbbGuestPolicy: 'ALWAYS_ACCEPT',
+    defaultBbbDisablePrivateChat: false,
+    defaultBbbDisablePublicChat: false,
+    defaultBbbDisableSharedNotes: false,
+    defaultBbbHideUserList: false,
+    defaultBbbEndWhenNoModerator: false,
     defaultNotifyByEmail: false,
     defaultNotifyByWhatsapp: false,
     defaultNotifyByPush: false,


### PR DESCRIPTION
New per-class Vacademy Meet (BBB) settings, wired end-to-end:
- Participants can't private message each other (lockSettingsDisablePrivateChat)
- Participants can't send messages in class chat (lockSettingsDisablePublicChat)
- Participants can't edit shared notes (lockSettingsDisableNotes)
- Participants can't see who else is in the class (lockSettingsHideUserList)
- End class automatically after the host leaves (endWhenNoModerator, 10 min delay)

Restrictions apply to viewers only; the host keeps full access. Old sessions without the new keys behave exactly as before (all default off).

Exposed in single-class step 1, the bulk schedule grid, and as institute-level defaults in Settings -> Live Session (stored in the existing settings JSON, so no migration needed). Labels use plain "Participants can't ..." wording.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
