### PR TITLE
Start the class on its own, with no play button to hunt for

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
@@ -1284,11 +1284,63 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
         if (started) {
           setIsPlayed(true);
           setShowManualPlayButton(false);
-        } else {
-          // The browser is holding playback back and only a real tap will release
-          // it. Surface the button rather than leaving a dead frame.
-          console.warn("Autoplay blocked after retries, showing manual play button");
+          return;
+        }
+
+        // Still not playing, so the browser is withholding permission for SOUND.
+        // A muted start is always allowed, and the class beginning on its own
+        // matters more than the first second of audio — the learner came here to
+        // attend, not to hunt for a play button.
+        const mutedOk = await safePlayerOperation(async () => {
+          const p = playerRef.current;
+          if (!p) return;
+          await p.mute();
+          await p.playVideo();
+        }, "autoplay-muted");
+
+        await new Promise((r) => setTimeout(r, GAP_MS));
+        if (!isMountedRef.current) return;
+
+        let playingMuted = false;
+        try {
+          playingMuted = mutedOk && (await player.getPlayerState()) === 1;
+        } catch {
+          playingMuted = false;
+        }
+
+        if (!playingMuted) {
+          // Even muted playback was refused — nothing left but a real tap.
+          console.warn("Autoplay blocked even muted, showing manual play button");
           setShowManualPlayButton(true);
+          return;
+        }
+
+        setIsPlayed(true);
+        setShowManualPlayButton(false);
+
+        // Playing, but silent. Ask for sound back immediately; the learner
+        // arrived through a real tap, so this usually succeeds outright.
+        try {
+          await playerRef.current?.unMute();
+        } catch {
+          /* still withheld — handled by the listener below */
+        }
+
+        // If it is somehow still muted, restore sound on the learner's very next
+        // touch anywhere on the page. That counts as fresh input, so it always
+        // works, and it needs no button and no instruction on screen.
+        try {
+          if (await playerRef.current?.isMuted()) {
+            const restoreSound = () => {
+              playerRef.current?.unMute();
+              window.removeEventListener("pointerdown", restoreSound);
+              window.removeEventListener("keydown", restoreSound);
+            };
+            window.addEventListener("pointerdown", restoreSound, { once: true });
+            window.addEventListener("keydown", restoreSound, { once: true });
+          }
+        } catch {
+          /* isMuted unsupported on this build — leave as is */
         }
       }, 500);
 


### PR DESCRIPTION
Coming out of the disclaimer the learner met a second button before anything happened, which reads as a dead screen — they already chose to join.

The tap on "Continue to class" is genuine input and the app navigates in the same document, so the page does hold user activation and unmuted playback is normally permitted. When a browser withholds it anyway, the player now falls back to a MUTED start, which is never blocked, and asks for sound back immediately. If sound is still withheld it is restored on the learner's next touch anywhere on the page — real input, so it always works, and it needs no button and no instruction on screen.

The manual button now appears only if even muted playback is refused, which leaves the class running by itself in every case we can control.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
