### PR TITLE
fix(cpo): reverse the ledger accrual when a discount is applied

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoDiscountService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoDiscountService.java
@@ -57,9 +57,19 @@ public class CpoDiscountService {
 
     private final UserPlanRepository userPlanRepository;
     private final StudentFeePaymentRepository studentFeePaymentRepository;
+    private final vacademy.io.admin_core_service.features.user_account.service.UserAccountLedgerService userAccountLedgerService;
+    private final vacademy.io.admin_core_service.features.user_account.repository.UserAccountLedgerRepository userAccountLedgerRepository;
 
     private static final int SCALE = 2;
     private static final RoundingMode RM = RoundingMode.HALF_UP;
+
+    /**
+     * source_type for the ledger rows this service posts. Deliberately NOT
+     * STUDENT_FEE_PAYMENT: that belongs to the original obligation written by
+     * StudentFeePaymentGenerationService, and the delta arithmetic below has to be able to
+     * tell its own discount entries apart from that accrual.
+     */
+    private static final String DISCOUNT_LEDGER_SOURCE_TYPE = "CPO_DISCOUNT";
 
     // ------------------------------------------------------------------ apply
 
@@ -210,6 +220,68 @@ public class CpoDiscountService {
         recomputeAndPersist(plan, snapshot);
     }
 
+    /**
+     * Keeps the ledger's total_accrued in step with a discounted fee row, so the Account
+     * Summary tiles agree with the Fee Plan block instead of reporting the pre-discount
+     * gross. A discount voids part of an obligation before any money moves, which is exactly
+     * DEBIT_REVERSAL — it subtracts from total_accrued rather than counting as a payment.
+     *
+     * <p>Written as a DELTA, not an absolute. {@code recomputeAndPersist} re-derives every
+     * row from {@code original_amount} on each edit, so posting (original - net) every time
+     * would stack duplicate reversals on an append-only table. Instead we compare the
+     * discount owed with what has already been booked under
+     * {@link #DISCOUNT_LEDGER_SOURCE_TYPE} and post only the difference — as a reversal when
+     * the discount grew, or as a fresh accrual when it shrank (or was removed), since a
+     * reversal can never be un-posted.
+     *
+     * <p>The reversal carries the row's due date so it cancels out of the past-due bucket as
+     * well as the total. Best-effort: a ledger hiccup must not fail the discount edit itself.
+     */
+    private void syncDiscountToLedger(UserPlan plan, StudentFeePayment sfp,
+                                      BigDecimal base, BigDecimal net) {
+        try {
+            if (base == null || net == null) return;
+            String instituteId = sfp.getInstituteId();
+            if (instituteId == null || instituteId.isBlank()) {
+                log.warn("Skipping discount ledger sync for sfp={}: no instituteId", sfp.getId());
+                return;
+            }
+
+            BigDecimal owed = scale(base.subtract(net));
+            if (owed.signum() < 0) owed = BigDecimal.ZERO;
+
+            BigDecimal reversed = nz(userAccountLedgerRepository.sumBySourceAndEventType(
+                    DISCOUNT_LEDGER_SOURCE_TYPE, sfp.getId(), "DEBIT_REVERSAL"));
+            BigDecimal restored = nz(userAccountLedgerRepository.sumBySourceAndEventType(
+                    DISCOUNT_LEDGER_SOURCE_TYPE, sfp.getId(), "DEBIT_ACCRUAL"));
+            BigDecimal alreadyBooked = reversed.subtract(restored);
+
+            BigDecimal delta = scale(owed.subtract(alreadyBooked));
+            if (delta.signum() == 0) return;
+
+            // Deliberately not the .toInstant() form used elsewhere in this package:
+            // due_date is written as a java.sql.Date, and java.sql.Date.toInstant() throws
+            // UnsupportedOperationException. Re-wrapping the epoch millis works whether the
+            // instance is a java.util.Date, java.sql.Date or java.sql.Timestamp.
+            LocalDate dueDate = sfp.getDueDate() != null
+                    ? new java.sql.Date(sfp.getDueDate().getTime()).toLocalDate()
+                    : null;
+            if (delta.signum() > 0) {
+                userAccountLedgerService.recordDebitReversal(
+                        plan.getUserId(), instituteId, delta, "INR", dueDate,
+                        DISCOUNT_LEDGER_SOURCE_TYPE, sfp.getId(), null,
+                        "Discount applied to installment");
+            } else {
+                userAccountLedgerService.recordDebitAccrual(
+                        plan.getUserId(), instituteId, delta.negate(), "INR", dueDate,
+                        DISCOUNT_LEDGER_SOURCE_TYPE, sfp.getId(), null,
+                        "Discount reduced on installment");
+            }
+        } catch (Exception e) {
+            log.error("Discount ledger sync failed for sfp={}: {}", sfp.getId(), e.getMessage(), e);
+        }
+    }
+
     private void recomputeAndPersist(UserPlan plan, UserPlanDiscountJson snapshot) {
         List<StudentFeePayment> sfps = studentFeePaymentRepository.findByUserPlanId(plan.getId());
         if (sfps.isEmpty()) {
@@ -218,6 +290,10 @@ public class CpoDiscountService {
         }
 
         Map<String, BigDecimal> postStep3 = new LinkedHashMap<>();
+        // The pre-discount value each row started from, kept so the ledger sync in the
+        // second pass can measure (original - net) without re-deriving it after
+        // amount_expected has already been overwritten.
+        Map<String, BigDecimal> baseById = new LinkedHashMap<>();
         BigDecimal totalPostStep3 = BigDecimal.ZERO;
 
         for (StudentFeePayment sfp : sfps) {
@@ -238,6 +314,7 @@ public class CpoDiscountService {
             if (afterOverride == null) afterOverride = afterInstDiscount;
 
             postStep3.put(sfp.getId(), afterOverride);
+            baseById.put(sfp.getId(), base);
             totalPostStep3 = totalPostStep3.add(afterOverride);
         }
 
@@ -268,6 +345,8 @@ public class CpoDiscountService {
             sfp.setAmountExpected(net);
             sfp.setStatus(recomputeStatus(sfp.getStatus(), nz(sfp.getAmountPaid()), net));
             studentFeePaymentRepository.save(sfp);
+
+            syncDiscountToLedger(plan, sfp, baseById.get(sfp.getId()), net);
 
             // Write CPO share for audit if material
             if (snapshot.getCpoDiscount() != null) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_account/repository/UserAccountLedgerRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_account/repository/UserAccountLedgerRepository.java
@@ -70,4 +70,19 @@ public interface UserAccountLedgerRepository extends JpaRepository<UserAccountLe
      * without this a single payment would be credited twice.
      */
     boolean existsByReferenceIdAndEventType(String referenceId, String eventType);
+
+    /**
+     * Total already booked for one (sourceType, sourceId, eventType) triple. Used by the CPO
+     * discount sync to work out the DELTA it still owes the ledger: the discount recompute
+     * runs from scratch on every edit, so posting the full discount each time would stack
+     * duplicate reversals on an append-only table.
+     */
+    @Query("""
+            SELECT COALESCE(SUM(l.amount), 0)
+            FROM UserAccountLedger l
+            WHERE l.sourceType = :sourceType AND l.sourceId = :sourceId AND l.eventType = :eventType
+            """)
+    BigDecimal sumBySourceAndEventType(@Param("sourceType") String sourceType,
+                                      @Param("sourceId") String sourceId,
+                                      @Param("eventType") String eventType);
 }


### PR DESCRIPTION
CpoDiscountService wrote discounts to student_fee_payment.amount_expected and the plan snapshot but never touched user_account_ledger, so the two halves of the Payment History tab disagreed by exactly the discount. Verified on prod for one learner with a 2,000 CPO-level discount:

  Account Summary (ledger)    Accrued 35,000 - Paid 8,000 = Due 27,000
  Fee Plan (fee rows)         Net 33,000 - Paid 8,000 = Outstanding 25,000

A discount voids part of an obligation before any money moves, which is what DEBIT_REVERSAL means - it subtracts from total_accrued rather than counting as money received. Booking it as a credit would instead report the discount as a payment.

Posted as a DELTA against what has already been booked, not as an absolute: recomputeAndPersist re-derives every row from original_amount on each edit, so posting (original - net) each time would stack duplicate reversals on an append-only table. Discount grew -> DEBIT_REVERSAL for the difference; discount shrank or was removed -> DEBIT_ACCRUAL restoring it, since a reversal cannot be un-posted. Entries use source_type CPO_DISCOUNT so the arithmetic can tell them apart from the STUDENT_FEE_PAYMENT accrual that carries the original obligation.

The reversal carries the row's due date so it clears the past-due bucket as well as the total. The sync is best-effort and logs on failure - a ledger problem must not fail the admin's discount edit. Note recordDebitReversal is REQUIRES_NEW, so a rollback of the enclosing edit could leave a reversal behind; the delta arithmetic self-corrects that on the next recompute.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
