### PR TITLE
fix(cpo): match enrollment overrides for one-off fees by asv_id

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoEnrollmentConfigApplier.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoEnrollmentConfigApplier.java
@@ -52,10 +52,24 @@ public class CpoEnrollmentConfigApplier {
             sfpByAftId.putIfAbsent(sfp.getIId(), sfp.getId());
         }
 
+        // A one-off fee type (has_installment = false) has no AftInstallment, so its SFP
+        // row carries i_id = null and can never appear in the map above. The enrollment UI
+        // still needs to target it — it synthesises a virtual installment row keyed on the
+        // AssignedFeeValue id — so accept that id as an alias. Only rows with a null i_id
+        // are indexed here, keeping real installment ids authoritative on the map above.
+        Map<String, String> sfpByAsvIdForLumpSum = new HashMap<>();
+        for (StudentFeePayment sfp : sfps) {
+            if (sfp.getIId() != null || sfp.getAsvId() == null) continue;
+            sfpByAsvIdForLumpSum.putIfAbsent(sfp.getAsvId(), sfp.getId());
+        }
+
         if (config.getInstallmentOverrides() != null) {
             for (InstallmentOverrideDTO ov : config.getInstallmentOverrides()) {
                 if (ov == null || ov.getAftInstallmentId() == null) continue;
                 String sfpId = sfpByAftId.get(ov.getAftInstallmentId());
+                if (sfpId == null) {
+                    sfpId = sfpByAsvIdForLumpSum.get(ov.getAftInstallmentId());
+                }
                 if (sfpId == null) {
                     log.warn("Override for aft_installment={} ignored — no matching SFP on userPlan={}",
                             ov.getAftInstallmentId(), userPlanId);

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/CpoEnrollmentConfigPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/CpoEnrollmentConfigPanel.tsx
@@ -30,9 +30,11 @@ const flattenInstallments = (feeTypes: CPOFeeType[] | undefined): InstallmentRow
         if (!afv) continue;
         const installments: CPOInstallment[] = afv.installments ?? [];
         if (installments.length === 0) {
-            // Lump-sum AFV synthesizes a single virtual row keyed off the AFV id —
-            // the backend stamps SFP.iId with the AFV id in this case (see
-            // StudentFeePaymentGenerationService line ~80).
+            // Lump-sum AFV synthesizes a single virtual row keyed off the AFV id.
+            // The SFP row for a one-off fee carries i_id = null (it has no
+            // AftInstallment), so CpoEnrollmentConfigApplier resolves this id
+            // against asv_id instead — see the lump-sum alias map there. Do not
+            // switch this to an installment id: there isn't one.
             rows.push({
                 id: afv.id,
                 feeTypeName: ft.name,


### PR DESCRIPTION
Discounts and date overrides targeting a one-off fee type (has_installment = false) were silently dropped at enrollment. CpoEnrollmentConfigApplier indexes the fee rows by i_id and skips rows where it is null - which is exactly the one-off fee row since it has no AftInstallment to point at. The override then found no match and was discarded with a log.warn nobody reads.

This is fallout from making i_id nullable. Before that the generator stamped i_id with the AssignedFeeValue id as a sentinel, which happened to make this lookup succeed; the insert failed outright, so the path never actually worked end to end, but the id contract was load-bearing and I missed it.

The enrollment UI synthesises a virtual installment row keyed on the AFV id for exactly this case (CpoEnrollmentConfigPanel.flattenInstallments), so accept that id as an alias: a second map, built only from rows whose i_id is null, resolves asv_id -> SFP id and is consulted after the installment map misses. Real installment ids stay authoritative.

Also corrects the frontend comment, which still described the removed sentinel.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
