### PR TITLE
Let workflow SpEL compute anchor dates via #dates

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/SpelEvaluator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/SpelEvaluator.java
@@ -23,6 +23,12 @@ import java.util.Set;
 @Component
 public class SpelEvaluator {
 
+    private final WorkflowDateFunctions dateFunctions;
+
+    public SpelEvaluator(WorkflowDateFunctions dateFunctions) {
+        this.dateFunctions = dateFunctions;
+    }
+
     /**
      * Evaluates a SpEL expression with the given context variables.
      *
@@ -56,6 +62,9 @@ public class SpelEvaluator {
         // in a node AFTER a multi-day delay would throw EL1008 and drop/abort the run.
         context.addPropertyAccessor(new MapAccessor());
         context.setVariable("ctx", contextVars);
+        // Date helpers: #dates.nextWeekday(...) lets any node compute an anchor date from config
+        // using the same strictly-next logic the DELAY node schedules against.
+        context.setVariable("dates", dateFunctions);
         if (extraVars != null) {
             extraVars.forEach(context::setVariable);
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/WorkflowDateFunctions.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/spel/WorkflowDateFunctions.java
@@ -1,0 +1,97 @@
+package vacademy.io.admin_core_service.features.workflow.spel;
+
+import org.springframework.stereotype.Component;
+import vacademy.io.admin_core_service.features.workflow.util.WorkflowDateUtil;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Date helpers exposed to workflow SpEL expressions as {@code #dates}. Registered once in
+ * {@link SpelEvaluator}, so every node type (TRANSFORM, SEND_WHATSAPP templateVars, SEND_EMAIL,
+ * CONDITION, ...) can compute an anchor date from config instead of relying on hardcoded Java.
+ *
+ * <p>Example — announce the drip's start day in a welcome message, no code change to switch
+ * weekday/format/timezone:
+ * <pre>
+ *   #dates.nextWeekday('MONDAY', 'Asia/Kolkata', 'do MMMM')   -&gt; "3rd August"
+ *   #dates.nextWeekday('TUESDAY', 'Asia/Kolkata', 'EEEE, do MMM')
+ * </pre>
+ *
+ * <p>Pattern is a standard {@link java.time.format.DateTimeFormatter} pattern, with one addition:
+ * the token {@code do} renders the day-of-month with an English ordinal suffix (1st, 2nd, 3rd...).
+ */
+@Component
+public class WorkflowDateFunctions {
+
+    /** 1 -> "1st", 2 -> "2nd", ... 31 -> "31st"; used to render the {@code do} pattern token. */
+    private static final Map<Long, String> ORDINAL_DAYS = buildOrdinalDays();
+
+    /**
+     * Next occurrence of {@code day}, strictly after today (today is never returned), formatted
+     * with {@code pattern} in {@code zone}. This is the common case for a "starts next &lt;weekday&gt;"
+     * announcement and matches the DELAY node's default (includeSameDay=false).
+     */
+    public String nextWeekday(String day, String zone, String pattern) {
+        return nextWeekday(day, "00:00", zone, pattern, false);
+    }
+
+    /**
+     * Next occurrence with explicit time-of-day and same-day handling. {@code time} only matters
+     * when {@code includeSameDay} is true (it decides whether today still qualifies).
+     */
+    public String nextWeekday(String day, String time, String zone, String pattern,
+                              boolean includeSameDay) {
+        ZoneId z = ZoneId.of(zone);
+        ZonedDateTime target = WorkflowDateUtil.nextOccurrence(
+                ZonedDateTime.now(z),
+                DayOfWeek.valueOf(day.trim().toUpperCase(Locale.ENGLISH)),
+                LocalTime.parse(time.trim()),
+                includeSameDay);
+        return format(target.toLocalDate(), pattern);
+    }
+
+    /** Format a date with a standard pattern, treating the literal token {@code do} as ordinal day. */
+    private String format(LocalDate date, String pattern) {
+        DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
+        // Split on the ordinal-day token; surrounding segments are ordinary DateTimeFormatter patterns.
+        String[] segments = pattern.split("do", -1);
+        for (int i = 0; i < segments.length; i++) {
+            if (!segments[i].isEmpty()) {
+                builder.appendPattern(segments[i]);
+            }
+            if (i < segments.length - 1) {
+                builder.appendText(ChronoField.DAY_OF_MONTH, ORDINAL_DAYS);
+            }
+        }
+        return builder.toFormatter(Locale.ENGLISH).format(date);
+    }
+
+    private static Map<Long, String> buildOrdinalDays() {
+        Map<Long, String> map = new HashMap<>();
+        for (long d = 1; d <= 31; d++) {
+            map.put(d, d + ordinalSuffix((int) d));
+        }
+        return map;
+    }
+
+    private static String ordinalSuffix(int day) {
+        if (day >= 11 && day <= 13) {
+            return "th";
+        }
+        return switch (day % 10) {
+            case 1 -> "st";
+            case 2 -> "nd";
+            case 3 -> "rd";
+            default -> "th";
+        };
+    }
+}


### PR DESCRIPTION
Messages that announce when something starts ("your drip begins next Monday") had the date built in Java, so changing the weekday, the format, or the timezone meant a code change and a deploy. WorkflowDateFunctions exposes that as #dates in every SpEL context, so it becomes config:

  #dates.nextWeekday('MONDAY', 'Asia/Kolkata', 'do MMMM')  -> "3rd August"

It reuses WorkflowDateUtil, the same strictly-next logic the DELAY node schedules against, so a message announcing the start day and the delay that waits for it cannot disagree. The 'do' token renders an English ordinal suffix, which DateTimeFormatter has no pattern for.

Registered once in SpelEvaluator, so TRANSFORM, CONDITION, SEND_WHATSAPP templateVars and SEND_EMAIL all get it without per-node plumbing.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
