### PR TITLE
fix: stop stripping <p> tags from question/option HTML on save

### DIFF
--- a/frontend-admin-dashboard/src/routes/assessment/assessment-list/assessment-details/$assessmentId/$examType/$assesssmentType/$assessmentTab/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/assessment-list/assessment-details/$assessmentId/$examType/$assesssmentType/$assessmentTab/-utils/helper.ts
@@ -578,7 +578,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                           text: {
                               id: null, // Assuming no direct mapping for option text ID
                               type: 'HTML', // Assuming option content is HTML
-                              content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                              content: opt?.name,
                           },
                           media_id: String(opt?.image?.imageName), // Assuming no direct mapping for option media ID
                           option_order: null,
@@ -597,7 +597,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                           text: {
                               id: null, // Assuming no direct mapping for option text ID
                               type: 'HTML', // Assuming option content is HTML
-                              content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                              content: opt?.name,
                           },
                           media_id: String(opt?.image?.imageName), // Assuming no direct mapping for option media ID
                           option_order: null,
@@ -631,7 +631,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                 text: {
                     id: null, // Assuming no direct mapping for text ID
                     type: 'HTML', // Assuming the content is HTML
-                    content: question?.questionName?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                    content: question?.questionName,
                 },
                 media_id: String(question?.imageDetails?.map((img) => img.imageName).join(',')), // Assuming no direct mapping for media_id
                 created_at: null,

--- a/frontend-admin-dashboard/src/routes/assessment/question-papers/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/assessment/question-papers/-utils/helper.ts
@@ -64,7 +64,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -84,7 +84,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -104,7 +104,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -124,7 +124,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -144,7 +144,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -206,7 +206,7 @@ export function transformQuestionPaperDataAI(data: MyQuestionPaperFormInterface)
                 text: {
                     id: null, // Assuming no direct mapping for text ID
                     type: 'HTML', // Assuming the content is HTML
-                    content: question.questionName.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                    content: question.questionName,
                 },
                 media_id: null, // Assuming no direct mapping for media_id
                 created_at: null,
@@ -254,7 +254,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -274,7 +274,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -294,7 +294,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -314,7 +314,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -334,7 +334,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                     text: {
                         id: null, // Assuming no direct mapping for option text ID
                         type: 'HTML', // Assuming option content is HTML
-                        content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                        content: opt?.name,
                     },
                     media_id: null, // Assuming no direct mapping for option media ID
                     option_order: null,
@@ -396,7 +396,7 @@ export function transformQuestionPaperData(data: MyQuestionPaperFormInterface) {
                 text: {
                     id: null, // Assuming no direct mapping for text ID
                     type: 'HTML', // Assuming the content is HTML
-                    content: question.questionName.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                    content: question.questionName,
                 },
                 media_id: null, // Assuming no direct mapping for media_id
                 created_at: null,
@@ -457,7 +457,7 @@ export function convertQuestionsDataToResponse(questions: MyQuestion[], key: str
                       text: {
                           id: null, // Assuming no mapping for text ID
                           type: 'HTML',
-                          content: opt?.name?.replace(/<\/?p>/g, ''),
+                          content: opt?.name,
                       },
                       media_id: null,
                       option_order: null,
@@ -476,7 +476,7 @@ export function convertQuestionsDataToResponse(questions: MyQuestion[], key: str
                       text: {
                           id: null,
                           type: 'HTML',
-                          content: opt?.name?.replace(/<\/?p>/g, ''),
+                          content: opt?.name,
                       },
                       media_id: null,
                       option_order: null,
@@ -510,7 +510,7 @@ export function convertQuestionsDataToResponse(questions: MyQuestion[], key: str
             text: {
                 id: null,
                 type: 'HTML',
-                content: question.questionName.replace(/<\/?p>/g, ''),
+                content: question.questionName,
             },
             media_id: null,
             created_at: null,
@@ -973,7 +973,7 @@ export function getEvaluationJSON(
             return JSON.stringify({
                 type: 'ONE_WORD',
                 data: {
-                    answer: subjectiveAnswerText?.replace(/<\/?p>/g, ''),
+                    answer: subjectiveAnswerText,
                 },
             });
         case 'LONG_ANSWER':
@@ -983,7 +983,7 @@ export function getEvaluationJSON(
                     answer: {
                         id: null,
                         type: 'HTML',
-                        content: subjectiveAnswerText?.replace(/<\/?p>/g, ''),
+                        content: subjectiveAnswerText,
                     },
                 },
             });

--- a/frontend-admin-dashboard/src/routes/homework-creation/assessment-list/assessment-details/$assessmentId/$examType/$assesssmentType/$assessmentTab/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/homework-creation/assessment-list/assessment-details/$assessmentId/$examType/$assesssmentType/$assessmentTab/-utils/helper.ts
@@ -540,7 +540,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                           text: {
                               id: null, // Assuming no direct mapping for option text ID
                               type: 'HTML', // Assuming option content is HTML
-                              content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                              content: opt?.name,
                           },
                           media_id: String(opt?.image?.imageName), // Assuming no direct mapping for option media ID
                           option_order: null,
@@ -559,7 +559,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                           text: {
                               id: null, // Assuming no direct mapping for option text ID
                               type: 'HTML', // Assuming option content is HTML
-                              content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                              content: opt?.name,
                           },
                           media_id: String(opt?.image?.imageName), // Assuming no direct mapping for option media ID
                           option_order: null,
@@ -593,7 +593,7 @@ export function transformSectionQuestions(questions: AssessmentSectionQuestionIn
                 text: {
                     id: null, // Assuming no direct mapping for text ID
                     type: 'HTML', // Assuming the content is HTML
-                    content: question?.questionName?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                    content: question?.questionName,
                 },
                 media_id: String(question?.imageDetails?.map((img) => img.imageName).join(',')), // Assuming no direct mapping for media_id
                 created_at: null,

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-helper/helper.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/subjects/modules/chapters/slides/-helper/helper.ts
@@ -248,7 +248,7 @@ export function convertStudyLibraryQuestion(question: MyQuestion) {
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -278,7 +278,7 @@ export function convertStudyLibraryQuestion(question: MyQuestion) {
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -293,7 +293,7 @@ export function convertStudyLibraryQuestion(question: MyQuestion) {
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -308,7 +308,7 @@ export function convertStudyLibraryQuestion(question: MyQuestion) {
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -528,7 +528,7 @@ export function convertToQuestionSlideFormat(question: MyQuestion, sourceId?: st
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -556,7 +556,7 @@ export function convertToQuestionSlideFormat(question: MyQuestion, sourceId?: st
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -570,7 +570,7 @@ export function convertToQuestionSlideFormat(question: MyQuestion, sourceId?: st
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID
@@ -584,7 +584,7 @@ export function convertToQuestionSlideFormat(question: MyQuestion, sourceId?: st
             text: {
                 id: null, // Assuming no direct mapping for option text ID
                 type: 'HTML', // Assuming option content is HTML
-                content: opt?.name?.replace(/<\/?p>/g, ''), // Remove <p> tags from content
+                content: opt?.name,
             },
             explanation_text: {
                 id: null, // Assuming no direct mapping for explanation text ID


### PR DESCRIPTION
The question-paper, homework, and slide-question save helpers blindly deleted every <p>/</p> from rich-text content with no replacement, collapsing multi-paragraph question text (e.g. numbered clue lists) into one run-on string with no line breaks. explanation_text was already sent unstripped elsewhere, so this brings question/option text in line with that and preserves formatting through the save/reload round trip.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
