### PR TITLE
fix(payments): drop the semicolon from the SQL comment breaking pagin…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/repository/UserPlanRepository.java
@@ -335,7 +335,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
                     -- Net obligation for plans that carry a fee schedule. amount_expected is
                     -- post-discount, so a discounted plan is billed at what the learner actually
-                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- owes. pp.actual_price is the undiscounted list price and would report the
                     -- discount itself as an outstanding due. Pre-aggregated rather than
                     -- correlated for the same reason the paid CTE is — see the note above.
                     LEFT JOIN (
@@ -428,7 +428,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
                     -- Net obligation for plans that carry a fee schedule. amount_expected is
                     -- post-discount, so a discounted plan is billed at what the learner actually
-                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- owes. pp.actual_price is the undiscounted list price and would report the
                     -- discount itself as an outstanding due. Pre-aggregated rather than
                     -- correlated for the same reason the paid CTE is — see the note above.
                     LEFT JOIN (
@@ -495,7 +495,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, String> {
                     LEFT JOIN payment_plan pp ON pp.id = up.plan_id
                     -- Net obligation for plans that carry a fee schedule. amount_expected is
                     -- post-discount, so a discounted plan is billed at what the learner actually
-                    -- owes; pp.actual_price is the undiscounted list price and would report the
+                    -- owes. pp.actual_price is the undiscounted list price and would report the
                     -- discount itself as an outstanding due. Pre-aggregated rather than
                     -- correlated for the same reason the paid CTE is — see the note above.
                     LEFT JOIN (


### PR DESCRIPTION
…ation

The comment I added to the billed CTEs contained "owes;", and Hibernate's limit handler splices its fetch clause in at the FIRST semicolon it finds in the statement - without excluding SQL comments. The shipped query became:

  -- owes fetch first ? rows only; pp.actual_price is the undiscounted list price

which adds a bind parameter the projection cannot map, so every paged call to /payment-logs/outstanding-learners failed with:

  The column index is out of range: 12, number of columns: 11

Reworded to a full stop. Also swept the file: no other SQL comment carries a semicolon or an apostrophe (the sibling trap, where an unbalanced quote makes the parameter scanner think a string literal opened).

Three other semicolon-in-comment instances exist in admin_core - two in InstitutePulseRepository, one in SlideRepository - but neither repository uses Pageable anywhere, so the limit handler never runs and they are inert.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
