### PR TITLE
Make the disclaimer toggle settable by admins

### DIFF
--- a/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
@@ -428,13 +428,10 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                 </CardContent>
             </Card>
 
-            {/* One-off disclaimer video.
-                Rendered ONLY for institutes opted into the feature. While
-                disclaimerVideoFeatureEnabled is false the card does not exist for
-                them — the feature is not advertised to institutes that are not
-                using it yet. */}
-            {settings.disclaimerVideoFeatureEnabled && (
-                <Card className="border-neutral-200 shadow-none">
+            {/* Disclaimer video. Always available here — this is where an admin
+                turns the feature on. While it is off, the per-class disclaimer
+                control stays hidden on the live-class form. */}
+            <Card className="border-neutral-200 shadow-none">
                     <CardHeader className="flex-row items-start gap-3 space-y-0 p-5 pb-4">
                         <div className="flex size-9 items-center justify-center rounded-md bg-primary-50 text-primary-500">
                             <ClipboardText size={18} />
@@ -442,16 +439,17 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                         <div className="flex-1">
                             <CardTitle className="text-base">Disclaimer Video</CardTitle>
                             <CardDescription>
-                                Played once, before a learner&apos;s very first live class — not
-                                per class and not per day. Every live class follows this one
-                                setting, including classes created automatically by a workflow.
+                                Shown before a learner joins a class they have not attended
+                                yet, and not again once they are marked present in it. One
+                                video for every live class, including classes created
+                                automatically by a workflow.
                             </CardDescription>
                         </div>
                     </CardHeader>
                     <CardContent className="border-t border-neutral-100 p-5">
                         <SettingRow
-                            title="Show a disclaimer before the first class"
-                            description="When on, learners watch the video below before joining their first live class. Once they attend a class they are never asked again."
+                            title="Show a disclaimer before joining a class"
+                            description="When on, a learner watches the video below before joining a class they have not attended yet. Marking them present retires it for that class."
                             checked={settings.disclaimerVideoEnabled}
                             onChange={(v) => togglePrimitive('disclaimerVideoEnabled', v)}
                         />
@@ -482,9 +480,8 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                                     </div>
                                 )}
                         </div>
-                    </CardContent>
-                </Card>
-            )}
+                </CardContent>
+            </Card>
 
             {/* Daily attendance default */}
             <Card className="border-neutral-200 shadow-none">

--- a/frontend-admin-dashboard/src/services/live-session-settings.ts
+++ b/frontend-admin-dashboard/src/services/live-session-settings.ts
@@ -243,19 +243,12 @@ export interface LiveSessionSettings {
     /** Default "add identity watermark". */
     defaultZoomWatermark: boolean;
     /**
-     * VISIBILITY GATE for the whole disclaimer feature. Not editable in the UI —
-     * it is set per institute by us. While `false` the Disclaimer Video card is
-     * not rendered at all, so institutes that have not opted in never see the
-     * feature exists.
+     * Master switch for the disclaimer video. Off for every institute by default,
+     * so nothing changes for anyone until an admin turns it on here.
      *
-     * Separate from `disclaimerVideoEnabled` on purpose: that one is the
-     * institute's own on/off switch. Gating visibility on it instead would mean
-     * that turning the disclaimer off also hid the card used to turn it back on.
-     */
-    disclaimerVideoFeatureEnabled: boolean;
-    /**
-     * The institute's own switch. When `false` the video is never shown even if a
-     * URL is still saved, so they can pause it without losing the link.
+     * This is also the VISIBILITY GATE for the per-class control: the disclaimer
+     * option only appears on the live-class form while this is on, so institutes
+     * not using the feature never meet it while scheduling.
      */
     disclaimerVideoEnabled: boolean;
     /**
@@ -331,9 +324,8 @@ export const DEFAULT_LIVE_SESSION_SETTINGS: LiveSessionSettings = {
     defaultZoomFocusMode: false,
     defaultZoomAllowMultipleDevices: false,
     defaultZoomWatermark: false,
-    // Hidden by default: an institute that has not been opted in must not see the
-    // feature at all, let alone have a disclaimer appear before its learners.
-    disclaimerVideoFeatureEnabled: false,
+    // Off by default: no institute gets a disclaimer in front of its learners,
+    // and the per-class control stays hidden, until an admin turns this on.
     disclaimerVideoEnabled: false,
     disclaimerVideoUrl: '',
 };


### PR DESCRIPTION
Follow-up to #2541. The disclaimer card was gated behind disclaimerVideoFeatureEnabled, a flag with no UI — so an admin had no way to switch the feature on at all; it needed someone to write the setting through the API. That is not a gate, it is a lockout, and it was a misreading of the ask.

The flag is removed. The card always renders in Settings -> Live Session, with its toggle and video link editable, and disclaimerVideoEnabled becomes the real gate: off by default, and while off the per-class disclaimer control stays hidden on the live-class form. So institutes still never meet the feature while scheduling unless they turn it on themselves.

Also corrects the card copy, which still described the original once-per-learner behaviour after the logic moved to once-per-class.

Verified: design-lint clean; admin-dashboard tsc shows the same 82 pre-existing errors as main, none in these files.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
