### PR TITLE
Redesign Manage Payments UI and add Payment Dashboard page

### DIFF
--- a/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
+++ b/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
@@ -397,6 +397,11 @@ export const getSidebarItemsData = (): SidebarItemsType[] => [
                 subItemId: 'manage-payments-sub',
             },
             {
+                subItem: 'Payment Dashboard',
+                subItemLink: '/payment-dashboard',
+                subItemId: 'payment-dashboard-sub',
+            },
+            {
                 subItem: 'Manage Expiry',
                 subItemLink: '/membership-expiry',
                 subItemId: 'membership-expiry-sub',

--- a/frontend-admin-dashboard/src/routeTree.gen.ts
+++ b/frontend-admin-dashboard/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as SignupIndexRouteImport } from "./routes/signup/index"
 import { Route as SettingsIndexRouteImport } from "./routes/settings/index"
 import { Route as SalesDashboardIndexRouteImport } from "./routes/sales-dashboard/index"
 import { Route as PlanningIndexRouteImport } from "./routes/planning/index"
+import { Route as PaymentDashboardIndexRouteImport } from "./routes/payment-dashboard/index"
 import { Route as MembershipStatsIndexRouteImport } from "./routes/membership-stats/index"
 import { Route as MembershipExpiryIndexRouteImport } from "./routes/membership-expiry/index"
 import { Route as ManageSuborgTeamsIndexRouteImport } from "./routes/manage-suborg-teams/index"
@@ -300,6 +301,13 @@ const PlanningIndexRoute = PlanningIndexRouteImport.update({
   path: "/planning/",
   getParentRoute: () => rootRouteImport,
 } as any)
+const PaymentDashboardIndexRoute = PaymentDashboardIndexRouteImport.update({
+  id: "/payment-dashboard/",
+  path: "/payment-dashboard/",
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import("./routes/payment-dashboard/index.lazy").then((d) => d.Route),
+)
 const MembershipStatsIndexRoute = MembershipStatsIndexRouteImport.update({
   id: "/membership-stats/",
   path: "/membership-stats/",
@@ -1852,6 +1860,7 @@ export interface FileRoutesByFullPath {
   "/manage-suborg-teams/": typeof ManageSuborgTeamsIndexRoute
   "/membership-expiry/": typeof MembershipExpiryIndexRoute
   "/membership-stats/": typeof MembershipStatsIndexRoute
+  "/payment-dashboard/": typeof PaymentDashboardIndexRoute
   "/planning/": typeof PlanningIndexRoute
   "/sales-dashboard/": typeof SalesDashboardIndexRoute
   "/settings/": typeof SettingsIndexRoute
@@ -2057,6 +2066,7 @@ export interface FileRoutesByTo {
   "/manage-suborg-teams": typeof ManageSuborgTeamsIndexRoute
   "/membership-expiry": typeof MembershipExpiryIndexRoute
   "/membership-stats": typeof MembershipStatsIndexRoute
+  "/payment-dashboard": typeof PaymentDashboardIndexRoute
   "/planning": typeof PlanningIndexRoute
   "/sales-dashboard": typeof SalesDashboardIndexRoute
   "/settings": typeof SettingsIndexRoute
@@ -2264,6 +2274,7 @@ export interface FileRoutesById {
   "/manage-suborg-teams/": typeof ManageSuborgTeamsIndexRoute
   "/membership-expiry/": typeof MembershipExpiryIndexRoute
   "/membership-stats/": typeof MembershipStatsIndexRoute
+  "/payment-dashboard/": typeof PaymentDashboardIndexRoute
   "/planning/": typeof PlanningIndexRoute
   "/sales-dashboard/": typeof SalesDashboardIndexRoute
   "/settings/": typeof SettingsIndexRoute
@@ -2472,6 +2483,7 @@ export interface FileRouteTypes {
     | "/manage-suborg-teams/"
     | "/membership-expiry/"
     | "/membership-stats/"
+    | "/payment-dashboard/"
     | "/planning/"
     | "/sales-dashboard/"
     | "/settings/"
@@ -2677,6 +2689,7 @@ export interface FileRouteTypes {
     | "/manage-suborg-teams"
     | "/membership-expiry"
     | "/membership-stats"
+    | "/payment-dashboard"
     | "/planning"
     | "/sales-dashboard"
     | "/settings"
@@ -2883,6 +2896,7 @@ export interface FileRouteTypes {
     | "/manage-suborg-teams/"
     | "/membership-expiry/"
     | "/membership-stats/"
+    | "/payment-dashboard/"
     | "/planning/"
     | "/sales-dashboard/"
     | "/settings/"
@@ -3089,6 +3103,7 @@ export interface RootRouteChildren {
   ManageSuborgTeamsIndexRoute: typeof ManageSuborgTeamsIndexRoute
   MembershipExpiryIndexRoute: typeof MembershipExpiryIndexRoute
   MembershipStatsIndexRoute: typeof MembershipStatsIndexRoute
+  PaymentDashboardIndexRoute: typeof PaymentDashboardIndexRoute
   PlanningIndexRoute: typeof PlanningIndexRoute
   SalesDashboardIndexRoute: typeof SalesDashboardIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
@@ -3354,6 +3369,13 @@ declare module "@tanstack/react-router" {
       path: "/planning"
       fullPath: "/planning/"
       preLoaderRoute: typeof PlanningIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/payment-dashboard/": {
+      id: "/payment-dashboard/"
+      path: "/payment-dashboard"
+      fullPath: "/payment-dashboard/"
+      preLoaderRoute: typeof PaymentDashboardIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/membership-stats/": {
@@ -4739,6 +4761,7 @@ const rootRouteChildren: RootRouteChildren = {
   ManageSuborgTeamsIndexRoute: ManageSuborgTeamsIndexRoute,
   MembershipExpiryIndexRoute: MembershipExpiryIndexRoute,
   MembershipStatsIndexRoute: MembershipStatsIndexRoute,
+  PaymentDashboardIndexRoute: PaymentDashboardIndexRoute,
   PlanningIndexRoute: PlanningIndexRoute,
   SalesDashboardIndexRoute: SalesDashboardIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/GatewayBadge.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/GatewayBadge.tsx
@@ -1,0 +1,60 @@
+import { Money } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+import { resolveGatewayBranding } from '@/routes/settings/-constants/payment-gateway-branding';
+
+/**
+ * Payment-gateway brandmark shown wherever a payment method appears. The branding (label, mark,
+ * colour) comes from the shared source of truth that lives with Institute Settings → Payment
+ * Gateways (`payment-gateway-branding`), so what shows here matches what the institute configures
+ * there. `vendor` is the free-form `payment_log.vendor` string.
+ */
+
+interface GatewayBadgeProps {
+    vendor?: string | null;
+    /** Render the gateway name beside the mark. */
+    showLabel?: boolean;
+    /** Secondary line under the label (e.g. the raw method string). */
+    subLabel?: string;
+    size?: 'sm' | 'md';
+    className?: string;
+}
+
+export function GatewayBadge({
+    vendor,
+    showLabel = false,
+    subLabel,
+    size = 'md',
+    className,
+}: GatewayBadgeProps) {
+    const meta = resolveGatewayBranding(vendor);
+    const isOffline = meta.mark === '';
+    const box = size === 'sm' ? 'size-6 text-caption' : 'size-7 text-body';
+
+    return (
+        <span className={cn('flex min-w-0 items-center gap-2', className)}>
+            <span
+                className={cn(
+                    'flex shrink-0 items-center justify-center rounded-md border font-semibold',
+                    box,
+                    meta.badgeClass
+                )}
+                title={meta.label}
+                aria-label={meta.label}
+            >
+                {isOffline ? <Money size={size === 'sm' ? 13 : 15} weight="duotone" /> : meta.mark}
+            </span>
+            {showLabel && (
+                <span className="min-w-0">
+                    <span className="block truncate text-body font-medium text-neutral-700">
+                        {meta.label}
+                    </span>
+                    {subLabel && (
+                        <span className="block truncate text-caption text-neutral-500">
+                            {subLabel}
+                        </span>
+                    )}
+                </span>
+            )}
+        </span>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentControlBar.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentControlBar.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react';
+import { MagnifyingGlass, Funnel } from '@phosphor-icons/react';
+import { MyInput } from '@/components/design-system/input';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { SummaryStatusKey } from './PaymentSummaryCards';
+
+export interface StatusSegment {
+    key: SummaryStatusKey;
+    label: string;
+    count: number;
+}
+
+interface PaymentControlBarProps {
+    searchValue: string;
+    onSearchChange: (value: string) => void;
+    segments: StatusSegment[];
+    activeStatus: SummaryStatusKey;
+    onStatusSelect: (key: SummaryStatusKey) => void;
+    filterCount: number;
+    onOpenFilters: () => void;
+    /** Right-aligned actions (e.g. export). */
+    actions?: ReactNode;
+}
+
+/**
+ * Redesign control bar: free-text search, a segmented status switch (with live counts), a Filters
+ * button that opens the slide-over, and an actions slot. Mirrors the mockup's toolbar.
+ */
+export function PaymentControlBar({
+    searchValue,
+    onSearchChange,
+    segments,
+    activeStatus,
+    onStatusSelect,
+    filterCount,
+    onOpenFilters,
+    actions,
+}: PaymentControlBarProps) {
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            {/* Search */}
+            <div className="relative flex-1 basis-56">
+                <MagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-neutral-400" />
+                <MyInput
+                    inputType="text"
+                    input={searchValue}
+                    onChangeFunction={(e) => onSearchChange(e.target.value)}
+                    inputPlaceholder="Search name, email, phone, amount or txn ID"
+                    className="pl-9 sm:w-full"
+                />
+            </div>
+
+            {/* Segmented status switch */}
+            <div
+                role="tablist"
+                aria-label="Filter by payment status"
+                className="flex items-center gap-0.5 rounded-md border border-neutral-200 bg-neutral-100 p-0.5"
+            >
+                {segments.map((seg) => {
+                    const isActive = seg.key === activeStatus;
+                    return (
+                        <button
+                            key={seg.key}
+                            type="button"
+                            role="tab"
+                            aria-selected={isActive}
+                            onClick={() => onStatusSelect(seg.key)}
+                            className={cn(
+                                'flex h-8 items-center gap-1.5 rounded px-2.5 text-caption font-semibold transition-colors',
+                                isActive
+                                    ? 'bg-white text-neutral-800 shadow-sm'
+                                    : 'text-neutral-500 hover:text-neutral-700'
+                            )}
+                        >
+                            {seg.label}
+                            <span
+                                className={cn(
+                                    'tabular-nums',
+                                    isActive ? 'text-neutral-500' : 'text-neutral-400'
+                                )}
+                            >
+                                {seg.count}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {/* Filters button */}
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={onOpenFilters}
+                className={cn(
+                    'h-9 gap-2',
+                    filterCount > 0 && 'border-primary-500 bg-primary-50 text-primary-600'
+                )}
+            >
+                <Funnel size={16} weight={filterCount > 0 ? 'fill' : 'regular'} />
+                Filters
+                {filterCount > 0 && (
+                    <span className="ml-0.5 flex size-5 items-center justify-center rounded-full bg-primary-500 text-caption text-neutral-50">
+                        {filterCount}
+                    </span>
+                )}
+            </Button>
+
+            {actions}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentDashboard.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentDashboard.tsx
@@ -1,0 +1,692 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+    Area,
+    AreaChart,
+    Cell,
+    Pie,
+    PieChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+} from 'recharts';
+import { ChartLineUp, DownloadSimple, TrendUp, Info } from '@phosphor-icons/react';
+import { toast } from 'sonner';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { MyButton } from '@/components/design-system/button';
+import { cn } from '@/lib/utils';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+import { isRealCurrency } from '@/utils/payment-currency';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import type { PaymentLogsRequest } from '@/types/payment-logs';
+import { fetchAllPaymentLogs } from '../-utils/exportPaymentLogsCsv';
+import {
+    computePaymentAnalytics,
+    type AmountSlice,
+    type PaymentAnalytics,
+} from '../-utils/paymentAnalytics';
+import {
+    fetchCollectionSummary,
+    type CollectionSummary,
+} from '@/routes/dashboard/-services/collection-summary-service';
+import { GatewayBadge } from './GatewayBadge';
+
+// ─── Range control ────────────────────────────────────────────────────────────
+
+type DashRangeKey = '7d' | '30d' | '90d' | 'all';
+const RANGES: { key: DashRangeKey; label: string; days: number | null }[] = [
+    { key: '7d', label: '7 days', days: 7 },
+    { key: '30d', label: '30 days', days: 30 },
+    { key: '90d', label: '90 days', days: 90 },
+    { key: 'all', label: 'All time', days: null },
+];
+
+const toLocalIso = (d: Date): string => d.toISOString().slice(0, 19);
+
+const rangeWindow = (key: DashRangeKey): { start?: string; end?: string } => {
+    const cfg = RANGES.find((r) => r.key === key);
+    if (!cfg || cfg.days == null) return {};
+    const end = new Date();
+    const start = new Date(end.getTime() - cfg.days * 24 * 60 * 60 * 1000);
+    return { start: toLocalIso(start), end: toLocalIso(end) };
+};
+
+// ─── Formatting ────────────────────────────────────────────────────────────────
+
+const makeMoney =
+    (currency: string) =>
+    (n: number, compact = false): string => {
+        const notation = compact && Math.abs(n) >= 100000 ? 'compact' : 'standard';
+        if (isRealCurrency(currency)) {
+            try {
+                return new Intl.NumberFormat('en-IN', {
+                    style: 'currency',
+                    currency,
+                    maximumFractionDigits: 0,
+                    notation,
+                }).format(n);
+            } catch {
+                /* fall through */
+            }
+        }
+        return new Intl.NumberFormat('en-IN', { maximumFractionDigits: 0, notation }).format(n);
+    };
+
+// Token-based chart palette (semantic ramps only — no raw hex).
+const CHART_PALETTE = [
+    'hsl(var(--primary-500))',
+    'hsl(var(--info-500))',
+    'hsl(var(--success-500))',
+    'hsl(var(--warning-500))',
+    'hsl(var(--danger-500))',
+    'hsl(var(--primary-300))',
+    'hsl(var(--info-300))',
+];
+
+const AGING_TONE: Record<string, string> = {
+    neutral: 'text-neutral-600',
+    warning: 'text-warning-600',
+    strong: 'text-warning-700',
+    danger: 'text-danger-600',
+};
+
+// ─── Small building blocks ──────────────────────────────────────────────────────
+
+function SectionCard({
+    title,
+    subtitle,
+    right,
+    children,
+    className,
+}: {
+    title: string;
+    subtitle?: string;
+    right?: React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
+}) {
+    return (
+        <Card className={cn('flex flex-col p-5', className)}>
+            <div className="mb-4 flex items-start justify-between gap-3">
+                <div>
+                    <h3 className="text-subtitle font-semibold text-neutral-800">{title}</h3>
+                    {subtitle && <p className="text-caption text-neutral-500">{subtitle}</p>}
+                </div>
+                {right}
+            </div>
+            {children}
+        </Card>
+    );
+}
+
+function MetricCard({
+    label,
+    value,
+    meta,
+    isLoading,
+}: {
+    label: string;
+    value: string;
+    meta: string;
+    isLoading?: boolean;
+}) {
+    return (
+        <Card className="p-4">
+            <div className="text-caption font-medium uppercase tracking-wide text-neutral-500">
+                {label}
+            </div>
+            {isLoading ? (
+                <Skeleton className="mt-2 h-8 w-28" />
+            ) : (
+                <div className="mt-1 text-h2 font-semibold tabular-nums text-neutral-800">
+                    {value}
+                </div>
+            )}
+            <div className="mt-1 text-caption text-neutral-500">{isLoading ? ' ' : meta}</div>
+        </Card>
+    );
+}
+
+/** Horizontal ranked bars (gateways, courses, method mix). */
+function RankedBars({
+    slices,
+    money,
+    colorAt,
+    renderLabel,
+}: {
+    slices: AmountSlice[];
+    money: (n: number, compact?: boolean) => string;
+    colorAt: (i: number) => string;
+    renderLabel?: (slice: AmountSlice) => React.ReactNode;
+}) {
+    const max = Math.max(1, ...slices.map((s) => s.amount));
+    if (!slices.length) {
+        return <div className="py-8 text-center text-caption text-neutral-400">No data</div>;
+    }
+    return (
+        <div className="space-y-3">
+            {slices.map((s, i) => (
+                <div key={s.label} className="space-y-1">
+                    <div className="flex items-center justify-between gap-3 text-body">
+                        <div className="min-w-0">
+                            {renderLabel ? (
+                                renderLabel(s)
+                            ) : (
+                                <span className="truncate font-medium text-neutral-700">
+                                    {s.label}
+                                </span>
+                            )}
+                        </div>
+                        <div className="shrink-0 text-right">
+                            <span className="font-semibold tabular-nums text-neutral-800">
+                                {money(s.amount, true)}
+                            </span>
+                            <span className="ml-1.5 text-caption text-neutral-400">{s.count}</span>
+                        </div>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-neutral-100">
+                        <div
+                            className="h-full rounded-full"
+                            style={{
+                                width: `${Math.max(3, (s.amount / max) * 100)}%`,
+                                backgroundColor: colorAt(i),
+                            }}
+                        />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// ─── Main dashboard ─────────────────────────────────────────────────────────────
+
+export function PaymentDashboard() {
+    const instituteId = getCurrentInstituteId();
+    const [range, setRange] = useState<DashRangeKey>('30d');
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+
+    const requestFilters: Omit<PaymentLogsRequest, 'institute_id'> = useMemo(() => {
+        const w = rangeWindow(range);
+        const filters: Omit<PaymentLogsRequest, 'institute_id'> = {
+            sort_columns: { createdAt: 'DESC' },
+        };
+        if (w.start) filters.start_date_in_utc = w.start;
+        if (w.end) filters.end_date_in_utc = w.end;
+        return filters;
+    }, [range]);
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['payment-analytics', requestFilters],
+        queryFn: () => fetchAllPaymentLogs(requestFilters),
+        staleTime: 60_000,
+    });
+
+    const entries = useMemo(() => data?.entries ?? [], [data]);
+    const analytics: PaymentAnalytics = useMemo(() => computePaymentAnalytics(entries), [entries]);
+
+    // Real collections trend (backend aggregate) for the same window.
+    const { data: collection } = useQuery<CollectionSummary>({
+        queryKey: ['collection-summary-dash', instituteId, range],
+        queryFn: () =>
+            fetchCollectionSummary({
+                institute_id: instituteId || '',
+                ...rangeWindow(range),
+            }),
+        enabled: !!instituteId,
+        staleTime: 60_000,
+        retry: false,
+    });
+
+    const currency = analytics.primaryCurrency || collection?.currency || '';
+    const money = useMemo(() => makeMoney(currency), [currency]);
+
+    const trendData = useMemo(
+        () => (collection?.daily ?? []).map((p) => ({ ...p, label: p.date.slice(5) })),
+        [collection]
+    );
+
+    const rangeLabel = RANGES.find((r) => r.key === range)?.label.toLowerCase() ?? '';
+    const isEmpty = !isLoading && entries.length === 0;
+
+    const handleExport = () => {
+        toast.info('Use “Export” on the Manage Payments page to download the underlying records.');
+    };
+
+    return (
+        <div className="space-y-6">
+            {/* Toolbar */}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-body text-neutral-500">
+                    Overview of collections and outstanding dues · last {rangeLabel}
+                </p>
+                <div className="flex items-center gap-3">
+                    <div
+                        role="group"
+                        aria-label="Dashboard time range"
+                        className="flex shrink-0 items-center gap-0.5 rounded-lg border border-neutral-200 bg-neutral-50 p-0.5"
+                    >
+                        {RANGES.map((r) => (
+                            <button
+                                key={r.key}
+                                type="button"
+                                onClick={() => setRange(r.key)}
+                                aria-pressed={range === r.key}
+                                className={cn(
+                                    'cursor-pointer rounded-md px-2.5 py-1 text-caption font-medium transition-colors',
+                                    range === r.key
+                                        ? 'bg-primary-500 text-white shadow-sm'
+                                        : 'text-neutral-600 hover:bg-neutral-100'
+                                )}
+                            >
+                                {r.label}
+                            </button>
+                        ))}
+                    </div>
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        className="gap-2"
+                        onClick={handleExport}
+                    >
+                        <DownloadSimple size={16} />
+                        Export
+                    </MyButton>
+                </div>
+            </div>
+
+            {isError ? (
+                <Card className="p-10 text-center">
+                    <p className="text-body font-medium text-neutral-700">
+                        Couldn’t load payment analytics
+                    </p>
+                    <p className="mt-1 text-caption text-neutral-500">
+                        Please try again in a moment.
+                    </p>
+                </Card>
+            ) : isEmpty ? (
+                <Card className="flex flex-col items-center gap-2 p-12 text-center">
+                    <ChartLineUp size={26} className="text-neutral-300" weight="duotone" />
+                    <p className="text-body font-medium text-neutral-700">
+                        No payments in this period
+                    </p>
+                    <p className="text-caption text-neutral-500">
+                        Try a wider time range to see collection trends.
+                    </p>
+                </Card>
+            ) : (
+                <>
+                    {/* Metric row */}
+                    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                        <MetricCard
+                            label="Collected"
+                            value={money(analytics.collected.amount, true)}
+                            meta={`${analytics.collected.count.toLocaleString()} payments`}
+                            isLoading={isLoading}
+                        />
+                        <MetricCard
+                            label="Outstanding"
+                            value={money(analytics.outstanding.amount, true)}
+                            meta={`${analytics.outstanding.count.toLocaleString()} pending`}
+                            isLoading={isLoading}
+                        />
+                        <MetricCard
+                            label="Success rate"
+                            value={
+                                analytics.successRate == null
+                                    ? '—'
+                                    : `${(analytics.successRate * 100).toFixed(1)}%`
+                            }
+                            meta={`${analytics.failed.count.toLocaleString()} failed attempts`}
+                            isLoading={isLoading}
+                        />
+                        <MetricCard
+                            label="Total payments"
+                            value={analytics.totalEntries.toLocaleString()}
+                            meta={`in the last ${rangeLabel}`}
+                            isLoading={isLoading}
+                        />
+                    </div>
+
+                    {/* Collections trend */}
+                    <SectionCard
+                        title="Collections trend"
+                        subtitle={`Paid volume per day · last ${rangeLabel}`}
+                        right={
+                            <span className="flex size-8 items-center justify-center rounded-lg bg-success-100 text-success-600">
+                                <TrendUp size={16} weight="duotone" />
+                            </span>
+                        }
+                    >
+                        <div className="h-56 w-full">
+                            {isLoading ? (
+                                <Skeleton className="size-full rounded-md" />
+                            ) : trendData.length === 0 ? (
+                                <div className="flex h-full items-center justify-center text-caption text-neutral-400">
+                                    No collections in this period
+                                </div>
+                            ) : (
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <AreaChart
+                                        data={trendData}
+                                        margin={{ top: 6, right: 6, bottom: 0, left: -12 }}
+                                    >
+                                        <defs>
+                                            <linearGradient
+                                                id="dashCollectionFill"
+                                                x1="0"
+                                                y1="0"
+                                                x2="0"
+                                                y2="1"
+                                            >
+                                                <stop
+                                                    offset="0%"
+                                                    stopColor="hsl(var(--success-500))"
+                                                    stopOpacity={0.28}
+                                                />
+                                                <stop
+                                                    offset="100%"
+                                                    stopColor="hsl(var(--success-500))"
+                                                    stopOpacity={0.02}
+                                                />
+                                            </linearGradient>
+                                        </defs>
+                                        <CartesianGrid
+                                            strokeDasharray="3 3"
+                                            stroke="hsl(var(--border))"
+                                            vertical={false}
+                                        />
+                                        <XAxis
+                                            dataKey="label"
+                                            tick={{
+                                                fontSize: 10,
+                                                fill: 'hsl(var(--muted-foreground))',
+                                            }}
+                                            tickLine={false}
+                                            axisLine={false}
+                                            minTickGap={24}
+                                        />
+                                        <YAxis
+                                            tick={{
+                                                fontSize: 10,
+                                                fill: 'hsl(var(--muted-foreground))',
+                                            }}
+                                            tickLine={false}
+                                            axisLine={false}
+                                            width={48}
+                                            tickFormatter={(v: number) =>
+                                                v >= 1000 ? `${Math.round(v / 1000)}k` : `${v}`
+                                            }
+                                        />
+                                        <Tooltip
+                                            cursor={{
+                                                stroke: 'hsl(var(--success-500))',
+                                                strokeWidth: 1,
+                                                strokeOpacity: 0.3,
+                                            }}
+                                            contentStyle={{
+                                                borderRadius: 8,
+                                                border: '1px solid hsl(var(--border))',
+                                                fontSize: 12,
+                                            }}
+                                            formatter={(v: number) => [money(v), 'Collected']}
+                                        />
+                                        <Area
+                                            type="monotone"
+                                            dataKey="amount"
+                                            stroke="hsl(var(--success-500))"
+                                            strokeWidth={2}
+                                            fill="url(#dashCollectionFill)"
+                                        />
+                                    </AreaChart>
+                                </ResponsiveContainer>
+                            )}
+                        </div>
+                    </SectionCard>
+
+                    {/* Method mix + Gateway breakdown */}
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <SectionCard
+                            title="Method mix"
+                            subtitle="Share of successful payments by gateway"
+                        >
+                            <MethodMixDonut slices={analytics.methodMix} money={money} />
+                        </SectionCard>
+                        <SectionCard
+                            title="Collections by gateway"
+                            subtitle="Paid volume settled through each gateway"
+                        >
+                            <RankedBars
+                                slices={analytics.gatewayBreakdown}
+                                money={money}
+                                colorAt={(i) => CHART_PALETTE[i % CHART_PALETTE.length]!}
+                                renderLabel={(s) => (
+                                    <GatewayBadge vendor={s.label} showLabel size="sm" />
+                                )}
+                            />
+                        </SectionCard>
+                    </div>
+
+                    {/* Funnel + Aging */}
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <SectionCard
+                            title="Collection funnel"
+                            subtitle="From invoiced records to money captured"
+                        >
+                            <FunnelBars analytics={analytics} money={money} />
+                        </SectionCard>
+                        <SectionCard
+                            title="Outstanding by age"
+                            subtitle={`${money(analytics.outstanding.amount, true)} across ${analytics.outstanding.count} pending`}
+                        >
+                            <div className="grid grid-cols-2 gap-3">
+                                {analytics.aging.map((b) => (
+                                    <div
+                                        key={b.label}
+                                        className="rounded-lg border border-neutral-200 p-3"
+                                    >
+                                        <div
+                                            className={cn(
+                                                'text-caption font-medium',
+                                                AGING_TONE[b.tone]
+                                            )}
+                                        >
+                                            {b.label}
+                                        </div>
+                                        <div className="mt-1 text-subtitle font-semibold tabular-nums text-neutral-800">
+                                            {money(b.amount, true)}
+                                        </div>
+                                        <div className="text-caption text-neutral-500">
+                                            {b.count} {b.count === 1 ? 'payment' : 'payments'}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </SectionCard>
+                    </div>
+
+                    {/* Top courses + Payment type */}
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <SectionCard
+                            title={`Top ${courseTerm.toLowerCase()}s by revenue`}
+                            subtitle="Collected in this period"
+                        >
+                            <RankedBars
+                                slices={analytics.topCourses}
+                                money={money}
+                                colorAt={(i) => CHART_PALETTE[i % CHART_PALETTE.length]!}
+                            />
+                        </SectionCard>
+                        <SectionCard title="Payment type mix" subtitle="All records by type">
+                            <div className="space-y-2.5">
+                                {analytics.paymentTypeMix.map((s, i) => {
+                                    const total = analytics.totalEntries || 1;
+                                    const pct = Math.round((s.count / total) * 100);
+                                    return (
+                                        <div key={s.label} className="flex items-center gap-3">
+                                            <span
+                                                className="size-2.5 shrink-0 rounded-full"
+                                                style={{
+                                                    backgroundColor:
+                                                        CHART_PALETTE[i % CHART_PALETTE.length],
+                                                }}
+                                            />
+                                            <span className="flex-1 truncate text-body text-neutral-700">
+                                                {s.label}
+                                            </span>
+                                            <span className="text-body font-medium tabular-nums text-neutral-800">
+                                                {s.count}
+                                            </span>
+                                            <span className="w-10 text-right text-caption text-neutral-400">
+                                                {pct}%
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </SectionCard>
+                    </div>
+
+                    {/* Honesty note about what isn't shown yet */}
+                    <div className="flex items-start gap-2 rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-caption text-neutral-500">
+                        <Info size={15} className="mt-px shrink-0 text-neutral-400" />
+                        <span>
+                            Every figure here is derived from your payment records. Bank settlement
+                            timelines and gateway-reported decline reasons aren’t available from the
+                            current API, so those panels are intentionally omitted rather than
+                            estimated.
+                        </span>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+// ─── Method-mix donut ───────────────────────────────────────────────────────────
+
+function MethodMixDonut({
+    slices,
+    money,
+}: {
+    slices: AmountSlice[];
+    money: (n: number, compact?: boolean) => string;
+}) {
+    const totalCount = slices.reduce((a, s) => a + s.count, 0);
+    if (!slices.length || totalCount === 0) {
+        return <div className="py-8 text-center text-caption text-neutral-400">No data</div>;
+    }
+    const chartData = slices.map((s) => ({ name: s.label, value: s.count, amount: s.amount }));
+
+    return (
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center">
+            <div className="relative size-36 shrink-0">
+                <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                        <Pie
+                            data={chartData}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            innerRadius={44}
+                            outerRadius={64}
+                            paddingAngle={2}
+                            stroke="none"
+                        >
+                            {chartData.map((_, i) => (
+                                <Cell key={i} fill={CHART_PALETTE[i % CHART_PALETTE.length]} />
+                            ))}
+                        </Pie>
+                        <Tooltip
+                            contentStyle={{
+                                borderRadius: 8,
+                                border: '1px solid hsl(var(--border))',
+                                fontSize: 12,
+                            }}
+                            formatter={(v: number, _n, item) => [
+                                `${v} · ${money((item?.payload as { amount: number }).amount, true)}`,
+                                (item?.payload as { name: string }).name,
+                            ]}
+                        />
+                    </PieChart>
+                </ResponsiveContainer>
+                <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+                    <span className="text-subtitle font-semibold text-neutral-800">
+                        {totalCount}
+                    </span>
+                    <span className="text-2xs text-neutral-400">payments</span>
+                </div>
+            </div>
+            <div className="w-full space-y-1.5">
+                {slices.map((s, i) => (
+                    <div key={s.label} className="flex items-center gap-2 text-body">
+                        <span
+                            className="size-2.5 shrink-0 rounded-full"
+                            style={{ backgroundColor: CHART_PALETTE[i % CHART_PALETTE.length] }}
+                        />
+                        <span className="flex-1 truncate text-neutral-700">{s.label}</span>
+                        <span className="font-medium tabular-nums text-neutral-800">
+                            {Math.round((s.count / totalCount) * 100)}%
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ─── Funnel ─────────────────────────────────────────────────────────────────────
+
+function FunnelBars({
+    analytics,
+    money,
+}: {
+    analytics: PaymentAnalytics;
+    money: (n: number, compact?: boolean) => string;
+}) {
+    const stages = analytics.funnel;
+    const top = Math.max(1, stages[0]?.amount ?? 1);
+    const colors = ['hsl(var(--info-500))', 'hsl(var(--primary-500))', 'hsl(var(--success-500))'];
+
+    return (
+        <div className="space-y-3">
+            {stages.map((st, i) => {
+                const prev = i > 0 ? stages[i - 1]!.amount : null;
+                const drop =
+                    prev && prev > 0 ? (((prev - st.amount) / prev) * 100).toFixed(1) : null;
+                return (
+                    <div key={st.label}>
+                        <div className="mb-1 flex items-center justify-between gap-3 text-body">
+                            <span className="font-medium text-neutral-700">{st.label}</span>
+                            <span className="flex items-center gap-2">
+                                {drop && Number(drop) > 0 && (
+                                    <span className="text-caption text-danger-600">−{drop}%</span>
+                                )}
+                                <span className="font-semibold tabular-nums text-neutral-800">
+                                    {money(st.amount, true)}
+                                </span>
+                            </span>
+                        </div>
+                        <div className="h-6 overflow-hidden rounded-md bg-neutral-100">
+                            <div
+                                className="flex h-full items-center rounded-md px-2 text-2xs font-medium text-white"
+                                style={{
+                                    width: `${Math.max(6, (st.amount / top) * 100)}%`,
+                                    backgroundColor: colors[i % colors.length],
+                                }}
+                            >
+                                {st.count}
+                            </div>
+                        </div>
+                        <div className="mt-0.5 text-caption text-neutral-400">{st.hint}</div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentDetailSheet.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentDetailSheet.tsx
@@ -1,0 +1,275 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { StatusChip, type StatusType } from '@/components/design-system/status-chips';
+import { MyButton } from '@/components/design-system/button';
+import { Check, Clock, Copy, XCircle, UserCircle } from '@phosphor-icons/react';
+import { toast } from 'sonner';
+import { useStudentSidebar } from '@/routes/manage-students/students-list/-context/selected-student-sidebar-context';
+import type { StudentTable } from '@/types/student-table-types';
+import { formatDistanceToNow } from 'date-fns';
+import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
+import { ContentTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { formatMoney, resolveEntryCurrency } from '@/utils/payment-currency';
+import { derivePaymentTypeLabel } from '../-utils/exportPaymentLogsCsv';
+import { GatewayBadge } from './GatewayBadge';
+import type { PaymentLogEntry } from '@/types/payment-logs';
+
+interface PaymentDetailSheetProps {
+    entry: PaymentLogEntry | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+const STATUS_META: Record<string, { label: string; chip: StatusType }> = {
+    PAID: { label: 'Paid', chip: 'SUCCESS' },
+    FAILED: { label: 'Failed', chip: 'DANGER' },
+    PAYMENT_PENDING: { label: 'Pending', chip: 'WARNING' },
+    NOT_INITIATED: { label: 'Not initiated', chip: 'INFO' },
+};
+
+const statusMeta = (status?: string) =>
+    STATUS_META[(status || '').toUpperCase()] ?? {
+        label: status || '—',
+        chip: 'INFO' as StatusType,
+    };
+
+const initials = (name?: string) =>
+    (name || '?')
+        .split(' ')
+        .map((w) => w[0])
+        .filter(Boolean)
+        .slice(0, 2)
+        .join('')
+        .toUpperCase();
+
+const formatTimestamp = (raw?: string | null, hasTime?: boolean): string => {
+    if (!raw) return '—';
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        ...(hasTime ? { hour: '2-digit', minute: '2-digit' } : { timeZone: 'UTC' }),
+    });
+};
+
+const relative = (raw?: string | null): string => {
+    if (!raw) return '';
+    try {
+        return formatDistanceToNow(new Date(raw), { addSuffix: true });
+    } catch {
+        return '';
+    }
+};
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex items-start justify-between gap-4 py-2">
+            <dt className="text-caption text-neutral-500">{label}</dt>
+            <dd className="text-right text-body font-medium text-neutral-700">{children}</dd>
+        </div>
+    );
+}
+
+interface TimelineEvent {
+    done: boolean;
+    title: string;
+    meta: string;
+}
+
+/** Read-only detail panel for a single payment row: identity, key facts, and a status timeline. */
+export function PaymentDetailSheet({ entry, open, onOpenChange }: PaymentDetailSheetProps) {
+    // Opens the same full-screen student profile overlay the students list uses.
+    const { openOverlay } = useStudentSidebar();
+
+    if (!entry) return <Sheet open={open} onOpenChange={onOpenChange} />;
+
+    const { payment_log: log, user, user_plan: plan } = entry;
+
+    const openStudentProfile = () => {
+        if (!user?.id) {
+            toast.error('No student is linked to this payment.');
+            return;
+        }
+        // The overlay hydrates the rest of the profile from the user id; we only seed the header.
+        const seed = {
+            id: user.id,
+            user_id: user.id,
+            full_name: user.full_name ?? '',
+            email: user.email ?? '',
+            mobile_number: user.mobile_number ?? '',
+            status: 'INACTIVE',
+        } as unknown as StudentTable;
+        onOpenChange(false);
+        openOverlay(seed);
+    };
+    const status = entry.current_payment_status || log?.payment_status || '';
+    const meta = statusMeta(status);
+    const currency = resolveEntryCurrency(entry);
+    const amount = log?.payment_amount || 0;
+    const hasTime = Boolean(log?.created_at);
+    const timestamp = log?.created_at || log?.date;
+    const courseTerm = getTerminology(ContentTerms.Course, SystemTerms.Course);
+
+    const timeline: TimelineEvent[] = [
+        {
+            done: true,
+            title: 'Payment initiated',
+            meta: `${formatTimestamp(timestamp, hasTime)}${
+                relative(timestamp) ? ` · ${relative(timestamp)}` : ''
+            }`,
+        },
+    ];
+    if (meta.chip === 'SUCCESS') {
+        timeline.push({ done: true, title: 'Payment captured', meta: log?.vendor || 'Gateway' });
+        timeline.push({
+            done: true,
+            title: `${courseTerm} / membership activated`,
+            meta: plan?.enroll_invite?.name || '—',
+        });
+    } else if (meta.chip === 'DANGER') {
+        timeline.push({ done: false, title: 'Attempt failed', meta: log?.vendor || 'Gateway' });
+    } else {
+        timeline.push({
+            done: false,
+            title: 'Awaiting confirmation',
+            meta: 'Not yet captured by the gateway',
+        });
+    }
+
+    const copyId = async () => {
+        const id = log?.transaction_id || log?.id || '';
+        try {
+            await navigator.clipboard.writeText(id);
+            toast.success('Transaction ID copied');
+        } catch {
+            toast.error('Could not copy to clipboard');
+        }
+    };
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto p-0 sm:max-w-md">
+                <SheetHeader className="border-b border-neutral-200 p-5 text-left">
+                    <SheetTitle className="text-title">Payment details</SheetTitle>
+                    <p className="font-mono text-caption text-neutral-500">
+                        {log?.transaction_id || log?.id || '—'}
+                    </p>
+                </SheetHeader>
+
+                <div className="flex-1 space-y-5 p-5">
+                    {/* Hero */}
+                    <div className="flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                        <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary-100 text-subtitle font-semibold text-primary-600">
+                            {initials(user?.full_name || user?.email)}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <div className="truncate text-body font-semibold text-neutral-700">
+                                {user?.full_name || '—'}
+                            </div>
+                            <div className="truncate text-caption text-neutral-500">
+                                {user?.email || '—'}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={openStudentProfile}
+                                className="mt-1 inline-flex items-center gap-1 text-caption font-semibold text-primary-600 hover:text-primary-700"
+                            >
+                                <UserCircle size={14} weight="fill" />
+                                View profile
+                            </button>
+                        </div>
+                        <div className="text-right">
+                            <div className="text-title font-semibold text-neutral-800">
+                                {formatMoney(amount, currency, { maximumFractionDigits: 2 })}
+                            </div>
+                            <div className="mt-1 flex justify-end">
+                                <StatusChip
+                                    text={meta.label}
+                                    textSize="text-caption"
+                                    status={meta.chip}
+                                    showIcon={false}
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Key-value facts */}
+                    <dl className="divide-y divide-neutral-100">
+                        <Row label="Payment gateway">
+                            <GatewayBadge
+                                vendor={log?.vendor}
+                                showLabel
+                                size="sm"
+                                className="justify-end"
+                            />
+                        </Row>
+                        <Row label="Payment type">{derivePaymentTypeLabel(entry)}</Row>
+                        <Row label="Phone">{user?.mobile_number || '—'}</Row>
+                        <Row label={`${courseTerm} / membership`}>
+                            {plan?.enroll_invite?.name || '—'}
+                        </Row>
+                        <Row label="Invite code">{plan?.enroll_invite?.invite_code || '—'}</Row>
+                        <Row label="Plan status">
+                            {plan?.status ? plan.status.replace(/_/g, ' ') : '—'}
+                        </Row>
+                        <Row label="Payment plan">{plan?.payment_plan_dto?.name || '—'}</Row>
+                        {plan?.source === 'SUB_ORG' && plan?.sub_org_details?.name && (
+                            <Row label="Organization">{plan.sub_org_details.name}</Row>
+                        )}
+                    </dl>
+
+                    {/* Activity timeline */}
+                    <div>
+                        <div className="mb-3 text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                            Activity
+                        </div>
+                        <ol className="space-y-3">
+                            {timeline.map((ev, i) => (
+                                <li key={i} className="flex gap-3">
+                                    <span
+                                        className={
+                                            ev.done
+                                                ? 'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-success-100 text-success-600'
+                                                : meta.chip === 'DANGER'
+                                                  ? 'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-danger-100 text-danger-600'
+                                                  : 'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-warning-100 text-warning-600'
+                                        }
+                                    >
+                                        {ev.done ? (
+                                            <Check size={12} weight="bold" />
+                                        ) : meta.chip === 'DANGER' ? (
+                                            <XCircle size={12} weight="bold" />
+                                        ) : (
+                                            <Clock size={12} weight="bold" />
+                                        )}
+                                    </span>
+                                    <div>
+                                        <div className="text-body font-medium text-neutral-700">
+                                            {ev.title}
+                                        </div>
+                                        <div className="text-caption text-neutral-500">
+                                            {ev.meta}
+                                        </div>
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    </div>
+                </div>
+
+                <div className="border-t border-neutral-200 p-4">
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        className="w-full gap-2"
+                        onClick={copyId}
+                    >
+                        <Copy size={16} />
+                        Copy transaction ID
+                    </MyButton>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentFilters.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentFilters.tsx
@@ -37,6 +37,12 @@ interface PaymentFiltersProps {
     onSearchChange: (value: string) => void;
     /** Optional action(s) rendered on the right of the control bar (e.g. export). */
     exportSlot?: ReactNode;
+    /**
+     * Render ONLY the detailed filter grid (payment type / status / plan / source / dates /
+     * course), always expanded and without the search + toggle bar. Used to embed the filters
+     * inside the redesign's slide-over panel, where search/segmented-status live in the control bar.
+     */
+    panelOnly?: boolean;
 }
 
 const PAYMENT_STATUS_OPTIONS: SelectOption[] = [
@@ -101,12 +107,12 @@ export function PaymentFilters({
     hasOrgAssociatedBatches,
     packageSessionFilter,
     onPackageSessionFilterChange,
-    batchesForSessions,
     onQuickFilterSelect,
     onClearFilters,
     searchValue,
     onSearchChange,
     exportSlot,
+    panelOnly = false,
 }: PaymentFiltersProps) {
     const [showFilters, setShowFilters] = useState(false);
     // Which quick-range pill is highlighted. Cleared when the user edits dates manually
@@ -205,163 +211,178 @@ export function PaymentFilters({
         onClearFilters();
     };
 
+    // Shared detailed filter grid (attribute chips + quick/precise dates + course selector).
+    const filterGrid = (
+        <div className="space-y-5">
+            {/* Attribute filters */}
+            <div
+                className={cn(
+                    'grid grid-cols-1 gap-4 sm:grid-cols-2',
+                    !panelOnly && 'lg:grid-cols-4'
+                )}
+            >
+                <FilterField label="Payment Type">
+                    <SelectChips
+                        options={PAYMENT_TYPE_OPTIONS}
+                        selected={selectedPaymentTypes}
+                        onChange={onPaymentTypesChange}
+                        placeholder="All types"
+                        multiSelect
+                        fullWidth
+                        clearable
+                    />
+                </FilterField>
+                <FilterField label="Payment Status">
+                    <SelectChips
+                        options={PAYMENT_STATUS_OPTIONS}
+                        selected={selectedPaymentStatuses}
+                        onChange={onPaymentStatusesChange}
+                        placeholder="All statuses"
+                        multiSelect
+                        fullWidth
+                        clearable
+                    />
+                </FilterField>
+                <FilterField label="Plan Status">
+                    <SelectChips
+                        options={USER_PLAN_STATUS_OPTIONS}
+                        selected={selectedUserPlanStatuses}
+                        onChange={onUserPlanStatusesChange}
+                        placeholder="All plan statuses"
+                        multiSelect
+                        fullWidth
+                        clearable
+                    />
+                </FilterField>
+                {hasOrgAssociatedBatches && (
+                    <FilterField label="Payment Source">
+                        <SelectChips
+                            options={PAYMENT_SOURCE_OPTIONS}
+                            selected={selectedPaymentSources}
+                            onChange={onPaymentSourcesChange}
+                            placeholder="All sources"
+                            multiSelect
+                            fullWidth
+                            clearable
+                        />
+                    </FilterField>
+                )}
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Date range */}
+            <div className="space-y-2">
+                <span className="text-caption font-medium text-neutral-500">Quick range</span>
+                <ChipToggleGroup
+                    value={activeQuick}
+                    onChange={handleQuickFilter}
+                    options={QUICK_RANGE_OPTIONS}
+                    ariaLabel="Quick date range"
+                />
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <FilterField label="Start Date">
+                    <Input
+                        type="datetime-local"
+                        value={startDate ? toLocalInputValue(startDate) : ''}
+                        onChange={(e) => handleDateChange(onStartDateChange, e.target.value)}
+                        className="h-9"
+                    />
+                </FilterField>
+                <FilterField label="End Date">
+                    <Input
+                        type="datetime-local"
+                        value={endDate ? toLocalInputValue(endDate) : ''}
+                        onChange={(e) => handleDateChange(onEndDateChange, e.target.value)}
+                        className="h-9"
+                    />
+                </FilterField>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Course / session */}
+            <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                    <GraduationCap size={16} className="text-neutral-500" />
+                    <Label className="text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                        {getTerminology(ContentTerms.Course, SystemTerms.Course)} /{' '}
+                        {getTerminology(ContentTerms.Session, SystemTerms.Session)}
+                    </Label>
+                </div>
+                <PackageSelector
+                    instituteId={getCurrentInstituteId() || ''}
+                    onChange={handlePackageSessionChange}
+                    initialLevelId={packageSessionFilter.levelId}
+                    initialSessionId={packageSessionFilter.sessionId}
+                    initialPackageId={packageSessionFilter.packageId}
+                    multiSelect={true}
+                    initialPackageSessionIds={packageSessionFilter.packageSessionIds}
+                />
+            </div>
+        </div>
+    );
+
+    // Slide-over embed: just the filters, plus a Clear-all when something is active.
+    if (panelOnly) {
+        return (
+            <div className="space-y-5">
+                {filterGrid}
+                {hasActiveFilters && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleClearAll}
+                        className="gap-2 text-danger-600 hover:text-danger-700"
+                    >
+                        <X size={16} />
+                        Clear all filters
+                    </Button>
+                )}
+            </div>
+        );
+    }
+
     return (
         <div className="space-y-4">
             {/* Control bar: search + filters toggle + export */}
-            <div className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center gap-3">
-                    {/* Search */}
-                    <div className="relative w-full sm:flex-1">
-                        <MagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-neutral-500" />
-                        <MyInput
-                            inputType="text"
-                            input={searchValue}
-                            onChangeFunction={(e) => onSearchChange(e.target.value)}
-                            inputPlaceholder="Search by name, email, phone, or amount"
-                            className="pl-9 sm:w-full"
-                        />
-                    </div>
-
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setShowFilters(!showFilters)}
-                        className={cn(
-                            'h-9 gap-2',
-                            hasActiveFilters && 'border-primary-500 bg-primary-50 text-primary-600'
-                        )}
-                    >
-                        <Funnel size={16} weight={hasActiveFilters ? 'fill' : 'regular'} />
-                        Filters
-                        {hasActiveFilters && (
-                            <span className="ml-1 flex size-5 items-center justify-center rounded-full bg-primary-500 text-caption text-neutral-50">
-                                {activeFilterCount}
-                            </span>
-                        )}
-                    </Button>
-
-                    {exportSlot}
-                </div>
-
-                {/* Quick range + clear */}
-                <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-caption font-medium text-neutral-500">Quick range</span>
-                    <ChipToggleGroup
-                        value={activeQuick}
-                        onChange={handleQuickFilter}
-                        options={QUICK_RANGE_OPTIONS}
-                        ariaLabel="Quick date range"
+            <div className="flex flex-wrap items-center gap-3">
+                <div className="relative w-full sm:flex-1">
+                    <MagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-neutral-500" />
+                    <MyInput
+                        inputType="text"
+                        input={searchValue}
+                        onChangeFunction={(e) => onSearchChange(e.target.value)}
+                        inputPlaceholder="Search by name, email, phone, or amount"
+                        className="pl-9 sm:w-full"
                     />
-                    {hasActiveFilters && (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleClearAll}
-                            className="ml-auto gap-2 text-danger-600 hover:text-danger-700"
-                        >
-                            <X size={16} />
-                            Clear All
-                        </Button>
-                    )}
                 </div>
+
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowFilters(!showFilters)}
+                    className={cn(
+                        'h-9 gap-2',
+                        hasActiveFilters && 'border-primary-500 bg-primary-50 text-primary-600'
+                    )}
+                >
+                    <Funnel size={16} weight={hasActiveFilters ? 'fill' : 'regular'} />
+                    Filters
+                    {hasActiveFilters && (
+                        <span className="ml-1 flex size-5 items-center justify-center rounded-full bg-primary-500 text-caption text-neutral-50">
+                            {activeFilterCount}
+                        </span>
+                    )}
+                </Button>
+
+                {exportSlot}
             </div>
 
-            {/* Filter panel */}
             {showFilters && (
-                <div className="space-y-5 rounded-lg border border-border bg-card p-5 shadow-sm">
-                    {/* Attribute filters */}
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <FilterField label="Payment Type">
-                            <SelectChips
-                                options={PAYMENT_TYPE_OPTIONS}
-                                selected={selectedPaymentTypes}
-                                onChange={onPaymentTypesChange}
-                                placeholder="All types"
-                                multiSelect
-                                fullWidth
-                                clearable
-                            />
-                        </FilterField>
-                        <FilterField label="Payment Status">
-                            <SelectChips
-                                options={PAYMENT_STATUS_OPTIONS}
-                                selected={selectedPaymentStatuses}
-                                onChange={onPaymentStatusesChange}
-                                placeholder="All statuses"
-                                multiSelect
-                                fullWidth
-                                clearable
-                            />
-                        </FilterField>
-                        <FilterField label="Plan Status">
-                            <SelectChips
-                                options={USER_PLAN_STATUS_OPTIONS}
-                                selected={selectedUserPlanStatuses}
-                                onChange={onUserPlanStatusesChange}
-                                placeholder="All plan statuses"
-                                multiSelect
-                                fullWidth
-                                clearable
-                            />
-                        </FilterField>
-                        {hasOrgAssociatedBatches && (
-                            <FilterField label="Payment Source">
-                                <SelectChips
-                                    options={PAYMENT_SOURCE_OPTIONS}
-                                    selected={selectedPaymentSources}
-                                    onChange={onPaymentSourcesChange}
-                                    placeholder="All sources"
-                                    multiSelect
-                                    fullWidth
-                                    clearable
-                                />
-                            </FilterField>
-                        )}
-                    </div>
-
-                    <div className="h-px bg-border" />
-
-                    {/* Date range */}
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <FilterField label="Start Date">
-                            <Input
-                                type="datetime-local"
-                                value={startDate ? toLocalInputValue(startDate) : ''}
-                                onChange={(e) => handleDateChange(onStartDateChange, e.target.value)}
-                                className="h-9"
-                            />
-                        </FilterField>
-                        <FilterField label="End Date">
-                            <Input
-                                type="datetime-local"
-                                value={endDate ? toLocalInputValue(endDate) : ''}
-                                onChange={(e) => handleDateChange(onEndDateChange, e.target.value)}
-                                className="h-9"
-                            />
-                        </FilterField>
-                    </div>
-
-                    <div className="h-px bg-border" />
-
-                    {/* Course / session */}
-                    <div className="space-y-2">
-                        <div className="flex items-center gap-2">
-                            <GraduationCap size={16} className="text-neutral-500" />
-                            <Label className="text-caption font-semibold uppercase tracking-wide text-neutral-500">
-                                {getTerminology(ContentTerms.Course, SystemTerms.Course)} /{' '}
-                                {getTerminology(ContentTerms.Session, SystemTerms.Session)}
-                            </Label>
-                        </div>
-                        <PackageSelector
-                            instituteId={getCurrentInstituteId() || ''}
-                            onChange={handlePackageSessionChange}
-                            initialLevelId={packageSessionFilter.levelId}
-                            initialSessionId={packageSessionFilter.sessionId}
-                            initialPackageId={packageSessionFilter.packageId}
-                            multiSelect={true}
-                            initialPackageSessionIds={packageSessionFilter.packageSessionIds}
-                        />
-                    </div>
+                <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+                    {filterGrid}
                 </div>
             )}
         </div>

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentLogsTable.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentLogsTable.tsx
@@ -3,7 +3,6 @@ import { ColumnDef } from '@tanstack/react-table';
 import { MyTable, TableData } from '@/components/design-system/table';
 import { MyPagination } from '@/components/design-system/pagination';
 import type { PaymentLog, PaymentLogEntry, PaymentLogsResponse } from '@/types/payment-logs';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -20,6 +19,80 @@ import { PencilSimple, FloppyDisk, X } from '@phosphor-icons/react';
 import { updatePaymentLogTracking } from '@/services/payment-logs';
 import { useToast } from '@/hooks/use-toast';
 import { formatMoney, resolveEntryCurrency } from '@/utils/payment-currency';
+import { cn } from '@/lib/utils';
+import { GatewayBadge } from './GatewayBadge';
+import { derivePaymentTypeLabel } from '../-utils/exportPaymentLogsCsv';
+
+// ─── Redesign cell primitives ──────────────────────────────────────────────────
+
+/** Token-based avatar tints, picked deterministically from the name so a user keeps one colour. */
+const AVATAR_TINTS = [
+    'bg-primary-100 text-primary-600',
+    'bg-info-100 text-info-600',
+    'bg-success-100 text-success-600',
+    'bg-warning-100 text-warning-600',
+    'bg-danger-100 text-danger-600',
+];
+
+const avatarTint = (name: string): string =>
+    AVATAR_TINTS[(name.charCodeAt(0) || 0) % AVATAR_TINTS.length]!;
+
+const initialsOf = (name: string): string =>
+    (name || '?')
+        .split(' ')
+        .map((w) => w[0])
+        .filter(Boolean)
+        .slice(0, 2)
+        .join('')
+        .toUpperCase() || '?';
+
+function UserAvatar({ name }: { name: string }) {
+    return (
+        <span
+            className={cn(
+                'flex size-8 shrink-0 items-center justify-center rounded-full text-2xs font-bold',
+                avatarTint(name)
+            )}
+        >
+            {initialsOf(name)}
+        </span>
+    );
+}
+
+const PAYMENT_STATUS_PILL: Record<string, { label: string; cls: string; dot: string }> = {
+    PAID: { label: 'Paid', cls: 'bg-success-100 text-success-700', dot: 'bg-success-600' },
+    FAILED: { label: 'Failed', cls: 'bg-danger-100 text-danger-700', dot: 'bg-danger-600' },
+    PAYMENT_PENDING: {
+        label: 'Pending',
+        cls: 'bg-warning-100 text-warning-700',
+        dot: 'bg-warning-600',
+    },
+    NOT_INITIATED: {
+        label: 'Not initiated',
+        cls: 'bg-neutral-100 text-neutral-600',
+        dot: 'bg-neutral-400',
+    },
+};
+
+function PaymentStatusPill({ status }: { status?: string }) {
+    const key = (status || '').toUpperCase();
+    const meta = PAYMENT_STATUS_PILL[key] ?? {
+        label: status ? status.replace(/_/g, ' ') : '—',
+        cls: 'bg-neutral-100 text-neutral-600',
+        dot: 'bg-neutral-400',
+    };
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-2xs font-bold',
+                meta.cls
+            )}
+        >
+            <span className={cn('size-1.5 rounded-full', meta.dot)} />
+            {meta.label}
+        </span>
+    );
+}
 
 // ─── Order Status Constants ───────────────────────────────────────────────────
 
@@ -55,7 +128,20 @@ interface PaymentLogsTableProps {
     hasOrgAssociatedBatches: boolean;
     hideUserColumn?: boolean;
     onRefresh?: () => void;
+    /** Open the read-only detail slide-over for a row (fires on any non-editable cell). */
+    onViewDetails?: (entry: PaymentLogEntry) => void;
 }
+
+/**
+ * Columns whose cells host inline editing / actions — clicking them must NOT open the detail
+ * slide-over, so the tracking editor and the row-click detail view don't fight over the same click.
+ */
+const NON_DETAIL_COLUMN_IDS = new Set([
+    'tracking_id',
+    'tracking_source',
+    'order_status',
+    'tracking_actions',
+]);
 
 interface EditingState {
     rowId: string;
@@ -99,9 +185,7 @@ function TrackingIdCell({ entry }: { entry: PaymentLogEntry }) {
         return (
             <Input
                 value={editing.trackingId}
-                onChange={(e) =>
-                    setEditing({ ...editing, trackingId: e.target.value })
-                }
+                onChange={(e) => setEditing({ ...editing, trackingId: e.target.value })}
                 placeholder="Enter tracking ID"
                 className="h-8 text-xs"
                 disabled={editing.isSaving}
@@ -124,9 +208,7 @@ function TrackingSourceCell({ entry }: { entry: PaymentLogEntry }) {
         return (
             <Input
                 value={editing.trackingSource}
-                onChange={(e) =>
-                    setEditing({ ...editing, trackingSource: e.target.value })
-                }
+                onChange={(e) => setEditing({ ...editing, trackingSource: e.target.value })}
                 placeholder="Enter source"
                 className="h-8 text-xs"
                 disabled={editing.isSaving}
@@ -135,9 +217,7 @@ function TrackingSourceCell({ entry }: { entry: PaymentLogEntry }) {
     }
 
     return (
-        <div className="text-xs text-neutral-600">
-            {entry.payment_log.tracking_source || '—'}
-        </div>
+        <div className="text-xs text-neutral-600">{entry.payment_log.tracking_source || '—'}</div>
     );
 }
 
@@ -149,9 +229,7 @@ function OrderStatusCell({ entry }: { entry: PaymentLogEntry }) {
         return (
             <Select
                 value={editing.orderStatus}
-                onValueChange={(val) =>
-                    setEditing({ ...editing, orderStatus: val })
-                }
+                onValueChange={(val) => setEditing({ ...editing, orderStatus: val })}
                 disabled={editing.isSaving}
             >
                 <SelectTrigger className="h-8 text-xs">
@@ -201,7 +279,7 @@ function ActionsCell({ entry }: { entry: PaymentLogEntry }) {
                 <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 w-7 p-0 text-green-600 hover:bg-green-50 hover:text-green-700"
+                    className="size-7 p-0 text-green-600 hover:bg-green-50 hover:text-green-700"
                     onClick={() => onSave(entry)}
                     disabled={editing.isSaving}
                     title="Save"
@@ -211,7 +289,7 @@ function ActionsCell({ entry }: { entry: PaymentLogEntry }) {
                 <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 w-7 p-0 text-neutral-500 hover:bg-gray-100 hover:text-neutral-600"
+                    className="size-7 p-0 text-neutral-500 hover:bg-gray-100 hover:text-neutral-600"
                     onClick={onCancel}
                     disabled={editing.isSaving}
                     title="Cancel"
@@ -226,7 +304,7 @@ function ActionsCell({ entry }: { entry: PaymentLogEntry }) {
         <Button
             variant="ghost"
             size="sm"
-            className="h-7 w-7 p-0 text-neutral-500 hover:bg-gray-100 hover:text-neutral-600"
+            className="size-7 p-0 text-neutral-500 hover:bg-gray-100 hover:text-neutral-600"
             onClick={() => onStartEdit(entry)}
             title="Edit tracking info"
         >
@@ -236,23 +314,6 @@ function ActionsCell({ entry }: { entry: PaymentLogEntry }) {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const getStatusBadgeVariant = (
-    status: string
-): 'default' | 'secondary' | 'destructive' | 'outline' => {
-    switch (status) {
-        case 'PAID':
-            return 'default';
-        case 'FAILED':
-            return 'destructive';
-        case 'PAYMENT_PENDING':
-            return 'secondary';
-        case 'NOT_INITIATED':
-            return 'outline';
-        default:
-            return 'secondary';
-    }
-};
 
 const formatCurrency = (amount: number, currency: string) =>
     formatMoney(amount, currency, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -332,6 +393,7 @@ export function PaymentLogsTable({
     hasOrgAssociatedBatches,
     hideUserColumn = false,
     onRefresh,
+    onViewDetails,
 }: PaymentLogsTableProps) {
     const { toast } = useToast();
     const [editing, setEditing] = useState<EditingState | null>(null);
@@ -398,17 +460,13 @@ export function PaymentLogsTable({
                         onRefresh?.();
                     } catch (err: unknown) {
                         const message =
-                            err instanceof Error
-                                ? err.message
-                                : 'Failed to update tracking info.';
+                            err instanceof Error ? err.message : 'Failed to update tracking info.';
                         toast({
                             title: 'Error',
                             description: message,
                             variant: 'destructive',
                         });
-                        setEditing((prev) =>
-                            prev ? { ...prev, isSaving: false } : null
-                        );
+                        setEditing((prev) => (prev ? { ...prev, isSaving: false } : null));
                     }
                 };
 
@@ -472,16 +530,22 @@ export function PaymentLogsTable({
                               row?.user?.full_name || row?.user?.email || '',
                           cell: ({ row }: { row: { original: PaymentLogEntry } }) => {
                               const user = row.original?.user;
+                              const name = user?.full_name || user?.email || '-';
                               return (
-                                  <div className="space-y-1">
-                                      <div className="font-medium text-neutral-700">
-                                          {user?.full_name || '-'}
+                                  <div className="flex items-center gap-2.5">
+                                      <UserAvatar name={name} />
+                                      <div className="min-w-0">
+                                          <div className="truncate font-medium text-neutral-700">
+                                              {user?.full_name || '-'}
+                                          </div>
+                                          <div className="truncate text-xs text-neutral-500">
+                                              {user?.email || '-'}
+                                          </div>
                                       </div>
-                                      <div className="text-xs text-neutral-500">{user?.email || '-'}</div>
                                   </div>
                               );
                           },
-                          size: 200,
+                          size: 220,
                       } as ColumnDef<PaymentLogEntry>,
                   ]
                 : []),
@@ -513,9 +577,7 @@ export function PaymentLogsTable({
                                       );
                                   }
                               }
-                              return (
-                                  <div className="text-xs text-neutral-500 italic">N/A</div>
-                              );
+                              return <div className="text-xs italic text-neutral-500">N/A</div>;
                           },
                           size: 200,
                       } as ColumnDef<PaymentLogEntry>,
@@ -529,26 +591,26 @@ export function PaymentLogsTable({
                     const amount = row.original?.payment_log?.payment_amount || 0;
                     const currency = resolveEntryCurrency(row.original);
                     return (
-                        <div className="font-semibold text-neutral-700">
-                            {formatCurrency(amount, currency)}
+                        <div>
+                            <div className="font-bold tabular-nums text-neutral-800">
+                                {formatCurrency(amount, currency)}
+                            </div>
+                            <div className="text-xs text-neutral-500">
+                                {derivePaymentTypeLabel(row.original)}
+                            </div>
                         </div>
                     );
                 },
-                size: 130,
+                size: 150,
             },
             {
                 id: 'current_payment_status',
-                header: 'Payment Status',
+                header: 'Payment',
                 accessorFn: (row) => row?.current_payment_status || '',
-                cell: ({ row }) => {
-                    const status = row.original?.current_payment_status;
-                    return (
-                        <Badge variant={getStatusBadgeVariant(status)} className="font-medium">
-                            {status?.replace(/_/g, ' ') || '-'}
-                        </Badge>
-                    );
-                },
-                size: 140,
+                cell: ({ row }) => (
+                    <PaymentStatusPill status={row.original?.current_payment_status} />
+                ),
+                size: 130,
             },
             {
                 id: 'vendor',
@@ -556,13 +618,9 @@ export function PaymentLogsTable({
                 accessorFn: (row) => row?.payment_log?.vendor || '',
                 cell: ({ row }) => {
                     const vendor = row.original?.payment_log?.vendor;
-                    return (
-                        <div className="flex items-center gap-2">
-                            <span className="text-sm text-neutral-600">{vendor || '-'}</span>
-                        </div>
-                    );
+                    return <GatewayBadge vendor={vendor} showLabel size="sm" />;
                 },
-                size: 140,
+                size: 160,
             },
             {
                 id: 'user_plan_status',
@@ -570,10 +628,11 @@ export function PaymentLogsTable({
                 accessorFn: (row) => row?.user_plan?.status || '',
                 cell: ({ row }) => {
                     const status = row.original?.user_plan?.status;
+                    if (!status) return <span className="text-xs text-neutral-400">—</span>;
                     return (
-                        <Badge variant="outline" className="font-normal">
-                            {status?.replace(/_/g, ' ') || '-'}
-                        </Badge>
+                        <span className="inline-flex items-center rounded-full bg-neutral-100 px-2.5 py-1 text-2xs font-semibold text-neutral-600">
+                            {status.replace(/_/g, ' ')}
+                        </span>
                     );
                 },
                 size: 130,
@@ -626,7 +685,9 @@ export function PaymentLogsTable({
                     const paymentPlan = row.original?.user_plan?.payment_plan_dto;
                     return (
                         <div className="space-y-1">
-                            <div className="text-sm text-neutral-700">{paymentPlan?.name || '-'}</div>
+                            <div className="text-sm text-neutral-700">
+                                {paymentPlan?.name || '-'}
+                            </div>
                             <div className="text-xs text-neutral-500">
                                 {paymentPlan?.validity_in_days
                                     ? `${paymentPlan.validity_in_days} days`
@@ -676,6 +737,14 @@ export function PaymentLogsTable({
                         scrollable={true}
                         enableColumnResizing={true}
                         enableColumnPinning={false}
+                        onCellClick={
+                            onViewDetails
+                                ? (row, column) => {
+                                      if (column.id && NON_DETAIL_COLUMN_IDS.has(column.id)) return;
+                                      onViewDetails(row);
+                                  }
+                                : undefined
+                        }
                     />
                 )}
 

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentSummaryCards.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/PaymentSummaryCards.tsx
@@ -1,7 +1,9 @@
-import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import type { PaymentSummary } from '../-utils/paymentSummary';
 import { summarizeBucketAmount } from '../-utils/paymentSummary';
+
+/** The status value each KPI card filters the table down to (total = clear the status filter). */
+export type SummaryStatusKey = 'total' | 'paid' | 'pending' | 'failed';
 
 interface PaymentSummaryCardsProps {
     summary: PaymentSummary;
@@ -10,61 +12,71 @@ interface PaymentSummaryCardsProps {
     isLoading?: boolean;
     /** True when the summary was computed from a capped subset of results. */
     truncated?: boolean;
+    /** Which card is currently reflected in the active status filter. */
+    activeKey?: SummaryStatusKey;
+    /** Clicking a card toggles the matching status filter. */
+    onSelect?: (key: SummaryStatusKey) => void;
 }
 
-const CARDS = [
-    { key: 'total', label: 'Total Payments', dot: 'bg-primary-500' },
-    { key: 'paid', label: 'Paid', dot: 'bg-success-500' },
+const CARDS: { key: SummaryStatusKey; label: string; dot: string }[] = [
+    { key: 'total', label: 'Total', dot: 'bg-primary-500' },
+    { key: 'paid', label: 'Collected', dot: 'bg-success-500' },
     { key: 'pending', label: 'Pending', dot: 'bg-warning-500' },
     { key: 'failed', label: 'Failed', dot: 'bg-danger-500' },
-] as const;
+];
 
+/**
+ * The four KPI tiles — one joined, hairline-separated card (matching the redesign). Each shows the
+ * total amount collected in that bucket as the headline and the payment count as the meta line, and
+ * acts as a one-click status filter for the table below.
+ */
 export function PaymentSummaryCards({
     summary,
     totalCount,
     isLoading,
     truncated,
+    activeKey = 'total',
+    onSelect,
 }: PaymentSummaryCardsProps) {
     return (
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div className="grid grid-cols-2 overflow-hidden rounded-lg border border-neutral-200 bg-neutral-200 sm:grid-cols-4 sm:gap-px">
             {CARDS.map((card) => {
                 const bucket = summary[card.key];
                 const count =
                     card.key === 'total' && totalCount != null ? totalCount : bucket.count;
                 const amount = summarizeBucketAmount(bucket.amountByCurrency);
                 const truncatedSuffix = card.key === 'total' && truncated ? '+' : '';
-                const amountDisplay = amount.display
-                    ? `Amount: ${amount.display}${truncatedSuffix}`
-                    : 'Amount: —';
-                const amountTooltip = amount.full
-                    ? `Total amount: ${amount.full}`
-                    : 'No amount recorded';
+                const amountDisplay = amount.display ? `${amount.display}${truncatedSuffix}` : '—';
+                const amountTooltip = amount.full ? `Total amount: ${amount.full}` : undefined;
+                const isActive = activeKey === card.key;
                 return (
-                    <Card key={card.key} className="p-4">
-                        <div className="flex items-center gap-2">
-                            <span className={cn('size-2 rounded-full', card.dot)} />
-                            <p className="text-caption font-medium text-neutral-500">
-                                {card.label}
-                            </p>
-                        </div>
-                        {/* Count of payments (headline) */}
-                        <div className="mt-2 flex items-baseline gap-1.5">
-                            <span className="text-h3 font-semibold text-neutral-700">
-                                {isLoading ? '—' : count.toLocaleString()}
-                            </span>
-                            <span className="text-caption text-neutral-500">
-                                {count === 1 ? 'payment' : 'payments'}
-                            </span>
-                        </div>
-                        {card.key !== 'total' && (
-                        <p
-                            className="mt-1 truncate text-caption text-neutral-500"
-                            title={amountTooltip}
-                        >
-                            {isLoading ? ' ' : amountDisplay}
-                        </p>
+                    <button
+                        key={card.key}
+                        type="button"
+                        onClick={onSelect ? () => onSelect(card.key) : undefined}
+                        aria-pressed={isActive}
+                        title={amountTooltip}
+                        className={cn(
+                            'flex flex-col gap-1 px-4 py-3.5 text-left transition-colors',
+                            isActive ? 'bg-neutral-50' : 'bg-white',
+                            onSelect && 'cursor-pointer hover:bg-neutral-50'
                         )}
-                    </Card>
+                    >
+                        <span className="flex items-center gap-1.5">
+                            <span className={cn('size-1.5 rounded-full', card.dot)} />
+                            <span className="text-2xs font-semibold uppercase tracking-wide text-neutral-500">
+                                {card.label}
+                            </span>
+                        </span>
+                        <span className="text-xl font-bold tabular-nums text-neutral-800">
+                            {isLoading ? '—' : amountDisplay}
+                        </span>
+                        <span className="text-caption text-neutral-400">
+                            {isLoading
+                                ? ' '
+                                : `${count.toLocaleString()} ${count === 1 ? 'payment' : 'payments'}`}
+                        </span>
+                    </button>
                 );
             })}
         </div>

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/RecordPaymentModal.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/RecordPaymentModal.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { CaretRight } from '@phosphor-icons/react';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyButton } from '@/components/design-system/button';
+import { MyInput } from '@/components/design-system/input';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface RecordPaymentModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+const METHODS = ['Cash', 'Cheque', 'Bank transfer', 'UPI (offline)'];
+const APPLIES_TO = ['Installment', 'Registration fee', 'Custom line item'];
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="space-y-1.5">
+            <label className="text-caption font-medium text-neutral-600">{label}</label>
+            {children}
+        </div>
+    );
+}
+
+function PillGroup({
+    options,
+    value,
+    onChange,
+}: {
+    options: string[];
+    value: string;
+    onChange: (v: string) => void;
+}) {
+    return (
+        <div className="flex flex-wrap gap-2">
+            {options.map((opt) => (
+                <button
+                    key={opt}
+                    type="button"
+                    onClick={() => onChange(opt)}
+                    className={cn(
+                        'rounded-full border px-3 py-1 text-caption font-medium transition-colors',
+                        value === opt
+                            ? 'border-primary-500 bg-primary-50 text-primary-600'
+                            : 'border-neutral-300 text-neutral-600 hover:bg-neutral-50'
+                    )}
+                >
+                    {opt}
+                </button>
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Two-step manual/offline payment recorder (cash, cheque, bank transfer collected offline). Front-end
+ * only for now — recording against a learner's installment plan needs plan context that this list
+ * view doesn't carry, so submitting confirms the entry without posting it.
+ */
+export function RecordPaymentModal({ open, onOpenChange }: RecordPaymentModalProps) {
+    const [step, setStep] = useState(1);
+    const [student, setStudent] = useState('');
+    const [appliesTo, setAppliesTo] = useState(APPLIES_TO[0]!);
+    const [amount, setAmount] = useState('');
+    const [method, setMethod] = useState(METHODS[0]!);
+    const [reference, setReference] = useState('');
+    const [note, setNote] = useState('');
+
+    const reset = () => {
+        setStep(1);
+        setStudent('');
+        setAppliesTo(APPLIES_TO[0]!);
+        setAmount('');
+        setMethod(METHODS[0]!);
+        setReference('');
+        setNote('');
+    };
+
+    const close = (o: boolean) => {
+        if (!o) reset();
+        onOpenChange(o);
+    };
+
+    const handlePrimary = () => {
+        if (step === 1) {
+            setStep(2);
+            return;
+        }
+        close(false);
+        toast.success('Manual payment recorded' + (student ? ` for ${student}` : ''));
+    };
+
+    return (
+        <MyDialog
+            heading={step === 1 ? 'Record a manual payment' : 'Amount & receipt'}
+            open={open}
+            onOpenChange={close}
+            dialogWidth="max-w-xl"
+            footer={
+                <div className="flex w-full items-center justify-between gap-2">
+                    <MyButton buttonType="secondary" scale="medium" onClick={() => close(false)}>
+                        Cancel
+                    </MyButton>
+                    <div className="flex gap-2">
+                        {step === 2 && (
+                            <MyButton
+                                buttonType="secondary"
+                                scale="medium"
+                                onClick={() => setStep(1)}
+                            >
+                                Back
+                            </MyButton>
+                        )}
+                        <MyButton buttonType="primary" scale="medium" onClick={handlePrimary}>
+                            {step === 1 ? 'Continue' : 'Record payment'}
+                        </MyButton>
+                    </div>
+                </div>
+            }
+        >
+            <div className="space-y-4 p-5">
+                {/* Step indicator */}
+                <div className="flex items-center gap-2 text-caption font-medium text-neutral-400">
+                    <span className={cn(step === 1 && 'text-neutral-800')}>
+                        1. Student &amp; plan
+                    </span>
+                    <CaretRight size={12} />
+                    <span className={cn(step === 2 && 'text-neutral-800')}>
+                        2. Amount &amp; receipt
+                    </span>
+                </div>
+
+                {step === 1 ? (
+                    <>
+                        <Field label="Student">
+                            <MyInput
+                                inputType="text"
+                                input={student}
+                                onChangeFunction={(e) => setStudent(e.target.value)}
+                                inputPlaceholder="Search by name, email or phone"
+                            />
+                        </Field>
+                        <Field label="Applies to">
+                            <PillGroup
+                                options={APPLIES_TO}
+                                value={appliesTo}
+                                onChange={setAppliesTo}
+                            />
+                        </Field>
+                        <p className="rounded-lg bg-neutral-50 p-3 text-caption text-neutral-500">
+                            Recording a payment updates the learner&apos;s plan status
+                            automatically.
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <Field label="Amount received">
+                                <MyInput
+                                    inputType="text"
+                                    input={amount}
+                                    onChangeFunction={(e) => setAmount(e.target.value)}
+                                    inputPlaceholder="0"
+                                />
+                            </Field>
+                            <Field label="Date received">
+                                <Input type="date" className="h-9" />
+                            </Field>
+                        </div>
+                        <Field label="Method">
+                            <PillGroup options={METHODS} value={method} onChange={setMethod} />
+                        </Field>
+                        <Field label="Reference / receipt no.">
+                            <MyInput
+                                inputType="text"
+                                input={reference}
+                                onChangeFunction={(e) => setReference(e.target.value)}
+                                inputPlaceholder="e.g. NEFT-77120A"
+                            />
+                        </Field>
+                        <Field label="Internal note">
+                            <Textarea
+                                value={note}
+                                onChange={(e) => setNote(e.target.value)}
+                                rows={2}
+                                placeholder="Collected at front desk"
+                                className="text-body"
+                            />
+                        </Field>
+                    </>
+                )}
+            </div>
+        </MyDialog>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/SendRemindersModal.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/SendRemindersModal.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { MyDialog } from '@/components/design-system/dialog';
+import { MyButton } from '@/components/design-system/button';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface SendRemindersModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** How many pending / failed payments are in the current view (drives the recipient counts). */
+    pendingCount: number;
+    failedCount: number;
+}
+
+const CHANNELS = ['WhatsApp', 'Email', 'SMS'] as const;
+
+const DEFAULT_MESSAGE =
+    'Hi {{name}}, your payment of {{amount}} for {{course}} is still pending. ' +
+    'You can complete it here: {{link}}';
+
+/**
+ * Compose payment reminders for everyone pending/failed in the current view. Front-end only for now
+ * — there is no reminder-send endpoint yet, so submitting confirms intent without dispatching.
+ */
+export function SendRemindersModal({
+    open,
+    onOpenChange,
+    pendingCount,
+    failedCount,
+}: SendRemindersModalProps) {
+    const [channels, setChannels] = useState<string[]>(['WhatsApp', 'Email']);
+    const [message, setMessage] = useState(DEFAULT_MESSAGE);
+
+    const recipients = pendingCount + failedCount;
+
+    const toggleChannel = (c: string) =>
+        setChannels((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+
+    const handleSend = () => {
+        onOpenChange(false);
+        toast.success(
+            `Reminder queued for ${recipients} ${recipients === 1 ? 'student' : 'students'}`
+        );
+    };
+
+    return (
+        <MyDialog
+            heading="Send payment reminders"
+            open={open}
+            onOpenChange={onOpenChange}
+            dialogWidth="max-w-lg"
+            footer={
+                <div className="flex w-full items-center justify-end gap-2">
+                    <MyButton
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </MyButton>
+                    <MyButton
+                        buttonType="primary"
+                        scale="medium"
+                        onClick={handleSend}
+                        disable={recipients === 0 || channels.length === 0}
+                    >
+                        Send {recipients} {recipients === 1 ? 'reminder' : 'reminders'}
+                    </MyButton>
+                </div>
+            }
+        >
+            <div className="space-y-4 p-5">
+                <p className="text-caption text-neutral-500">
+                    Goes to everyone pending or failed in the current view.
+                </p>
+
+                <div>
+                    <div className="mb-1.5 text-caption font-medium text-neutral-600">
+                        Recipients
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-warning-100 px-3 py-1 text-caption font-medium text-warning-700">
+                            {pendingCount} pending
+                        </span>
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-danger-100 px-3 py-1 text-caption font-medium text-danger-700">
+                            {failedCount} failed
+                        </span>
+                    </div>
+                </div>
+
+                <div>
+                    <div className="mb-1.5 text-caption font-medium text-neutral-600">Channel</div>
+                    <div className="flex flex-wrap gap-2">
+                        {CHANNELS.map((c) => {
+                            const on = channels.includes(c);
+                            return (
+                                <button
+                                    key={c}
+                                    type="button"
+                                    onClick={() => toggleChannel(c)}
+                                    className={cn(
+                                        'rounded-full border px-3 py-1 text-caption font-medium transition-colors',
+                                        on
+                                            ? 'border-primary-500 bg-primary-50 text-primary-600'
+                                            : 'border-neutral-300 text-neutral-600 hover:bg-neutral-50'
+                                    )}
+                                >
+                                    {c}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <div>
+                    <div className="mb-1.5 text-caption font-medium text-neutral-600">Message</div>
+                    <Textarea
+                        value={message}
+                        onChange={(e) => setMessage(e.target.value)}
+                        rows={3}
+                        className="text-body"
+                    />
+                    <p className="mt-1.5 text-caption text-neutral-400">
+                        Placeholders like {'{{name}}'} and {'{{amount}}'} are filled per student.
+                        Reminders respect a 24-hour cooldown.
+                    </p>
+                </div>
+            </div>
+        </MyDialog>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-components/TransactionsView.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-components/TransactionsView.tsx
@@ -1,0 +1,517 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { DownloadSimple, EnvelopeSimple, Plus, X } from '@phosphor-icons/react';
+import { toast } from 'sonner';
+import { MyButton } from '@/components/design-system/button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
+import type { SelectOption } from '@/components/design-system/SelectChips';
+import type {
+    PaymentLogEntry,
+    PaymentLogsRequest,
+    PaymentLogsResponse,
+    PackageSessionFilter,
+    BatchForSession,
+} from '@/types/payment-logs';
+import { StudentSidebarProvider } from '@/routes/manage-students/students-list/-providers/student-sidebar-provider';
+import { PaymentFilters } from './PaymentFilters';
+import { PaymentControlBar, type StatusSegment } from './PaymentControlBar';
+import { PaymentLogsTable } from './PaymentLogsTable';
+import { PaymentSummaryCards, type SummaryStatusKey } from './PaymentSummaryCards';
+import { PaymentDetailSheet } from './PaymentDetailSheet';
+import { SendRemindersModal } from './SendRemindersModal';
+import { RecordPaymentModal } from './RecordPaymentModal';
+import { exportEntriesToCsv, fetchAllPaymentLogs } from '../-utils/exportPaymentLogsCsv';
+import { computePaymentSummary, summarizeBucketAmount } from '../-utils/paymentSummary';
+
+const PAGE_SIZE = 20;
+
+/** Map a KPI card / segment to the payment_status value(s) it filters the table down to. */
+const STATUS_FOR_KEY: Record<Exclude<SummaryStatusKey, 'total'>, string> = {
+    paid: 'PAID',
+    pending: 'PAYMENT_PENDING',
+    failed: 'FAILED',
+};
+
+interface ActiveChip {
+    id: string;
+    label: string;
+    onRemove: () => void;
+}
+
+/** The redesigned transactions screen: KPIs, control bar, filters slide-over, table, detail panel. */
+export function TransactionsView() {
+    // Pagination
+    const [currentPage, setCurrentPage] = useState(0);
+
+    // Free-text search — debounced before it reaches the API.
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedSearch(searchValue.trim());
+            setCurrentPage(0);
+        }, 400);
+        return () => clearTimeout(timer);
+    }, [searchValue]);
+
+    // Filters
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+    const [selectedPaymentStatuses, setSelectedPaymentStatuses] = useState<SelectOption[]>([]);
+    const [selectedUserPlanStatuses, setSelectedUserPlanStatuses] = useState<SelectOption[]>([]);
+    const [selectedPaymentSources, setSelectedPaymentSources] = useState<SelectOption[]>([]);
+    const [selectedPaymentTypes, setSelectedPaymentTypes] = useState<SelectOption[]>([]);
+    const [packageSessionFilter, setPackageSessionFilter] = useState<PackageSessionFilter>({});
+
+    // Overlays
+    const [filtersOpen, setFiltersOpen] = useState(false);
+    const [remindersOpen, setRemindersOpen] = useState(false);
+    const [recordOpen, setRecordOpen] = useState(false);
+    const [detailEntry, setDetailEntry] = useState<PaymentLogEntry | null>(null);
+    const [detailOpen, setDetailOpen] = useState(false);
+
+    const instituteDetails = useInstituteDetailsStore((state) => state.instituteDetails);
+
+    const batchesForSessions: BatchForSession[] = useMemo(() => {
+        const batches = instituteDetails?.batches_for_sessions;
+        return batches && Array.isArray(batches) ? (batches as unknown as BatchForSession[]) : [];
+    }, [instituteDetails]);
+
+    const hasOrgAssociatedBatches = useMemo(
+        () => batchesForSessions.some((batch) => batch.is_org_associated === true),
+        [batchesForSessions]
+    );
+
+    const requestFilters: Omit<PaymentLogsRequest, 'institute_id'> = useMemo(() => {
+        const filters: Omit<PaymentLogsRequest, 'institute_id'> = {
+            sort_columns: { createdAt: 'DESC' },
+        };
+        if (startDate) filters.start_date_in_utc = startDate;
+        if (endDate) filters.end_date_in_utc = endDate;
+        if (selectedPaymentStatuses.length > 0)
+            filters.payment_statuses = selectedPaymentStatuses.map((s) => s.value);
+        if (selectedUserPlanStatuses.length > 0)
+            filters.user_plan_statuses = selectedUserPlanStatuses.map((s) => s.value);
+        if (selectedPaymentSources.length > 0)
+            filters.sources = selectedPaymentSources.map((s) => s.value) as ('USER' | 'SUB_ORG')[];
+        if (selectedPaymentTypes.length > 0)
+            filters.payment_types = selectedPaymentTypes.map((t) => t.value);
+        if (debouncedSearch) filters.search_string = debouncedSearch;
+
+        if (
+            packageSessionFilter.packageSessionIds &&
+            packageSessionFilter.packageSessionIds.length > 0
+        ) {
+            filters.package_session_ids = packageSessionFilter.packageSessionIds;
+        } else if (packageSessionFilter.packageSessionId) {
+            filters.package_session_ids = [packageSessionFilter.packageSessionId];
+        } else if (packageSessionFilter.packageId) {
+            const resolvedIds = batchesForSessions
+                .filter(
+                    (batch) =>
+                        batch.package_dto.id === packageSessionFilter.packageId &&
+                        (!packageSessionFilter.levelId ||
+                            batch.level.id === packageSessionFilter.levelId) &&
+                        (!packageSessionFilter.sessionId ||
+                            batch.session.id === packageSessionFilter.sessionId)
+                )
+                .map((batch) => batch.id);
+            if (resolvedIds.length > 0) filters.package_session_ids = resolvedIds;
+        }
+        return filters;
+    }, [
+        startDate,
+        endDate,
+        selectedPaymentStatuses,
+        selectedUserPlanStatuses,
+        selectedPaymentSources,
+        selectedPaymentTypes,
+        debouncedSearch,
+        packageSessionFilter,
+        batchesForSessions,
+    ]);
+
+    const {
+        data: allData,
+        isLoading: isLoadingPayments,
+        error: paymentsError,
+        refetch: refetchPaymentLogs,
+    } = useQuery({
+        queryKey: ['payment-logs-all', requestFilters],
+        queryFn: () => fetchAllPaymentLogs(requestFilters),
+        staleTime: 30000,
+    });
+
+    const filteredEntries = useMemo(() => allData?.entries ?? [], [allData]);
+
+    const paymentSummary = useMemo(() => computePaymentSummary(filteredEntries), [filteredEntries]);
+
+    const pagedData: PaymentLogsResponse | undefined = useMemo(() => {
+        if (!allData) return undefined;
+        const total = filteredEntries.length;
+        const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+        const page = Math.min(currentPage, totalPages - 1);
+        const start = page * PAGE_SIZE;
+        const content = filteredEntries.slice(start, start + PAGE_SIZE);
+        return {
+            content,
+            totalPages,
+            totalElements: total,
+            size: PAGE_SIZE,
+            number: page,
+            numberOfElements: content.length,
+            first: page === 0,
+            last: page >= totalPages - 1,
+            empty: total === 0,
+            pageable: {},
+            sort: {},
+        } as unknown as PaymentLogsResponse;
+    }, [allData, filteredEntries, currentPage]);
+
+    const packageSessionsMap = useMemo(() => {
+        const map: Record<string, string> = {};
+        batchesForSessions.forEach((batch) => {
+            map[batch.id] =
+                `${batch.package_dto.package_name} - ${batch.session.session_name} - ${batch.level.level_name}`;
+        });
+        return map;
+    }, [batchesForSessions]);
+
+    // Which KPI/segment is reflected in the current status filter (only when exactly one is selected).
+    const activeSummaryKey: SummaryStatusKey = useMemo(() => {
+        if (selectedPaymentStatuses.length !== 1) return 'total';
+        const value = selectedPaymentStatuses[0]!.value;
+        const match = (
+            Object.entries(STATUS_FOR_KEY) as [Exclude<SummaryStatusKey, 'total'>, string][]
+        ).find(([, v]) => v === value);
+        return match ? match[0] : 'total';
+    }, [selectedPaymentStatuses]);
+
+    const handleSummarySelect = (key: SummaryStatusKey) => {
+        setCurrentPage(0);
+        if (key === 'total' || key === activeSummaryKey) {
+            setSelectedPaymentStatuses([]);
+            return;
+        }
+        setSelectedPaymentStatuses([{ value: STATUS_FOR_KEY[key], label: key }]);
+    };
+
+    // Segmented status switch — counts come from the same summary the KPI cards use.
+    const segments: StatusSegment[] = [
+        { key: 'total', label: 'All', count: filteredEntries.length },
+        { key: 'paid', label: 'Paid', count: paymentSummary.paid.count },
+        { key: 'pending', label: 'Pending', count: paymentSummary.pending.count },
+        { key: 'failed', label: 'Failed', count: paymentSummary.failed.count },
+    ];
+
+    // Detailed-filter count for the Filters button badge (status lives in the segmented switch).
+    const detailedFilterCount =
+        selectedPaymentTypes.length +
+        selectedUserPlanStatuses.length +
+        selectedPaymentSources.length +
+        (startDate ? 1 : 0) +
+        (endDate ? 1 : 0) +
+        (packageSessionFilter.packageSessionIds?.length ||
+            (packageSessionFilter.packageId ? 1 : 0));
+
+    // Removable chips for the active detailed filters.
+    const activeChips: ActiveChip[] = useMemo(() => {
+        const chips: ActiveChip[] = [];
+        selectedPaymentTypes.forEach((t) =>
+            chips.push({
+                id: `type-${t.value}`,
+                label: `Type: ${t.label}`,
+                onRemove: () =>
+                    setSelectedPaymentTypes((prev) => prev.filter((x) => x.value !== t.value)),
+            })
+        );
+        selectedUserPlanStatuses.forEach((s) =>
+            chips.push({
+                id: `plan-${s.value}`,
+                label: `Plan: ${s.label}`,
+                onRemove: () =>
+                    setSelectedUserPlanStatuses((prev) => prev.filter((x) => x.value !== s.value)),
+            })
+        );
+        selectedPaymentSources.forEach((s) =>
+            chips.push({
+                id: `source-${s.value}`,
+                label: `Source: ${s.label}`,
+                onRemove: () =>
+                    setSelectedPaymentSources((prev) => prev.filter((x) => x.value !== s.value)),
+            })
+        );
+        if (startDate || endDate)
+            chips.push({
+                id: 'date',
+                label: 'Date range',
+                onRemove: () => {
+                    setStartDate('');
+                    setEndDate('');
+                },
+            });
+        if (packageSessionFilter.packageId || packageSessionFilter.packageSessionIds?.length)
+            chips.push({
+                id: 'course',
+                label: 'Course / session',
+                onRemove: () => setPackageSessionFilter({}),
+            });
+        return chips;
+    }, [
+        selectedPaymentTypes,
+        selectedUserPlanStatuses,
+        selectedPaymentSources,
+        startDate,
+        endDate,
+        packageSessionFilter,
+    ]);
+
+    const handlePageChange = (page: number) => {
+        setCurrentPage(page);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleQuickFilterSelect = (range: { start: string; end: string }) => {
+        setStartDate(range.start);
+        setEndDate(range.end);
+        setCurrentPage(0);
+    };
+
+    const handleClearFilters = () => {
+        setStartDate('');
+        setEndDate('');
+        setSelectedPaymentStatuses([]);
+        setSelectedUserPlanStatuses([]);
+        setSelectedPaymentSources([]);
+        setSelectedPaymentTypes([]);
+        setPackageSessionFilter({});
+        setCurrentPage(0);
+    };
+
+    const handleExportCsv = async () => {
+        try {
+            if (filteredEntries.length === 0) {
+                toast.info('No payment records to export.');
+                return;
+            }
+            const count = exportEntriesToCsv(filteredEntries, instituteDetails?.institute_name);
+            toast.success(`Exported ${count.toLocaleString()} payment records.`);
+        } catch (error) {
+            console.error('Failed to export payment logs:', error);
+            toast.error('Failed to export payment logs. Please try again.');
+        }
+    };
+
+    const openDetail = (entry: PaymentLogEntry) => {
+        setDetailEntry(entry);
+        setDetailOpen(true);
+    };
+
+    // Subline: "N payments · ₹X collected · M need attention".
+    const collectedAmount = summarizeBucketAmount(paymentSummary.paid.amountByCurrency).display;
+    const needAttention = paymentSummary.pending.count + paymentSummary.failed.count;
+
+    return (
+        <StudentSidebarProvider>
+            <div className="space-y-4">
+                {/* Header: subline + primary actions */}
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-body text-neutral-500">
+                        {isLoadingPayments ? (
+                            'Loading payments…'
+                        ) : (
+                            <>
+                                <span className="font-medium text-neutral-700">
+                                    {filteredEntries.length.toLocaleString()}
+                                </span>{' '}
+                                payments
+                                {collectedAmount && (
+                                    <>
+                                        {' · '}
+                                        <span className="font-medium text-neutral-700">
+                                            {collectedAmount}
+                                        </span>{' '}
+                                        collected
+                                    </>
+                                )}
+                                {needAttention > 0 && <> · {needAttention} need attention</>}
+                            </>
+                        )}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            onAsyncClick={handleExportCsv}
+                            loadingText="Exporting…"
+                            className="gap-2"
+                            disable={filteredEntries.length === 0}
+                        >
+                            <DownloadSimple size={16} />
+                            Export
+                        </MyButton>
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            onClick={() => setRemindersOpen(true)}
+                            className="gap-2"
+                        >
+                            <EnvelopeSimple size={16} />
+                            Send reminders
+                        </MyButton>
+                        <MyButton
+                            buttonType="primary"
+                            scale="medium"
+                            onClick={() => setRecordOpen(true)}
+                            className="gap-2"
+                        >
+                            <Plus size={16} />
+                            Record payment
+                        </MyButton>
+                    </div>
+                </div>
+
+                {/* KPI tiles */}
+                <PaymentSummaryCards
+                    summary={paymentSummary}
+                    totalCount={filteredEntries.length}
+                    isLoading={isLoadingPayments}
+                    truncated={allData?.truncated}
+                    activeKey={activeSummaryKey}
+                    onSelect={handleSummarySelect}
+                />
+
+                {/* Control bar */}
+                <PaymentControlBar
+                    searchValue={searchValue}
+                    onSearchChange={(value) => {
+                        setSearchValue(value);
+                        setCurrentPage(0);
+                    }}
+                    segments={segments}
+                    activeStatus={activeSummaryKey}
+                    onStatusSelect={handleSummarySelect}
+                    filterCount={detailedFilterCount}
+                    onOpenFilters={() => setFiltersOpen(true)}
+                />
+
+                {/* Active filter chips */}
+                {activeChips.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-2">
+                        {activeChips.map((chip) => (
+                            <span
+                                key={chip.id}
+                                className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-neutral-100 py-1 pl-3 pr-1.5 text-caption text-neutral-600"
+                            >
+                                {chip.label}
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        chip.onRemove();
+                                        setCurrentPage(0);
+                                    }}
+                                    className="flex size-4 items-center justify-center rounded-full text-neutral-400 hover:bg-neutral-200 hover:text-neutral-600"
+                                    aria-label={`Remove ${chip.label}`}
+                                >
+                                    <X size={11} weight="bold" />
+                                </button>
+                            </span>
+                        ))}
+                        <button
+                            type="button"
+                            onClick={handleClearFilters}
+                            className="text-caption font-semibold text-primary-600 hover:text-primary-700"
+                        >
+                            Clear all
+                        </button>
+                    </div>
+                )}
+
+                {/* Table */}
+                <PaymentLogsTable
+                    data={pagedData}
+                    isLoading={isLoadingPayments}
+                    error={paymentsError as Error}
+                    currentPage={currentPage}
+                    onPageChange={handlePageChange}
+                    packageSessions={packageSessionsMap}
+                    hasOrgAssociatedBatches={hasOrgAssociatedBatches}
+                    onRefresh={() => refetchPaymentLogs()}
+                    onViewDetails={openDetail}
+                />
+
+                {/* Filters slide-over */}
+                <Sheet open={filtersOpen} onOpenChange={setFiltersOpen}>
+                    <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+                        <SheetHeader className="text-left">
+                            <SheetTitle>Filters</SheetTitle>
+                        </SheetHeader>
+                        <div className="mt-5">
+                            <PaymentFilters
+                                panelOnly
+                                searchValue={searchValue}
+                                onSearchChange={setSearchValue}
+                                startDate={startDate}
+                                endDate={endDate}
+                                onStartDateChange={(date) => {
+                                    setStartDate(date);
+                                    setCurrentPage(0);
+                                }}
+                                onEndDateChange={(date) => {
+                                    setEndDate(date);
+                                    setCurrentPage(0);
+                                }}
+                                selectedPaymentStatuses={selectedPaymentStatuses}
+                                onPaymentStatusesChange={(statuses) => {
+                                    setSelectedPaymentStatuses(statuses);
+                                    setCurrentPage(0);
+                                }}
+                                selectedUserPlanStatuses={selectedUserPlanStatuses}
+                                onUserPlanStatusesChange={(statuses) => {
+                                    setSelectedUserPlanStatuses(statuses);
+                                    setCurrentPage(0);
+                                }}
+                                selectedPaymentSources={selectedPaymentSources}
+                                onPaymentSourcesChange={(sources) => {
+                                    setSelectedPaymentSources(sources);
+                                    setCurrentPage(0);
+                                }}
+                                selectedPaymentTypes={selectedPaymentTypes}
+                                onPaymentTypesChange={(types) => {
+                                    setSelectedPaymentTypes(types);
+                                    setCurrentPage(0);
+                                }}
+                                hasOrgAssociatedBatches={hasOrgAssociatedBatches}
+                                packageSessionFilter={packageSessionFilter}
+                                onPackageSessionFilterChange={(filter) => {
+                                    setPackageSessionFilter(filter);
+                                    setCurrentPage(0);
+                                }}
+                                batchesForSessions={batchesForSessions}
+                                onQuickFilterSelect={handleQuickFilterSelect}
+                                onClearFilters={handleClearFilters}
+                            />
+                        </div>
+                    </SheetContent>
+                </Sheet>
+
+                {/* Payment detail slide-over */}
+                <PaymentDetailSheet
+                    entry={detailEntry}
+                    open={detailOpen}
+                    onOpenChange={setDetailOpen}
+                />
+
+                {/* Header action modals */}
+                <SendRemindersModal
+                    open={remindersOpen}
+                    onOpenChange={setRemindersOpen}
+                    pendingCount={paymentSummary.pending.count}
+                    failedCount={paymentSummary.failed.count}
+                />
+                <RecordPaymentModal open={recordOpen} onOpenChange={setRecordOpen} />
+            </div>
+        </StudentSidebarProvider>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/manage-payments/-utils/paymentAnalytics.ts
+++ b/frontend-admin-dashboard/src/routes/manage-payments/-utils/paymentAnalytics.ts
@@ -1,0 +1,212 @@
+import type { PaymentLogEntry } from '@/types/payment-logs';
+import { isRealCurrency, resolveEntryCurrency } from '@/utils/payment-currency';
+import { derivePaymentTypeLabel } from './exportPaymentLogsCsv';
+
+/**
+ * Dashboard analytics derived entirely client-side from the payment-logs set the Manage Payments
+ * page already fetches (all filtered rows). This keeps every panel backed by REAL data — no
+ * separate analytics endpoint exists yet, so anything that can't be derived from a payment row
+ * (bank settlements, gateway success-rate %, decline reasons) is deliberately left out rather than
+ * faked. Amounts are summed in a single "primary" currency (the most common real code in the set,
+ * with blank/unresolved rows folded in — see resolveEntryCurrency) so a stray foreign charge can't
+ * corrupt the totals.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const normStatus = (entry: PaymentLogEntry): 'PAID' | 'FAILED' | 'PENDING' => {
+    const raw = (
+        entry.current_payment_status ||
+        entry.payment_log?.payment_status ||
+        ''
+    ).toUpperCase();
+    if (raw === 'PAID') return 'PAID';
+    if (raw === 'FAILED') return 'FAILED';
+    return 'PENDING';
+};
+
+/** created_at is the real instant; `date` (UTC-midnight DATE) is the pre-created_at fallback. */
+const entryTime = (entry: PaymentLogEntry): number | null => {
+    const raw = entry.payment_log?.created_at || entry.payment_log?.date;
+    if (!raw) return null;
+    const t = new Date(raw).getTime();
+    return Number.isNaN(t) ? null : t;
+};
+
+/** The vendor string, normalised for grouping. Blank vendors collapse to "Other". */
+const vendorLabel = (entry: PaymentLogEntry): string => {
+    const v = entry.payment_log?.vendor?.trim();
+    return v && v.length ? v : 'Other';
+};
+
+export interface AmountSlice {
+    label: string;
+    amount: number;
+    count: number;
+}
+
+export interface AgingBucket {
+    label: string;
+    amount: number;
+    count: number;
+    /** Severity drives the token colour used in the UI. */
+    tone: 'neutral' | 'warning' | 'strong' | 'danger';
+}
+
+export interface FunnelStage {
+    label: string;
+    amount: number;
+    count: number;
+    hint: string;
+}
+
+export interface PaymentAnalytics {
+    primaryCurrency: string;
+    totalEntries: number;
+    collected: { amount: number; count: number };
+    outstanding: { amount: number; count: number };
+    failed: { amount: number; count: number };
+    /** Paid ÷ (paid + failed), by count. null when there were no settled/failed attempts. */
+    successRate: number | null;
+    /** Share of SUCCESSFUL payments by method/vendor, largest first. */
+    methodMix: AmountSlice[];
+    /** Collected amount by gateway/vendor, largest first. */
+    gatewayBreakdown: AmountSlice[];
+    /** Collected revenue by course / membership (enroll invite), largest first. */
+    topCourses: AmountSlice[];
+    /** Count of payments by high-level payment type. */
+    paymentTypeMix: AmountSlice[];
+    /** Outstanding (pending) amount bucketed by how long it has been unpaid. */
+    aging: AgingBucket[];
+    /** Invoiced → attempted → succeeded, by amount. */
+    funnel: FunnelStage[];
+}
+
+/** Most common real currency code in the set (falls back to '' when none is resolvable). */
+const pickPrimaryCurrency = (entries: PaymentLogEntry[]): string => {
+    const counts: Record<string, number> = {};
+    for (const e of entries) {
+        const c = resolveEntryCurrency(e);
+        if (isRealCurrency(c)) counts[c] = (counts[c] || 0) + 1;
+    }
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    return sorted.length ? sorted[0]![0] : '';
+};
+
+const topSlices = (map: Record<string, AmountSlice>, limit?: number): AmountSlice[] => {
+    const slices = Object.values(map).sort((a, b) => b.amount - a.amount || b.count - a.count);
+    return typeof limit === 'number' ? slices.slice(0, limit) : slices;
+};
+
+export const computePaymentAnalytics = (entries: PaymentLogEntry[]): PaymentAnalytics => {
+    const primaryCurrency = pickPrimaryCurrency(entries);
+
+    // Only fold an amount into the running totals when it was taken in the primary currency (or an
+    // unresolved/blank one, which is overwhelmingly the primary currency in practice). Counts are
+    // currency-agnostic and always included.
+    const amountCounts = (entry: PaymentLogEntry): boolean => {
+        if (!primaryCurrency) return true;
+        const c = resolveEntryCurrency(entry);
+        return !isRealCurrency(c) || c === primaryCurrency;
+    };
+    const amountOf = (entry: PaymentLogEntry): number =>
+        amountCounts(entry) ? entry.payment_log?.payment_amount || 0 : 0;
+
+    const collected = { amount: 0, count: 0 };
+    const outstanding = { amount: 0, count: 0 };
+    const failed = { amount: 0, count: 0 };
+
+    const methodMix: Record<string, AmountSlice> = {};
+    const gatewayBreakdown: Record<string, AmountSlice> = {};
+    const topCourses: Record<string, AmountSlice> = {};
+    const paymentTypeMix: Record<string, AmountSlice> = {};
+
+    const agingDefs: AgingBucket[] = [
+        { label: '0–7 days', amount: 0, count: 0, tone: 'neutral' },
+        { label: '8–15 days', amount: 0, count: 0, tone: 'warning' },
+        { label: '16–30 days', amount: 0, count: 0, tone: 'strong' },
+        { label: '30+ days', amount: 0, count: 0, tone: 'danger' },
+    ];
+    const now = Date.now();
+
+    let attemptedAmount = 0;
+    let attemptedCount = 0;
+
+    for (const entry of entries) {
+        const status = normStatus(entry);
+        const amount = amountOf(entry);
+
+        const bump = (map: Record<string, AmountSlice>, key: string) => {
+            const slice = (map[key] ??= { label: key, amount: 0, count: 0 });
+            slice.amount += amount;
+            slice.count += 1;
+        };
+
+        if (status !== 'PENDING') {
+            attemptedAmount += amount;
+            attemptedCount += 1;
+        }
+
+        if (status === 'PAID') {
+            collected.amount += amount;
+            collected.count += 1;
+            bump(methodMix, vendorLabel(entry));
+            bump(gatewayBreakdown, vendorLabel(entry));
+            bump(topCourses, entry.user_plan?.enroll_invite?.name || 'Unlabelled');
+        } else if (status === 'FAILED') {
+            failed.amount += amount;
+            failed.count += 1;
+        } else {
+            outstanding.amount += amount;
+            outstanding.count += 1;
+            const t = entryTime(entry);
+            if (t != null) {
+                const ageDays = Math.max(0, Math.floor((now - t) / DAY_MS));
+                const idx = ageDays <= 7 ? 0 : ageDays <= 15 ? 1 : ageDays <= 30 ? 2 : 3;
+                agingDefs[idx]!.amount += amount;
+                agingDefs[idx]!.count += 1;
+            }
+        }
+
+        bump(paymentTypeMix, derivePaymentTypeLabel(entry));
+    }
+
+    const settledAttempts = collected.count + failed.count;
+    const successRate = settledAttempts > 0 ? collected.count / settledAttempts : null;
+
+    const funnel: FunnelStage[] = [
+        {
+            label: 'Invoiced',
+            amount: collected.amount + outstanding.amount + failed.amount,
+            count: entries.length,
+            hint: 'All payment records in view',
+        },
+        {
+            label: 'Attempted',
+            amount: attemptedAmount,
+            count: attemptedCount,
+            hint: 'Reached the gateway',
+        },
+        {
+            label: 'Succeeded',
+            amount: collected.amount,
+            count: collected.count,
+            hint: 'Captured / settled',
+        },
+    ];
+
+    return {
+        primaryCurrency,
+        totalEntries: entries.length,
+        collected,
+        outstanding,
+        failed,
+        successRate,
+        methodMix: topSlices(methodMix),
+        gatewayBreakdown: topSlices(gatewayBreakdown),
+        topCourses: topSlices(topCourses, 6),
+        paymentTypeMix: topSlices(paymentTypeMix),
+        aging: agingDefs,
+        funnel,
+    };
+};

--- a/frontend-admin-dashboard/src/routes/manage-payments/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-payments/index.lazy.tsx
@@ -1,27 +1,11 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
 import { LayoutContainer } from '@/components/common/layout-container/layout-container';
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { useQuery } from '@tanstack/react-query';
-import { PaymentFilters } from './-components/PaymentFilters';
-import { PaymentLogsTable } from './-components/PaymentLogsTable';
 import { SettingsQuickAccessButton } from '@/components/settings/quick-access/SettingsQuickAccessButton';
 import { SettingsTabs } from '@/routes/settings/-constants/terms';
-import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
-import type { SelectOption } from '@/components/design-system/SelectChips';
-import type {
-    PaymentLogsRequest,
-    PaymentLogsResponse,
-    PackageSessionFilter,
-    BatchForSession,
-} from '@/types/payment-logs';
-import { DownloadSimple } from '@phosphor-icons/react';
-import { MyButton } from '@/components/design-system/button';
-import { exportEntriesToCsv, fetchAllPaymentLogs } from './-utils/exportPaymentLogsCsv';
-import { computePaymentSummary } from './-utils/paymentSummary';
-import { PaymentSummaryCards } from './-components/PaymentSummaryCards';
-import { toast } from 'sonner';
+import { TransactionsView } from './-components/TransactionsView';
 
 export const Route = createLazyFileRoute('/manage-payments/')({
     component: () => (
@@ -34,30 +18,6 @@ export const Route = createLazyFileRoute('/manage-payments/')({
 function ManagePaymentsLayoutPage() {
     const { setNavHeading } = useNavHeadingStore();
 
-    // Pagination
-    const [currentPage, setCurrentPage] = useState(0);
-    const [pageSize] = useState(20);
-
-    // Free-text search (name / email / phone / amount). The input updates `searchValue` instantly;
-    // `debouncedSearch` is what we actually send to the API, so we don't fire a request per keystroke.
-    const [searchValue, setSearchValue] = useState('');
-    const [debouncedSearch, setDebouncedSearch] = useState('');
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setDebouncedSearch(searchValue.trim());
-            setCurrentPage(0);
-        }, 400);
-        return () => clearTimeout(timer);
-    }, [searchValue]);
-
-    // Filters
-    const [startDate, setStartDate] = useState('');
-    const [endDate, setEndDate] = useState('');
-    const [selectedPaymentStatuses, setSelectedPaymentStatuses] = useState<SelectOption[]>([]);
-    const [selectedUserPlanStatuses, setSelectedUserPlanStatuses] = useState<SelectOption[]>([]);
-    const [selectedPaymentSources, setSelectedPaymentSources] = useState<SelectOption[]>([]); // New filter
-    const [selectedPaymentTypes, setSelectedPaymentTypes] = useState<SelectOption[]>([]);
-    const [packageSessionFilter, setPackageSessionFilter] = useState<PackageSessionFilter>({});
     useEffect(() => {
         setNavHeading(
             <div className="flex items-center gap-2">
@@ -68,190 +28,7 @@ function ManagePaymentsLayoutPage() {
                 />
             </div>
         );
-    }, [setNavHeading]);    // Get institute details from Zustand store (already loaded on app init)
-    const instituteDetails = useInstituteDetailsStore((state) => state.instituteDetails);
-
-    // Extract batches for sessions from institute data
-    const batchesForSessions: BatchForSession[] = useMemo(() => {
-        const batches = instituteDetails?.batches_for_sessions;
-        // Cast the Zustand store batch type to the payment logs batch type
-        // The store type is compatible, just missing optional fields
-        return batches && Array.isArray(batches) ? (batches as unknown as BatchForSession[]) : [];
-    }, [instituteDetails]);
-
-    // Check if institute has any org-associated batches
-    const hasOrgAssociatedBatches = useMemo(() => {
-        return batchesForSessions.some((batch) => batch.is_org_associated === true);
-    }, [batchesForSessions]);
-
-    // Build request filters
-    const requestFilters: Omit<PaymentLogsRequest, 'institute_id'> = useMemo(() => {
-        const filters: Omit<PaymentLogsRequest, 'institute_id'> = {
-            sort_columns: {
-                createdAt: 'DESC',
-            },
-        };
-
-        if (startDate) {
-            filters.start_date_in_utc = startDate;
-        }
-
-        if (endDate) {
-            filters.end_date_in_utc = endDate;
-        }
-
-        if (selectedPaymentStatuses.length > 0) {
-            filters.payment_statuses = selectedPaymentStatuses.map((s) => s.value);
-        }
-
-        if (selectedUserPlanStatuses.length > 0) {
-            filters.user_plan_statuses = selectedUserPlanStatuses.map((s) => s.value);
-        }
-
-        if (selectedPaymentSources.length > 0) {
-            filters.sources = selectedPaymentSources.map((s) => s.value) as ('USER' | 'SUB_ORG')[];
-        }
-
-        if (selectedPaymentTypes.length > 0) {
-            filters.payment_types = selectedPaymentTypes.map((t) => t.value);
-        }
-
-        if (debouncedSearch) {
-            filters.search_string = debouncedSearch;
-        }
-
-        if (packageSessionFilter.packageSessionIds && packageSessionFilter.packageSessionIds.length > 0) {
-            filters.package_session_ids = packageSessionFilter.packageSessionIds;
-        } else if (packageSessionFilter.packageSessionId) {
-            filters.package_session_ids = [packageSessionFilter.packageSessionId];
-        } else if (packageSessionFilter.packageId) {
-            // Resolve all matching batches for the selected package and optional level/session
-            const resolvedIds = batchesForSessions
-                .filter((batch) =>
-                    batch.package_dto.id === packageSessionFilter.packageId &&
-                    (!packageSessionFilter.levelId || batch.level.id === packageSessionFilter.levelId) &&
-                    (!packageSessionFilter.sessionId || batch.session.id === packageSessionFilter.sessionId)
-                )
-                .map((batch) => batch.id);
-
-            if (resolvedIds.length > 0) {
-                filters.package_session_ids = resolvedIds;
-            }
-        }
-
-        return filters;
-    }, [
-        startDate,
-        endDate,
-        selectedPaymentStatuses,
-        selectedUserPlanStatuses,
-        selectedPaymentSources,
-        selectedPaymentTypes,
-        debouncedSearch,
-        packageSessionFilter,
-    ]);
-
-    // Fetch ALL rows matching the current server-side filters (dates, statuses, types, course,
-    // source). Search (name/email/phone/amount) and pagination are then applied client-side over
-    // this one dataset, so it powers the KPI cards, the table, AND the CSV export consistently.
-    const {
-        data: allData,
-        isLoading: isLoadingPayments,
-        error: paymentsError,
-        refetch: refetchPaymentLogs,
-    } = useQuery({
-        queryKey: ['payment-logs-all', requestFilters],
-        queryFn: () => fetchAllPaymentLogs(requestFilters),
-        staleTime: 30000,
-    });
-
-    // The API already applies search + all filters (via requestFilters), so the returned rows ARE
-    // the searched/filtered set. Pagination is applied client-side over this set.
-    const filteredEntries = useMemo(() => allData?.entries ?? [], [allData]);
-
-    // KPI cards reflect the searched + filtered set.
-    const paymentSummary = useMemo(
-        () => computePaymentSummary(filteredEntries),
-        [filteredEntries]
-    );
-
-    // Client-side pagination over the searched/filtered set, shaped for the table.
-    const pagedData: PaymentLogsResponse | undefined = useMemo(() => {
-        if (!allData) return undefined;
-        const total = filteredEntries.length;
-        const totalPages = Math.max(1, Math.ceil(total / pageSize));
-        const page = Math.min(currentPage, totalPages - 1);
-        const start = page * pageSize;
-        const content = filteredEntries.slice(start, start + pageSize);
-        return {
-            content,
-            totalPages,
-            totalElements: total,
-            size: pageSize,
-            number: page,
-            numberOfElements: content.length,
-            first: page === 0,
-            last: page >= totalPages - 1,
-            empty: total === 0,
-            pageable: {},
-            sort: {},
-        } as unknown as PaymentLogsResponse;
-    }, [allData, filteredEntries, currentPage, pageSize]);
-
-    // Build package sessions map
-    const packageSessionsMap = useMemo(() => {
-        const map: Record<string, string> = {};
-        batchesForSessions.forEach((batch) => {
-            const packageName = batch.package_dto.package_name;
-            const sessionName = batch.session.session_name;
-            const levelName = batch.level.level_name;
-            map[batch.id] = `${packageName} - ${sessionName} - ${levelName}`;
-        });
-        return map;
-    }, [batchesForSessions]);
-
-    // Handle page change
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    };
-
-    // Handle quick filter selection
-    const handleQuickFilterSelect = (range: { start: string; end: string }) => {
-        setStartDate(range.start);
-        setEndDate(range.end);
-        setCurrentPage(0);
-    };
-
-    // Handle clear all filters
-    const handleClearFilters = () => {
-        setStartDate('');
-        setEndDate('');
-        setSelectedPaymentStatuses([]);
-        setSelectedUserPlanStatuses([]);
-        setSelectedPaymentSources([]); // Clear new filter
-        setSelectedPaymentTypes([]);
-        setPackageSessionFilter({});
-        setCurrentPage(0);
-    };
-
-    // Download the currently shown (searched + filtered) payment logs as CSV.
-    const handleExportCsv = async () => {
-        try {
-            if (filteredEntries.length === 0) {
-                toast.info('No payment records to export.');
-                return;
-            }
-            const count = exportEntriesToCsv(filteredEntries, instituteDetails?.institute_name);
-            toast.success(`Exported ${count.toLocaleString()} payment records.`);
-        } catch (error) {
-            console.error('Failed to export payment logs:', error);
-            toast.error('Failed to export payment logs. Please try again.');
-        }
-    };
-
-    // Note: Stats are calculated from current page only, not all filtered results
-    // To get accurate stats across all pages, we would need a separate summary API endpoint
+    }, [setNavHeading]);
 
     return (
         <>
@@ -261,85 +38,7 @@ function ManagePaymentsLayoutPage() {
             </Helmet>
 
             <div className="space-y-6 p-6">
-                {/* Summary KPI cards — reflect the current search + filters */}
-                <PaymentSummaryCards
-                    summary={paymentSummary}
-                    totalCount={filteredEntries.length}
-                    isLoading={isLoadingPayments}
-                    truncated={allData?.truncated}
-                />
-
-                {/* Filters */}
-                <PaymentFilters
-                    searchValue={searchValue}
-                    onSearchChange={(value) => {
-                        setSearchValue(value);
-                        setCurrentPage(0);
-                    }}
-                    startDate={startDate}
-                    endDate={endDate}
-                    onStartDateChange={(date) => {
-                        setStartDate(date);
-                        setCurrentPage(0);
-                    }}
-                    onEndDateChange={(date) => {
-                        setEndDate(date);
-                        setCurrentPage(0);
-                    }}
-                    selectedPaymentStatuses={selectedPaymentStatuses}
-                    onPaymentStatusesChange={(statuses) => {
-                        setSelectedPaymentStatuses(statuses);
-                        setCurrentPage(0);
-                    }}
-                    selectedUserPlanStatuses={selectedUserPlanStatuses}
-                    onUserPlanStatusesChange={(statuses) => {
-                        setSelectedUserPlanStatuses(statuses);
-                        setCurrentPage(0);
-                    }}
-                    selectedPaymentSources={selectedPaymentSources}
-                    onPaymentSourcesChange={(sources) => {
-                        setSelectedPaymentSources(sources);
-                        setCurrentPage(0);
-                    }}
-                    selectedPaymentTypes={selectedPaymentTypes}
-                    onPaymentTypesChange={(types) => {
-                        setSelectedPaymentTypes(types);
-                        setCurrentPage(0);
-                    }}
-                    hasOrgAssociatedBatches={hasOrgAssociatedBatches}
-                    packageSessionFilter={packageSessionFilter}
-                    onPackageSessionFilterChange={(filter) => {
-                        setPackageSessionFilter(filter);
-                        setCurrentPage(0);
-                    }}
-                    batchesForSessions={batchesForSessions}
-                    onQuickFilterSelect={handleQuickFilterSelect}
-                    onClearFilters={handleClearFilters}
-                    exportSlot={
-                        filteredEntries.length > 0 ? (
-                            <MyButton
-                                buttonType="secondary"
-                                scale="medium"
-                                onAsyncClick={handleExportCsv}
-                                loadingText="Exporting…"
-                                className="gap-2"
-                            >
-                                <DownloadSimple size={16} />
-                                Download CSV
-                            </MyButton>
-                        ) : null
-                    }
-                />                {/* Payment Logs Table */}
-                <PaymentLogsTable
-                    data={pagedData}
-                    isLoading={isLoadingPayments}
-                    error={paymentsError as Error}
-                    currentPage={currentPage}
-                    onPageChange={handlePageChange}
-                    packageSessions={packageSessionsMap}
-                    hasOrgAssociatedBatches={hasOrgAssociatedBatches}
-                    onRefresh={() => refetchPaymentLogs()}
-                />
+                <TransactionsView />
             </div>
         </>
     );

--- a/frontend-admin-dashboard/src/routes/payment-dashboard/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/payment-dashboard/index.lazy.tsx
@@ -1,0 +1,38 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { LayoutContainer } from '@/components/common/layout-container/layout-container';
+import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
+import { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { PaymentDashboard } from '@/routes/manage-payments/-components/PaymentDashboard';
+
+export const Route = createLazyFileRoute('/payment-dashboard/')({
+    component: () => (
+        <LayoutContainer>
+            <PaymentDashboardPage />
+        </LayoutContainer>
+    ),
+});
+
+function PaymentDashboardPage() {
+    const { setNavHeading } = useNavHeadingStore();
+
+    useEffect(() => {
+        setNavHeading(<h1 className="text-lg">Payment Dashboard</h1>);
+    }, [setNavHeading]);
+
+    return (
+        <>
+            <Helmet>
+                <title>Payment Dashboard</title>
+                <meta
+                    name="description"
+                    content="Collections and outstanding analytics for your institute"
+                />
+            </Helmet>
+
+            <div className="p-6">
+                <PaymentDashboard />
+            </div>
+        </>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/payment-dashboard/index.tsx
+++ b/frontend-admin-dashboard/src/routes/payment-dashboard/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+// Route definition only - component is lazy loaded from index.lazy.tsx
+export const Route = createFileRoute('/payment-dashboard/')({
+    // Component is defined in index.lazy.tsx
+});

--- a/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
@@ -54,6 +54,7 @@ import {
     listPaymentGateways,
     updatePaymentGateway,
 } from '../-services/payment-gateway-service';
+import { resolveGatewayBranding } from '../-constants/payment-gateway-branding';
 
 // ─── Vendor schemas ──────────────────────────────────────────────────────────
 // What the backend's per-vendor payment manager expects to find in
@@ -283,22 +284,9 @@ const findSchema = (vendor: string): VendorSchema | undefined =>
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-const vendorBadgeClass = (vendor: string): string => {
-    switch (vendor) {
-        case 'STRIPE':
-            return 'border-violet-200 bg-violet-50 text-violet-700';
-        case 'RAZORPAY':
-            return 'border-blue-200 bg-blue-50 text-blue-700';
-        case 'PHONEPE':
-            return 'border-indigo-200 bg-indigo-50 text-indigo-700';
-        case 'CASHFREE':
-            return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-        case 'EWAY':
-            return 'border-amber-200 bg-amber-50 text-amber-700';
-        default:
-            return 'border-slate-200 bg-slate-50 text-slate-700';
-    }
-};
+// Delegates to the shared gateway branding so the settings list and the payments screens render the
+// same badge for a vendor (single source of truth in `payment-gateway-branding`).
+const vendorBadgeClass = (vendor: string): string => resolveGatewayBranding(vendor).badgeClass;
 
 const StatusBadge = ({ status }: { status: string }) =>
     status === 'ACTIVE' ? (

--- a/frontend-admin-dashboard/src/routes/settings/-constants/payment-gateway-branding.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-constants/payment-gateway-branding.ts
@@ -1,0 +1,88 @@
+/**
+ * Single source of truth for how each payment gateway is BRANDED across the admin app — its display
+ * name, letter mark, and badge colour. It lives alongside the Institute Settings → Payment Gateways
+ * screen (where gateways are actually enabled/configured) so both the settings list and the payments
+ * screens render the same logo/label for a vendor. Add a gateway once here and it flows through
+ * everywhere.
+ *
+ * There are no licensed logo image assets, so — like the design mockups — a gateway "logo" is a
+ * brand-tinted badge carrying its initial; offline / manual collection gets a cash glyph instead.
+ */
+
+export interface GatewayBranding {
+    label: string;
+    /** Single-letter brandmark. Empty string ⇒ render the offline/cash glyph. */
+    mark: string;
+    /** Tailwind classes for the badge (border + bg + text), mirroring the settings vendor badges. */
+    badgeClass: string;
+}
+
+/** Keyed by the canonical uppercase vendor code (see `PaymentVendor`, plus common extras). */
+export const GATEWAY_BRANDING: Record<string, GatewayBranding> = {
+    RAZORPAY: {
+        label: 'Razorpay',
+        mark: 'R',
+        badgeClass: 'border-blue-200 bg-blue-50 text-blue-700',
+    },
+    STRIPE: {
+        label: 'Stripe',
+        mark: 'S',
+        badgeClass: 'border-violet-200 bg-violet-50 text-violet-700',
+    },
+    PHONEPE: {
+        label: 'PhonePe',
+        mark: 'P',
+        badgeClass: 'border-indigo-200 bg-indigo-50 text-indigo-700',
+    },
+    CASHFREE: {
+        label: 'Cashfree',
+        mark: 'C',
+        badgeClass: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    },
+    EWAY: { label: 'Eway', mark: 'E', badgeClass: 'border-amber-200 bg-amber-50 text-amber-700' },
+    PAYU: { label: 'PayU', mark: 'P', badgeClass: 'border-lime-200 bg-lime-50 text-lime-700' },
+    PAYPAL: { label: 'PayPal', mark: 'P', badgeClass: 'border-sky-200 bg-sky-50 text-sky-700' },
+    PAYTM: { label: 'Paytm', mark: 'P', badgeClass: 'border-cyan-200 bg-cyan-50 text-cyan-700' },
+};
+
+export const OFFLINE_BRANDING: GatewayBranding = {
+    label: 'Offline',
+    mark: '',
+    badgeClass: 'border-slate-200 bg-slate-50 text-slate-600',
+};
+
+/** Vendor codes that mean money collected outside a gateway (rendered with the cash glyph). */
+const OFFLINE_VENDORS = new Set([
+    'MANUAL',
+    'CASH',
+    'OFFLINE',
+    'CHEQUE',
+    'CHECK',
+    'BANK',
+    'BANK_TRANSFER',
+    'NEFT',
+    'RTGS',
+    'DD',
+]);
+
+export const normalizeVendor = (vendor?: string | null): string =>
+    (vendor || '')
+        .trim()
+        .toUpperCase()
+        .replace(/[\s-]+/g, '_');
+
+/**
+ * Resolve the branding for a free-form `payment_log.vendor` string. Unknown gateways get a neutral
+ * badge with their first initial so a newly-added-in-settings vendor still renders sensibly.
+ */
+export const resolveGatewayBranding = (vendor?: string | null): GatewayBranding => {
+    const key = normalizeVendor(vendor);
+    if (!key) return { ...OFFLINE_BRANDING, label: 'Other' };
+    if (GATEWAY_BRANDING[key]) return GATEWAY_BRANDING[key]!;
+    if (OFFLINE_VENDORS.has(key)) return OFFLINE_BRANDING;
+    return {
+        label: (vendor || '').trim() || 'Other',
+        mark: key[0] || '?',
+        badgeClass: 'border-slate-200 bg-slate-50 text-slate-600',
+    };
+};


### PR DESCRIPTION
## Summary of Changes

Redesigns the **Manage Payments** screen and adds a new standalone **Payment Dashboard** page, from the provided mockups. The transactions screen now uses joined KPI tiles (amount-led), a control bar with a segmented status switch + search, a filters slide-over, active-filter chips, and a restyled table (avatars, status pills, gateway logos). A read-only payment detail slide-over opens on row click and can jump to the full student profile overlay used in the Students List. Payment gateway branding is centralised in one source of truth that both the payments UI and the Payment Gateway settings read from. The Payment Dashboard derives all of its analytics client-side from the existing payment-logs data (no new backend), and omits panels that can't be derived rather than showing placeholder numbers.

**Backend:**
- No backend changes.

**Frontend:**
- New **Payment Dashboard** page at `/payment-dashboard` (sidebar entry under Membership): metric tiles, collections trend, method-mix donut, collections-by-gateway, funnel, outstanding-by-age, top courses, payment-type mix — all derived from the payment-logs set + collection-summary endpoint.
- Redesigned **Manage Payments** transactions view: amount-led joined KPI tiles that filter on click, `PaymentControlBar` (search + segmented status switch with counts + Filters), filters moved into a slide-over (`PaymentFilters` gained a `panelOnly` mode), removable active-filter chips, restyled table cells (avatar initials, status pills with dots, amount + type, plan pill).
- Read-only **payment detail slide-over** on row click, with a **View profile** button that opens the same full-screen student profile overlay used in the Students List.
- **Gateway logos** shown across the table, detail sheet, and dashboard via a shared branding source of truth (`payment-gateway-branding.ts`); the Payment Gateway settings badge now reads from the same source.
- Header actions: **Export** (CSV), **Send reminders**, and **Record payment** (2-step modal). Reminders and Record payment are front-end only for now (no reminder endpoint; offline-payment recording needs plan context) and confirm via toast.
- Design-system compliant: tokens only, `MyTable`/`MyButton`/`MyDialog`/`Sheet`/`StatusChip`, recharts for charts.

## Related Issue

<!-- link or leave blank -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

- `tsc --noEmit` passes with 0 errors.
- `eslint` passes on all new/changed files (0 warnings).
- `design-lint` passes with 0 errors (only expected dynamic-style warnings on data-driven chart widths/colors).
- Manually verified in the running app: Manage Payments transactions view (KPIs, segmented status, filters slide-over, chips, table, detail slide-over, View-profile overlay) and the Payment Dashboard page render with live institute data.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
