### PR TITLE
fix(chat): serve message timestamps as UTC instants, not bare local-time

### DIFF
--- a/frontend-admin-dashboard/src/components/chat/ChatThread.tsx
+++ b/frontend-admin-dashboard/src/components/chat/ChatThread.tsx
@@ -5,6 +5,7 @@ import type {
     ChatConversationResponse,
     ChatMessageResponse,
 } from '@/services/chat/chatApi';
+import { toUtcDate } from './chatTime';
 
 export interface ThreadMessage extends ChatMessageResponse {
     /** Local-only dedup key threaded through the optimistic send for reconciliation/retry. */
@@ -31,8 +32,8 @@ interface ChatThreadProps {
 }
 
 const dayLabel = (iso: string): string => {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return '';
+    const d = toUtcDate(iso);
+    if (!d) return '';
     const now = new Date();
     const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
     const diffDays = Math.round((startOf(now) - startOf(d)) / 86400000);
@@ -42,13 +43,13 @@ const dayLabel = (iso: string): string => {
 };
 
 const dayKey = (iso: string): string => {
-    const d = new Date(iso);
-    return Number.isNaN(d.getTime()) ? '' : d.toDateString();
+    const d = toUtcDate(iso);
+    return d ? d.toDateString() : '';
 };
 
 const timeLabel = (iso: string): string => {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return '';
+    const d = toUtcDate(iso);
+    if (!d) return '';
     return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
 };
 

--- a/frontend-admin-dashboard/src/components/chat/ConversationList.tsx
+++ b/frontend-admin-dashboard/src/components/chat/ConversationList.tsx
@@ -20,6 +20,7 @@ import type {
     ChatBatchResponse,
     ChatPersonResponse,
 } from '@/services/chat/chatApi';
+import { toUtcDate } from './chatTime';
 
 interface ConversationListProps {
     conversations: ChatConversationResponse[];
@@ -67,9 +68,8 @@ const conversationTitle = (c: ChatConversationResponse): string => {
 };
 
 const formatTime = (iso?: string): string => {
-    if (!iso) return '';
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return '';
+    const d = toUtcDate(iso);
+    if (!d) return '';
     const now = new Date();
     const sameDay =
         d.getFullYear() === now.getFullYear() &&

--- a/frontend-admin-dashboard/src/components/chat/ReportsReviewQueue.tsx
+++ b/frontend-admin-dashboard/src/components/chat/ReportsReviewQueue.tsx
@@ -9,6 +9,7 @@ import {
     type ChatReportResponse,
     type ReportStatus,
 } from '@/services/chat/chatApi';
+import { toUtcDate } from './chatTime';
 
 const STATUS_FILTERS: { label: string; value?: ReportStatus }[] = [
     { label: 'Open', value: 'OPEN' },
@@ -41,8 +42,8 @@ const statusBadgeClass = (status: string): string => {
 };
 
 const formatDate = (iso: string): string => {
-    const d = new Date(iso);
-    return Number.isNaN(d.getTime())
+    const d = toUtcDate(iso);
+    return !d
         ? ''
         : d.toLocaleString(undefined, {
               day: '2-digit',

--- a/frontend-admin-dashboard/src/components/chat/__tests__/chat-time/test.ts
+++ b/frontend-admin-dashboard/src/components/chat/__tests__/chat-time/test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { toUtcDate } from '@/components/chat/chatTime';
+
+/**
+ * The regression this guards: a message sent at 2:17 PM IST is stored as the UTC wall clock
+ * 08:47:03, and a service build that serialised it without a zone marker made every browser
+ * read it as 8:47 AM local.
+ */
+const SENT_AT = Date.parse('2026-08-19T08:47:03.767Z');
+
+describe('toUtcDate', () => {
+    it('reads a zone-less server timestamp as UTC', () => {
+        expect(toUtcDate('2026-08-19T08:47:03.767725')?.getTime()).toBe(SENT_AT);
+    });
+
+    it('leaves an explicit UTC timestamp alone', () => {
+        expect(toUtcDate('2026-08-19T08:47:03.767725Z')?.getTime()).toBe(SENT_AT);
+    });
+
+    it('leaves an explicit offset alone rather than shifting it twice', () => {
+        expect(toUtcDate('2026-08-19T14:17:03.767+05:30')?.getTime()).toBe(SENT_AT);
+    });
+
+    it('accepts the space-separated form', () => {
+        expect(toUtcDate('2026-08-19 08:47:03.767725')?.getTime()).toBe(SENT_AT);
+    });
+
+    it('returns null for empty or unparseable input', () => {
+        expect(toUtcDate(undefined)).toBeNull();
+        expect(toUtcDate(null)).toBeNull();
+        expect(toUtcDate('')).toBeNull();
+        expect(toUtcDate('not a date')).toBeNull();
+    });
+});

--- a/frontend-admin-dashboard/src/components/chat/chatTime.ts
+++ b/frontend-admin-dashboard/src/components/chat/chatTime.ts
@@ -1,0 +1,13 @@
+/**
+ * Chat timestamps are recorded in UTC, but service builds before the Instant switch serialise
+ * them without a zone marker — and `new Date('2026-08-19T08:47:03')` reads a bare value as
+ * *local* time, so a 2:17 PM IST message rendered as 8:47 AM. Force UTC when the marker is
+ * missing; values that already carry one (including our optimistic `toISOString()` echoes)
+ * pass through untouched.
+ */
+export const toUtcDate = (raw: string | null | undefined): Date | null => {
+    if (!raw) return null;
+    const hasZone = /Z$|[+-]\d{2}:?\d{2}$/i.test(raw);
+    const date = new Date(hasZone ? raw : `${raw.replace(' ', 'T')}Z`);
+    return Number.isNaN(date.getTime()) ? null : date;
+};

--- a/frontend-learner-dashboard-app/src/components/chat/chatUtils.test.ts
+++ b/frontend-learner-dashboard-app/src/components/chat/chatUtils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { toUtcDate } from "./chatUtils";
+
+/**
+ * The regression this guards: a message sent at 2:17 PM IST is stored as the UTC wall clock
+ * 08:47:03, and a service build that serialised it without a zone marker made every browser
+ * read it as 8:47 AM local.
+ */
+const SENT_AT = Date.parse("2026-08-19T08:47:03.767Z");
+
+describe("toUtcDate", () => {
+  it("reads a zone-less server timestamp as UTC", () => {
+    expect(toUtcDate("2026-08-19T08:47:03.767725")?.getTime()).toBe(SENT_AT);
+  });
+
+  it("leaves an explicit UTC timestamp alone", () => {
+    expect(toUtcDate("2026-08-19T08:47:03.767725Z")?.getTime()).toBe(SENT_AT);
+  });
+
+  it("leaves an explicit offset alone rather than shifting it twice", () => {
+    expect(toUtcDate("2026-08-19T14:17:03.767+05:30")?.getTime()).toBe(SENT_AT);
+  });
+
+  it("accepts the space-separated form", () => {
+    expect(toUtcDate("2026-08-19 08:47:03.767725")?.getTime()).toBe(SENT_AT);
+  });
+
+  it("returns null for empty or unparseable input", () => {
+    expect(toUtcDate(undefined)).toBeNull();
+    expect(toUtcDate(null)).toBeNull();
+    expect(toUtcDate("")).toBeNull();
+    expect(toUtcDate("not a date")).toBeNull();
+  });
+});

--- a/frontend-learner-dashboard-app/src/components/chat/chatUtils.ts
+++ b/frontend-learner-dashboard-app/src/components/chat/chatUtils.ts
@@ -1,16 +1,30 @@
 /** Small presentation helpers shared across chat components. */
 
+/**
+ * Chat timestamps are recorded in UTC, but service builds before the Instant switch serialise
+ * them without a zone marker — and `new Date("2026-08-19T08:47:03")` reads a bare value as
+ * *local* time, so a 2:17 PM IST message rendered as 8:47 AM. Force UTC when the marker is
+ * missing; values that already carry one (including our optimistic `toISOString()` echoes)
+ * pass through untouched.
+ */
+export function toUtcDate(raw?: string | null): Date | null {
+  if (!raw) return null;
+  const hasZone = /Z$|[+-]\d{2}:?\d{2}$/i.test(raw);
+  const d = new Date(hasZone ? raw : `${raw.replace(" ", "T")}Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
 /** Returns a YYYY-MM-DD day key for grouping messages into day buckets. */
 export function dayKey(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
+  const d = toUtcDate(iso);
+  if (!d) return "";
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
 }
 
 /** Human-friendly day label: "Today", "Yesterday", or a full date. */
 export function dayLabel(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
+  const d = toUtcDate(iso);
+  if (!d) return "";
   const now = new Date();
   const startOf = (x: Date) =>
     new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
@@ -27,8 +41,8 @@ export function dayLabel(iso: string): string {
 
 /** Short clock time for a message bubble, e.g. "3:07 PM". */
 export function timeLabel(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
+  const d = toUtcDate(iso);
+  if (!d) return "";
   return d.toLocaleTimeString(undefined, {
     hour: "numeric",
     minute: "2-digit",

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatConversationResponse.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatConversationResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -20,7 +20,7 @@ public class ChatConversationResponse {
     private String otherUserId;      // for DIRECT: the counterpart user id
     private String lastMessagePreview;
     private String lastMessageSenderId;
-    private LocalDateTime lastMessageAt;
+    private Instant lastMessageAt;
     private Long lastMessageSeq;
     private long unreadCount;
     private String memberRole;       // caller's role in the conversation

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatMessageResponse.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatMessageResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -28,5 +28,5 @@ public class ChatMessageResponse {
     private Boolean isEdited;
     private Boolean isDeleted;
     private Boolean isFlagged;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatReportResponse.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/dto/ChatReportResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -21,8 +21,8 @@ public class ChatReportResponse {
     private String details;
     private String status;
     private String reviewedBy;
-    private LocalDateTime reviewedAt;
-    private LocalDateTime createdAt;
+    private Instant reviewedAt;
+    private Instant createdAt;
     // Only the reported message's content is exposed (never arbitrary DM history).
     private ChatMessageResponse reportedMessage;
 }

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatConversationService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatConversationService.java
@@ -25,6 +25,7 @@ import vacademy.io.notification_service.features.chat.event.ChatFanoutEvent;
 import vacademy.io.notification_service.features.chat.repository.ChatConversationMemberRepository;
 import vacademy.io.notification_service.features.chat.repository.ChatConversationRepository;
 import vacademy.io.notification_service.features.chat.repository.ChatMessageRepository;
+import vacademy.io.notification_service.features.chat.util.ChatTimeUtil;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -392,7 +393,7 @@ public class ChatConversationService {
                 .otherUserId(otherUserId)
                 .lastMessagePreview(c.getLastMessagePreview())
                 .lastMessageSenderId(c.getLastMessageSenderId())
-                .lastMessageAt(c.getLastMessageAt())
+                .lastMessageAt(ChatTimeUtil.toInstant(c.getLastMessageAt()))
                 .lastMessageSeq(c.getLastMessageSeq())
                 .unreadCount(unread)
                 .memberRole(callerMember != null ? callerMember.getMemberRole() : null)

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatMessageMapper.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatMessageMapper.java
@@ -6,6 +6,7 @@ import vacademy.io.notification_service.features.announcements.entity.RichTextDa
 import vacademy.io.notification_service.features.announcements.repository.RichTextDataRepository;
 import vacademy.io.notification_service.features.chat.dto.ChatMessageResponse;
 import vacademy.io.notification_service.features.chat.entity.ChatMessage;
+import vacademy.io.notification_service.features.chat.util.ChatTimeUtil;
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +37,7 @@ public class ChatMessageMapper {
                 .isEdited(msg.getIsEdited())
                 .isDeleted(msg.getIsDeleted())
                 .isFlagged(msg.getIsFlagged())
-                .createdAt(msg.getCreatedAt())
+                .createdAt(ChatTimeUtil.toInstant(msg.getCreatedAt()))
                 .build();
     }
 

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatReportService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/service/ChatReportService.java
@@ -20,6 +20,7 @@ import vacademy.io.notification_service.features.chat.repository.ChatConversatio
 import vacademy.io.notification_service.features.chat.repository.ChatConversationRepository;
 import vacademy.io.notification_service.features.chat.repository.ChatMessageReportRepository;
 import vacademy.io.notification_service.features.chat.repository.ChatMessageRepository;
+import vacademy.io.notification_service.features.chat.util.ChatTimeUtil;
 
 import java.time.LocalDateTime;
 
@@ -124,8 +125,8 @@ public class ChatReportService {
                 .details(r.getDetails())
                 .status(r.getStatus())
                 .reviewedBy(r.getReviewedBy())
-                .reviewedAt(r.getReviewedAt())
-                .createdAt(r.getCreatedAt());
+                .reviewedAt(ChatTimeUtil.toInstant(r.getReviewedAt()))
+                .createdAt(ChatTimeUtil.toInstant(r.getCreatedAt()));
         // Only expose the single reported message — never arbitrary conversation history.
         if (r.getMessageId() != null) {
             messageRepository.findById(r.getMessageId()).ifPresent(m -> b.reportedMessage(messageMapper.toResponse(m)));

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chat/util/ChatTimeUtil.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chat/util/ChatTimeUtil.java
@@ -1,0 +1,22 @@
+package vacademy.io.notification_service.features.chat.util;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Chat rows store wall-clock {@link LocalDateTime} values in the server's zone (UTC in every
+ * deployed environment). Serialising those straight to JSON emits no offset, so a browser parses
+ * "2026-08-19T08:47:03" as its own local time and renders a 2:17 PM IST message as 8:47 AM.
+ * Converting to {@link Instant} on the way out keeps an explicit offset on the wire.
+ */
+public final class ChatTimeUtil {
+
+    private ChatTimeUtil() {
+    }
+
+    /** Reads a stored wall-clock value as an instant in the zone that wrote it. */
+    public static Instant toInstant(LocalDateTime value) {
+        return value == null ? null : value.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}


### PR DESCRIPTION
Chat times rendered 5:30 early — a message sent at 2:17 PM IST showed as 8:47 AM. The notification-service pods run TZ=UTC, so LocalDateTime.now() records the UTC wall clock, and Jackson serialises a LocalDateTime with no zone marker ("2026-08-19T08:47:03.767725"). JS `new Date()` reads a bare date-time as *local*, so browsers re-labelled 08:47 UTC as 08:47 IST.

Backend: the four chat response time fields become Instant, converted in the mappers via ChatTimeUtil.toInstant(). It resolves through ZoneId.systemDefault() rather than hardcoding UTC, so it stays correct if a pod is ever not UTC. The SSE fanout carries the same DTO, so live messages are covered too.

Frontends: both apps normalise defensively (toUtcDate) before formatting, so the display is right whichever backend version is live and the service deploy need not be coordinated with the learner-app OTA publish. Values that already carry a zone — including our optimistic toISOString() echoes — pass through untouched, so nothing shifts twice.

Verified against the real prod row and covered by unit tests in both apps.

Announcements/notification-hub DTOs still expose bare LocalDateTime and have the same 5:30 skew; left for a separate change.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
