### PR TITLE
fix(payments): bill learners at the discounted amount, not the list p…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
@@ -326,13 +326,23 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
         @Query(value = """
                 WITH billed AS (
                   SELECT up.user_id AS user_id,
-                         SUM(COALESCE(pp.actual_price, 0)) AS price,
+                         SUM(COALESCE(sfp_tot.expected, pp.actual_price, 0)) AS price,
                          COUNT(*) AS plans,
                          MAX(UPPER(COALESCE(NULLIF(TRIM(pp.currency), ''),
                                             NULLIF(TRIM(ei.currency), '')))) AS cur
                     FROM user_plan up
                     JOIN enroll_invite ei ON ei.id = up.enroll_invite_id
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
+                    -- Net obligation for plans that carry a fee schedule. amount_expected is
+                    -- post-discount, so a discounted plan is billed at what the learner actually
+                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- discount itself as an outstanding due. Pre-aggregated rather than
+                    -- correlated for the same reason the paid CTE is — see the note above.
+                    LEFT JOIN (
+                      SELECT user_plan_id, SUM(amount_expected) AS expected
+                        FROM student_fee_payment
+                       GROUP BY user_plan_id
+                    ) sfp_tot ON sfp_tot.user_plan_id = up.id
                    WHERE ei.institute_id = :instituteId
                      AND up.status IN ('ACTIVE', 'PENDING_FOR_PAYMENT')
                      AND up.created_at >= :startDate
@@ -401,7 +411,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
         @Query(value = """
                 WITH billed AS (
                   SELECT up.user_id AS user_id,
-                         SUM(COALESCE(pp.actual_price, 0)) AS billed,
+                         SUM(COALESCE(sfp_tot.expected, pp.actual_price, 0)) AS billed,
                          COUNT(*) AS plan_count,
                          MIN(ei.name) AS course_name,
                          MIN(up.status) AS plan_status,
@@ -416,6 +426,16 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                     FROM user_plan up
                     JOIN enroll_invite ei ON ei.id = up.enroll_invite_id
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
+                    -- Net obligation for plans that carry a fee schedule. amount_expected is
+                    -- post-discount, so a discounted plan is billed at what the learner actually
+                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- discount itself as an outstanding due. Pre-aggregated rather than
+                    -- correlated for the same reason the paid CTE is — see the note above.
+                    LEFT JOIN (
+                      SELECT user_plan_id, SUM(amount_expected) AS expected
+                        FROM student_fee_payment
+                       GROUP BY user_plan_id
+                    ) sfp_tot ON sfp_tot.user_plan_id = up.id
                     LEFT JOIN payment_option po ON po.id = up.payment_option_id
                    WHERE ei.institute_id = :instituteId
                      AND up.status IN ('ACTIVE', 'PENDING_FOR_PAYMENT')
@@ -469,10 +489,20 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                  ORDER BY due DESC
                 """, countQuery = """
                 WITH billed AS (
-                  SELECT up.user_id AS user_id, SUM(COALESCE(pp.actual_price, 0)) AS billed
+                  SELECT up.user_id AS user_id, SUM(COALESCE(sfp_tot.expected, pp.actual_price, 0)) AS billed
                     FROM user_plan up
                     JOIN enroll_invite ei ON ei.id = up.enroll_invite_id
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
+                    -- Net obligation for plans that carry a fee schedule. amount_expected is
+                    -- post-discount, so a discounted plan is billed at what the learner actually
+                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- discount itself as an outstanding due. Pre-aggregated rather than
+                    -- correlated for the same reason the paid CTE is — see the note above.
+                    LEFT JOIN (
+                      SELECT user_plan_id, SUM(amount_expected) AS expected
+                        FROM student_fee_payment
+                       GROUP BY user_plan_id
+                    ) sfp_tot ON sfp_tot.user_plan_id = up.id
                    WHERE ei.institute_id = :instituteId
                      AND up.status IN ('ACTIVE', 'PENDING_FOR_PAYMENT')
                      AND up.created_at >= :startDate


### PR DESCRIPTION
…rice

Manage Payments reported a discount as an outstanding due. The billed CTE summed pp.actual_price - the plan's undiscounted list price - while collected came from payment_log, so a learner billed 70,000 with an 8,000 discount who paid the full 62,000 showed up as owing exactly the 8,000 that had been discounted away.

Worse, the same learner appeared in BOTH tabs: Paid (a PAID payment_log exists) and Due (billed - paid > 0). The two tabs disagreed because they answered from different definitions of what was owed.

billed now prefers SUM(student_fee_payment.amount_expected) for plans that carry a fee schedule, falling back to pp.actual_price for those that don't. amount_expected is post-discount, so it is what the learner actually owes - the same figure the side-view Account Summary and Fee Plan already report, which is why those two were right while this page was wrong.

Applied to all three billed CTEs: the billing-summary query, the outstanding-learners query, and its countQuery. Missing the countQuery would have left the Due tab's pagination disagreeing with its own rows.

The join is pre-aggregated by user_plan_id rather than correlated, for the reason already documented on the paid CTE: as a correlated subquery this shape took 33 s on an institute with 8,380 live plans.

Side effect worth knowing: settledPlanCount (COLLECTED's "N fully paid up") counts paid >= billed, which against list prices almost never matched - hence "0 fully paid up" beside 92,000 collected. It now counts learners who have genuinely settled.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
