### PR TITLE
fix(learner-dashboard): adapt layout to sparse widget settings; render configured font

### DIFF
--- a/frontend-admin-dashboard/index.html
+++ b/frontend-admin-dashboard/index.html
@@ -95,7 +95,7 @@
     <!-- Curated institute fonts (Settings > Appearance font picker). Keep in
          sync with constants/themes/fonts.ts and the learner app's index.html. -->
     <link
-        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=Lexend:wght@300;400;500;600;700&family=Work+Sans:wght@300;400;500;600;700&family=Cairo:wght@300;400;500;600;700&family=Playpen+Sans:wght@300;400;500;600;700&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=Lexend:wght@300;400;500;600;700&family=Work+Sans:wght@300;400;500;600;700&family=Cairo:wght@300;400;500;600;700&family=Playpen+Sans:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap"
         rel="stylesheet" />
     <!-- <link
             rel="stylesheet"

--- a/frontend-admin-dashboard/src/constants/themes/fonts.ts
+++ b/frontend-admin-dashboard/src/constants/themes/fonts.ts
@@ -27,6 +27,7 @@ export const FONT_CHOICES: FontChoice[] = [
     },
     { key: 'Inter', label: 'Inter', previewFamily: 'Inter, sans-serif', note: 'Admin default' },
     { key: 'Lexend', label: 'Lexend', previewFamily: 'Lexend, sans-serif' },
+    { key: 'Poppins', label: 'Poppins', previewFamily: 'Poppins, sans-serif' },
     { key: 'Work Sans', label: 'Work Sans', previewFamily: "'Work Sans', sans-serif" },
     { key: 'Open Sans', label: 'Open Sans', previewFamily: "'Open Sans', sans-serif" },
     { key: 'Cairo', label: 'Cairo', previewFamily: 'Cairo, sans-serif', note: 'Good for Arabic' },

--- a/frontend-admin-dashboard/src/utils/font.ts
+++ b/frontend-admin-dashboard/src/utils/font.ts
@@ -13,6 +13,7 @@ const CURATED: Record<string, string> = {
     'OPEN SANS': 'Open Sans',
     CAIRO: 'Cairo',
     'PLAYPEN SANS': 'Playpen Sans',
+    POPPINS: 'Poppins',
 };
 
 /**

--- a/frontend-learner-dashboard-app/index.html
+++ b/frontend-learner-dashboard-app/index.html
@@ -132,7 +132,7 @@
     />
     <!-- White-label font options (selected per-tenant via TabBranding); Open Sans kept as a fallback option. -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Cairo:wght@300;400;500;600;700&family=Playpen+Sans:wght@300;400;500;600;700&family=Work+Sans:wght@300;400;500;600;700&family=Lexend:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Cairo:wght@300;400;500;600;700&family=Playpen+Sans:wght@300;400;500;600;700&family=Work+Sans:wght@300;400;500;600;700&family=Lexend:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
 

--- a/frontend-learner-dashboard-app/src/constants/themes/fonts.ts
+++ b/frontend-learner-dashboard-app/src/constants/themes/fonts.ts
@@ -27,6 +27,7 @@ export const FONT_CHOICES: FontChoice[] = [
     },
     { key: 'Inter', label: 'Inter', previewFamily: 'Inter, sans-serif', note: 'Admin default' },
     { key: 'Lexend', label: 'Lexend', previewFamily: 'Lexend, sans-serif' },
+    { key: 'Poppins', label: 'Poppins', previewFamily: 'Poppins, sans-serif' },
     { key: 'Work Sans', label: 'Work Sans', previewFamily: "'Work Sans', sans-serif" },
     { key: 'Open Sans', label: 'Open Sans', previewFamily: "'Open Sans', sans-serif" },
     { key: 'Cairo', label: 'Cairo', previewFamily: 'Cairo, sans-serif', note: 'Good for Arabic' },

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/AttendanceWidget.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/AttendanceWidget.tsx
@@ -89,7 +89,14 @@ function DayDot({
   );
 }
 
-export function AttendanceWidget() {
+/**
+ * The streak is a game mechanic, not an attendance fact, so it rides the same
+ * `gamification` widget flag as the XP / badges panel: an institute that turned
+ * game mechanics off was still getting "start your streak" copy and a Fire
+ * counter inside the attendance card. Defaults to on, so institutes that never
+ * touched the flag are unaffected.
+ */
+export function AttendanceWidget({ showStreak = true }: { showStreak?: boolean } = {}) {
   const [period, setPeriod] = useState<AttendancePeriod>("7d");
   const { data: stats, isLoading } = useAttendanceStats({ period });
   const { data: weeklyData, isLoading: isLoadingWeekly } =
@@ -136,7 +143,18 @@ export function AttendanceWidget() {
       (d) => d.status === "PRESENT" || d.status === "ABSENT"
     ) ?? false;
   const isEmpty =
-    (total === 0 && streak === 0) || (present === 0 && !hasMarkedDay);
+    (total === 0 && (!showStreak || streak === 0)) ||
+    (present === 0 && !hasMarkedDay);
+
+  // Empty-state copy has to drop the streak framing too, else an institute with
+  // game mechanics off still reads "start your streak".
+  const emptyTitle = showStreak
+    ? "Attend today's class to start your streak"
+    : "Attend today's class to start tracking attendance";
+  const emptyBody = showStreak
+    ? "Your attendance stats and weekly streak will appear here."
+    : "Your attendance stats for the week will appear here.";
+  const statGridClass = showStreak ? "grid-cols-3" : "grid-cols-2";
 
   const goToAttendance = () =>
     navigate({ to: "/learning-centre/attendance" });
@@ -199,16 +217,12 @@ export function AttendanceWidget() {
 
         {isEmpty ? (
           <div className="space-y-1.5 py-3 text-center">
-            <p className="text-body font-black text-play-ink">
-              Attend today's class to start your streak
-            </p>
-            <p className="text-caption font-bold text-play-ink/60">
-              Your attendance stats and weekly streak will appear here.
-            </p>
+            <p className="text-body font-black text-play-ink">{emptyTitle}</p>
+            <p className="text-caption font-bold text-play-ink/60">{emptyBody}</p>
           </div>
         ) : (
           <>
-            <div className="grid grid-cols-3 gap-2">
+            <div className={cn("grid gap-2", statGridClass)}>
               <div className="min-w-0 rounded-xl bg-white/70 px-2 py-2 text-center">
                 <div className={cn("text-h3 font-black", getPercentageColor(pct))}>
                   {isLoading ? <Skeleton className="mx-auto h-8 w-12" /> : `${pct}%`}
@@ -216,23 +230,25 @@ export function AttendanceWidget() {
                 <div className="mt-0.5 text-3xs font-bold text-play-ink/60">Overall</div>
               </div>
 
-              <div className="min-w-0 rounded-xl bg-white/70 px-2 py-2 text-center">
-                <div className="flex items-center justify-center gap-1 text-h3 font-black text-play-ink">
-                  {isLoading ? (
-                    <Skeleton className="h-8 w-12" />
-                  ) : (
-                    <>
-                      <Fire
-                        size={18}
-                        weight="fill"
-                        className={streak > 0 ? "text-play-warn" : "text-play-ink/30"}
-                      />
-                      {streak}
-                    </>
-                  )}
+              {showStreak && (
+                <div className="min-w-0 rounded-xl bg-white/70 px-2 py-2 text-center">
+                  <div className="flex items-center justify-center gap-1 text-h3 font-black text-play-ink">
+                    {isLoading ? (
+                      <Skeleton className="h-8 w-12" />
+                    ) : (
+                      <>
+                        <Fire
+                          size={18}
+                          weight="fill"
+                          className={streak > 0 ? "text-play-warn" : "text-play-ink/30"}
+                        />
+                        {streak}
+                      </>
+                    )}
+                  </div>
+                  <div className="mt-0.5 text-3xs font-bold text-play-ink/60">Streak</div>
                 </div>
-                <div className="mt-0.5 text-3xs font-bold text-play-ink/60">Streak</div>
-              </div>
+              )}
 
               <div className="min-w-0 rounded-xl bg-white/70 px-2 py-2 text-center">
                 <div className="text-h3 font-black text-play-ink">
@@ -327,16 +343,12 @@ export function AttendanceWidget() {
 
         {isEmpty ? (
           <div className="space-y-1.5 py-3 text-center">
-            <p className="cp-heading text-body">
-              Attend today's class to start your streak
-            </p>
-            <p className="cp-muted text-caption">
-              Your attendance stats and weekly streak will appear here.
-            </p>
+            <p className="cp-heading text-body">{emptyTitle}</p>
+            <p className="cp-muted text-caption">{emptyBody}</p>
           </div>
         ) : (
           <>
-            <div className="grid grid-cols-3 gap-2">
+            <div className={cn("grid gap-2", statGridClass)}>
               <div className="min-w-0 rounded-xl bg-cp-bg-deep px-2 py-2 text-center">
                 <div className={cn("text-h3 font-bold", getPercentageColor(pct))}>
                   {isLoading ? <Skeleton className="mx-auto h-8 w-12" /> : `${pct}%`}
@@ -344,23 +356,25 @@ export function AttendanceWidget() {
                 <div className="cp-muted mt-0.5 text-3xs">Overall</div>
               </div>
 
-              <div className="min-w-0 rounded-xl bg-cp-bg-deep px-2 py-2 text-center">
-                <div className="cp-heading flex items-center justify-center gap-1 text-h3">
-                  {isLoading ? (
-                    <Skeleton className="h-8 w-12" />
-                  ) : (
-                    <>
-                      <Fire
-                        size={18}
-                        weight="fill"
-                        className={streak > 0 ? "text-cp-gold" : "cp-muted"}
-                      />
-                      {streak}
-                    </>
-                  )}
+              {showStreak && (
+                <div className="min-w-0 rounded-xl bg-cp-bg-deep px-2 py-2 text-center">
+                  <div className="cp-heading flex items-center justify-center gap-1 text-h3">
+                    {isLoading ? (
+                      <Skeleton className="h-8 w-12" />
+                    ) : (
+                      <>
+                        <Fire
+                          size={18}
+                          weight="fill"
+                          className={streak > 0 ? "text-cp-gold" : "cp-muted"}
+                        />
+                        {streak}
+                      </>
+                    )}
+                  </div>
+                  <div className="cp-muted mt-0.5 text-3xs">Streak</div>
                 </div>
-                <div className="cp-muted mt-0.5 text-3xs">Streak</div>
-              </div>
+              )}
 
               <div className="min-w-0 rounded-xl bg-cp-bg-deep px-2 py-2 text-center">
                 <div className="cp-heading text-h3">
@@ -460,16 +474,12 @@ export function AttendanceWidget() {
       <CardContent className="px-4 pb-4 space-y-4">
         {isEmpty ? (
           <div className="text-center py-3 space-y-1.5">
-            <p className="text-sm font-bold text-foreground">
-              Attend today's class to start your streak
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Your attendance stats and weekly streak will appear here.
-            </p>
+            <p className="text-sm font-bold text-foreground">{emptyTitle}</p>
+            <p className="text-xs text-muted-foreground">{emptyBody}</p>
           </div>
         ) : (
           <>
-            <div className="grid grid-cols-3 gap-3">
+            <div className={cn("grid gap-3", statGridClass)}>
               {/* Overall % */}
               <div className="text-center">
                 <div className={cn("text-2xl font-bold", getPercentageColor(pct))}>
@@ -485,25 +495,27 @@ export function AttendanceWidget() {
               </div>
 
               {/* Streak */}
-              <div className="text-center">
-                <div className="text-2xl font-bold text-foreground flex items-center justify-center gap-1">
-                  {isLoading ? (
-                    <Skeleton className="h-8 w-12" />
-                  ) : (
-                    <>
-                      <Fire
-                        size={20}
-                        weight="fill"
-                        className={streak > 0 ? "text-orange-500" : "text-slate-300"}
-                      />
-                      {streak}
-                    </>
-                  )}
+              {showStreak && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-foreground flex items-center justify-center gap-1">
+                    {isLoading ? (
+                      <Skeleton className="h-8 w-12" />
+                    ) : (
+                      <>
+                        <Fire
+                          size={20}
+                          weight="fill"
+                          className={streak > 0 ? "text-orange-500" : "text-slate-300"}
+                        />
+                        {streak}
+                      </>
+                    )}
+                  </div>
+                  <div className="text-caption text-muted-foreground mt-0.5">
+                    Streak
+                  </div>
                 </div>
-                <div className="text-caption text-muted-foreground mt-0.5">
-                  Streak
-                </div>
-              </div>
+              )}
 
               {/* Present / Total */}
               <div className="text-center">

--- a/frontend-learner-dashboard-app/src/routes/dashboard/-components/DashboardStatCard.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/-components/DashboardStatCard.tsx
@@ -21,6 +21,15 @@ export const StatCardSkeleton = () => (
     </Card>
 );
 
+/**
+ * "stack" is the tile used when stat cards sit side by side in a row of two or
+ * three. "row" is for the case where the institute's display settings left only
+ * ONE stat visible: a lone tile stretched across the full column reads as a
+ * mostly-empty box, so it lays out horizontally (icon | text | chevron) and
+ * becomes a banner instead.
+ */
+export type StatCardLayout = "stack" | "row";
+
 export const StatCard = ({
     title,
     count,
@@ -31,6 +40,7 @@ export const StatCard = ({
     iconClassName,
     cleanerIllustrationSrc,
     emptyActionLabel,
+    layout = "stack",
 }: {
     title: string;
     count: number | undefined;
@@ -46,10 +56,13 @@ export const StatCard = ({
     /** Shown instead of the title when the count is genuinely 0, turning the
      *  card into an invitation (e.g. "Browse Courses") rather than a dead zero. */
     emptyActionLabel?: string;
+    /** See {@link StatCardLayout}. Defaults to the side-by-side tile. */
+    layout?: StatCardLayout;
 }) => {
     const { t } = useTranslation("dashboard");
     const isPlay = usePlayTheme();
     const isCleanerPlay = useCleanerPlayTheme();
+    const isRow = layout === "row";
 
     // Skeleton while loading — covers the count-not-yet-known (undefined/null) case
     if (isLoading) return <StatCardSkeleton />;
@@ -68,10 +81,18 @@ export const StatCard = ({
                 onClick={onClick}
                 aria-label={cardAriaLabel}
                 className={cn(
-                    "cp-card group flex h-full w-full flex-col items-start gap-3 p-4 text-start transition-transform duration-base ease-out-soft hover:-translate-y-0.5"
+                    "cp-card group flex h-full w-full gap-3 p-4 text-start transition-transform duration-base ease-out-soft hover:-translate-y-0.5",
+                    isRow
+                        ? "flex-row items-center sm:gap-4"
+                        : "flex-col items-start"
                 )}
             >
-                <div className="flex w-full items-center justify-between">
+                <div
+                    className={cn(
+                        "flex items-center",
+                        isRow ? "shrink-0" : "w-full justify-between"
+                    )}
+                >
                     {cleanerIllustrationSrc ? (
                         <img
                             src={cleanerIllustrationSrc}
@@ -84,22 +105,39 @@ export const StatCard = ({
                             <Icon size={20} weight="duotone" />
                         </span>
                     )}
+                    {!isRow && (
+                        <CaretRight
+                            size={16}
+                            className="cp-muted transition-transform duration-300 group-hover:translate-x-0.5"
+                        />
+                    )}
+                </div>
+                <div
+                    className={cn(
+                        "flex flex-col",
+                        isRow ? "min-w-0 flex-1 gap-1" : "gap-3"
+                    )}
+                >
+                    {showAction ? (
+                        <span className="cp-heading inline-flex flex-wrap items-center gap-1 text-h3 sm:text-h2">
+                            {t("statCard.getStarted")}
+                            <ArrowRight size={16} weight="bold" />
+                        </span>
+                    ) : (
+                        <span className="cp-heading block text-h3 tabular-nums sm:text-h2">
+                            {(count ?? 0).toLocaleString()}
+                        </span>
+                    )}
+                    <span className="cp-muted block text-caption font-medium">
+                        {subtitleText}
+                    </span>
+                </div>
+                {isRow && (
                     <CaretRight
                         size={16}
-                        className="cp-muted transition-transform duration-300 group-hover:translate-x-0.5"
+                        className="cp-muted shrink-0 transition-transform duration-300 group-hover:translate-x-0.5"
                     />
-                </div>
-                {showAction ? (
-                    <span className="cp-heading inline-flex flex-wrap items-center gap-1 text-h3 sm:text-h2">
-                        {t("statCard.getStarted")}
-                        <ArrowRight size={16} weight="bold" />
-                    </span>
-                ) : (
-                    <span className="cp-heading text-h3 tabular-nums sm:text-h2">
-                        {(count ?? 0).toLocaleString()}
-                    </span>
                 )}
-                <span className="cp-muted text-caption font-medium">{subtitleText}</span>
             </button>
         );
     }
@@ -132,8 +170,20 @@ export const StatCard = ({
         >
             {/* Play mode: pastel-tint card, felted icon top-left + chevron, ink text below */}
             {isPlay ? (
-                <div className="flex h-full flex-col justify-between p-3 sm:p-4">
-                    <div className="mb-3 flex items-center justify-between">
+                <div
+                    className={cn(
+                        "flex h-full p-3 sm:p-4",
+                        isRow
+                            ? "flex-row items-center gap-3 sm:gap-4"
+                            : "flex-col justify-between"
+                    )}
+                >
+                    <div
+                        className={cn(
+                            "flex items-center",
+                            isRow ? "shrink-0" : "mb-3 justify-between"
+                        )}
+                    >
                         {cleanerIllustrationSrc ? (
                             <img
                                 src={cleanerIllustrationSrc}
@@ -146,12 +196,14 @@ export const StatCard = ({
                                 <Icon size={20} weight="fill" className="w-5 h-5 sm:w-6 sm:h-6" />
                             </div>
                         )}
-                        <CaretRight
-                            size={16}
-                            className="text-play-ink/50 transition-all duration-300 group-hover:translate-x-0.5 group-hover:text-play-ink"
-                        />
+                        {!isRow && (
+                            <CaretRight
+                                size={16}
+                                className="text-play-ink/50 transition-all duration-300 group-hover:translate-x-0.5 group-hover:text-play-ink"
+                            />
+                        )}
                     </div>
-                    <div className="space-y-1">
+                    <div className={cn("space-y-1", isRow && "min-w-0 flex-1")}>
                         {showAction ? (
                             <div className="inline-flex items-center gap-1 text-xl font-black tracking-tight text-play-ink sm:text-2xl">
                                 {t("statCard.getStarted")}
@@ -166,12 +218,26 @@ export const StatCard = ({
                             {subtitleText}
                         </div>
                     </div>
+                    {isRow && (
+                        <CaretRight
+                            size={16}
+                            className="shrink-0 text-play-ink/50 transition-all duration-300 group-hover:translate-x-0.5 group-hover:text-play-ink"
+                        />
+                    )}
                 </div>
             ) : (
                 /* Default / Vibrant layout */
                 <>
-                    <CardContent className="p-3 sm:p-4 flex flex-col justify-between h-full relative z-10">
-                        <div className="flex items-center justify-between mb-3">
+                    <CardContent className={cn(
+                        "p-3 sm:p-4 flex h-full relative z-10",
+                        isRow
+                            ? "flex-row items-center gap-3 sm:gap-4"
+                            : "flex-col justify-between"
+                    )}>
+                        <div className={cn(
+                            "flex items-center",
+                            isRow ? "shrink-0" : "justify-between mb-3"
+                        )}>
                             <div className={cn(
                                 "p-2 bg-primary/10 rounded-md text-primary ring-1 ring-primary/20 transition-colors group-hover:bg-primary/20",
                                 "[.ui-vibrant_&]:ring-0",
@@ -179,11 +245,13 @@ export const StatCard = ({
                             )}>
                                 <Icon size={20} weight="duotone" className="w-5 h-5 sm:w-6 sm:h-6" />
                             </div>
-                            <CaretRight size={16}
-                                className="text-muted-foreground group-hover:text-primary transition-all duration-300 group-hover:translate-x-0.5"
-                            />
+                            {!isRow && (
+                                <CaretRight size={16}
+                                    className="text-muted-foreground group-hover:text-primary transition-all duration-300 group-hover:translate-x-0.5"
+                                />
+                            )}
                         </div>
-                        <div className="space-y-1">
+                        <div className={cn("space-y-1", isRow && "min-w-0 flex-1")}>
                             {showAction ? (
                                 // Empty: a "Get started" invitation, never a dead "0".
                                 <div className="inline-flex items-center gap-1 text-lg sm:text-xl font-bold tracking-tight text-primary">
@@ -207,6 +275,11 @@ export const StatCard = ({
                                 {subtitleText}
                             </div>
                         </div>
+                        {isRow && (
+                            <CaretRight size={16}
+                                className="shrink-0 text-muted-foreground group-hover:text-primary transition-all duration-300 group-hover:translate-x-0.5"
+                            />
+                        )}
                     </CardContent>
                     {/* Vibrant Decorator */}
                     <div className="absolute -bottom-6 -end-6 w-24 h-24 bg-primary/5 rounded-full blur-2xl hidden [.ui-vibrant_&]:block group-hover:scale-150 transition-transform duration-500 pointer-events-none" />

--- a/frontend-learner-dashboard-app/src/routes/dashboard/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/dashboard/index.tsx
@@ -68,6 +68,7 @@ import {
   formatSessionTimeInUserTimezone,
 } from "@/utils/timezone";
 import { StatCard } from "./-components/DashboardStatCard";
+import type { StatCardLayout } from "./-components/DashboardStatCard";
 import { ContinueLearningCard } from "./-components/DashboardContinueLearningCard";
 import { DashboardHero } from "./-components/DashboardHero";
 import { PlayDashboardHero } from "./-components/play/PlayDashboardHero";
@@ -748,11 +749,18 @@ export function DashboardComponent() {
   // Column assignment is fixed by the redesign; institutes' saved widget
   // orders still sort widgets within their column.
 
-  const statCards = [
+  // `render` is a factory (not a prebuilt element) because the card's internal
+  // layout depends on how many cards survive the institute's flags — which is
+  // only known once this array has been filtered.
+  const statCards: Array<{
+    id: StudentDashboardWidgetConfig["id"];
+    render: (layout: StatCardLayout) => JSX.Element;
+  }> = [
     {
       id: "coursesStat" as const,
-      render: (
+      render: (layout) => (
         <StatCard
+          layout={layout}
           title={getTerminologyPlural(ContentTerms.Course, SystemTerms.Course)}
           count={data?.courses}
           icon={BookOpen}
@@ -776,8 +784,9 @@ export function DashboardComponent() {
     },
     {
       id: "liveClasses" as const,
-      render: (
+      render: (layout) => (
         <StatCard
+          layout={layout}
           title={getTerminologyPlural(
             ContentTerms.LiveSession,
             SystemTerms.LiveSession
@@ -798,8 +807,9 @@ export function DashboardComponent() {
     },
     {
       id: "evaluationStat" as const,
-      render: (
+      render: (layout) => (
         <StatCard
+          layout={layout}
           title="Assessments"
           count={testAssignedCount}
           icon={Trophy}
@@ -821,6 +831,19 @@ export function DashboardComponent() {
   ]
     .filter((w) => isWidgetVisible(w.id))
     .sort((a, b) => getWidgetOrder(a.id) - getWidgetOrder(b.id));
+
+  // The stats row tracks how many cards actually survived the institute's
+  // widget flags. Hard-coding sm:grid-cols-3 left an institute that shows only
+  // one stat (e.g. Live Sessions) with a third-width card and two empty
+  // columns; a lone card becomes a full-width row instead.
+  const statGridColsClass =
+    statCards.length >= 3
+      ? "sm:grid-cols-3"
+      : statCards.length === 2
+        ? "sm:grid-cols-2"
+        : "sm:grid-cols-1";
+  const statCardLayout: StatCardLayout =
+    statCards.length === 1 ? "row" : "stack";
 
   // MAIN column (lg:col-span-2): continue learning, stats row, progress
   // insights, custom widget, commerce. Commerce is hidden for the play
@@ -846,9 +869,18 @@ export function DashboardComponent() {
         : Number.MAX_SAFE_INTEGER,
       visible: statCards.length > 0,
       render: (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 max-sm:[.ui-cleaner-play_&]:grid-cols-2 max-sm:[.ui-play_&]:grid-cols-2 max-sm:[.ui-cleaner-play_&]:[&>*:last-child:nth-child(odd)]:col-span-2 max-sm:[.ui-play_&]:[&>*:last-child:nth-child(odd)]:col-span-2">
+        <div
+          className={cn(
+            "grid grid-cols-1 gap-3 sm:gap-4",
+            statGridColsClass,
+            // Play skins pair the cards two-up on phones; with a single card
+            // there is nothing to pair, so keep it one-up.
+            statCards.length > 1 &&
+              "max-sm:[.ui-cleaner-play_&]:grid-cols-2 max-sm:[.ui-play_&]:grid-cols-2 max-sm:[.ui-cleaner-play_&]:[&>*:last-child:nth-child(odd)]:col-span-2 max-sm:[.ui-play_&]:[&>*:last-child:nth-child(odd)]:col-span-2"
+          )}
+        >
           {statCards.map((w) => (
-            <div key={w.id}>{w.render}</div>
+            <div key={w.id}>{w.render(statCardLayout)}</div>
           ))}
         </div>
       ),
@@ -943,7 +975,8 @@ export function DashboardComponent() {
       id: "thisWeekAttendance" as const,
       order: getWidgetOrder("thisWeekAttendance"),
       visible: isWidgetVisible("thisWeekAttendance"),
-      render: <AttendanceWidget />,
+      // Streak rides the gamification flag — see AttendanceWidget.
+      render: <AttendanceWidget showStreak={showGamification} />,
     },
     {
       id: "myMentors" as const,
@@ -954,6 +987,12 @@ export function DashboardComponent() {
   ]
     .filter((w) => w.visible)
     .sort((a, b) => a.order - b.order);
+
+  // With every rail widget switched off there is nothing to reserve a third of
+  // the page for. The pins panel is not a reason to keep the column: it only
+  // renders when the institute has live announcements, so it would strand an
+  // empty rail on most days — it moves to the top of the main column instead.
+  const hasRail = railWidgets.length > 0;
 
   return (
     <div className="min-h-screen bg-background relative overflow-hidden w-full dashboard-container smooth-scroll">
@@ -1042,21 +1081,51 @@ export function DashboardComponent() {
               />
             )}
 
-            {/* Main 2/3 + 1/3 layout */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6 items-start">
-              <div className="space-y-4 lg:col-span-2 lg:space-y-6">
+            {/* Main 2/3 + 1/3 layout. The rail's third is only reserved when
+                the institute actually left rail widgets on — otherwise the
+                main column runs full width instead of stranding an empty
+                column beside it.
+
+                Widget wrappers are `empty:hidden` because several widgets
+                decide at runtime that they have nothing to show and return
+                null (no sessions in the next 24h, no memberships, reader-mode
+                commerce) — the `w.visible && w.render` filter can't see that,
+                since `w.render` is a non-null element either way. The wrapper
+                then survived as a zero-height div that still collected a
+                space-y margin, leaving a phantom gap. `display: none`
+                generates no box at all, so the margin stops applying. */}
+            <div
+              className={cn(
+                "grid grid-cols-1 gap-4 lg:gap-6 items-start",
+                hasRail && "lg:grid-cols-3"
+              )}
+            >
+              <div
+                className={cn(
+                  "space-y-4 lg:space-y-6",
+                  hasRail && "lg:col-span-2"
+                )}
+              >
+                {/* Without a rail, announcements lead the main column */}
+                {!hasRail && <DashboardPinsPanel maxPins={3} />}
                 {mainColumnWidgets.map((w) => (
-                  <div key={w.id}>{w.render}</div>
+                  <div key={w.id} className="empty:hidden">
+                    {w.render}
+                  </div>
                 ))}
               </div>
 
-              <div className="space-y-4 lg:col-span-1 lg:space-y-6">
-                {/* Institute announcements pin to the top of the rail */}
-                <DashboardPinsPanel maxPins={3} />
-                {railWidgets.map((w) => (
-                  <div key={w.id}>{w.render}</div>
-                ))}
-              </div>
+              {hasRail && (
+                <div className="space-y-4 lg:col-span-1 lg:space-y-6">
+                  {/* Institute announcements pin to the top of the rail */}
+                  <DashboardPinsPanel maxPins={3} />
+                  {railWidgets.map((w) => (
+                    <div key={w.id} className="empty:hidden">
+                      {w.render}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Gamification (badges / XP / streak) — bottom of the main flow.

--- a/frontend-learner-dashboard-app/src/utils/branding.ts
+++ b/frontend-learner-dashboard-app/src/utils/branding.ts
@@ -91,8 +91,21 @@ export function resolveFontStack(fontFamily?: string | null): string {
       return buildFontStack("Work Sans");
     case "LEXEND":
       return buildFontStack("Lexend");
+    case "POPPINS":
+      return buildFontStack("Poppins");
+    case "PLUS JAKARTA SANS":
+      return buildFontStack("Plus Jakarta Sans");
+    case "OPEN SANS":
+      return buildFontStack("Open Sans");
     default:
-      return withArabicFallback(String(fontFamily));
+      // An unrecognised value is a literal CSS family, but it MUST still get the
+      // system tail. Without it the stack was just `<font>, 'Noto Naskh Arabic'`
+      // — and the Arabic face is unicode-range-scoped to Arabic codepoints, so
+      // Latin text can't match it. If the literal font isn't loaded, nothing in
+      // the stack can render Latin and the browser falls back to its own
+      // default, which in Chrome is a SERIF. That is how an institute
+      // configured with an unloaded font ended up rendering in Times New Roman.
+      return `${withArabicFallback(String(fontFamily))}, ${SYSTEM_TAIL}`;
   }
 }
 


### PR DESCRIPTION

Institutes that hide most dashboard widgets rendered a broken layout, and an institute whose configured font was not in the resolver's enum rendered in the browser's default serif.

Layout
- The stat row hard-coded sm:grid-cols-3, so an institute with one visible stat (e.g. only Live Sessions) got a third-width card beside two empty columns. Columns now follow the surviving card count, and a lone card switches to a horizontal banner via a new StatCard `layout` prop.
- Widget wrappers are `empty:hidden`. Several widgets decide at runtime that they have nothing to show and return null; the `visible && render` filter cannot see that, so the wrapper survived as a zero-height div still collecting a space-y margin and left a phantom gap.
- The rail's third of the page is only reserved when rail widgets are actually enabled; otherwise the main column runs full width and the pins panel moves to its top.

Attendance streak
- The streak was hard-coded in all three skins, so no setting could turn it off. It now rides the existing `gamification` widget flag (defaults on), hiding the Fire tile and dropping the streak framing from the empty state.

Font
- resolveFontStack's `default:` branch returned `<font>, 'Noto Naskh Arabic'` with no system tail. The Arabic face is unicode-range-scoped to Arabic codepoints, so when the literal font was not loaded nothing in the stack could render Latin and the browser fell back to its own default serif. It now appends SYSTEM_TAIL.
- Poppins is loaded in both apps and added to the resolvers and pickers. PLUS JAKARTA SANS / OPEN SANS were already loaded and offered in the picker but missing from the learner switch, so they hit the same broken path.

No institute ids are referenced; all behaviour is driven by existing settings.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
