### PR TITLE
Fix lead-edit dedup bypass: honor LEAD_SETTING.data.dedup, not the le…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -1565,8 +1565,11 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
 
         /**
          * Institute-level lead-uniqueness setting support (LEAD_SETTING.data.dedup).
-         * All four exclude opted-out and already-flagged-duplicate rows so a lead
-         * that opted out can re-enter, and duplicates don't chain-match.
+         * All six exclude opted-out and already-flagged-duplicate rows so a lead that
+         * opted out can re-enter, and duplicates don't chain-match. excludeResponseId
+         * lets an in-place lead edit (updateLeadProfile) check "does this new value
+         * collide with some OTHER lead" without matching its own not-yet-saved row —
+         * pass null from creation-flow callers, where there is no self to exclude.
          */
         @Query("""
                             SELECT COUNT(ar) > 0 FROM AudienceResponse ar
@@ -1574,10 +1577,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND LOWER(TRIM(ar.parentEmail)) = LOWER(TRIM(:email))
                             AND (ar.isDuplicate IS NULL OR ar.isDuplicate = false)
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND (:excludeResponseId IS NULL OR ar.id <> :excludeResponseId)
                         """)
         boolean existsByAudienceIdAndParentEmailIgnoreCase(
                         @Param("audienceId") String audienceId,
-                        @Param("email") String email);
+                        @Param("email") String email,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         @Query("""
                             SELECT COUNT(ar) > 0 FROM AudienceResponse ar
@@ -1586,10 +1591,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND LOWER(TRIM(ar.parentEmail)) = LOWER(TRIM(:email))
                             AND (ar.isDuplicate IS NULL OR ar.isDuplicate = false)
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND (:excludeResponseId IS NULL OR ar.id <> :excludeResponseId)
                         """)
         boolean existsByInstituteIdAndParentEmailIgnoreCase(
                         @Param("instituteId") String instituteId,
-                        @Param("email") String email);
+                        @Param("email") String email,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         @Query(value = """
                             SELECT COUNT(*) > 0 FROM audience_response ar
@@ -1598,10 +1605,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND RIGHT(regexp_replace(ar.parent_mobile, '[^0-9]', '', 'g'), 10) = :last10
                             AND (ar.is_duplicate IS NULL OR ar.is_duplicate = false)
                             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                            AND (COALESCE(:excludeResponseId, '') = '' OR ar.id <> :excludeResponseId)
                         """, nativeQuery = true)
         boolean existsByAudienceIdAndPhoneLast10(
                         @Param("audienceId") String audienceId,
-                        @Param("last10") String last10);
+                        @Param("last10") String last10,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         @Query(value = """
                             SELECT COUNT(*) > 0 FROM audience_response ar
@@ -1611,10 +1620,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND RIGHT(regexp_replace(ar.parent_mobile, '[^0-9]', '', 'g'), 10) = :last10
                             AND (ar.is_duplicate IS NULL OR ar.is_duplicate = false)
                             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                            AND (COALESCE(:excludeResponseId, '') = '' OR ar.id <> :excludeResponseId)
                         """, nativeQuery = true)
         boolean existsByInstituteIdAndPhoneLast10(
                         @Param("instituteId") String instituteId,
-                        @Param("last10") String last10);
+                        @Param("last10") String last10,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         /**
          * SELECTED-scope variant of the two above — dedup checked across an
@@ -1627,10 +1638,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND LOWER(TRIM(ar.parentEmail)) = LOWER(TRIM(:email))
                             AND (ar.isDuplicate IS NULL OR ar.isDuplicate = false)
                             AND (ar.overallStatus IS NULL OR ar.overallStatus != 'OPTED_OUT')
+                            AND (:excludeResponseId IS NULL OR ar.id <> :excludeResponseId)
                         """)
         boolean existsByAudienceIdInAndParentEmailIgnoreCase(
                         @Param("audienceIds") java.util.List<String> audienceIds,
-                        @Param("email") String email);
+                        @Param("email") String email,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         @Query(value = """
                             SELECT COUNT(*) > 0 FROM audience_response ar
@@ -1639,10 +1652,12 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                             AND RIGHT(regexp_replace(ar.parent_mobile, '[^0-9]', '', 'g'), 10) = :last10
                             AND (ar.is_duplicate IS NULL OR ar.is_duplicate = false)
                             AND (ar.overall_status IS NULL OR ar.overall_status != 'OPTED_OUT')
+                            AND (COALESCE(:excludeResponseId, '') = '' OR ar.id <> :excludeResponseId)
                         """, nativeQuery = true)
         boolean existsByAudienceIdInAndPhoneLast10(
                         @Param("audienceIds") java.util.List<String> audienceIds,
-                        @Param("last10") String last10);
+                        @Param("last10") String last10,
+                        @Param("excludeResponseId") String excludeResponseId);
 
         // ── TAT / Follow-up SLA scan (emit-only scheduler) ────────────────────────
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/AudienceService.java
@@ -3559,6 +3559,29 @@ public class AudienceService {
             String newEmail = updates.getEmail();
             String newPhone = updates.getMobileNumber();
             if (StringUtils.hasText(newEmail) || StringUtils.hasText(newPhone)) {
+                // Institute-configured dedup (LEAD_SETTING.data.dedup) — the same check used
+                // at lead creation, so editing a lead's contact info can't silently collide
+                // with another lead the admin's field/scope setting is supposed to catch.
+                // excludeResponseId keeps this row from matching its own not-yet-saved self.
+                // An in-place edit always blocks on a match regardless of action
+                // (REJECT/ALLOW_REASSIGN) — there is no new response here to reassign.
+                String instituteId = response.getAudienceId() != null
+                        ? audienceRepository.findById(response.getAudienceId())
+                                .map(Audience::getInstituteId).orElse(null)
+                        : null;
+                if (StringUtils.hasText(instituteId)) {
+                    leadDeduplicationService
+                            .checkDuplicate(instituteId, response.getAudienceId(), newEmail, newPhone, responseId)
+                            .ifPresent(match -> {
+                                throw new ConflictException(StringUtils.hasText(match.rejectionMessage())
+                                        ? match.rejectionMessage()
+                                        : "A lead already exists with this phone number or email.");
+                            });
+                }
+
+                // Legacy campaign-scoped combined-key check — kept as the baseline safety net
+                // for institutes that haven't configured LEAD_SETTING.data.dedup, and to keep
+                // dedupeKey (used by the enquiry flow's soft-merge) up to date either way.
                 String newKey = leadDeduplicationService.generateDedupeKey(newEmail, newPhone);
                 if (newKey != null && response.getAudienceId() != null) {
                     leadDeduplicationService.findDuplicate(response.getAudienceId(), newKey)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadDeduplicationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadDeduplicationService.java
@@ -118,6 +118,17 @@ public class LeadDeduplicationService {
      *         before) or ALLOW_REASSIGN (let it through, caller applies repeatLeadSettings).
      */
     public Optional<DuplicateMatch> checkDuplicate(String instituteId, String audienceId, String email, String phone) {
+        return checkDuplicate(instituteId, audienceId, email, phone, null);
+    }
+
+    /**
+     * Same as {@link #checkDuplicate(String, String, String, String)}, but excludes a specific
+     * response id from the match — for an in-place lead edit (updateLeadProfile), so checking
+     * "does this new value collide with some OTHER lead" doesn't match the row being edited
+     * against its own not-yet-saved self. Creation-flow callers pass null (nothing to exclude).
+     */
+    public Optional<DuplicateMatch> checkDuplicate(String instituteId, String audienceId, String email, String phone,
+            String excludeResponseId) {
         LeadDedupSettingService.DedupSettings settings = leadDedupSettingService.get(instituteId);
         if (!settings.enabled()) return Optional.empty();
 
@@ -141,10 +152,12 @@ public class LeadDeduplicationService {
             String last10 = lastNDigits(phone, 10);
             if (last10 == null) return Optional.empty();
             exists = switch (scope) {
-                case INSTITUTE -> audienceResponseRepository.existsByInstituteIdAndPhoneLast10(instituteId, last10);
+                case INSTITUTE -> audienceResponseRepository
+                        .existsByInstituteIdAndPhoneLast10(instituteId, last10, excludeResponseId);
                 case SELECTED -> audienceResponseRepository.existsByAudienceIdInAndPhoneLast10(
-                        settings.audienceIds(), last10);
-                case CAMPAIGN -> audienceResponseRepository.existsByAudienceIdAndPhoneLast10(audienceId, last10);
+                        settings.audienceIds(), last10, excludeResponseId);
+                case CAMPAIGN -> audienceResponseRepository
+                        .existsByAudienceIdAndPhoneLast10(audienceId, last10, excludeResponseId);
             };
             matchedFieldLabel = "phone number";
         } else {
@@ -152,11 +165,11 @@ public class LeadDeduplicationService {
             if (normalizedEmail.isEmpty()) return Optional.empty();
             exists = switch (scope) {
                 case INSTITUTE -> audienceResponseRepository
-                        .existsByInstituteIdAndParentEmailIgnoreCase(instituteId, normalizedEmail);
-                case SELECTED -> audienceResponseRepository
-                        .existsByAudienceIdInAndParentEmailIgnoreCase(settings.audienceIds(), normalizedEmail);
+                        .existsByInstituteIdAndParentEmailIgnoreCase(instituteId, normalizedEmail, excludeResponseId);
+                case SELECTED -> audienceResponseRepository.existsByAudienceIdInAndParentEmailIgnoreCase(
+                        settings.audienceIds(), normalizedEmail, excludeResponseId);
                 case CAMPAIGN -> audienceResponseRepository
-                        .existsByAudienceIdAndParentEmailIgnoreCase(audienceId, normalizedEmail);
+                        .existsByAudienceIdAndParentEmailIgnoreCase(audienceId, normalizedEmail, excludeResponseId);
             };
             matchedFieldLabel = "email";
         }


### PR DESCRIPTION
…gacy campaign-only combined key

updateLeadProfile (the lead-edit endpoint) had its own, older dedup check that ran instead of the institute's configured setting: it was always scoped to the current campaign only (ignoring scope=INSTITUTE/SELECTED) and matched on a combined email+phone hash (ignoring field=PHONE, so a matching phone with a different email never triggered it). An admin correcting/adding a lead's phone number after creation could silently recreate a duplicate the setting was supposed to prevent.

Now the edit path calls the same LeadDeduplicationService.checkDuplicate used at creation, with a new excludeResponseId parameter (threaded through all six dedup exists-queries) so the row being edited never matches its own not-yet-saved self. The legacy campaign-scoped check stays as a fallback for institutes that haven't configured the setting.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
