### PR TITLE
fix(deassign): deactivate the enrollment on a back-dated soft cancel

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkDeassignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkDeassignmentService.java
@@ -157,6 +157,36 @@ public class BulkDeassignmentService {
         }
     }
 
+    /**
+     * Back-dated soft cancel: when the admin sets the last access date to today or earlier,
+     * the access window has already closed, so the mapping must not stay ACTIVE. Moving the
+     * expiry alone is not enough — every learner/product list filters on
+     * {@code ssigm.status}, with no expiry check, so an ACTIVE row with a past expiry keeps
+     * rendering the product as live.
+     *
+     * <p>INACTIVE rather than TERMINATED on purpose. It is the established "access lapsed but
+     * the learner stays on the roster" state (see {@code RenewalChargeService.deactivateMappings},
+     * which {@code RenewalPaymentService} reverses back to ACTIVE when payment resumes), it is
+     * denied by the ACTIVE-only content gates, and — unlike TERMINATED — it is present in the
+     * institute's {@code studentStatuses} roster, so the learner remains visible and filterable
+     * in Manage Students instead of vanishing from the list.
+     *
+     * <p>A future access date leaves the mapping ACTIVE: access genuinely continues until then,
+     * and the expiry sweep retires it on the day.
+     */
+    private void deactivateIfAccessAlreadyEnded(StudentSessionInstituteGroupMapping mapping,
+                                                Date accessTillDate) {
+        if (mapping == null || accessTillDate == null) {
+            return;
+        }
+        if (accessTillDate.toInstant().isAfter(Instant.now())) {
+            return;
+        }
+        mapping.setStatus(LearnerSessionStatusEnum.INACTIVE.name());
+        log.info("Soft-cancel with a past access date — marking mapping {} INACTIVE (accessTill={})",
+                mapping.getId(), accessTillDate);
+    }
+
     private void validateRequest(BulkDeassignRequestDTO request) {
         if (!StringUtils.hasText(request.getInstituteId())) {
             throw new VacademyException("institute_id is required");
@@ -257,9 +287,16 @@ public class BulkDeassignmentService {
                 String actionDesc = MODE_HARD.equals(mode)
                         ? "HARD_TERMINATED"
                         : "SOFT_CANCELED";
-                String softMessage = accessTillDate != null
-                        ? "soft-cancel (access until " + accessTillDate + ")"
-                        : "soft-cancel (access until plan expiry)";
+                String softMessage;
+                if (accessTillDate == null) {
+                    softMessage = "soft-cancel (access until plan expiry)";
+                } else if (accessTillDate.toInstant().isAfter(Instant.now())) {
+                    softMessage = "soft-cancel (access until " + accessTillDate + ")";
+                } else {
+                    // Back-dated: the access window has already closed, so this deactivates now.
+                    softMessage = "soft-cancel (access already ended " + accessTillDate
+                            + " — learner will be marked INACTIVE for this course)";
+                }
                 return BulkDeassignResponseDTO.DeassignResultItemDTO.builder()
                         .userId(userId).userEmail(userEmail)
                         .packageSessionId(packageSessionId)
@@ -283,6 +320,7 @@ public class BulkDeassignmentService {
                 // expiry so access ends on that date instead of the plan's own expiry.
                 if (!hard && accessTillDate != null) {
                     mapping.setExpiryDate(accessTillDate);
+                    deactivateIfAccessAlreadyEnded(mapping, accessTillDate);
                     studentSessionRepository.save(mapping);
                 }
                 log.info("De-assigned: userId={}, packageSession={}, userPlan={}, mode={}, accessTill={}",
@@ -300,6 +338,7 @@ public class BulkDeassignmentService {
                     // freed — the learner still occupies it until they actually expire.
                     if (accessTillDate != null) {
                         mapping.setExpiryDate(accessTillDate);
+                        deactivateIfAccessAlreadyEnded(mapping, accessTillDate);
                     }
                 }
                 studentSessionRepository.save(mapping);


### PR DESCRIPTION
Soft-cancelling a learner off a product with a last-access date of today or earlier left the product showing as live. SOFT deliberately keeps the mapping ACTIVE and only moved expiry_date, but every learner/product list filters on ssigm.status with no expiry check - so an ACTIVE row with a past expiry still renders as an active enrollment. The plan flipped to CANCELED (hence the "Cancelled Member" badge) while the course stayed put.

A back-dated access date means the window has already closed, so the mapping now goes INACTIVE. A future date is untouched: access genuinely continues until then and the expiry sweep retires it on the day.

INACTIVE rather than TERMINATED, deliberately:

- it is the established "access lapsed, learner stays on the roster" state - RenewalChargeService.deactivateMappings sets it and RenewalPaymentService reverses it back to ACTIVE when payment resumes, so it suits a reversible soft cancel
- the ACTIVE-only content gates deny it, so access really does stop
- it is on the institute's studentStatuses roster (ACTIVE/INACTIVE/...) whereas TERMINATED is not, so the learner stays visible and filterable in Manage Students. Using TERMINATED would have dropped a learner whose only enrollment this was straight out of the list - the same complaint we have about hard cancellation.

The dry-run preview now says so too, instead of promising "access until <a date already in the past>".

Not addressed here: hard cancellation still evicts the learner from the list, because cancelUserPlan(force=true) deletes the ACTIVE mappings and recreates them as INVITED. That needs a decision on whether removing one product should cancel a plan spanning several.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
