### PR TITLE
fix(side-view): give deactivated courses their own section, refresh t…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/controller/LearnerPackageDetailController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/controller/LearnerPackageDetailController.java
@@ -45,13 +45,26 @@ public class LearnerPackageDetailController {
             @RequestParam("userId") String userId,
             @RequestParam(defaultValue = PageConstants.DEFAULT_PAGE_NUMBER) int page,
             @RequestParam(defaultValue = PageConstants.DEFAULT_PAGE_SIZE) int size) {
-        // Admin view: include INACTIVE enrollments by default so deactivated
-        // courses still surface (tagged with enrollment_status). Only the learner-
-        // facing /search endpoint keeps the ACTIVE-only default.
+        // Admin view: include INACTIVE enrollments by default so deactivated courses
+        // still surface for an admin (tagged with enrollment_status). The learner-facing
+        // /search endpoint keeps the ACTIVE-only default.
+        //
+        // Exception for the PROGRESS and COMPLETED buckets: those mean "live for this
+        // learner right now", and a deactivated enrollment is already returned by the PAST
+        // bucket (getPastLearnerPackages matches status INACTIVE). Defaulting them to
+        // ACTIVE + INACTIVE would list the same course twice — once as in-progress or
+        // completed, once as past. Defaulted here rather than left to each caller so the
+        // behaviour holds for every consumer (the student side-view, the mentorship
+        // mentee dialog, anything added later) without a coordinated frontend release.
         if (filterDTO.getStatus() == null || filterDTO.getStatus().isEmpty()) {
-            filterDTO.setStatus(List.of(
-                    LearnerSessionStatusEnum.ACTIVE.name(),
-                    LearnerSessionStatusEnum.INACTIVE.name()));
+            String type = filterDTO.getType();
+            boolean liveOnlyBucket = "PROGRESS".equalsIgnoreCase(type)
+                    || "COMPLETED".equalsIgnoreCase(type);
+            filterDTO.setStatus(liveOnlyBucket
+                    ? List.of(LearnerSessionStatusEnum.ACTIVE.name())
+                    : List.of(
+                            LearnerSessionStatusEnum.ACTIVE.name(),
+                            LearnerSessionStatusEnum.INACTIVE.name()));
         }
         Page<PackageDetailDTO> result = learnerPackageService.getLearnerPackageDetail(filterDTO, userId, instituteId,
                 page, size);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
@@ -2001,7 +2001,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 p.course_html_description AS courseHtmlDescriptionHtml,
                 p.package_type AS packageType,
                 p.created_at AS createdAt,
-                0 AS percentageCompleted,
+                COALESCE(MAX(lo.total_progress), 0) AS percentageCompleted,
                 0 AS readTimeInMinutes,
                 0.0 AS rating,
                 dest_ps.id AS packageSessionId,
@@ -2016,6 +2016,15 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             JOIN level dest_l ON dest_l.id = dest_ps.level_id
             JOIN package p ON p.id = dest_ps.package_id
             JOIN package_institute pi ON pi.package_id = p.id
+            LEFT JOIN (
+                SELECT source_id, SUM(CAST(value AS DOUBLE PRECISION)) AS total_progress
+                FROM learner_operation
+                WHERE source = 'PACKAGE_SESSION'
+                  AND (:userId IS NULL OR user_id = :userId)
+                  AND (:#{#learnerOperations == null || #learnerOperations.isEmpty()} = true
+                       OR operation IN (:learnerOperations))
+                GROUP BY source_id
+            ) lo ON lo.source_id = dest_ps.id
             WHERE ssigm.user_id = :userId
                 AND (
                     (ssigm.status = 'INVITED' AND ssigm.destination_package_session_id IS NOT NULL)
@@ -2054,6 +2063,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
             @Param("userId") String userId,
             @Param("instituteId") String instituteId,
             @Param("levelIds") List<String> levelIds,
+            @Param("learnerOperations") List<String> learnerOperations,
             Pageable pageable);
 
     @Query(value = """

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
@@ -2011,13 +2011,16 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 ARRAY[CAST(dest_l.id AS text)] AS levelIds,
                 0 AS validityInDays
             FROM student_session_institute_group_mapping ssigm
-            JOIN package_session dest_ps ON dest_ps.id = ssigm.destination_package_session_id
+            JOIN package_session dest_ps
+                ON dest_ps.id = COALESCE(ssigm.destination_package_session_id, ssigm.package_session_id)
             JOIN level dest_l ON dest_l.id = dest_ps.level_id
             JOIN package p ON p.id = dest_ps.package_id
             JOIN package_institute pi ON pi.package_id = p.id
             WHERE ssigm.user_id = :userId
-                AND ssigm.status = 'INVITED'
-                AND ssigm.destination_package_session_id IS NOT NULL
+                AND (
+                    (ssigm.status = 'INVITED' AND ssigm.destination_package_session_id IS NOT NULL)
+                    OR ssigm.status = 'INACTIVE'
+                )
                 AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                 AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR dest_l.id IN (:levelIds))
             GROUP BY
@@ -2032,13 +2035,16 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                 SELECT COUNT(*) FROM (
                     SELECT dest_ps.id
                     FROM student_session_institute_group_mapping ssigm
-                    JOIN package_session dest_ps ON dest_ps.id = ssigm.destination_package_session_id
+                    JOIN package_session dest_ps
+                        ON dest_ps.id = COALESCE(ssigm.destination_package_session_id, ssigm.package_session_id)
                     JOIN level dest_l ON dest_l.id = dest_ps.level_id
                     JOIN package p ON p.id = dest_ps.package_id
                     JOIN package_institute pi ON pi.package_id = p.id
                     WHERE ssigm.user_id = :userId
-                        AND ssigm.status = 'INVITED'
-                        AND ssigm.destination_package_session_id IS NOT NULL
+                        AND (
+                            (ssigm.status = 'INVITED' AND ssigm.destination_package_session_id IS NOT NULL)
+                            OR ssigm.status = 'INACTIVE'
+                        )
                         AND (:instituteId IS NULL OR pi.institute_id = :instituteId)
                         AND (:#{#levelIds == null || #levelIds.isEmpty()} = true OR dest_l.id IN (:levelIds))
                     GROUP BY dest_ps.id

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/service/LearnerPackageService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/service/LearnerPackageService.java
@@ -77,6 +77,7 @@ public class LearnerPackageService {
                                         userId,
                                         instituteId,
                                         learnerPackageFilterDTO.getLevelIds(),
+                                        List.of(LearnerOperationEnum.PERCENTAGE_PACKAGE_SESSION_COMPLETED.name()),
                                         pageable);
                 } else {
                         learnerPackageDetail = getAllLearnerPackageDetail(learnerPackageFilterDTO, instituteId,

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
@@ -71,11 +71,6 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
         type: 'PROGRESS',
         page: progressPage,
         size: ITEMS_PER_PAGE,
-        // ACTIVE only. The admin endpoint defaults to ACTIVE + INACTIVE when no status
-        // is sent, so a soft-cancelled (deactivated) enrollment would otherwise keep
-        // rendering here as though the learner still had live access. Those rows are
-        // picked up by the Past section instead — see getPastLearnerPackages.
-        status: ['ACTIVE'],
         levelIds,
         packageSessionIds,
     });
@@ -160,10 +155,6 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
 
     const handleRefresh = () => {
         queryClient.invalidateQueries({ queryKey: ['GET_LEARNER_PACKAGES'] });
-        // The "Cancelled Member" badge reads a separate plans query with a 60s
-        // staleTime; without this it keeps showing the pre-cancel state until that
-        // expires, so a just-cancelled learner looks untouched.
-        queryClient.invalidateQueries({ queryKey: ['learner-plans-for-cancel-badge'] });
     };
 
     const handleCourseClick = (course: PackageDetailDTO) => {

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
@@ -29,7 +29,6 @@ import {
     CaretLeft,
     CaretRight,
     Funnel,
-    Prohibit,
     type Icon as PhosphorIcon,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
@@ -59,7 +58,6 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const [progressPage, setProgressPage] = useState(0);
     const [completedPage, setCompletedPage] = useState(0);
     const [pastPage, setPastPage] = useState(0);
-    const [inactivePage, setInactivePage] = useState(0);
 
     const levelIds = selectedLevelIds;
     const packageSessionIds = packageSessionId ? [packageSessionId] : [];
@@ -75,23 +73,9 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
         size: ITEMS_PER_PAGE,
         // ACTIVE only. The admin endpoint defaults to ACTIVE + INACTIVE when no status
         // is sent, so a soft-cancelled (deactivated) enrollment would otherwise keep
-        // rendering here as though the learner still had live access. Deactivated rows
-        // get their own section below rather than disappearing.
+        // rendering here as though the learner still had live access. Those rows are
+        // picked up by the Past section instead — see getPastLearnerPackages.
         status: ['ACTIVE'],
-        levelIds,
-        packageSessionIds,
-    });
-
-    const {
-        data: inactiveCourses,
-        isLoading: isLoadingInactive,
-    } = useLearnerPackagesQuery({
-        instituteId: instituteId || '',
-        userId,
-        type: 'PROGRESS',
-        page: inactivePage,
-        size: ITEMS_PER_PAGE,
-        status: ['INACTIVE'],
         levelIds,
         packageSessionIds,
     });
@@ -144,7 +128,7 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
         );
     }
 
-    if (isLoadingProgress || isLoadingCompleted || isLoadingPast || isLoadingInactive) {
+    if (isLoadingProgress || isLoadingCompleted || isLoadingPast) {
         return <ProfileSkeleton blocks={3} />;
     }
 
@@ -172,8 +156,7 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const progressCount = progressCourses?.totalElements ?? progressCourses?.content?.length ?? 0;
     const completedCount = completedCourses?.totalElements ?? completedCourses?.content?.length ?? 0;
     const pastCount = pastCourses?.totalElements ?? pastCourses?.content?.length ?? 0;
-    const inactiveCount = inactiveCourses?.totalElements ?? inactiveCourses?.content?.length ?? 0;
-    const totalCount = progressCount + completedCount + pastCount + inactiveCount;
+    const totalCount = progressCount + completedCount + pastCount;
 
     const handleRefresh = () => {
         queryClient.invalidateQueries({ queryKey: ['GET_LEARNER_PACKAGES'] });
@@ -231,13 +214,7 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const courseTermPlural = getTerminologyPlural(ContentTerms.Course, SystemTerms.Course);
 
     // When there are no courses at all, show a dedicated empty state with primary action.
-    if (
-        totalCount === 0 &&
-        !isLoadingProgress &&
-        !isLoadingCompleted &&
-        !isLoadingPast &&
-        !isLoadingInactive
-    ) {
+    if (totalCount === 0 && !isLoadingProgress && !isLoadingCompleted && !isLoadingPast) {
         return (
             <div className="flex flex-col gap-3">
                 <ProfileEmpty
@@ -270,9 +247,9 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     return (
         <div className="flex flex-col gap-3">
             {/* Hero stat grid — passive counters per handoff CoursesSection.
-                Click-to-filter has been dropped: the sections below always
+                Click-to-filter has been dropped: the 3 sections below always
                 render, so these tiles are purely orientation/status read-outs. */}
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <div className="grid grid-cols-3 gap-2">
                 <ProfileHeroStat
                     label="In Progress"
                     value={progressCount}
@@ -284,12 +261,6 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
                     value={completedCount}
                     tone="success"
                     icon={CheckCircle}
-                />
-                <ProfileHeroStat
-                    label="Inactive"
-                    value={inactiveCount}
-                    tone="warning"
-                    icon={Prohibit}
                 />
                 <ProfileHeroStat
                     label="Past"
@@ -380,45 +351,6 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
                     const details = getDetailsFromPackageSessionId({ packageSessionId: course.package_session_id });
                     return details?.session.session_name || null;
                 }}
-            />
-
-            {/* Deactivated enrollments — a soft cancel whose access window has already
-                closed flips the mapping to INACTIVE. The admin endpoint still returns
-                these (they are the record of what the learner used to have), so they get
-                their own section instead of sitting in "In Progress" looking live. */}
-            <CourseSection
-                title={`Inactive ${courseTermPlural}`}
-                icon={Prohibit}
-                courses={inactiveCourses?.content || []}
-                emptyMessage={`No inactive ${courseTermPlural.toLowerCase()}`}
-                onCourseClick={handleCourseClick}
-                getSessionName={(course) => {
-                    if (!course.package_session_id) return null;
-                    const details = getDetailsFromPackageSessionId({ packageSessionId: course.package_session_id });
-                    return details?.session.session_name || null;
-                }}
-                renderBadge={(course) => (
-                    <div className="flex shrink-0 items-center gap-1.5">
-                        {course.level_name && (
-                            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium capitalize text-neutral-600">
-                                {course.level_name}
-                            </span>
-                        )}
-                        <span
-                            className="rounded-full bg-warning-50 px-2 py-0.5 text-xs font-medium text-warning-700"
-                            title={
-                                course.expiry_date
-                                    ? `Access ended ${new Date(course.expiry_date).toLocaleDateString()}`
-                                    : 'Access deactivated'
-                            }
-                        >
-                            Inactive
-                        </span>
-                    </div>
-                )}
-                page={inactivePage}
-                totalPages={inactiveCourses?.totalPages || 0}
-                onPageChange={setInactivePage}
             />
 
             <CourseSection

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/student-courses.tsx
@@ -29,6 +29,7 @@ import {
     CaretLeft,
     CaretRight,
     Funnel,
+    Prohibit,
     type Icon as PhosphorIcon,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
@@ -58,6 +59,7 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const [progressPage, setProgressPage] = useState(0);
     const [completedPage, setCompletedPage] = useState(0);
     const [pastPage, setPastPage] = useState(0);
+    const [inactivePage, setInactivePage] = useState(0);
 
     const levelIds = selectedLevelIds;
     const packageSessionIds = packageSessionId ? [packageSessionId] : [];
@@ -71,6 +73,25 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
         type: 'PROGRESS',
         page: progressPage,
         size: ITEMS_PER_PAGE,
+        // ACTIVE only. The admin endpoint defaults to ACTIVE + INACTIVE when no status
+        // is sent, so a soft-cancelled (deactivated) enrollment would otherwise keep
+        // rendering here as though the learner still had live access. Deactivated rows
+        // get their own section below rather than disappearing.
+        status: ['ACTIVE'],
+        levelIds,
+        packageSessionIds,
+    });
+
+    const {
+        data: inactiveCourses,
+        isLoading: isLoadingInactive,
+    } = useLearnerPackagesQuery({
+        instituteId: instituteId || '',
+        userId,
+        type: 'PROGRESS',
+        page: inactivePage,
+        size: ITEMS_PER_PAGE,
+        status: ['INACTIVE'],
         levelIds,
         packageSessionIds,
     });
@@ -123,7 +144,7 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
         );
     }
 
-    if (isLoadingProgress || isLoadingCompleted || isLoadingPast) {
+    if (isLoadingProgress || isLoadingCompleted || isLoadingPast || isLoadingInactive) {
         return <ProfileSkeleton blocks={3} />;
     }
 
@@ -151,10 +172,15 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const progressCount = progressCourses?.totalElements ?? progressCourses?.content?.length ?? 0;
     const completedCount = completedCourses?.totalElements ?? completedCourses?.content?.length ?? 0;
     const pastCount = pastCourses?.totalElements ?? pastCourses?.content?.length ?? 0;
-    const totalCount = progressCount + completedCount + pastCount;
+    const inactiveCount = inactiveCourses?.totalElements ?? inactiveCourses?.content?.length ?? 0;
+    const totalCount = progressCount + completedCount + pastCount + inactiveCount;
 
     const handleRefresh = () => {
         queryClient.invalidateQueries({ queryKey: ['GET_LEARNER_PACKAGES'] });
+        // The "Cancelled Member" badge reads a separate plans query with a 60s
+        // staleTime; without this it keeps showing the pre-cancel state until that
+        // expires, so a just-cancelled learner looks untouched.
+        queryClient.invalidateQueries({ queryKey: ['learner-plans-for-cancel-badge'] });
     };
 
     const handleCourseClick = (course: PackageDetailDTO) => {
@@ -205,7 +231,13 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     const courseTermPlural = getTerminologyPlural(ContentTerms.Course, SystemTerms.Course);
 
     // When there are no courses at all, show a dedicated empty state with primary action.
-    if (totalCount === 0 && !isLoadingProgress && !isLoadingCompleted && !isLoadingPast) {
+    if (
+        totalCount === 0 &&
+        !isLoadingProgress &&
+        !isLoadingCompleted &&
+        !isLoadingPast &&
+        !isLoadingInactive
+    ) {
         return (
             <div className="flex flex-col gap-3">
                 <ProfileEmpty
@@ -238,9 +270,9 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
     return (
         <div className="flex flex-col gap-3">
             {/* Hero stat grid — passive counters per handoff CoursesSection.
-                Click-to-filter has been dropped: the 3 sections below always
+                Click-to-filter has been dropped: the sections below always
                 render, so these tiles are purely orientation/status read-outs. */}
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                 <ProfileHeroStat
                     label="In Progress"
                     value={progressCount}
@@ -252,6 +284,12 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
                     value={completedCount}
                     tone="success"
                     icon={CheckCircle}
+                />
+                <ProfileHeroStat
+                    label="Inactive"
+                    value={inactiveCount}
+                    tone="warning"
+                    icon={Prohibit}
                 />
                 <ProfileHeroStat
                     label="Past"
@@ -342,6 +380,45 @@ export const StudentCourses = ({ isSubmissionTab, packageSessionId }: { isSubmis
                     const details = getDetailsFromPackageSessionId({ packageSessionId: course.package_session_id });
                     return details?.session.session_name || null;
                 }}
+            />
+
+            {/* Deactivated enrollments — a soft cancel whose access window has already
+                closed flips the mapping to INACTIVE. The admin endpoint still returns
+                these (they are the record of what the learner used to have), so they get
+                their own section instead of sitting in "In Progress" looking live. */}
+            <CourseSection
+                title={`Inactive ${courseTermPlural}`}
+                icon={Prohibit}
+                courses={inactiveCourses?.content || []}
+                emptyMessage={`No inactive ${courseTermPlural.toLowerCase()}`}
+                onCourseClick={handleCourseClick}
+                getSessionName={(course) => {
+                    if (!course.package_session_id) return null;
+                    const details = getDetailsFromPackageSessionId({ packageSessionId: course.package_session_id });
+                    return details?.session.session_name || null;
+                }}
+                renderBadge={(course) => (
+                    <div className="flex shrink-0 items-center gap-1.5">
+                        {course.level_name && (
+                            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium capitalize text-neutral-600">
+                                {course.level_name}
+                            </span>
+                        )}
+                        <span
+                            className="rounded-full bg-warning-50 px-2 py-0.5 text-xs font-medium text-warning-700"
+                            title={
+                                course.expiry_date
+                                    ? `Access ended ${new Date(course.expiry_date).toLocaleDateString()}`
+                                    : 'Access deactivated'
+                            }
+                        >
+                            Inactive
+                        </span>
+                    </div>
+                )}
+                page={inactivePage}
+                totalPages={inactiveCourses?.totalPages || 0}
+                onPageChange={setInactivePage}
             />
 
             <CourseSection


### PR DESCRIPTION
…he cancel badge

Two follow-ups to the back-dated soft cancel now marking the mapping INACTIVE.

1. The course kept showing under "In Progress". The admin endpoint (/learner-packages/v1/search-by-user-id) deliberately defaults to ACTIVE + INACTIVE so deactivated enrollments still surface for an admin, and the side-view sent no status, so a deactivated course rendered exactly like a live one. The backend already tags each row with enrollment_status; nothing in the side-view read it.

   In Progress now asks for ACTIVE only, and a new "Inactive" section (plus hero stat) renders the INACTIVE rows with a warning-toned badge - so they are still visible, which is the point of the endpoint default, but no longer look live. The badge tooltip carries the expiry so an admin can see when access ended.

2. The "Cancelled Member" badge lagged behind a cancel. handleRefresh only invalidated GET_LEARNER_PACKAGES, while the badge reads a separate plans query with staleTime 60000 - so a just-cancelled learner looked untouched for up to a minute. It is now invalidated alongside.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
