### PR TITLE
fix(course-details): stop stray 0 rendering under invite links

### DIFF
--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/course-details-page.tsx
@@ -1821,7 +1821,7 @@ export const CourseDetailsPage = () => {
 
                                 {showOverviewMetrics &&
                                     courseDuration &&
-                                    (courseDuration.hours || courseDuration.minutes) && (
+                                    (courseDuration.hours > 0 || courseDuration.minutes > 0) && (
                                         <MetaChip
                                             icon={
                                                 <Clock size={14} className="shrink-0 text-gray-500" />


### PR DESCRIPTION
## Problem

A bare `0` renders on the course details page, directly under the Invite Links card.

## Cause

The course-duration `MetaChip` guard did a truthiness check on numbers:

```tsx
{showOverviewMetrics &&
    courseDuration &&
    (courseDuration.hours || courseDuration.minutes) && (
```

`calculateTotalTimeForCourseDuration` returns `{hours: 0, minutes: 0}` for a course with no slide read time, and `courseDuration` is non-null as soon as `slideCounts` resolves — even to an empty array. So the sub-expression evaluates to the **number** `0`, the chain short-circuits to `0`, and React renders it as a literal text node in the metrics strip.

It becomes visible when every other chip in that strip is also hidden (single session/level, no slides, no instructors) — the `0` is then the only thing left in the row.

## Fix

Compare against 0 explicitly so the guard yields a boolean.

## Verification

- `tsc --noEmit`: no errors in this file (3 pre-existing errors elsewhere, all in `MonacoHtmlEditor.tsx`)
- `eslint`: output byte-identical to the pre-change baseline — 23 problems / 13 errors before and after, so nothing new introduced
- Chip rendering is unchanged whenever a real duration exists; `hours`/`minutes` are sums of read-time minutes and never negative

🤖 Generated with [Claude Code](https://claude.com/claude-code)