### PR TITLE
fix(deassign): stop the date calendar clipping, allow typing the date

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/deassign-course-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-courses/deassign-course-dialog.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { MyDialog } from '@/components/design-system/dialog';
 import { MyButton } from '@/components/design-system/button';
 import { Calendar } from '@/components/ui/calendar';
+import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { CalendarBlank } from '@phosphor-icons/react';
 import { format } from 'date-fns';
-import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { getInstituteId } from '@/constants/helper';
 import { useBulkDeassign } from '@/routes/manage-students/students-list/-services/bulkAssignService';
@@ -200,47 +200,66 @@ export const DeassignCourseDialog = ({
                         <p className="text-[11px] font-medium text-neutral-600">
                             Last access date
                         </p>
-                        <Popover>
-                            <PopoverTrigger asChild>
-                                <button
-                                    type="button"
-                                    className={cn(
-                                        'flex items-center gap-2 rounded-md border border-neutral-200 bg-white px-2.5 py-1.5 text-xs transition-colors hover:border-neutral-300',
-                                        accessTillDate ? 'text-neutral-800' : 'text-neutral-500'
-                                    )}
-                                >
-                                    <CalendarBlank className="size-3.5 text-neutral-400" />
-                                    {accessTillDate
-                                        ? format(new Date(accessTillDate), 'dd MMM yyyy')
-                                        : defaultExpiry
-                                          ? `Plan expiry — ${format(defaultExpiry, 'dd MMM yyyy')}`
-                                          : 'Respect plan expiry'}
-                                </button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-auto p-0" align="start" portal={false}>
-                                <Calendar
-                                    mode="single"
-                                    selected={
-                                        accessTillDate
-                                            ? new Date(accessTillDate)
-                                            : defaultExpiry ?? undefined
-                                    }
-                                    defaultMonth={
-                                        accessTillDate
-                                            ? new Date(accessTillDate)
-                                            : defaultExpiry ?? undefined
-                                    }
-                                    onSelect={(date) => {
-                                        if (date) setAccessTillDate(format(date, 'yyyy-MM-dd'));
-                                    }}
-                                    initialFocus
-                                />
-                            </PopoverContent>
-                        </Popover>
+                        <div className="flex items-center gap-1.5">
+                            {/* Typed entry. yyyy-MM-dd is exactly the shape accessTillDate
+                                holds and the API expects, so the value maps straight through
+                                with no parsing. Also gives the browser's own picker, which
+                                renders natively and can never be clipped by the dialog. */}
+                            <Input
+                                type="date"
+                                aria-label="Last access date"
+                                value={accessTillDate ?? ''}
+                                onChange={(e) => setAccessTillDate(e.target.value || null)}
+                                className="h-8 w-36 text-xs"
+                            />
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <button
+                                        type="button"
+                                        aria-label="Pick last access date from calendar"
+                                        className="flex items-center gap-1.5 rounded-md border border-neutral-200 bg-white px-2 py-1.5 text-xs text-neutral-600 transition-colors hover:border-neutral-300"
+                                    >
+                                        <CalendarBlank className="size-3.5 text-neutral-400" />
+                                    </button>
+                                </PopoverTrigger>
+                                {/* Portalled (the default) rather than inline: MyDialog wraps its
+                                    body in a vertical scroll area inside a capped-height,
+                                    overflow-hidden shell, so an inline popover gets clipped —
+                                    a 6-row month lost its last week. The popover has no internal
+                                    scrolling, so the reason PopoverContent offers the inline
+                                    escape hatch doesn't apply here. Stacking is left to DOM
+                                    order: the portal mounts after the dialog, so at equal
+                                    z-index it still paints above it. */}
+                                <PopoverContent className="w-auto p-0" align="start">
+                                    <Calendar
+                                        mode="single"
+                                        // Always render 6 week rows so the height is identical
+                                        // in every month — no reflow, nothing to clip.
+                                        fixedWeeks
+                                        selected={
+                                            accessTillDate
+                                                ? new Date(accessTillDate)
+                                                : defaultExpiry ?? undefined
+                                        }
+                                        defaultMonth={
+                                            accessTillDate
+                                                ? new Date(accessTillDate)
+                                                : defaultExpiry ?? undefined
+                                        }
+                                        onSelect={(date) => {
+                                            if (date) setAccessTillDate(format(date, 'yyyy-MM-dd'));
+                                        }}
+                                        initialFocus
+                                    />
+                                </PopoverContent>
+                            </Popover>
+                        </div>
                         <p className="text-[10px] text-neutral-400">
                             {accessTillDate
                                 ? 'Access ends on the selected date.'
-                                : 'Leave as-is to keep access until the plan’s own expiry.'}
+                                : defaultExpiry
+                                  ? `Leave empty to keep access until the plan’s own expiry — ${format(defaultExpiry, 'dd MMM yyyy')}.`
+                                  : 'Leave empty to keep access until the plan’s own expiry.'}
                             {accessTillDate && (
                                 <button
                                     type="button"


### PR DESCRIPTION
The last-access-date calendar lost its bottom week rows in months that render six of them. The popover was rendered inline (portal={false}) and MyDialog wraps its body in a vertical scroll area inside a capped-height, overflow-hidden shell, so anything taller than the visible box was cut off. Five-row months happened to fit, six-row months did not - hence it only looked broken some of the time.

Three changes:

- The popover portals again (the default). PopoverContent offers the inline escape hatch for content that scrolls internally inside a scroll-locked container; a calendar does not scroll, so that reason never applied here. Stacking is left to DOM order - the portal mounts after the dialog, so at equal z-index it still paints above - rather than hardcoding a z-index.
- fixedWeeks on the Calendar, so every month renders six week rows and the popover height stops changing as you page through months.
- A date input beside the calendar button for typing a date directly, which was the other request. It stores yyyy-MM-dd, exactly the shape accessTillDate already holds and the API expects, so the value maps straight through with no parsing. It also gives the browser's native picker, which is rendered outside the page and cannot be clipped at all.

The trigger no longer doubles as the value display, so the plan's own expiry date moved into the helper text where it still tells the admin what "leave empty" falls back to.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
