### PR TITLE
Revert live-class autoplay changes; stop the title wrapping on phones

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
@@ -614,8 +614,12 @@ function EmbedComponent() {
       </Helmet>
 
       <div className="flex flex-col h-nav-offset">
-        <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold text-center mb-6">
+        <div className="mb-6 flex items-center justify-between gap-2">
+          {/* Scales with the viewport: a session title like
+              "Suchbliss.com - 07:30 (Day 2)" wrapped onto two lines on a phone
+              at a fixed 2xl. min-w-0 lets it shrink beside the LIVE badge
+              instead of pushing it off the row. */}
+          <h1 className="min-w-0 text-subtitle font-bold leading-tight xs:text-h3 md-tablets:text-h2">
             {sessionDetails?.title || getTerminology(ContentTerms.Session, SystemTerms.Session)}
           </h1>
           <span className={`rounded px-3 py-1 text-sm font-semibold uppercase text-white shadow ${sessionId ? "bg-red-600" : "bg-primary-300"}`}>


### PR DESCRIPTION
### What this does

Reverts the autoplay work on the live-class player, and fixes the session title wrapping onto two lines on a phone.

**Autoplay — fully reverted** (reported as slow video loading)
- Removed the 5x800ms retry loop and the muted-start fallback. When a browser withholds playback it refuses immediately, so the loop mostly spent ~4s waiting to be told "no" again — before the learner saw anything happen.
- Removed the `shouldAutoPlay` trigger, so autoplay is back to firing only when the learner is not allowed to pause, exactly as before.
- The autoplay block is **byte-identical** to its pre-change version (extracted from git, not retyped).

**Title**
- `text-2xl` was fixed, so "Suchbliss.com - 07:30 (Day 2)" broke across two lines and pushed the video down. Now scales `text-subtitle` -> `xs:text-h3` -> `md-tablets:text-h2`, with `min-w-0` so it shrinks beside the LIVE badge instead of shoving it off the row. Bottom margin moved from the heading to the row so the badge aligns.

### Deliberately kept

- **Caption suppression** (confirmed working in production) — `unloadModule` + `setOption("track", {})`, on ready and again on PLAYING.
- **End-of-class fixes** — the live-sync no longer seeks past the video's duration (an out-of-range seek is treated as a seek to zero, which is what silently restarted a 57-minute video in a 60-minute slot), and ENDED holds the last frame.

Against the pre-change file only 2 lines are missing: a dead `cc_load_policy` comment, and a `setTimeout` that had to become `async` to await `getDuration()`.

### Verification

- `tsc --noEmit` - exit 0, 0 errors
- `design-lint` - clean on the embed route; 0 errors on the player (7 pre-existing inline-style warnings, untouched)
- Confirmed `shouldAutoPlayAfterSeekRef` is preserved (4 uses) — a pre-existing resume-after-seek flag that merely shares a prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
