### PR TITLE
Make instituteId optional on the by-username join-link lookup

### DIFF
--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/user/controller/OpenUserController.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/user/controller/OpenUserController.java
@@ -26,11 +26,19 @@ public class OpenUserController {
         return ResponseEntity.ok(user);
     }
 
+    /**
+     * Look up a learner by username for the public join-link flow.
+     *
+     * <p>{@code instituteId} is optional: usernames are globally unique, and institutes
+     * served from a shared domain have no institute_domain_routing row to resolve an id
+     * from — demanding one 400'd/404'd their learners out of their own join link. Supply
+     * it to scope the lookup, omit it to match on username + portal role alone.</p>
+     */
     @GetMapping("/by-username")
     public ResponseEntity<UserDTO> findUserByUsername(
             @RequestParam String username,
             @RequestParam String portal,
-            @RequestParam String instituteId) {
+            @RequestParam(required = false) String instituteId) {
 
         Optional<UserDTO> optionalUser = userOperationService.findByUserName(username, instituteId, portal);
 

--- a/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/UserOperationService.java
+++ b/auth_service/src/main/java/vacademy/io/auth_service/feature/user/service/UserOperationService.java
@@ -192,9 +192,17 @@ public class UserOperationService {
         List<String> allowedStatuses = getAllowedStatuses(portal);
         List<String> allowedRoleNames = getValidRoleNames(portal);
 
+        // instituteId is OPTIONAL. Usernames are globally unique — findByUsername above
+        // returns at most one user — so the portal's role + status already identify a
+        // legitimate learner without it. Requiring it locked out every institute on a
+        // shared domain: with no institute_domain_routing row the caller has no id to
+        // send, and a valid learner got a 404 on their own join link. When an id IS
+        // supplied it still scopes the match, so single-tenant callers are unchanged.
+        boolean instituteScoped = instituteId != null && !instituteId.isBlank();
         boolean hasValidRole = user.getRoles() != null && user.getRoles().stream()
                 .anyMatch(ur ->
-                        ur.getInstituteId() != null && ur.getInstituteId().equals(instituteId)
+                        (!instituteScoped
+                                || (ur.getInstituteId() != null && ur.getInstituteId().equals(instituteId)))
                                 && ur.getStatus() != null && allowedStatuses.contains(ur.getStatus())
                                 && ur.getRole() != null && allowedRoleNames.contains(ur.getRole().getName())
                 );

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/$username/components/SessionLoginForm.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/$username/components/SessionLoginForm.tsx
@@ -44,6 +44,23 @@ const usernameSchema = z.object({
 
 type UsernameFormValues = z.infer<typeof usernameSchema>;
 
+/**
+ * The institute to continue with after login.
+ *
+ * Prefers the one the caller already knows (domain routing resolved it). When it
+ * could not — a shared domain has no institute_domain_routing row — fall back to
+ * the access token, whose `authorities` map is keyed by institute id. Without this
+ * the learner authenticates successfully and then stalls, because every follow-up
+ * fetch is gated on having an institute.
+ */
+const resolveInstituteId = (
+  known: string | undefined,
+  tokenData: { authorities?: Record<string, unknown> } | null | undefined
+): string | undefined => {
+  if (known) return known;
+  return Object.keys(tokenData?.authorities ?? {})[0];
+};
+
 interface UserDetails {
   id: string;
   username: string;
@@ -54,7 +71,13 @@ interface UserDetails {
 
 interface SessionLoginFormProps {
   username: string;
-  instituteId: string;
+  /**
+   * Optional. Institutes served from a shared domain have no domain-routing row,
+   * so the caller genuinely cannot resolve one. The username is globally unique,
+   * so lookup works without it and the institute is read back off the JWT after
+   * login (see resolveInstituteId).
+   */
+  instituteId?: string;
   onLoginSuccess: () => void;
   /**
    * Post-login navigation override. Default keeps the original behavior
@@ -99,7 +122,9 @@ export const SessionLoginForm: React.FC<SessionLoginFormProps> = ({
         params: {
           username,
           portal: "LEARNER",
-          instituteId,
+          // Omitted entirely when unknown — the endpoint treats it as optional
+          // and matches on username + portal role instead.
+          ...(instituteId ? { instituteId } : {}),
         },
       });
       return response.data;
@@ -130,22 +155,29 @@ export const SessionLoginForm: React.FC<SessionLoginFormProps> = ({
             // Decode token to get user data
             const tokenData = getTokenDecodedData(response.data.accessToken);
             const userId = tokenData?.user;
+            const resolvedInstituteId = resolveInstituteId(
+              instituteId,
+              tokenData
+            );
 
-            if (instituteId && userId) {
+            if (resolvedInstituteId && userId) {
               identifyUser(userId, {
                 username: tokenData?.username,
                 email: tokenData?.email,
               });
 
               try {
-                await fetchAndStoreInstituteDetails(instituteId, userId);
+                await fetchAndStoreInstituteDetails(
+                  resolvedInstituteId,
+                  userId
+                );
                 getStudentDisplaySettings(true);
               } catch (error) {
                 console.error("Error fetching institute details:", error);
               }
 
               try {
-                await fetchAndStoreStudentDetails(instituteId, userId);
+                await fetchAndStoreStudentDetails(resolvedInstituteId, userId);
               } catch {
                 toast.error("Failed to fetch student details");
               }
@@ -252,8 +284,9 @@ export const SessionLoginForm: React.FC<SessionLoginFormProps> = ({
         // Decode token to get user data
         const tokenData = getTokenDecodedData(response.data.accessToken);
         const userId = tokenData?.user;
+        const resolvedInstituteId = resolveInstituteId(instituteId, tokenData);
 
-        if (instituteId && userId) {
+        if (resolvedInstituteId && userId) {
           identifyUser(userId, {
             username: tokenData?.username,
             email: tokenData?.email,
@@ -261,15 +294,15 @@ export const SessionLoginForm: React.FC<SessionLoginFormProps> = ({
 
           try {
             // Fetch and store institute details
-            await fetchAndStoreInstituteDetails(instituteId, userId);
+            await fetchAndStoreInstituteDetails(resolvedInstituteId, userId);
             getStudentDisplaySettings(true);
           } catch (error) {
             console.error("Error fetching institute details:", error);
-            
+
           }
 
           try {
-            await fetchAndStoreStudentDetails(instituteId, userId);
+            await fetchAndStoreStudentDetails(resolvedInstituteId, userId);
           } catch {
             toast.error("Failed to fetch student details");
           }

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/$username/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/$username/index.tsx
@@ -308,24 +308,17 @@ function RouteComponent() {
       {/* Main Content */}
       <div className="flex-1 flex items-center justify-center px-4 py-8">
         <div className="w-full max-w-md">
-          {/* Login Form */}
-          {domainRouting.instituteId ? (
-            <SessionLoginForm
-              username={username}
-              instituteId={domainRouting.instituteId}
-              onLoginSuccess={handleLoginSuccess}
-            />
-          ) : (
-            <div className="text-center space-y-4">
-              <h2 className="text-2xl font-semibold text-gray-900">
-                Unable to Load Session
-              </h2>
-              <p className="text-gray-600">
-                Could not determine the institute for this session. Please check
-                the URL or contact support.
-              </p>
-            </div>
-          )}
+          {/* Login Form.
+              instituteId is optional: institutes served from a shared domain have
+              no domain-routing row, so it resolves to null here. The username in
+              the URL is globally unique, which is enough to look the learner up —
+              blocking on a missing institute locked those learners out of their
+              own join link. */}
+          <SessionLoginForm
+            username={username}
+            instituteId={domainRouting.instituteId ?? undefined}
+            onLoginSuccess={handleLoginSuccess}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
Institutes served from a shared domain have no institute_domain_routing row, so GET /public/domain-routing/v1/resolve 404s and the learner app has no instituteId to send. The join link then dead-ended before login:

  - /auth-service/open/user-details/by-username required instituteId, so a missing one was a 400 -- even though the lookup finds the user by username first and only used instituteId as a filter afterwards.
  - the live-class page refused to render the login form at all without one, showing "Unable to Load Session" to a perfectly valid learner.

Usernames are globally unique (findByUsername returns at most one user), so the portal role + status already identify the learner. instituteId is now optional on both sides and still scopes the match when supplied, leaving single-tenant callers unchanged. login-by-username-trusted already documented institute_id as optional -- this brings the lookup in line with it.

After login the frontend reads the institute back off the JWT, whose authorities map is keyed by institute id; without that the learner would authenticate and then stall, since every follow-up fetch was gated on having an institute.

Verified: auth_service compiles (only the pre-existing notifyUsernameChanged error remains), learner app tsc and design-lint clean.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
