### PR TITLE
feat(learner): in-place mentor chat drawer on My Mentors

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/my-mentors/-components/MentorCard.tsx
+++ b/frontend-learner-dashboard-app/src/routes/my-mentors/-components/MentorCard.tsx
@@ -1,22 +1,21 @@
-import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { CalendarPlus, ChatCircle } from "@phosphor-icons/react";
-import { toast } from "sonner";
 import { MyButton } from "@/components/design-system/button";
 import { ModernCard, ModernCardContent } from "@/components/design-system/modern-card";
-import { openDirectConversation } from "@/services/chat/chatApi";
 import type { MyMentor } from "../-services/my-mentors-service";
 import { MentorAvatar } from "./MentorAvatar";
 
 export function MentorCard({
     mentor,
     instituteId,
+    onMessage,
 }: {
     mentor: MyMentor;
     instituteId: string | undefined;
+    /** Open the in-place chat drawer for this mentor. */
+    onMessage: (mentor: MyMentor) => void;
 }) {
     const navigate = useNavigate();
-    const [messaging, setMessaging] = useState(false);
     const canBook = !!mentor.booking_page_slug && !!instituteId;
 
     const book = () => {
@@ -25,22 +24,6 @@ export function MentorCard({
             to: "/booking-response",
             search: { instituteId, slug: mentor.booking_page_slug, authed: "1" },
         });
-    };
-
-    const message = async () => {
-        setMessaging(true);
-        try {
-            const conv = await openDirectConversation({
-                targetUserId: mentor.user_id,
-                targetUserName: mentor.name ?? undefined,
-                targetUserRole: "TEACHER",
-            });
-            navigate({ to: "/chat", search: { conversationId: conv.id } });
-        } catch {
-            toast.error("Couldn't open the chat. Please try again.");
-        } finally {
-            setMessaging(false);
-        }
     };
 
     return (
@@ -85,8 +68,7 @@ export function MentorCard({
                                 type="button"
                                 buttonType="secondary"
                                 scale="medium"
-                                onClick={message}
-                                disable={messaging}
+                                onClick={() => onMessage(mentor)}
                                 className="flex-1"
                             >
                                 <ChatCircle size={16} /> Message

--- a/frontend-learner-dashboard-app/src/routes/my-mentors/-components/MentorChatSheet.tsx
+++ b/frontend-learner-dashboard-app/src/routes/my-mentors/-components/MentorChatSheet.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { CircleNotch } from "@phosphor-icons/react";
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet";
+import { ChatScreen } from "@/components/chat/ChatScreen";
+import { openDirectConversation } from "@/services/chat/chatApi";
+import type { MyMentor } from "../-services/my-mentors-service";
+import { MentorAvatar } from "./MentorAvatar";
+
+/**
+ * In-place mentor chat: opens the direct conversation with the mentor in a
+ * right-side drawer so the learner chats without leaving My Mentors (the
+ * In-App Messages tab may not even be visible in their sidebar).
+ */
+export function MentorChatSheet({
+    mentor,
+    open,
+    onOpenChange,
+}: {
+    mentor: MyMentor | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [conversationId, setConversationId] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!open || !mentor) return;
+        let cancelled = false;
+        setConversationId(null);
+        openDirectConversation({
+            targetUserId: mentor.user_id,
+            targetUserName: mentor.display_name || mentor.name || undefined,
+            targetUserRole: "TEACHER",
+        })
+            .then((conv) => {
+                if (!cancelled) setConversationId(conv.id);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    toast.error("Couldn't open the chat. Please try again.");
+                    onOpenChange(false);
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, mentor?.user_id]);
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-3xl">
+                {/* h-14 (3.5rem) matches ChatScreen's own height calc, so the
+                    thread fills the rest of the drawer exactly. */}
+                <SheetHeader className="h-14 shrink-0 flex-row items-center gap-3 space-y-0 border-b border-border px-4 text-start">
+                    <MentorAvatar
+                        fileId={mentor?.profile_image_file_id || mentor?.profile_pic_file_id}
+                        name={mentor?.display_name || mentor?.name}
+                        className="size-8 text-caption"
+                    />
+                    <div className="flex min-w-0 flex-col">
+                        <SheetTitle className="truncate text-body font-semibold text-neutral-700">
+                            {mentor?.display_name || mentor?.name || "Mentor"}
+                        </SheetTitle>
+                        <SheetDescription className="truncate text-caption text-neutral-500">
+                            {mentor?.title || "Your mentor"}
+                        </SheetDescription>
+                    </div>
+                </SheetHeader>
+                {conversationId ? (
+                    <ChatScreen initialConversationId={conversationId} />
+                ) : (
+                    <div className="flex flex-1 flex-col items-center justify-center gap-2 text-neutral-400">
+                        <CircleNotch size={24} className="animate-spin" />
+                        <span className="text-caption">Opening chat…</span>
+                    </div>
+                )}
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/frontend-learner-dashboard-app/src/routes/my-mentors/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/my-mentors/index.tsx
@@ -5,8 +5,9 @@ import { UsersThree } from "@phosphor-icons/react";
 import { LayoutContainer } from "@/components/common/layout-container/layout-container";
 import { EmptyState, ErrorState, LoadingState } from "@/components/design-system/states";
 import { getInstituteId } from "@/constants/helper";
-import { handleGetMyMentors } from "./-services/my-mentors-service";
+import { handleGetMyMentors, type MyMentor } from "./-services/my-mentors-service";
 import { MentorCard } from "./-components/MentorCard";
+import { MentorChatSheet } from "./-components/MentorChatSheet";
 
 export const Route = createFileRoute("/my-mentors/")({
     component: MyMentorsRoute,
@@ -22,6 +23,8 @@ function MyMentorsRoute() {
 
 function MyMentorsPage() {
     const [instituteId, setInstituteId] = useState<string | undefined>();
+    // Mentor whose chat drawer is open — chat happens without leaving this page.
+    const [chatMentor, setChatMentor] = useState<MyMentor | null>(null);
 
     useEffect(() => {
         getInstituteId().then((id) => setInstituteId(id ?? undefined));
@@ -52,10 +55,23 @@ function MyMentorsPage() {
             ) : (
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     {mentors.map((m) => (
-                        <MentorCard key={m.id} mentor={m} instituteId={instituteId} />
+                        <MentorCard
+                            key={m.id}
+                            mentor={m}
+                            instituteId={instituteId}
+                            onMessage={setChatMentor}
+                        />
                     ))}
                 </div>
             )}
+
+            <MentorChatSheet
+                mentor={chatMentor}
+                open={!!chatMentor}
+                onOpenChange={(o) => {
+                    if (!o) setChatMentor(null);
+                }}
+            />
         </div>
     );
 }


### PR DESCRIPTION
Message now opens the direct mentor conversation in a right-side drawer on the same page (mentor name + photo in the header, full chat thread below) instead of navigating to In-App Messages — which may not even be visible in the learner's sidebar. Booking stays as-is; chat-disabled institutes get ChatScreen's own 'messaging isn't available' fallback inside the drawer.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
