### PR TITLE
fix(cpo): credit the ledger for a payment taken at enrollment

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -97,6 +97,8 @@ public class BulkAssignmentService {
     private final vacademy.io.admin_core_service.features.audience.service.UserLeadProfileService userLeadProfileService;
     private final StudentFeePaymentGenerationService studentFeePaymentGenerationService;
     private final FeeLedgerAllocationService feeLedgerAllocationService;
+
+    private final vacademy.io.admin_core_service.features.user_account.service.UserAccountLedgerService userAccountLedgerService;
     private final vacademy.io.admin_core_service.features.fee_management.service.CpoEnrollmentConfigApplier cpoEnrollmentConfigApplier;
     private final FeeTypeRepository feeTypeRepository;
     private final AssignedFeeValueRepository assignedFeeValueRepository;
@@ -1784,6 +1786,23 @@ public class BulkAssignmentService {
                     vacademy.io.admin_core_service.features.user_subscription.enums.PaymentLogStatusEnum.SUCCESS.name(),
                     vacademy.io.common.payment.enums.PaymentStatusEnum.PAID.name(),
                     vacademy.io.admin_core_service.features.common.util.JsonUtil.toJson(paymentSpecificData));
+
+            // Ledger credit for the money just taken. Without this the Account Summary
+            // tiles (which read user_account_ledger via sumCredits) report Total Paid 0
+            // and Due at the full accrued amount, while the Fee Plan block — driven by
+            // student_fee_payment.amount_paid, updated by the allocator below — shows the
+            // real figure. Same call the side-view offline-payment path makes
+            // (CpoSideViewService.recordOfflinePayment); idempotent on the PaymentLog id.
+            if (instituteId != null) {
+                userAccountLedgerService.recordCreditPayment(
+                        userId, instituteId,
+                        amount, currency,
+                        "USER_PLAN", userPlan.getId(),
+                        paymentLogId, null, "CPO payment recorded at enrollment");
+            } else {
+                log.warn("Skipping ledger credit for CPO enrollment payment userPlan={}: no instituteId",
+                        userPlan.getId());
+            }
 
             feeLedgerAllocationService.allocatePaymentForNewLog(
                     paymentLogId, amount, userPlan.getId());


### PR DESCRIPTION
The bulk-assign CPO payment path created a PaymentLog, FIFO-allocated it across the fee rows and generated an invoice, but never posted a CREDIT_PAYMENT to user_account_ledger. The two halves of the Payment History tab then disagreed:

  Account Summary (user_account_ledger via sumCredits)  Total Paid 0, Due 35,000
  Fee Plan        (student_fee_payment.amount_paid)     Paid 8,000, Outstanding 27,000

Verified on prod for one learner: a MANUAL PaymentLog of 8,000 PAID/SUCCESS, correctly allocated as 5,000 + 3,000 across two fee rows, with only the four DEBIT_ACCRUAL rows on the ledger and no credit.

Posts the same recordCreditPayment the side-view offline-payment path already makes (CpoSideViewService.recordOfflinePayment), keyed on the PaymentLog id so it stays idempotent across webhook or request retries.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
