### PR TITLE
fix(workflow): subOrgAdmin must be the sub-org's leader, not whoever …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContext.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContext.java
@@ -39,17 +39,34 @@ public final class SubOrgMemberEnrollmentContext {
     }
 
     /**
-     * @param member      the person being enrolled into the sub-org
-     * @param subOrgAdmin the admin performing the enrollment; may be null
-     * @param packageSession the batch being enrolled into
+     * Convenience overload for callers where the person acting IS the sub-org's leader — the
+     * /sub-org/v1/add-member route, where a practice admin adds their own staff.
      */
     public static Map<String, Object> build(UserDTO member, UserDTO subOrgAdmin,
+                                            PackageSession packageSession) {
+        return build(member, subOrgAdmin, subOrgAdmin, packageSession);
+    }
+
+    /**
+     * @param member      the person being enrolled into the sub-org
+     * @param subOrgAdmin the sub-org's OWN leader — NOT whoever clicked enroll. Workflow nodes
+     *                    resolve the practice's LearnDash group from this person's email
+     *                    ({@code get-leader-group?email=#ctx['subOrgAdmin']['email']}), so passing
+     *                    the acting platform admin here either 404s or, worse, silently returns
+     *                    THEIR group and files the member under the wrong practice. May be null
+     *                    when the sub-org has no resolvable leader — deliberately left null rather
+     *                    than falling back to the actor, because no group beats the wrong group.
+     * @param enrolledBy  who performed the enrollment; for audit and notification nodes
+     * @param packageSession the batch being enrolled into
+     */
+    public static Map<String, Object> build(UserDTO member, UserDTO subOrgAdmin, UserDTO enrolledBy,
                                             PackageSession packageSession) {
         Map<String, Object> contextData = new HashMap<>();
         contextData.put("member", member);
         // Alias — see class javadoc. Same object, so nodes written against either key resolve.
         contextData.put("user", member);
         contextData.put("subOrgAdmin", subOrgAdmin);
+        contextData.put("enrolledBy", enrolledBy);
         contextData.put("packageSessionIds", packageSession != null ? packageSession.getId() : null);
         contextData.put("packageId",
                 packageSession != null && packageSession.getPackageEntity() != null

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -20,6 +20,7 @@ import vacademy.io.admin_core_service.features.institute_learner.manager.Student
 import vacademy.io.admin_core_service.features.institute_learner.enums.LearnerSessionStatusEnum;
 import vacademy.io.admin_core_service.features.institute_learner.enums.LearnerSessionTypeEnum;
 import vacademy.io.admin_core_service.features.institute_learner.notification.LearnerEnrollmentNotificationService;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionRepository;
 import vacademy.io.admin_core_service.features.learner.service.LearnerService;
 import vacademy.io.admin_core_service.features.fee_management.entity.AftInstallment;
@@ -102,6 +103,8 @@ public class BulkAssignmentService {
     private final AftInstallmentRepository aftInstallmentRepository;
     private final SubOrgService subOrgService;
     private final InstituteSubOrgRepository instituteSubOrgRepository;
+    // Used only to resolve a sub-org's own leader for the workflow context — see resolveSubOrgLeader.
+    private final StudentSessionInstituteGroupMappingRepository studentSessionInstituteGroupMappingRepository;
 
     @org.springframework.beans.factory.annotation.Autowired
     @org.springframework.context.annotation.Lazy
@@ -1143,7 +1146,7 @@ public class BulkAssignmentService {
 
         if (subOrg != null && hasLearnerRole(subOrgRoles)) {
             triggerSubOrgMemberEnrollmentWorkflow(
-                    instituteId, userDTO, packageSession, subOrgRoles, adminUserId);
+                    instituteId, userDTO, packageSession, subOrg, subOrgRoles, adminUserId);
             return;
         }
 
@@ -1168,21 +1171,22 @@ public class BulkAssignmentService {
      */
     private void triggerSubOrgMemberEnrollmentWorkflow(
             String instituteId, UserDTO userDTO, PackageSession packageSession,
-            String subOrgRoles, String adminUserId) {
+            Institute subOrg, String subOrgRoles, String adminUserId) {
         if (userDTO == null || packageSession == null || !hasLearnerRole(subOrgRoles)) {
             return;
         }
         try {
-            UserDTO adminDTO = null;
-            if (StringUtils.hasText(adminUserId)) {
-                List<UserDTO> admins = authService.getUsersFromAuthServiceByUserIds(List.of(adminUserId));
-                adminDTO = CollectionUtils.isEmpty(admins) ? null : admins.get(0);
-            }
+            UserDTO enrolledBy = resolveUser(adminUserId);
+            // The sub-org's OWN leader, not whoever clicked enroll — see the javadoc on
+            // SubOrgMemberEnrollmentContext.build. Unlike /sub-org/v1/add-member (where the
+            // caller IS the practice admin), this wizard is driven by a platform admin whose
+            // email resolves to the wrong practice group, or to none at all.
+            UserDTO subOrgLeader = resolveSubOrgLeader(subOrg, packageSession.getId());
 
             // Built centrally so this and /sub-org/v1/add-member publish an identical context —
             // see SubOrgMemberEnrollmentContext for why 'user' is published alongside 'member'.
-            Map<String, Object> contextData =
-                    SubOrgMemberEnrollmentContext.build(userDTO, adminDTO, packageSession);
+            Map<String, Object> contextData = SubOrgMemberEnrollmentContext.build(
+                    userDTO, subOrgLeader, enrolledBy, packageSession);
 
             workflowTriggerService.handleTriggerEvents(
                     WorkflowTriggerEvent.SUB_ORG_MEMBER_ENROLLMENT.name(),
@@ -1190,6 +1194,54 @@ public class BulkAssignmentService {
         } catch (Exception e) {
             log.warn("Failed to trigger SUB_ORG_MEMBER_ENROLLMENT for userId={} packageSession={}: {}",
                     userDTO.getId(), packageSession.getId(), e.getMessage());
+        }
+    }
+
+    /** Single user fetch from auth-service, null-safe on both a blank id and an empty response. */
+    private UserDTO resolveUser(String userId) {
+        if (!StringUtils.hasText(userId)) {
+            return null;
+        }
+        List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(userId));
+        return CollectionUtils.isEmpty(users) ? null : users.get(0);
+    }
+
+    /**
+     * The sub-org's own leader: its ROOT_ADMIN for this batch, falling back to any ACTIVE member
+     * carrying ADMIN. Workflow nodes look the practice's LearnDash group up by this person's
+     * email, so it must be someone who actually leads the practice.
+     *
+     * <p>Returns null when the sub-org has no resolvable admin. That is deliberate: the caller
+     * publishes the null rather than substituting the acting admin, because a lookup keyed on the
+     * wrong person silently files the member into the wrong practice's group — a far worse
+     * outcome than the node skipping.
+     */
+    private UserDTO resolveSubOrgLeader(Institute subOrg, String packageSessionId) {
+        if (subOrg == null || !StringUtils.hasText(subOrg.getId())) {
+            return null;
+        }
+        try {
+            String leaderUserId = studentSessionInstituteGroupMappingRepository
+                    .findRootAdminMappingBySubOrgAndPackageSession(subOrg.getId(), packageSessionId)
+                    .map(StudentSessionInstituteGroupMapping::getUserId)
+                    .orElse(null);
+
+            if (!StringUtils.hasText(leaderUserId)) {
+                List<String> adminIds = studentSessionInstituteGroupMappingRepository
+                        .findActiveAdminUserIdsBySubOrg(subOrg.getId());
+                leaderUserId = CollectionUtils.isEmpty(adminIds) ? null : adminIds.get(0);
+            }
+
+            if (!StringUtils.hasText(leaderUserId)) {
+                log.warn("No leader found for sub-org {} — SUB_ORG_MEMBER_ENROLLMENT will carry a "
+                        + "null subOrgAdmin, so practice-group nodes will skip rather than enroll "
+                        + "into the wrong group", subOrg.getId());
+                return null;
+            }
+            return resolveUser(leaderUserId);
+        } catch (Exception e) {
+            log.warn("Failed to resolve leader for sub-org {}: {}", subOrg.getId(), e.getMessage());
+            return null;
         }
     }
 

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContextTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContextTest.java
@@ -58,6 +58,50 @@ class SubOrgMemberEnrollmentContextTest {
     }
 
     @Test
+    @DisplayName("subOrgAdmin is the sub-org's leader, kept distinct from whoever enrolled")
+    void subOrgAdminIsTheLeaderNotTheActor() {
+        UserDTO leader = user("leader-1", "leader@practice.com.au");
+        UserDTO actor = user("platform-1", "platformadmin@vidyayatan.com");
+
+        Map<String, Object> ctx = SubOrgMemberEnrollmentContext.build(
+                user("u-1", "staff@example.com"), leader, actor, packageSession("ps-1", "pkg-1"));
+
+        // Nodes resolve the practice's LearnDash group from subOrgAdmin's email. If the acting
+        // platform admin leaks into this key the lookup 404s — or silently returns THEIR group
+        // and files the member under the wrong practice.
+        assertSame(leader, ctx.get("subOrgAdmin"));
+        assertSame(actor, ctx.get("enrolledBy"));
+    }
+
+    @Test
+    @DisplayName("a sub-org with no resolvable leader publishes null, never the actor")
+    void neverSubstitutesTheActorForAMissingLeader() {
+        UserDTO actor = user("platform-1", "platformadmin@vidyayatan.com");
+
+        Map<String, Object> ctx = SubOrgMemberEnrollmentContext.build(
+                user("u-1", "staff@example.com"), null, actor, packageSession("ps-1", "pkg-1"));
+
+        // No group is a better outcome than the wrong group: the practice-group node skips on a
+        // null lookup, whereas the actor's email would resolve to a real but unrelated practice.
+        assertNull(ctx.get("subOrgAdmin"));
+        assertSame(actor, ctx.get("enrolledBy"));
+    }
+
+    @Test
+    @DisplayName("the 3-arg overload treats the actor as the leader (add-member route)")
+    void threeArgOverloadKeepsAddMemberSemantics() {
+        UserDTO practiceAdmin = user("admin-1", "admin@practice.com.au");
+
+        Map<String, Object> ctx = SubOrgMemberEnrollmentContext.build(
+                user("u-1", "staff@example.com"), practiceAdmin, packageSession("ps-1", "pkg-1"));
+
+        // On /sub-org/v1/add-member the caller IS the practice admin, so both keys are the same
+        // person and the existing lookup keeps working unchanged.
+        assertSame(practiceAdmin, ctx.get("subOrgAdmin"));
+        assertSame(practiceAdmin, ctx.get("enrolledBy"));
+    }
+
+    @Test
     @DisplayName("carries the batch/package identifiers workflow nodes route on")
     void carriesRoutingIdentifiers() {
         Map<String, Object> ctx = SubOrgMemberEnrollmentContext.build(


### PR DESCRIPTION
…enrolled

Workflow nodes resolve a practice's LearnDash group from get-leader-group?email=#ctx['subOrgAdmin']['email']. The bulk-assign publisher put the ACTING admin in that key, mirroring /sub-org/v1/add-member without noticing the key means something different there: on that route the caller IS the practice admin, whereas the Enroll Learner wizard is driven by a platform admin.

So every wizard enrollment looked up the platform admin's email. Rita, Emile and Neeraj all queried manshu@vidyayatan.com. Neeraj's 404'd with no_user, which left targetPracticeGroupId null and skipped the practice-group enrol entirely — he landed in no group at all, despite his sub-org having a perfectly good one (LearnDash group 83237, "test vtc clinic", created when its admin was onboarded). Emile's lookup returned 200 against that same wrong email, so he may be sitting in an unrelated practice's group.

subOrgAdmin is now the sub-org's own leader: its ROOT_ADMIN for the batch, falling back to any ACTIVE member carrying ADMIN. The actor moves to a new 'enrolledBy' key so audit information is not lost.

When no leader resolves, the context carries null and NOT the actor. The practice-group node then skips, which is the correct trade: no group is recoverable, the wrong group silently files someone under another practice.

/sub-org/v1/add-member keeps its existing behaviour through a 3-arg overload — its caller genuinely is the practice admin.

Three tests pin it: leader is distinct from actor, a missing leader never falls back to the actor, and the add-member overload keeps both keys the same person.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
