### PR TITLE
Mentorship: invite external mentors directly, simplify the UI

### DIFF
--- a/docs/MENTORSHIP_FEATURE.md
+++ b/docs/MENTORSHIP_FEATURE.md
@@ -1,0 +1,326 @@
+# Mentorship
+
+End-to-end reference for the mentorship feature: what it does, how it is built, what
+it deliberately reuses, and where the edges are.
+
+Mentorship started as admin-push only — an admin promoted a team member and pushed
+students onto them. It is now a full loop: learners can find and request mentors,
+capacity is enforced, sessions resolve to an outcome, learners rate them, and admins
+get a dashboard over the whole thing.
+
+---
+
+## 1. Architecture at a glance
+
+The load-bearing decision: **mentorship owns relationships and outcomes; it owns no
+scheduling.** A mentorship session *is* a `booking_instance` created by the existing
+booking module, hosted by the mentor, with the existing Meet link, reminders and
+calendar sync. Mentorship adds facts *beside* that row, never a parallel system.
+
+```
+auth_service.users ──┐
+                     ├─► mentor ──────────────► booking_page  (availability, slots, buffers)
+                     │     │                         │
+                     │     │                         ▼
+                     │     │                   booking_instance   ← THE SESSION
+                     │     │                         │  (CONFIRMED / CANCELLED / RESCHEDULED)
+                     │     ▼                         │
+                     │  mentor_student_assignment    ├─► mentor_session_record    (mentor: outcome + notes)
+                     │     ▲                         └─► mentor_session_feedback  (learner: rating + comment)
+                     │     │
+                     └──► mentor_request ────────────┘  (learner asks → admin approves → creates the assignment)
+```
+
+### Why outcome does not live on `booking_instance.status`
+
+`booking_instance` is shared with non-mentorship bookings (lead calls, counselling).
+Its status describes the **appointment** — was the slot kept. Mentorship needs to
+know whether the **session** happened and what came of it. Those are different
+questions: a `CONFIRMED` booking can still be a `NO_SHOW`.
+
+Keeping them separate means non-mentorship bookings are completely unaffected, and
+the displayed lifecycle is derived rather than stored twice:
+
+```
+cancellation  >  recorded outcome  >  time
+```
+
+So a cancelled session reads `CANCELLED` even if someone recorded an outcome, and a
+past session nobody recorded reads `AWAITING_REVIEW` rather than silently counting
+as delivered.
+
+---
+
+## 2. Data model
+
+| Table | Migration | Holds |
+|---|---|---|
+| `mentor` | V411, +V417, +V454 | The mentor persona: display name, title, bio, photo, booking page, Google account, **expertise tags, max_mentees, is_discoverable** |
+| `mentor_student_assignment` | V411 | Mentor↔student pairing. Many-to-many, soft-deleted, records method and who assigned |
+| `mentorship_notification_log` | V434 | Idempotency ledger for scheduled notifications |
+| `mentor_request` | V454 | A learner asking for a mentor; `mentor_id` NULL means "any available" |
+| `mentor_session_feedback` | V456 | Learner's 1–5 rating + comment for one session |
+| `mentor_session_record` | V457 | Mentor's outcome (`COMPLETED`/`NO_SHOW`), topic and notes for one session |
+| `booking_instance` | (booking module) +V458 | The session itself. V458 adds the double-booking guard |
+
+### Constraints that matter
+
+Enforced in the **database**, not only in service code:
+
+- `uq_mentor_institute_user` — a user is a mentor once per institute (soft-deleted rows release the slot)
+- `uq_msa_mentor_student` — one live pairing per (mentor, student); multiple mentors per student stay possible
+- `uq_mentor_request_pending` + `uq_mentor_request_pending_any` — one live request per (student, mentor), and one open-ended request per student
+- `ck_msf_rating` — rating is 1–5; `uq_msf_booking_student` — one rating per learner per session
+- `ck_msr_outcome` — outcome is `COMPLETED` or `NO_SHOW`; `uq_msr_booking` — one record per session
+- `uq_booking_host_slot` (V458) — one live booking per (host, exact start)
+
+---
+
+## 3. Feature areas
+
+### 3.1 Mentors and assignment
+
+There are two ways to get a mentor, both in the same **Add mentor** dialog:
+
+- **From your team** — promote an existing member (grants the auth `MENTOR` role
+  best-effort, creates the profile row).
+- **Invite by email** — for someone not in the institute yet. This reuses the
+  existing `handleInviteUsers` invitation with `roleType: ['MENTOR']`, takes the
+  returned user id, and creates the mentor row against it. No second trip to the
+  Teams tab, and no second invitation mechanism.
+
+If the invite succeeds but the mentor row fails, the person is left as an invited
+team member — recoverable from the team list, and better than dropping the
+invitation on the floor. Everything past "who is this" (photo, title, bio,
+expertise, capacity) is folded behind **Add photo, expertise and capacity**, since
+all of it is optional and editable afterwards.
+
+Students are assigned manually or by **bulk round-robin**, which distributes by
+least-current-load and skips anyone already paired.
+
+**Capacity** (`max_mentees`, NULL = unlimited) is enforced on every path: manual
+assign, round-robin, request creation, and request approval. Results report three
+separate outcomes so no student silently disappears from the report:
+
+```
+assigned + skipped + capacityFull == students submitted
+```
+
+`skipped` means already paired with that mentor; `capacityFull` means no candidate
+had room. Every existing mentor has `max_mentees = NULL`, so behaviour is unchanged
+until a cap is set.
+
+### 3.2 Discovery and requests (the pull direction)
+
+Mentors an admin marks `is_discoverable` appear in the learner's **Find a mentor**
+directory, searchable by name, title, bio and expertise tags. A learner requests one
+(or leaves it open-ended); an admin approves or declines with a reason.
+
+Approval routes through the **ordinary `assignManual` path**, so the pairing, its
+audit fields and the "you have a new mentor" notice are identical to an admin-made
+one — there is no second assignment code path. An approval is only recorded if a
+pairing row exists afterwards; otherwise it rolls back and the request stays
+`PENDING`, so a learner is never told "approved" while having no mentor.
+
+Removing a mentor releases their pending requests as `CANCELLED` (not `DECLINED` —
+it is not a judgement on the learner), freeing them to ask someone else.
+
+`is_discoverable` defaults **false**, so no existing mentor becomes learner-visible
+without an explicit opt-in.
+
+### 3.3 Sessions
+
+Booked through the existing booking page. After it happens the mentor records
+`COMPLETED` or `NO_SHOW` plus optional topic and notes; the learner is prompted to
+rate it 1–5.
+
+- Only the invitee may rate; only the hosting mentor may record.
+- Only after the session has started, and never for a cancelled one.
+- Re-rating and re-recording revise in place rather than adding a second row.
+- Mentor averages are **derived per read, never stored**, so deleting a rating
+  genuinely removes its effect.
+
+### 3.4 Cancellation and rescheduling
+
+Previously reachable only via the invitee's emailed manage-token link. Now also
+available to admins (any session) and mentors (their own).
+
+The token lookup was split out of the operations (`cancelInstance` /
+`rescheduleInstance`), so the emailed link and the authenticated endpoints run
+**exactly the same code** — same teardown of the live session, reminders and
+calendar event, same notification. Authorization is the only difference.
+
+Rescheduling claims the old row under its optimistic `@Version` before creating the
+replacement, so two concurrent reschedules cannot both produce one; a failure to
+create the replacement restores the previous status. The replacement records
+`reschedule_of_instance_id`, so history stays linked rather than duplicated.
+
+### 3.5 Double-booking
+
+Booking creation validated the slot and then inserted, with nothing in between — two
+simultaneous requests for one mentor slot could both pass the check. V458 adds a
+partial unique index over live bookings so the **database** decides the race; the
+insert flushes immediately and the loser's constraint violation is translated into
+the same *"This slot is no longer available"* message the pre-check produces.
+
+The migration checks for pre-existing duplicates first and **warns rather than
+failing**, so it can never take a deploy down.
+
+> ⚠️ If production already contains duplicate `(host_user_id, scheduled_start_utc)`
+> pairs among live bookings, the index is skipped and you get the warning instead of
+> the protection. Resolve those rows, then create the index manually.
+
+### 3.6 Notifications
+
+Six triggers, each independently gated per channel (email / in-app / push /
+WhatsApp) by the institute's `MENTORSHIP_SETTING` blob and editable from Settings:
+
+| Trigger | Goes to | Default |
+|---|---|---|
+| `assignment` | learner + mentor | on |
+| `booking` | learner | on (email off — the booking page already emails) |
+| `cancellation` | learner | on |
+| `session_reminder` | learner | on, 24h before |
+| `checkin_reminder` | learner | **off** (opt-in — it emails out of the blue) |
+| `request` | mentor on submit, learner on decline | on |
+
+Approval deliberately sends nothing extra — the assignment it creates already fires
+"You have a new mentor".
+
+Scheduled triggers run under ShedLock with a claim-before-send ledger, so a crash
+mid-send drops one notification rather than double-sending.
+
+---
+
+## 4. Screens
+
+### Admin (`/mentorship/*`)
+
+| Route | Purpose |
+|---|---|
+| `dashboard` | KPIs, needs-attention, session outcomes, mentor workload, coming up |
+| `mentors` | The list: search, expertise, capacity and rating chips, assign, edit, detail |
+| `sessions` | Every session, filterable by lifecycle, scopeable per mentor/learner, with detail |
+| `requests` | Learner request queue |
+| `my-mentorship` | A mentor's own view: mentees, availability, booking link, sessions to record |
+
+The first four are one section, so they share a `MentorshipTabs` strip (Overview /
+Mentors / Sessions / Requests) with a count badge on Requests. The sidebar carries
+only two entries — **Mentorship** and **My Mentorship** — because the admin side is
+one destination with tabs, not four sidebar items.
+
+### Learner
+
+**My Mentors** with three tabs — My mentors, Find a mentor, My requests — plus a
+post-session rating prompt. The sidebar entry and dashboard widget appear when the
+learner has a mentor *or* their institute lists mentors, so a learner with none is
+not stuck at a dead end.
+
+### Design notes
+
+The dashboard follows the existing widget vocabulary (Card, tinted icon square,
+Skeleton, drill-through link). Two deliberate choices:
+
+- **No donut for outcomes.** Four statuses that are often mostly zero read better as
+  a segmented bar with labelled counts, and degrade to a real empty state.
+- **No separate workload chart.** With a handful of mentors, an inline meter per row
+  beats a plot with its own axes.
+
+Every outcome carries an icon *and* a label, so colour is never the only cue. The
+average rating is weighted by rating count, so one five-star review cannot outrank a
+busy mentor.
+
+---
+
+## 5. Error handling and observability
+
+Every mentorship API call site reports through a shared reporter that shows the
+**backend's actual sentence** ("Asha Nair is at capacity (3 mentees)") rather than a
+generic failure, and forwards genuine faults to Sentry.
+
+Expected 4xx — validation, permission, already-requested — leave a **breadcrumb
+rather than a captured event**: a user being told "no" is not a bug, and capturing
+those was previously the dominant Sentry quota drain. 5xx and network errors are
+captured, tagged `feature=mentorship` plus the action.
+
+On the backend, mentorship deliberately swallows failures so a notification can
+never roll back the assignment that triggered it. `MentorshipErrorReporter` keeps
+the swallow but makes 13 such paths visible — six notification triggers, three
+scheduler paths, four identity-hydration fallbacks that otherwise render a whole
+list nameless.
+
+---
+
+## 6. Gotchas
+
+**Spring `Page` responses mix two naming conventions.** The envelope is named from
+`Page`'s getters (`totalElements`, `totalPages`) because the service sets no global
+Jackson strategy, while the DTOs inside `content` are snake_case from their own
+`@JsonNaming`. Reading `total_elements` off the envelope yields `undefined` — which
+once rendered a populated mentor list as *"No mentors yet"*. Paginated mentorship
+reads go through `normalizePage()`, which accepts either spelling, and empty states
+key off `content.length` rather than a total.
+
+**Booking status ≠ session outcome.** See §1. Do not "simplify" these into one field.
+
+**Capacity is checked against live load *and* rows queued in the same request**, so
+one oversized assign cannot push a mentor past their cap.
+
+**`mentor_request` uses two partial unique indexes**, because Postgres treats NULLs
+as distinct — one open-ended request per student needs its own index.
+
+---
+
+## 7. Verification status
+
+| Area | State |
+|---|---|
+| Backend | 121 tests (assignment/capacity, discovery/requests, feedback, sessions, cancel/reschedule, double-booking, removal, scheduler, notifications) |
+| Admin FE | 285 tests across the app; 103 mentorship |
+| Learner FE | 155 tests |
+| Migrations | V454–V458 applied against PostgreSQL and behaviour-verified: constraints, idempotency, triggers, duplicate-tolerant index creation |
+| Dashboard | Verified against **production data** — every KPI, outcome count and workload figure computed from the prod DB and matched what renders |
+| Responsive | Rendered at 1440 / 834 / 390px, zero horizontal overflow; zero-data state checked |
+
+### Known limitations
+
+- **Live meeting-join flow is untested.** Needs a running backend.
+- **Authenticated screens were never rendered** — no credentials available. Mentors,
+  Sessions and My Mentorship are covered by tests and route/type checks only.
+- **"Next 5 upcoming" ordering unverified against real data** — production currently
+  has no upcoming mentorship sessions, so only the empty state was exercised.
+- **Visual mobile rendering is not proven.** Layout tests pin wrapping, truncation
+  and the absence of fixed pixel widths; they cannot prove appearance.
+- **V458 indexes exact start, not overlap.** True overlap prevention needs a Postgres
+  exclusion constraint over a range type, which would change how start/end are
+  stored. Exact-start collision is what the booking UI can actually produce, since
+  invitees pick from generated slots.
+- **Reschedule moves a session but cannot change its duration or mentor.**
+
+---
+
+## 8. Where the code lives
+
+```
+admin_core_service/…/features/mentorship/
+  controller/   MentorController (admin)   MyMentorshipController (mentor + learner)
+  service/      MentorService               mentor profiles, dashboard aggregate
+                MentorAssignmentService     manual + round-robin, capacity
+                MentorDiscoveryService      directory + request lifecycle
+                MentorFeedbackService       learner ratings
+                MentorSessionService        outcomes, admin session views, cancel/reschedule
+                MentorshipNotificationService / MentorshipErrorReporter
+  scheduler/    MentorshipReminderScheduler  session reminders + check-in nudges
+  resources/db/migration/  V411, V417, V424, V433, V434, V454–V458
+
+frontend-admin-dashboard/src/routes/mentorship/
+  dashboard/ mentors/ sessions/ requests/ my-mentorship/
+  -components/  MentorshipDashboard, MentorSessionsPanel, MentorDetailDialog,
+                MentorRequestsPanel, RecordSessionDialog, SessionActionDialog,
+                EditMentorDialog, MentorProfileFields, MentorChips …
+  -utils/       page-response, assignment-result, filter-mentors
+
+frontend-learner-dashboard-app/src/routes/my-mentors/
+  -components/  MentorCard, DirectoryMentorCard, RequestMentorDialog, RateSessionDialog
+  -utils/       directory, feedback
+```

--- a/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
+++ b/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
@@ -609,21 +609,9 @@ export const getSidebarItemsData = (): SidebarItemsType[] => [
         category: 'CRM',
         subItems: [
             {
-                subItem: 'Dashboard',
+                subItem: 'Mentorship',
                 subItemLink: '/mentorship/dashboard',
                 subItemId: 'mentorship-dashboard',
-                adminOnly: true,
-            },
-            {
-                subItem: 'Mentors',
-                subItemLink: '/mentorship/mentors',
-                subItemId: 'mentorship-mentors',
-                adminOnly: true,
-            },
-            {
-                subItem: 'Sessions',
-                subItemLink: '/mentorship/sessions',
-                subItemId: 'mentorship-sessions',
                 adminOnly: true,
             },
             {

--- a/frontend-admin-dashboard/src/routes/mentorship/-components/AddMentorDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/-components/AddMentorDialog.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Check, UploadSimple, UserCircle } from '@phosphor-icons/react';
+import { CaretRight, Check, UploadSimple, UserCircle } from '@phosphor-icons/react';
 import { toast } from 'sonner';
 import { MyButton } from '@/components/design-system/button';
 import { MyInput } from '@/components/design-system/input';
@@ -12,6 +12,7 @@ import {
     fetchEligibleOrgUsers,
     type InstituteUser,
 } from '@/routes/manage-institute/teams/-services/institute-users-service';
+import { handleInviteUsers } from '@/routes/dashboard/-services/dashboard-services';
 import { useCreateMentor } from '../-hooks/use-mentorship';
 import { MentorProfileFields, type MentorProfileValues } from './MentorProfileFields';
 
@@ -21,17 +22,72 @@ interface AddMentorDialogProps {
     onOpenChange: (open: boolean) => void;
 }
 
-function initials(name?: string | null): string {
-    if (!name) return '?';
-    const parts = name.trim().split(/\s+/);
-    return (parts[0]?.[0] ?? '').concat(parts.length > 1 ? (parts[1]?.[0] ?? '') : '').toUpperCase() || '?';
+/** Good enough to catch a typo before we spend an invitation on it. */
+function isEmail(value: string): boolean {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
 }
 
 /**
- * Make an existing institute team member (staff) a mentor: pick them from the
- * team, optionally set a mentor photo / display name / title / bio.
+ * Expertise, capacity, photo and titles are all optional and editable afterwards,
+ * so they start folded. The dialog then asks one question — who is this? — and
+ * only expands for an admin who wants to fill the rest in now.
+ */
+function OptionalDetails({
+    open,
+    onToggle,
+    children,
+}: {
+    open: boolean;
+    onToggle: () => void;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="flex flex-col gap-3">
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={open}
+                className="flex w-fit items-center gap-1.5 text-caption font-medium text-primary-600 hover:text-primary-700"
+            >
+                <CaretRight
+                    size={12}
+                    weight="bold"
+                    className={`transition-transform ${open ? 'rotate-90' : ''}`}
+                />
+                {open ? 'Hide details' : 'Add photo, expertise and capacity'}
+            </button>
+            {open && <div className="flex flex-col gap-4">{children}</div>}
+        </div>
+    );
+}
+
+function initials(name?: string | null): string {
+    if (!name) return '?';
+    const parts = name.trim().split(/\s+/);
+    return (
+        (parts[0]?.[0] ?? '').concat(parts.length > 1 ? parts[1]?.[0] ?? '' : '').toUpperCase() ||
+        '?'
+    );
+}
+
+/**
+ * Add a mentor, from either direction:
+ *   - someone already on the team, picked from the list, or
+ *   - someone who isn't yet, invited by name + email right here.
+ *
+ * The invite path exists because the alternative was a detour: leave mentorship,
+ * go to Teams, invite the person, wait, come back, find them. It reuses the
+ * platform's own invitation endpoint with the MENTOR role, which creates the user
+ * immediately and returns its id — so the mentor row is created in the same step
+ * and the person appears in the list straight away, pending their acceptance.
  */
 export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDialogProps) {
+    const [mode, setMode] = useState<'team' | 'invite'>('team');
+    // Everything past "who is it" is optional and editable later, so the dialog
+    // opens short and only grows if the admin asks it to.
+    const [showDetails, setShowDetails] = useState(false);
+    const [inviteName, setInviteName] = useState('');
+    const [inviteEmail, setInviteEmail] = useState('');
     const [search, setSearch] = useState('');
     const [selected, setSelected] = useState<InstituteUser | null>(null);
     const [displayName, setDisplayName] = useState('');
@@ -78,6 +134,10 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
         setPhotoFileId(null);
         setPhotoUrl(null);
         setProfile({ expertiseTags: [], maxMentees: '', isDiscoverable: false });
+        setMode('team');
+        setShowDetails(false);
+        setInviteName('');
+        setInviteEmail('');
     };
 
     const pick = async (m: InstituteUser) => {
@@ -123,16 +183,40 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
     };
 
     const submit = async () => {
-        if (!selected) {
+        if (mode === 'team' && !selected) {
             toast.error('Select a team member');
+            return;
+        }
+        if (mode === 'invite' && (!inviteName.trim() || !isEmail(inviteEmail))) {
+            toast.error('Enter a name and a valid email address');
             return;
         }
         setSubmitting(true);
         try {
+            // Inviting first yields the new user's id, which the mentor row needs.
+            // If the invite succeeds but the mentor row fails, the person is left as
+            // an invited team member — recoverable by adding them from the team list,
+            // and better than silently losing the invitation.
+            const userId =
+                mode === 'team'
+                    ? selected!.id
+                    : ((
+                          await handleInviteUsers(instituteId, {
+                              name: inviteName.trim(),
+                              email: inviteEmail.trim(),
+                              roleType: ['MENTOR'],
+                          })
+                      )?.id as string | undefined);
+
+            if (!userId) {
+                throw new Error('The invitation did not return a user to add as a mentor');
+            }
+
             await createMentor.mutateAsync({
                 institute_id: instituteId,
-                user_id: selected.id,
-                display_name: displayName || selected.full_name,
+                user_id: userId,
+                display_name:
+                    displayName || (mode === 'team' ? selected!.full_name : inviteName.trim()),
                 title,
                 bio,
                 profile_image_file_id: photoFileId || undefined,
@@ -141,7 +225,11 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                     profile.maxMentees.trim() === '' ? undefined : Number(profile.maxMentees),
                 is_discoverable: profile.isDiscoverable,
             });
-            toast.success('Mentor added');
+            toast.success(
+                mode === 'invite'
+                    ? `Invitation sent to ${inviteEmail.trim()} — they're a mentor already`
+                    : 'Mentor added'
+            );
             reset();
             onOpenChange(false);
         } catch (error) {
@@ -150,8 +238,9 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
             reportApiError(error, {
                 feature: 'mentorship',
                 tags: { 'mentorship.action': 'create-mentor' },
-                extra: { userId: selected.id },
-                fallbackMessage: 'Failed to add mentor',
+                extra: { mode, userId: selected?.id },
+                fallbackMessage:
+                    mode === 'invite' ? 'Failed to invite this mentor' : 'Failed to add mentor',
             });
         } finally {
             setSubmitting(false);
@@ -169,7 +258,12 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
             dialogWidth="max-w-lg"
             footer={
                 <div className="flex justify-end gap-2">
-                    <MyButton type="button" buttonType="secondary" scale="medium" onClick={() => onOpenChange(false)}>
+                    <MyButton
+                        type="button"
+                        buttonType="secondary"
+                        scale="medium"
+                        onClick={() => onOpenChange(false)}
+                    >
                         Cancel
                     </MyButton>
                     <MyButton
@@ -177,40 +271,112 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                         buttonType="primary"
                         scale="medium"
                         onClick={submit}
-                        disable={submitting || !selected}
-                        title={!selected ? 'Choose a team member above first' : undefined}
+                        disable={
+                            submitting ||
+                            (mode === 'team'
+                                ? !selected
+                                : !inviteName.trim() || !isEmail(inviteEmail))
+                        }
+                        title={
+                            mode === 'team' && !selected
+                                ? 'Choose a team member above first'
+                                : undefined
+                        }
                     >
-                        {submitting ? 'Adding…' : 'Add mentor'}
+                        {submitting
+                            ? mode === 'invite'
+                                ? 'Inviting…'
+                                : 'Adding…'
+                            : mode === 'invite'
+                              ? 'Invite as mentor'
+                              : 'Add mentor'}
                     </MyButton>
                 </div>
             }
         >
             <div className="flex flex-col gap-4">
                 <p className="text-body text-neutral-600">
-                    Pick a member of your institute&apos;s team to make them a mentor. They get the
-                    Mentor role and appear to their assigned students.
+                    Mentors get the Mentor role and appear to the students you assign them.
                 </p>
 
-                {!selected ? (
+                {!selected && (
+                    <div className="flex gap-1 rounded-lg bg-neutral-100 p-1">
+                        {(
+                            [
+                                { key: 'team', label: 'From your team' },
+                                { key: 'invite', label: 'Invite by email' },
+                            ] as const
+                        ).map((t) => (
+                            <button
+                                key={t.key}
+                                type="button"
+                                onClick={() => setMode(t.key)}
+                                className={`flex-1 rounded-md px-3 py-1.5 text-body transition-colors ${
+                                    mode === t.key
+                                        ? 'bg-white font-medium text-neutral-700 shadow-sm'
+                                        : 'text-neutral-500 hover:text-neutral-700'
+                                }`}
+                            >
+                                {t.label}
+                            </button>
+                        ))}
+                    </div>
+                )}
+
+                {mode === 'invite' && !selected && (
+                    <div className="flex flex-col gap-3">
+                        <p className="text-caption text-neutral-500">
+                            They&apos;ll get an invitation email and the Mentor role, and appear in
+                            this list right away — no need to go to Teams first.
+                        </p>
+                        <MyInput
+                            input={inviteName}
+                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                setInviteName(e.target.value)
+                            }
+                            inputType="text"
+                            inputPlaceholder="e.g. Asha Nair"
+                            label="Full name"
+                            required
+                            className="sm:w-full"
+                        />
+                        <MyInput
+                            input={inviteEmail}
+                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                setInviteEmail(e.target.value)
+                            }
+                            inputType="email"
+                            inputPlaceholder="asha@example.com"
+                            label="Email"
+                            required
+                            className="sm:w-full"
+                        />
+                    </div>
+                )}
+
+                {mode === 'team' && !selected ? (
                     <div className="flex flex-col gap-2">
-                        <span className="text-caption font-semibold uppercase tracking-wide text-neutral-400">
-                            Choose a team member
-                        </span>
                         <MyInput
                             input={search}
-                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                setSearch(e.target.value)
+                            }
                             inputType="text"
                             inputPlaceholder="Search your team by name or email"
-                            label="Team member"
+                            className="sm:w-full"
                         />
                         <div className="max-h-64 overflow-y-auto rounded-md border border-neutral-200">
                             {membersQuery.isLoading ? (
                                 <div className="p-4 text-body text-neutral-400">Loading team…</div>
                             ) : membersQuery.isError ? (
-                                <div className="p-4 text-body text-danger-600">Couldn&apos;t load your team.</div>
+                                <div className="p-4 text-body text-danger-600">
+                                    Couldn&apos;t load your team.
+                                </div>
                             ) : filtered.length === 0 ? (
                                 <div className="p-4 text-body text-neutral-400">
-                                    {members.length === 0 ? 'No team members found.' : 'No matches.'}
+                                    {members.length === 0
+                                        ? 'No team members found.'
+                                        : 'No matches.'}
                                 </div>
                             ) : (
                                 filtered.map((m) => (
@@ -229,7 +395,9 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                                             </span>
                                             <span className="text-caption text-neutral-400">
                                                 {m.email}
-                                                {m.roles && m.roles.length ? ` · ${m.roles.join(', ')}` : ''}
+                                                {m.roles && m.roles.length
+                                                    ? ` · ${m.roles.join(', ')}`
+                                                    : ''}
                                             </span>
                                         </span>
                                     </button>
@@ -237,7 +405,11 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                             )}
                         </div>
                     </div>
-                ) : (
+                ) : mode === 'invite' ? (
+                    <OptionalDetails open={showDetails} onToggle={() => setShowDetails((v) => !v)}>
+                        <MentorProfileFields values={profile} onChange={setProfile} />
+                    </OptionalDetails>
+                ) : selected ? (
                     <>
                         <div className="flex items-center justify-between gap-3 rounded-md border border-primary-200 bg-primary-50 px-3 py-2">
                             <div className="flex items-center gap-2">
@@ -246,7 +418,9 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                                     <span className="text-body font-medium text-neutral-700">
                                         {selected.full_name || selected.email}
                                     </span>
-                                    <span className="text-caption text-neutral-400">{selected.email}</span>
+                                    <span className="text-caption text-neutral-400">
+                                        {selected.email}
+                                    </span>
                                 </div>
                             </div>
                             <MyButton
@@ -260,73 +434,85 @@ export function AddMentorDialog({ instituteId, open, onOpenChange }: AddMentorDi
                             </MyButton>
                         </div>
 
-                        <span className="text-caption font-semibold uppercase tracking-wide text-neutral-400">
-                            Mentor profile
-                        </span>
-                        <p className="-mt-2 text-caption text-neutral-400">
-                            How this mentor appears to their assigned students.
-                        </p>
+                        <OptionalDetails
+                            open={showDetails}
+                            onToggle={() => setShowDetails((v) => !v)}
+                        >
+                            <div className="flex items-center gap-4">
+                                <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-neutral-100">
+                                    {photoUrl ? (
+                                        <img
+                                            src={photoUrl}
+                                            alt="Mentor"
+                                            className="h-full w-full object-cover"
+                                        />
+                                    ) : (
+                                        <UserCircle size={40} className="text-neutral-300" />
+                                    )}
+                                </div>
+                                <div className="flex flex-col gap-1">
+                                    <MyButton
+                                        type="button"
+                                        buttonType="secondary"
+                                        scale="small"
+                                        onClick={() => fileInputRef.current?.click()}
+                                        disable={uploadingPhoto}
+                                    >
+                                        <UploadSimple size={16} />{' '}
+                                        {uploadingPhoto
+                                            ? 'Uploading…'
+                                            : photoUrl
+                                              ? 'Change photo'
+                                              : 'Upload photo'}
+                                    </MyButton>
+                                    <span className="text-caption text-neutral-400">
+                                        Optional. Defaults to their team profile photo.
+                                    </span>
+                                </div>
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    className="hidden"
+                                    onChange={onPhotoChange}
+                                />
+                            </div>
 
-                        <div className="flex items-center gap-4">
-                            <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-neutral-100">
-                                {photoUrl ? (
-                                    <img src={photoUrl} alt="Mentor" className="h-full w-full object-cover" />
-                                ) : (
-                                    <UserCircle size={40} className="text-neutral-300" />
-                                )}
-                            </div>
-                            <div className="flex flex-col gap-1">
-                                <MyButton
-                                    type="button"
-                                    buttonType="secondary"
-                                    scale="small"
-                                    onClick={() => fileInputRef.current?.click()}
-                                    disable={uploadingPhoto}
-                                >
-                                    <UploadSimple size={16} />{' '}
-                                    {uploadingPhoto ? 'Uploading…' : photoUrl ? 'Change photo' : 'Upload photo'}
-                                </MyButton>
-                                <span className="text-caption text-neutral-400">
-                                    Optional. Defaults to their team profile photo.
-                                </span>
-                            </div>
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                accept="image/*"
-                                className="hidden"
-                                onChange={onPhotoChange}
+                            <MyInput
+                                input={displayName}
+                                onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setDisplayName(e.target.value)
+                                }
+                                inputType="text"
+                                inputPlaceholder={selected.full_name || 'Display name'}
+                                label="Display name"
+                                className="sm:w-full"
                             />
-                        </div>
+                            <MyInput
+                                input={title}
+                                onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setTitle(e.target.value)
+                                }
+                                inputType="text"
+                                inputPlaceholder="e.g. Senior Career Mentor"
+                                label="Title"
+                                className="sm:w-full"
+                            />
+                            <MyInput
+                                input={bio}
+                                onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setBio(e.target.value)
+                                }
+                                inputType="text"
+                                inputPlaceholder="Short bio (optional)"
+                                label="Bio"
+                                className="sm:w-full"
+                            />
 
-                        <MyInput
-                            input={displayName}
-                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) => setDisplayName(e.target.value)}
-                            inputType="text"
-                            inputPlaceholder={selected.full_name || 'Display name'}
-                            label="Display name"
-                            className="sm:w-full"
-                        />
-                        <MyInput
-                            input={title}
-                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
-                            inputType="text"
-                            inputPlaceholder="e.g. Senior Career Mentor"
-                            label="Title"
-                            className="sm:w-full"
-                        />
-                        <MyInput
-                            input={bio}
-                            onChangeFunction={(e: React.ChangeEvent<HTMLInputElement>) => setBio(e.target.value)}
-                            inputType="text"
-                            inputPlaceholder="Short bio (optional)"
-                            label="Bio"
-                            className="sm:w-full"
-                        />
-
-                        <MentorProfileFields values={profile} onChange={setProfile} />
+                            <MentorProfileFields values={profile} onChange={setProfile} />
+                        </OptionalDetails>
                     </>
-                )}
+                ) : null}
             </div>
         </MyDialog>
     );

--- a/frontend-admin-dashboard/src/routes/mentorship/-components/MentorChips.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/-components/MentorChips.tsx
@@ -9,16 +9,9 @@ export function RatingChip({ mentor, onClick }: { mentor: MentorDTO; onClick: ()
     const avg = mentor.average_rating;
     const count = mentor.rating_count ?? 0;
 
-    if (avg == null || count === 0) {
-        return (
-            <span
-                className="rounded-full bg-neutral-100 px-2.5 py-1 text-caption text-neutral-400"
-                title="No sessions rated yet — learners are asked after a session takes place"
-            >
-                Not rated
-            </span>
-        );
-    }
+    // Nothing is drawn for an unrated mentor: a row of greyed "Not rated" chips is
+    // noise, and the absence of a score already carries the same meaning.
+    if (avg == null || count === 0) return null;
     return (
         <button
             type="button"
@@ -45,7 +38,7 @@ export function CapacityChip({ mentor }: { mentor: MentorDTO }) {
     if (!cap) {
         return (
             <span
-                className="rounded-full bg-neutral-100 px-2.5 py-1 text-caption text-neutral-500"
+                className="shrink-0 rounded-full bg-neutral-100 px-2.5 py-1 text-caption text-neutral-500"
                 title="Students currently assigned to this mentor (no limit set)"
             >
                 {count} students
@@ -63,14 +56,15 @@ export function CapacityChip({ mentor }: { mentor: MentorDTO }) {
 
     return (
         <span
-            className={`rounded-full px-2.5 py-1 text-caption ${tone}`}
+            className={`shrink-0 rounded-full px-2.5 py-1 text-caption ${tone}`}
             title={
                 full
                     ? `At capacity — no new students can be assigned until the limit is raised or a mentee is unassigned`
                     : `${cap - count} of ${cap} places still open`
             }
         >
-            {count}/{cap} students{full ? ' · Full' : ''}
+            {count}/{cap}
+            {full ? ' · full' : ' students'}
         </span>
     );
 }

--- a/frontend-admin-dashboard/src/routes/mentorship/-components/MentorSessionsPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/-components/MentorSessionsPanel.tsx
@@ -3,6 +3,7 @@ import {
     CalendarBlank,
     CheckCircle,
     Clock,
+    CaretRight,
     Star,
     UserMinus,
     VideoCamera,
@@ -13,7 +14,9 @@ import { MyButton } from '@/components/design-system/button';
 import { MyDialog } from '@/components/design-system/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useMentorSessions } from '../-hooks/use-mentorship';
+import { dayOfMonth, sessionDateTime, shortMonth, timeOfDay } from '../-utils/format-session-time';
 import { SessionActionDialog } from './SessionActionDialog';
+import { MentorAvatar } from './MentorAvatar';
 import type { MentorSessionDTO } from '../-types/mentorship-types';
 
 /** The lifecycle states an admin filters by, in the order they matter. */
@@ -25,12 +28,6 @@ const FILTERS = [
     { key: 'NO_SHOW', label: 'No-shows' },
     { key: 'CANCELLED', label: 'Cancelled' },
 ] as const;
-
-function fmtDateTime(v?: number | null): string {
-    if (!v) return '—';
-    const d = new Date(v);
-    return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString();
-}
 
 /**
  * Every mentorship session in one place: who, when, what happened, and how the
@@ -117,19 +114,45 @@ export function MentorSessionsPanel({
                             key={s.booking_instance_id}
                             type="button"
                             onClick={() => setDetail(s)}
-                            className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-white p-4 text-left hover:border-primary-200 hover:bg-primary-50/30"
+                            className="group flex w-full flex-wrap items-center gap-4 rounded-xl border border-neutral-200 bg-white p-3 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/30"
                         >
-                            <div className="flex min-w-0 flex-col gap-0.5">
-                                <span className="truncate text-body font-medium text-neutral-700">
-                                    {s.mentor_name || 'Mentor'} &rarr; {s.student_name || 'Learner'}
+                            {/* Leading date block — turns a wall of rows into something scannable. */}
+                            <span className="flex size-12 shrink-0 flex-col items-center justify-center rounded-lg bg-neutral-50 leading-none text-neutral-600 group-hover:bg-white">
+                                <span className="text-body font-semibold tabular-nums">
+                                    {dayOfMonth(s.scheduled_start_utc)}
                                 </span>
-                                <span className="truncate text-caption text-neutral-500">
-                                    {fmtDateTime(s.scheduled_start_utc)}
+                                <span className="text-caption font-medium tracking-wide text-neutral-400">
+                                    {shortMonth(s.scheduled_start_utc)}
+                                </span>
+                            </span>
+
+                            <span className="flex min-w-0 flex-1 basis-1/2 flex-col gap-1">
+                                <span className="flex min-w-0 items-center gap-1.5">
+                                    <MentorAvatar
+                                        fileId={null}
+                                        name={s.mentor_name}
+                                        className="size-5 shrink-0 text-caption"
+                                    />
+                                    <span className="truncate text-body font-medium text-neutral-700">
+                                        {s.mentor_name || 'Mentor'}
+                                    </span>
+                                    <CaretRight
+                                        size={11}
+                                        weight="bold"
+                                        className="shrink-0 text-neutral-300"
+                                    />
+                                    <span className="truncate text-body text-neutral-600">
+                                        {s.student_name || 'Learner'}
+                                    </span>
+                                </span>
+                                <span className="truncate text-caption text-neutral-400">
+                                    {timeOfDay(s.scheduled_start_utc)}
                                     {s.duration_minutes ? ` · ${s.duration_minutes} min` : ''}
                                     {s.topic ? ` · ${s.topic}` : ''}
                                 </span>
-                            </div>
-                            <div className="flex shrink-0 items-center gap-2">
+                            </span>
+
+                            <span className="flex w-full shrink-0 items-center gap-2 sm:w-auto">
                                 {s.lifecycle === 'UPCOMING' && (
                                     <>
                                         <MyButton
@@ -167,7 +190,7 @@ export function MentorSessionsPanel({
                                     </span>
                                 )}
                                 <LifecycleBadge lifecycle={s.lifecycle} />
-                            </div>
+                            </span>
                         </button>
                     ))}
                 </div>
@@ -267,7 +290,7 @@ function SessionDetailDialog({
                         value={session.student_name}
                         sub={session.student_email}
                     />
-                    <Field label="When" value={fmtDateTime(session.scheduled_start_utc)} />
+                    <Field label="When" value={sessionDateTime(session.scheduled_start_utc)} />
                     <Field
                         label="Duration"
                         value={session.duration_minutes ? `${session.duration_minutes} min` : '—'}

--- a/frontend-admin-dashboard/src/routes/mentorship/-components/MentorshipDashboard.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/-components/MentorshipDashboard.tsx
@@ -7,6 +7,7 @@ import {
     GraduationCap,
     Star,
     UserMinus,
+    TrayArrowDown,
     UsersThree,
     WarningCircle,
     XCircle,
@@ -17,6 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { MyButton } from '@/components/design-system/button';
 import { cn } from '@/lib/utils';
 import { useMentorDashboard, useMentorSessions } from '../-hooks/use-mentorship';
+import { dayOfMonth, relativeDay, shortMonth, timeOfDay } from '../-utils/format-session-time';
 import type { MentorDTO } from '../-types/mentorship-types';
 import { MentorAvatar } from './MentorAvatar';
 
@@ -63,6 +65,7 @@ export function MentorshipDashboard({ instituteId }: { instituteId: string | und
     const attention = [
         {
             key: 'requests',
+            icon: TrayArrowDown,
             count: data?.pending_requests ?? 0,
             label: 'learner waiting to be paired with a mentor',
             pluralLabel: 'learners waiting to be paired with a mentor',
@@ -71,6 +74,7 @@ export function MentorshipDashboard({ instituteId }: { instituteId: string | und
         },
         {
             key: 'awaiting',
+            icon: Clock,
             count: data?.sessions_awaiting_review ?? 0,
             label: 'session held but not recorded — it counts nowhere until it is',
             pluralLabel: 'sessions held but not recorded — they count nowhere until they are',
@@ -116,30 +120,32 @@ export function MentorshipDashboard({ instituteId }: { instituteId: string | und
             </section>
 
             {attention.length > 0 && (
-                <section className="flex flex-col gap-2">
-                    {attention.map((a) => (
-                        <div
-                            key={a.key}
-                            className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-warning-200 bg-warning-50 px-4 py-3"
-                        >
-                            <span className="flex items-center gap-2 text-body text-neutral-700">
-                                <Clock
-                                    size={16}
-                                    weight="fill"
-                                    className="shrink-0 text-warning-600"
-                                />
-                                <span>
-                                    <b>{a.count}</b> {a.count === 1 ? a.label : a.pluralLabel}
+                <Card className="flex flex-col divide-y divide-warning-100 border-warning-200 bg-warning-50/60 p-0 shadow-sm">
+                    {attention.map((a) => {
+                        const AttentionIcon = a.icon;
+                        return (
+                            <div
+                                key={a.key}
+                                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+                            >
+                                <span className="flex items-center gap-2.5 text-body text-neutral-700">
+                                    <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-warning-100 text-warning-700">
+                                        <AttentionIcon size={14} weight="fill" />
+                                    </span>
+                                    <span>
+                                        <b className="tabular-nums">{a.count}</b>{' '}
+                                        {a.count === 1 ? a.label : a.pluralLabel}
+                                    </span>
                                 </span>
-                            </span>
-                            <Link to={a.to}>
-                                <MyButton type="button" buttonType="secondary" scale="small">
-                                    {a.cta}
-                                </MyButton>
-                            </Link>
-                        </div>
-                    ))}
-                </section>
+                                <Link to={a.to}>
+                                    <MyButton type="button" buttonType="secondary" scale="small">
+                                        {a.cta}
+                                    </MyButton>
+                                </Link>
+                            </div>
+                        );
+                    })}
+                </Card>
             )}
 
             <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-2">
@@ -348,12 +354,20 @@ function WorkloadCard({ mentors, loading }: { mentors: MentorDTO[]; loading: boo
                                         <div
                                             className={cn(
                                                 'h-full rounded-full',
-                                                full ? 'bg-danger-500' : 'bg-primary-500'
+                                                full
+                                                    ? 'bg-danger-500'
+                                                    : cap
+                                                      ? 'bg-primary-500'
+                                                      : 'bg-primary-300'
                                             )}
-                                            // Data-driven width; floored at 2% so a
-                                            // mentor with one student still shows a mark.
+                                            // Data-driven width. With a cap this is a true
+                                            // fill; without one it is only relative to the
+                                            // busiest mentor, so it tops out at 80% — a full
+                                            // bar would imply a limit that doesn't exist.
                                             style={{
-                                                width: `${Math.max(2, (count / (cap ?? peak)) * 100)}%`,
+                                                width: cap
+                                                    ? `${Math.max(2, (count / cap) * 100)}%`
+                                                    : `${Math.max(2, (count / peak) * 80)}%`,
                                             }}
                                         />
                                     </div>
@@ -398,24 +412,28 @@ function UpcomingCard({
                     <CalendarBlank size={14} /> Nothing booked yet.
                 </p>
             ) : (
-                <ul className="flex flex-col divide-y divide-neutral-100">
+                <ul className="flex flex-col gap-2">
                     {sessions.slice(0, 5).map((s) => (
                         <li
                             key={s.booking_instance_id}
-                            className="flex flex-wrap items-center justify-between gap-2 py-2 first:pt-0 last:pb-0"
+                            className="flex items-center gap-3 rounded-lg bg-neutral-50 p-2"
                         >
-                            <span className="truncate text-caption text-neutral-700">
-                                {s.mentor_name || 'Mentor'} &rarr; {s.student_name || 'Learner'}
+                            <span className="flex size-9 shrink-0 flex-col items-center justify-center rounded-md bg-white leading-none text-neutral-600">
+                                <span className="text-caption font-semibold tabular-nums">
+                                    {dayOfMonth(s.scheduled_start_utc)}
+                                </span>
+                                <span className="text-caption font-medium leading-none tracking-wide text-neutral-400">
+                                    {shortMonth(s.scheduled_start_utc)}
+                                </span>
                             </span>
-                            <span className="shrink-0 text-caption tabular-nums text-neutral-400">
-                                {s.scheduled_start_utc
-                                    ? new Date(s.scheduled_start_utc).toLocaleString(undefined, {
-                                          day: 'numeric',
-                                          month: 'short',
-                                          hour: 'numeric',
-                                          minute: '2-digit',
-                                      })
-                                    : ''}
+                            <span className="flex min-w-0 flex-1 flex-col">
+                                <span className="truncate text-caption text-neutral-700">
+                                    {s.mentor_name || 'Mentor'} &rarr; {s.student_name || 'Learner'}
+                                </span>
+                                <span className="text-caption text-neutral-400">
+                                    {relativeDay(s.scheduled_start_utc)} ·{' '}
+                                    {timeOfDay(s.scheduled_start_utc)}
+                                </span>
                             </span>
                         </li>
                     ))}

--- a/frontend-admin-dashboard/src/routes/mentorship/-components/MentorshipTabs.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/-components/MentorshipTabs.tsx
@@ -1,0 +1,52 @@
+import { Link, useLocation } from '@tanstack/react-router';
+import { cn } from '@/lib/utils';
+
+/**
+ * One header for the whole admin mentorship area.
+ *
+ * Overview, Mentors, Sessions and Requests are four views of the same thing, and
+ * four sidebar entries made you decide where to go before you knew what you wanted.
+ * They now live behind a single "Mentorship" entry with tabs here, which is both
+ * fewer decisions and a clearer mental model: one area, four lenses.
+ *
+ * "My Mentorship" deliberately stays separate — it belongs to a different person
+ * (the mentor looking at their own mentees), not the admin looking at everyone.
+ */
+const TABS = [
+    { to: '/mentorship/dashboard', label: 'Overview' },
+    { to: '/mentorship/mentors', label: 'Mentors' },
+    { to: '/mentorship/sessions', label: 'Sessions' },
+    { to: '/mentorship/requests', label: 'Requests' },
+] as const;
+
+export function MentorshipTabs({ badge }: { badge?: { requests?: number } }) {
+    const { pathname } = useLocation();
+
+    return (
+        <nav className="flex flex-wrap gap-1 border-b border-neutral-200" aria-label="Mentorship">
+            {TABS.map((tab) => {
+                const active = pathname.startsWith(tab.to);
+                const count = tab.to.endsWith('/requests') ? badge?.requests ?? 0 : 0;
+                return (
+                    <Link
+                        key={tab.to}
+                        to={tab.to}
+                        className={cn(
+                            '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-body transition-colors',
+                            active
+                                ? 'border-primary-500 font-medium text-primary-600'
+                                : 'border-transparent text-neutral-500 hover:text-neutral-700'
+                        )}
+                    >
+                        {tab.label}
+                        {count > 0 && (
+                            <span className="rounded-full bg-danger-100 px-1.5 py-0.5 text-caption font-medium text-danger-600">
+                                {count}
+                            </span>
+                        )}
+                    </Link>
+                );
+            })}
+        </nav>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/mentorship/-utils/format-session-time.ts
+++ b/frontend-admin-dashboard/src/routes/mentorship/-utils/format-session-time.ts
@@ -1,0 +1,71 @@
+/**
+ * Session date/time formatting, in one place so every mentorship surface agrees.
+ *
+ * `toLocaleString()` on its own produces "8/14/2026, 2:30:00 PM" — numeric, with
+ * seconds nobody needs, and ambiguous between day/month conventions. These give a
+ * scannable form instead, and split the parts so a row can lay a date block beside
+ * the detail rather than running it all into one line.
+ */
+
+const isValid = (d: Date) => !Number.isNaN(d.getTime());
+
+/** Day number, e.g. "14". */
+export function dayOfMonth(epochMillis?: number | null): string {
+    if (!epochMillis) return '–';
+    const d = new Date(epochMillis);
+    return isValid(d) ? String(d.getDate()) : '–';
+}
+
+/** Short month, upper-cased for the date block, e.g. "AUG". */
+export function shortMonth(epochMillis?: number | null): string {
+    if (!epochMillis) return '';
+    const d = new Date(epochMillis);
+    return isValid(d) ? d.toLocaleString(undefined, { month: 'short' }).toUpperCase() : '';
+}
+
+/** Time only, e.g. "2:30 PM" — no seconds. */
+export function timeOfDay(epochMillis?: number | null): string {
+    if (!epochMillis) return '';
+    const d = new Date(epochMillis);
+    return isValid(d)
+        ? d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+        : '';
+}
+
+/** Weekday + date, e.g. "Thu 14 Aug". Year only when it isn't the current one. */
+export function dayAndMonth(epochMillis?: number | null): string {
+    if (!epochMillis) return '';
+    const d = new Date(epochMillis);
+    if (!isValid(d)) return '';
+    const sameYear = d.getFullYear() === new Date().getFullYear();
+    return d.toLocaleDateString(undefined, {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+        ...(sameYear ? {} : { year: 'numeric' }),
+    });
+}
+
+/** Full "Thu 14 Aug, 2:30 PM" for detail views and single-line summaries. */
+export function sessionDateTime(epochMillis?: number | null): string {
+    if (!epochMillis) return '—';
+    const date = dayAndMonth(epochMillis);
+    const time = timeOfDay(epochMillis);
+    return date && time ? `${date}, ${time}` : date || time || '—';
+}
+
+/**
+ * Relative day label for grouping — "Today" / "Tomorrow" / "Yesterday", else the
+ * date. Lets a list say when something is without the reader doing date arithmetic.
+ */
+export function relativeDay(epochMillis?: number | null): string {
+    if (!epochMillis) return '';
+    const d = new Date(epochMillis);
+    if (!isValid(d)) return '';
+    const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+    const days = Math.round((startOf(d) - startOf(new Date())) / 86_400_000);
+    if (days === 0) return 'Today';
+    if (days === 1) return 'Tomorrow';
+    if (days === -1) return 'Yesterday';
+    return dayAndMonth(epochMillis);
+}

--- a/frontend-admin-dashboard/src/routes/mentorship/dashboard/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/dashboard/index.lazy.tsx
@@ -4,6 +4,7 @@ import { LayoutContainer } from '@/components/common/layout-container/layout-con
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { getInstituteId } from '@/constants/helper';
 import { MentorshipDashboard } from '../-components/MentorshipDashboard';
+import { MentorshipTabs } from '../-components/MentorshipTabs';
 
 export const Route = createLazyFileRoute('/mentorship/dashboard/')({
     component: MentorshipDashboardRoute,
@@ -24,6 +25,7 @@ function MentorshipDashboardRoute() {
                         How mentoring is going across your institute.
                     </p>
                 </div>
+                <MentorshipTabs />
                 <MentorshipDashboard instituteId={getInstituteId()} />
             </div>
         </LayoutContainer>

--- a/frontend-admin-dashboard/src/routes/mentorship/mentors/add-mentor-dialog.test.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/mentors/add-mentor-dialog.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const inviteUsers = vi.fn(async () => ({ id: 'new-user-1' }));
+const createMentor = vi.fn(async () => ({}));
+const fetchEligibleOrgUsers = vi.fn(async () => [
+    { id: 'u1', full_name: 'Asha Nair', email: 'asha@example.com', roles: ['TEACHER'] },
+]);
+const reportApiError = vi.fn();
+
+vi.mock('@/routes/dashboard/-services/dashboard-services', () => ({
+    handleInviteUsers: (...a: unknown[]) => inviteUsers(...(a as [])),
+}));
+vi.mock('@/routes/manage-institute/teams/-services/institute-users-service', () => ({
+    fetchEligibleOrgUsers: (...a: unknown[]) => fetchEligibleOrgUsers(...(a as [])),
+}));
+vi.mock('@/routes/mentorship/-hooks/use-mentorship', () => ({
+    useCreateMentor: () => ({ mutateAsync: createMentor, isPending: false }),
+}));
+vi.mock('@/hooks/use-file-upload', () => ({
+    useFileUpload: () => ({ uploadFile: vi.fn(), getPublicUrl: vi.fn(async () => '') }),
+}));
+vi.mock('@/lib/report-api-error', () => ({
+    reportApiError: (...a: unknown[]) => reportApiError(...(a as [])),
+}));
+vi.mock('@/utils/userDetails', () => ({ getUserId: () => 'admin-1' }));
+
+import { AddMentorDialog } from '@/routes/mentorship/-components/AddMentorDialog';
+
+function open() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <QueryClientProvider client={client}>
+            <AddMentorDialog instituteId="inst-1" open onOpenChange={vi.fn()} />
+        </QueryClientProvider>
+    );
+}
+
+const inviteMode = () => fireEvent.click(screen.getByRole('button', { name: 'Invite by email' }));
+const type = (placeholder: string, value: string) =>
+    fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+
+describe('AddMentorDialog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('opens on the team picker, so the common path costs no extra clicks', async () => {
+        open();
+        expect(await screen.findByText('Asha Nair')).toBeInTheDocument();
+        expect(screen.queryByPlaceholderText('asha@example.com')).not.toBeInTheDocument();
+    });
+
+    it('keeps the optional profile fields folded away until asked', async () => {
+        open();
+        fireEvent.click(await screen.findByRole('button', { name: /Asha Nair/ }));
+
+        expect(screen.queryByLabelText('Display name')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: /Add photo, expertise and capacity/ }));
+        expect(screen.getByPlaceholderText('e.g. Senior Career Mentor')).toBeInTheDocument();
+    });
+
+    it('invites an external mentor without a trip to the Teams tab', async () => {
+        open();
+        inviteMode();
+        type('e.g. Asha Nair', 'Ravi Kumar');
+        type('asha@example.com', 'ravi@example.com');
+        fireEvent.click(screen.getByRole('button', { name: 'Invite as mentor' }));
+
+        await waitFor(() => expect(inviteUsers).toHaveBeenCalled());
+        // The invite must carry the mentor role, else they land as a plain team member.
+        expect(inviteUsers).toHaveBeenCalledWith('inst-1', {
+            name: 'Ravi Kumar',
+            email: 'ravi@example.com',
+            roleType: ['MENTOR'],
+        });
+        // …and the returned user id is what the mentor row is created against.
+        await waitFor(() =>
+            expect(createMentor).toHaveBeenCalledWith(
+                expect.objectContaining({ user_id: 'new-user-1', display_name: 'Ravi Kumar' })
+            )
+        );
+    });
+
+    it('will not spend an invitation on a malformed email', async () => {
+        open();
+        inviteMode();
+        type('e.g. Asha Nair', 'Ravi Kumar');
+        type('asha@example.com', 'ravi@');
+
+        const submit = screen.getByRole('button', { name: 'Invite as mentor' });
+        fireEvent.click(submit);
+        expect(inviteUsers).not.toHaveBeenCalled();
+    });
+
+    it('never creates a mentor row when the invitation returns no user', async () => {
+        inviteUsers.mockResolvedValueOnce(undefined as never);
+        open();
+        inviteMode();
+        type('e.g. Asha Nair', 'Ravi Kumar');
+        type('asha@example.com', 'ravi@example.com');
+        fireEvent.click(screen.getByRole('button', { name: 'Invite as mentor' }));
+
+        await waitFor(() => expect(reportApiError).toHaveBeenCalled());
+        expect(createMentor).not.toHaveBeenCalled();
+    });
+
+    it('keeps what was typed when the admin flips modes to check the team list', async () => {
+        open();
+        inviteMode();
+        type('e.g. Asha Nair', 'Ravi Kumar');
+
+        fireEvent.click(screen.getByRole('button', { name: 'From your team' }));
+        expect(await screen.findByText('Asha Nair')).toBeInTheDocument();
+
+        inviteMode();
+        expect((screen.getByPlaceholderText('e.g. Asha Nair') as HTMLInputElement).value).toBe(
+            'Ravi Kumar'
+        );
+    });
+
+    it('a team-mode add ignores anything left in the invite fields', async () => {
+        open();
+        inviteMode();
+        type('e.g. Asha Nair', 'Ravi Kumar');
+        type('asha@example.com', 'ravi@example.com');
+
+        fireEvent.click(screen.getByRole('button', { name: 'From your team' }));
+        fireEvent.click(await screen.findByRole('button', { name: /Asha Nair/ }));
+        fireEvent.click(screen.getByRole('button', { name: 'Add mentor' }));
+
+        await waitFor(() => expect(createMentor).toHaveBeenCalled());
+        expect(inviteUsers).not.toHaveBeenCalled();
+        expect(createMentor).toHaveBeenCalledWith(
+            expect.objectContaining({ user_id: 'u1', display_name: 'Asha Nair' })
+        );
+    });
+});

--- a/frontend-admin-dashboard/src/routes/mentorship/mentors/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/mentors/index.lazy.tsx
@@ -56,6 +56,7 @@ import { MentorAvatar } from '../-components/MentorAvatar';
 import { EditMentorDialog } from '../-components/EditMentorDialog';
 import { MentorFeedbackDialog } from '../-components/MentorFeedbackDialog';
 import { MentorDetailDialog } from '../-components/MentorDetailDialog';
+import { MentorshipTabs } from '../-components/MentorshipTabs';
 import { CapacityChip, RatingChip } from '../-components/MentorChips';
 import { MyInput } from '@/components/design-system/input';
 import { filterMentors } from '../-utils/filter-mentors';
@@ -155,7 +156,7 @@ function MentorsPage() {
         <div className="flex flex-col gap-6 p-6">
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-col">
-                    <h2 className="text-title font-semibold text-neutral-700">Mentors</h2>
+                    <h2 className="text-title font-semibold text-neutral-700">Mentorship</h2>
                     <p className="text-body text-neutral-500">
                         Add mentors and assign students to them.
                     </p>
@@ -175,11 +176,18 @@ function MentorsPage() {
                     >
                         <UsersThree size={18} /> Bulk assign
                     </MyButton>
-                    <MyButton type="button" buttonType="primary" scale="medium" onClick={() => setAddOpen(true)}>
+                    <MyButton
+                        type="button"
+                        buttonType="primary"
+                        scale="medium"
+                        onClick={() => setAddOpen(true)}
+                    >
                         <Plus size={18} /> Add mentor
                     </MyButton>
                 </div>
             </div>
+
+            <MentorshipTabs />
 
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="relative w-full sm:w-80">
@@ -282,27 +290,20 @@ function MentorsPage() {
                                     >
                                         {m.display_name || m.name || 'Mentor'}
                                     </button>
-                                    <span className="truncate text-caption text-neutral-400">{m.title || m.email || ''}</span>
-                                    {(m.expertise_tags?.length ?? 0) > 0 && (
-                                        <span className="mt-1 flex flex-wrap gap-1">
-                                            {m.expertise_tags?.slice(0, 2).map((tag) => (
-                                                <span
-                                                    key={tag}
-                                                    className="rounded-full bg-primary-50 px-2 py-0.5 text-caption text-primary-600"
-                                                >
-                                                    {tag}
+                                    <span className="flex min-w-0 items-center gap-1.5 text-caption text-neutral-400">
+                                        <span className="truncate">{m.title || m.email || ''}</span>
+                                        {(m.expertise_tags?.length ?? 0) > 0 && (
+                                            <>
+                                                <span className="text-neutral-300">·</span>
+                                                <span className="truncate text-primary-600">
+                                                    {m.expertise_tags?.slice(0, 2).join(', ')}
+                                                    {(m.expertise_tags?.length ?? 0) > 2
+                                                        ? ` +${(m.expertise_tags?.length ?? 0) - 2}`
+                                                        : ''}
                                                 </span>
-                                            ))}
-                                            {(m.expertise_tags?.length ?? 0) > 2 && (
-                                                <span
-                                                    className="rounded-full bg-neutral-100 px-2 py-0.5 text-caption text-neutral-500"
-                                                    title={m.expertise_tags?.slice(2).join(', ')}
-                                                >
-                                                    +{(m.expertise_tags?.length ?? 0) - 2}
-                                                </span>
-                                            )}
-                                        </span>
-                                    )}
+                                            </>
+                                        )}
+                                    </span>
                                 </div>
                             </div>
                             <div className="flex flex-wrap items-center gap-2">
@@ -396,7 +397,11 @@ function MentorsPage() {
             )}
 
             {instituteId && (
-                <AddMentorDialog instituteId={instituteId} open={addOpen} onOpenChange={setAddOpen} />
+                <AddMentorDialog
+                    instituteId={instituteId}
+                    open={addOpen}
+                    onOpenChange={setAddOpen}
+                />
             )}
             {instituteId && (
                 <EditMentorDialog
@@ -452,7 +457,8 @@ function MentorsPage() {
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>
-                            Remove {confirmRemove?.display_name || confirmRemove?.name || 'this mentor'}?
+                            Remove{' '}
+                            {confirmRemove?.display_name || confirmRemove?.name || 'this mentor'}?
                         </AlertDialogTitle>
                         <AlertDialogDescription>
                             {confirmRemove?.assigned_student_count

--- a/frontend-admin-dashboard/src/routes/mentorship/mentors/mentor-chips.test.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/mentors/mentor-chips.test.tsx
@@ -30,12 +30,12 @@ describe('CapacityChip', () => {
                 mentor={mentor({ assigned_student_count: 10, max_mentees: 10, at_capacity: true })}
             />
         );
-        expect(screen.getByText('10/10 students · Full')).toBeInTheDocument();
+        expect(screen.getByText('10/10 · full')).toBeInTheDocument();
     });
 
     it('derives fullness from the numbers when the server omits the flag', () => {
         render(<CapacityChip mentor={mentor({ assigned_student_count: 5, max_mentees: 5 })} />);
-        expect(screen.getByText('5/5 students · Full')).toBeInTheDocument();
+        expect(screen.getByText('5/5 · full')).toBeInTheDocument();
     });
 
     it('warns before a mentor is full, not only once they are', () => {
@@ -77,20 +77,20 @@ describe('RatingChip', () => {
         expect(screen.getByText('5.0')).toBeInTheDocument();
     });
 
-    it('says "Not rated" instead of implying a zero score', () => {
-        render(<RatingChip mentor={mentor()} onClick={vi.fn()} />);
-        expect(screen.getByText('Not rated')).toBeInTheDocument();
-        expect(screen.queryByText('0.0')).not.toBeInTheDocument();
+    it('renders nothing at all for an unrated mentor', () => {
+        // A row of greyed "Not rated" chips is noise; absence says the same thing.
+        const { container } = render(<RatingChip mentor={mentor()} onClick={vi.fn()} />);
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('treats an average with no ratings behind it as unrated', () => {
-        render(
+        const { container } = render(
             <RatingChip
                 mentor={mentor({ average_rating: 4.2, rating_count: 0 })}
                 onClick={vi.fn()}
             />
         );
-        expect(screen.getByText('Not rated')).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('opens the feedback list when there is something to read', () => {

--- a/frontend-admin-dashboard/src/routes/mentorship/requests/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/requests/index.lazy.tsx
@@ -4,6 +4,7 @@ import { LayoutContainer } from '@/components/common/layout-container/layout-con
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { getInstituteId } from '@/constants/helper';
 import { MentorRequestsPanel } from '../-components/MentorRequestsPanel';
+import { MentorshipTabs } from '../-components/MentorshipTabs';
 
 export const Route = createLazyFileRoute('/mentorship/requests/')({
     component: MentorRequestsRoute,
@@ -17,6 +18,7 @@ function MentorRequestsRoute() {
 
     return (
         <LayoutContainer>
+            <MentorshipTabs />
             <MentorRequestsPanel instituteId={getInstituteId()} />
         </LayoutContainer>
     );

--- a/frontend-admin-dashboard/src/routes/mentorship/sessions/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/sessions/index.lazy.tsx
@@ -4,6 +4,7 @@ import { LayoutContainer } from '@/components/common/layout-container/layout-con
 import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore';
 import { getInstituteId } from '@/constants/helper';
 import { MentorSessionsPanel } from '../-components/MentorSessionsPanel';
+import { MentorshipTabs } from '../-components/MentorshipTabs';
 
 export const Route = createLazyFileRoute('/mentorship/sessions/')({
     component: MentorSessionsRoute,
@@ -24,6 +25,7 @@ function MentorSessionsRoute() {
                         Every mentor session, what came of it, and how learners rated it.
                     </p>
                 </div>
+                <MentorshipTabs />
                 <MentorSessionsPanel instituteId={getInstituteId()} />
             </div>
         </LayoutContainer>

--- a/frontend-admin-dashboard/src/routes/mentorship/sessions/responsive-layout.test.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/sessions/responsive-layout.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/routes/mentorship/-hooks/use-mentorship', () => ({
     useSessionAction: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+vi.mock('@/routes/mentorship/-components/MentorAvatar', () => ({
+    MentorAvatar: () => <span data-testid="avatar" />,
+}));
+
 import { MentorSessionsPanel } from '@/routes/mentorship/-components/MentorSessionsPanel';
 
 /**

--- a/frontend-admin-dashboard/src/routes/mentorship/sessions/sessions-panel.test.tsx
+++ b/frontend-admin-dashboard/src/routes/mentorship/sessions/sessions-panel.test.tsx
@@ -9,6 +9,10 @@ vi.mock('@/routes/mentorship/-hooks/use-mentorship', () => ({
     useSessionAction: () => ({ mutateAsync: sessionActionMutate, isPending: false }),
 }));
 
+vi.mock('@/routes/mentorship/-components/MentorAvatar', () => ({
+    MentorAvatar: () => <span data-testid="avatar" />,
+}));
+
 import { MentorSessionsPanel } from '@/routes/mentorship/-components/MentorSessionsPanel';
 
 const session = (over: Partial<MentorSessionDTO> = {}): MentorSessionDTO => ({
@@ -42,7 +46,8 @@ describe('MentorSessionsPanel', () => {
 
     it('lists a session with both parties, as the admin view requires', () => {
         render(<MentorSessionsPanel instituteId="inst-1" />);
-        expect(screen.getByText(/Asha Nair.*Riya Sharma/)).toBeInTheDocument();
+        expect(screen.getByText('Asha Nair')).toBeInTheDocument();
+        expect(screen.getByText('Riya Sharma')).toBeInTheDocument();
         expect(screen.getByText(/30 min/)).toBeInTheDocument();
     });
 
@@ -98,7 +103,7 @@ describe('MentorSessionsPanel', () => {
             ])
         );
         render(<MentorSessionsPanel instituteId="inst-1" />);
-        fireEvent.click(screen.getByText(/Asha Nair.*Riya Sharma/));
+        fireEvent.click(screen.getByRole('button', { name: /Asha Nair/ }));
 
         expect(await screen.findByText('Session details')).toBeInTheDocument();
         expect(screen.getByText('asha@example.com')).toBeInTheDocument();
@@ -141,7 +146,9 @@ describe('MentorSessionsPanel', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
         // Copy unique to the dialog — "Cancel session" is also its submit button.
-        expect(await screen.findByText(/calendar entry and reminders are removed/)).toBeInTheDocument();
+        expect(
+            await screen.findByText(/calendar entry and reminders are removed/)
+        ).toBeInTheDocument();
         // Destructive actions must never fire straight off a row click.
         expect(sessionActionMutate).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Add mentor now has two modes — pick from your team, or invite by email. The invite reuses the existing invitation with roleType MENTOR and creates the mentor row against the returned user id, so an external mentor no longer needs a separate trip to the Teams tab.

Simplify what the admin sees: optional profile fields fold behind a disclosure so the dialog asks one question, the four admin screens share a tab strip with a request count, and the sidebar drops from four mentorship entries to two.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
