### PR TITLE
fix(cpo): stop one-off fees aborting the whole fee-bill insert batch

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeePaymentGenerationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/StudentFeePaymentGenerationService.java
@@ -16,6 +16,7 @@ import vacademy.io.common.exceptions.VacademyException;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -80,9 +81,19 @@ public class StudentFeePaymentGenerationService {
                     payment.setUserPlanId(userPlanId);
                     payment.setCpoId(cpoId);
                     payment.setAsvId(afv.getId());
-                    payment.setIId(afv.getId()); // No installment; use AFV ID as sentinel
+                    // No AftInstallment exists for a one-off fee. i_id is a FK to
+                    // aft_installments (fk_sfp_installment), so the previous "use the AFV id
+                    // as a sentinel" trick could only ever violate it — and since Hibernate
+                    // batches these inserts, that one row aborted the entire batch and took
+                    // the sibling installment rows down with it. Leave it null (V452 drops
+                    // the NOT NULL); asv_id already carries the link to the fee value.
+                    payment.setIId(null);
                     payment.setAmountExpected(afv.getAmount());
                     payment.setAmountPaid(BigDecimal.ZERO);
+                    // A schedule-less fee is payable from enrollment day. Without a due date
+                    // it never enters the "dues now" calculation, so the side-view offers
+                    // nothing to collect against and an admin can't record a payment for it.
+                    payment.setDueDate(Date.valueOf(LocalDate.now()));
                     payment.setStatus("PENDING");
                     payment.setInstituteId(instituteId);
 

--- a/admin_core_service/src/main/resources/db/migration/V452__student_fee_payment_nullable_installment.sql
+++ b/admin_core_service/src/main/resources/db/migration/V452__student_fee_payment_nullable_installment.sql
@@ -1,0 +1,13 @@
+-- A CPO fee type with has_installment = false has no aft_installments row to point
+-- at, but student_fee_payment.i_id was NOT NULL and carries FK fk_sfp_installment
+-- (i_id -> aft_installments.id, added in V119). The generator worked around the
+-- NOT NULL by writing the AssignedFeeValue id into i_id as a sentinel, which could
+-- only ever violate the FK -- and because Hibernate batches the inserts, that one
+-- bad row aborted the whole batch and took the sibling installment rows with it.
+-- The learner ended up enrolled, with ledger accruals (posted REQUIRES_NEW, so they
+-- survived the rollback) but zero fee bills and nothing an admin could collect against.
+--
+-- Allow i_id to be null so a one-off fee can simply have no installment. asv_id
+-- (NOT NULL) still links the row back to its AssignedFeeValue, and every reader of
+-- i_id already tolerates null or looks the id up defensively.
+ALTER TABLE student_fee_payment ALTER COLUMN i_id DROP NOT NULL;


### PR DESCRIPTION
A CPO fee type with has_installment = false has no aft_installments row, but student_fee_payment.i_id is NOT NULL and carries FK fk_sfp_installment (i_id -> aft_installments.id, added back in V119). generateFeeBills worked around the NOT NULL by writing the AssignedFeeValue id into i_id as a sentinel, which could only ever violate that FK.

Because Hibernate batches the inserts, the one bad row aborted the entire batch and took its sibling installment rows with it. The learner ended up ACTIVE and enrolled, with ledger accruals committed (recordDebitAccrual is REQUIRES_NEW, so it survives the caller's rollback) but zero fee bills - a balance owing with nothing to pay against, and no row for an admin to record a manual payment or raise an invoice against.

The sentinel has never once persisted: 0 of 861 existing rows have i_id = asv_id. The branch simply had not run in production until a CPO was configured with a non-installment fee type in mid-August.

- V452 drops the NOT NULL on i_id
- one-off fees now store i_id = null; asv_id still links to the fee value
- one-off fees get a due date of the enrollment day, so they enter the "dues now" calculation and are actually collectible

Four CPO templates currently carry a zero-installment fee value and fail on every enrollment: 35a218c5, 361d084b, d4eddde8, fd69ed51.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
