### PR TITLE
fix(cpo): make StudentFeePayment.iId nullable on the entity too

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeePayment.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/entity/StudentFeePayment.java
@@ -44,7 +44,11 @@ public class StudentFeePayment {
     @Column(name = "asv_id", nullable = false)
     private String asvId;
 
-    @Column(name = "i_id", nullable =  false)
+    // Nullable since V452: a one-off fee type (has_installment = false) has no
+    // AftInstallment to point at. Hibernate enforces nullable = false itself and
+    // rejects the insert before it reaches the database, so dropping the DB
+    // constraint alone was not enough. asv_id still links the row to its fee value.
+    @Column(name = "i_id")
     private String iId;
 
     @Column(name = "amount_expected", nullable = false)


### PR DESCRIPTION
V452 dropped the NOT NULL on student_fee_payment.i_id, but the JPA entity still declared @Column(nullable = false). Hibernate enforces that itself and throws PropertyValueException before the insert ever reaches Postgres, so one-off fee types kept failing after the migration shipped - the error simply changed from a foreign-key violation to:

  not-null property references a null or transient value
    : ...fee_management.entity.StudentFeePayment.iId

This variant is worse in one way: Hibernate rejects on the first save() rather than at batch flush, so generateFeeBills now aborts before recording any ledger accrual. The learner ends up ACTIVE with no fee bills AND no ledger rows, which is why Payment History and the cpo-plans endpoint both come back empty.

asv_id (still NOT NULL) continues to link the row to its AssignedFeeValue.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
