### PR TITLE
fix(payments): send invite name, not course description, to Razorpay …

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/razorpay-checkout-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/-components/razorpay-checkout-form.tsx
@@ -8,16 +8,38 @@ import {
 import { parseHtmlToString } from "@/lib/utils";
 
 // Razorpay rejects payment creation when `description` exceeds 255 characters
-// (BAD_REQUEST_ERROR: "The description may not be greater than 255 characters").
-// Course descriptions arrive as rich-text HTML, so strip markup and truncate.
-const RAZORPAY_DESCRIPTION_MAX = 255;
+// ("Could not validate payment create request due to: description: the length
+// must be no more than 255"). Callers pass a short label — the enroll-invite
+// name — never the course's rich-text description; this is the last-resort
+// guard for the callers that still pass free text.
+//
+// The cap is measured in BYTES, not JS string length: Razorpay counts the
+// encoded payload, so a 255-char string of ₹ / — / Devanagari is well over the
+// limit even though `String.length` says it fits.
+const RAZORPAY_DESCRIPTION_MAX_BYTES = 255;
+const RAZORPAY_DESCRIPTION_ELLIPSIS = "..."; // ASCII: 1 byte per char
 
 function toRazorpayDescription(raw: string): string {
   const text = parseHtmlToString(raw).replace(/\s+/g, " ").trim();
   if (!text) return "Payment for course enrollment";
-  return text.length > RAZORPAY_DESCRIPTION_MAX
-    ? `${text.slice(0, RAZORPAY_DESCRIPTION_MAX - 1)}…`
-    : text;
+
+  const encoder = new TextEncoder();
+  if (encoder.encode(text).length <= RAZORPAY_DESCRIPTION_MAX_BYTES) {
+    return text;
+  }
+
+  const budget =
+    RAZORPAY_DESCRIPTION_MAX_BYTES - RAZORPAY_DESCRIPTION_ELLIPSIS.length;
+  let truncated = "";
+  let bytes = 0;
+  // Iterate by code point so surrogate pairs are never split in half.
+  for (const char of text) {
+    const size = encoder.encode(char).length;
+    if (bytes + size > budget) break;
+    truncated += char;
+    bytes += size;
+  }
+  return `${truncated.trimEnd()}${RAZORPAY_DESCRIPTION_ELLIPSIS}`;
 }
 
 export interface RazorpayCheckoutFormRef {

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -2789,9 +2789,14 @@ const EnrollByInvite = ({
               enrollmentData.selectedPayment?.name ||
               "Course Enrollment"
             }
+            // Razorpay caps `description` at 255 chars, and courseData.description
+            // is the invite's rich-text course description — routinely far longer,
+            // which made checkout fail outright. Send the invite name instead: it
+            // is short, identifies the purchase, and still gets capped downstream.
             courseDescription={
-              courseData.description ||
-              enrollmentData.selectedPayment?.description ||
+              inviteData?.name ||
+              courseData.course ||
+              enrollmentData.selectedPayment?.name ||
               "Payment for course enrollment"
             }
             razorpayRef={razorpayRef}


### PR DESCRIPTION
…checkout

Razorpay rejects the payment-create call when the description exceeds 255 chars ("Could not validate payment create request due to: description: the length must be no more than 255"), which failed checkout outright for invites with a long course description.

The enroll flow was passing courseData.description - the invite's rich-text course description, routinely far longer than the cap. Pass the invite name instead: short, identifies the purchase, and still capped downstream.

Also make the checkout-form backstop measure the cap in BYTES rather than String.length. The earlier char-based truncation still overflowed for text with multibyte characters (a 255-char string of INR sign / em-dash / Devanagari is ~700 bytes). Truncation now iterates by code point so surrogate pairs are never split, and uses an ASCII ellipsis.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
