### PR TITLE
feat(doubts): let the built-in Doubt type route to a role or specific…

### DIFF
--- a/frontend-admin-dashboard/src/routes/settings/-components/DoubtManagementSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/DoubtManagementSettings.tsx
@@ -112,13 +112,15 @@ const DEFAULT_LEARNER_QUERY: LearnerQueryPrefs = {
 };
 
 // Always-present academic type — cannot be removed (historical rows keep type='DOUBT').
+// `assignee: null` = no per-type override, so it follows the global "Default auto-assignment"
+// radio. Admins can override it (including to specific staff) from the Query types card.
 const SYSTEM_DOUBT_TYPE: QueryTypeConfig = {
     key: 'DOUBT',
     label: 'Doubt',
     enabled: true,
     is_system: true,
     learner_selectable: true,
-    assignee: { source: 'SUBJECT_TEACHER' },
+    assignee: null,
 };
 
 // Seeded defaults shown to institutes that haven't configured types yet. Nothing is persisted (or
@@ -144,7 +146,17 @@ const DEFAULT_QUERY_TYPES: QueryTypeConfig[] = [
 // Roles offered when a type routes by ROLE.
 const ROLE_OPTIONS = ['ADMIN', 'TEACHER', 'EVALUATOR', 'CONTENT CREATOR', 'ASSESSMENT CREATOR'];
 
-const ASSIGNEE_SOURCE_OPTIONS: { value: QueryTypeAssigneeSource; label: string }[] = [
+/**
+ * Frontend-only sentinel for "no per-type override" — the type defers to the institute-wide
+ * "Default auto-assignment" radio above. It is never persisted as a source string: picking it
+ * clears the type's `assignee` entirely, which is what makes the backend
+ * (DoubtsManager.resolveAssigneesForDoubt) fall back to `default_assignee_source`.
+ */
+const INHERIT_DEFAULT = 'DEFAULT';
+type RouteSelectValue = QueryTypeAssigneeSource | typeof INHERIT_DEFAULT;
+
+const ASSIGNEE_SOURCE_OPTIONS: { value: RouteSelectValue; label: string }[] = [
+    { value: INHERIT_DEFAULT, label: 'Default auto-assignment (set above)' },
     { value: 'SUBJECT_TEACHER', label: 'Subject teacher' },
     { value: 'BATCH_TEACHER', label: 'Batch teacher' },
     { value: 'ROLE', label: 'A role' },
@@ -259,7 +271,9 @@ function mergeWithDefaults(
         enabled: t.enabled ?? true,
         learner_selectable: t.learner_selectable ?? true,
         is_system: t.key?.toUpperCase() === 'DOUBT' ? true : t.is_system ?? false,
-        assignee: t.assignee ?? { source: 'SUBJECT_TEACHER' },
+        // A stored type with no assignee keeps deferring to `default_assignee_source`. Seeding a
+        // concrete source here would silently start overriding that global choice on the next save.
+        assignee: t.assignee ?? null,
     }));
     return {
         default_assignee_source:
@@ -314,7 +328,7 @@ const fetchEmailTemplates = async (): Promise<EmailTemplateOption[]> => {
 export default function DoubtManagementSettings() {
     const queryClient = useQueryClient();
     const instituteId = getCurrentInstituteId() ?? undefined;
-    const { assignees } = useInstituteAssignees(instituteId);
+    const { assignees, isLoading: assigneesLoading } = useInstituteAssignees(instituteId);
     const [settings, setSettings] = useState<DoubtManagementSettingsData>(DEFAULT_SETTINGS);
     const [hasChanges, setHasChanges] = useState(false);
     const { ensurePermission } = usePushNotifications();
@@ -454,10 +468,10 @@ export default function DoubtManagementSettings() {
                 ...t,
                 key,
                 label: label || t.label,
-                // The built-in DOUBT type always defers to the global "Default auto-assignment"
-                // radio above — never persist a per-type assignee for it, otherwise it would
-                // silently override default_assignee_source on the backend.
-                assignee: t.is_system ? undefined : t.assignee,
+                // Every type — the built-in DOUBT included — may carry its own routing. A null
+                // assignee means the admin chose "Default auto-assignment", so it's dropped from
+                // the payload and the backend keeps falling back to default_assignee_source.
+                assignee: t.assignee ?? undefined,
             });
         }
         save({ ...settings, query_types: normalizedTypes });
@@ -750,6 +764,7 @@ export default function DoubtManagementSettings() {
             <QueryTypesCard
                 types={settings.query_types}
                 assignees={assignees}
+                assigneesLoading={assigneesLoading}
                 onUpdate={updateQueryType}
                 onAdd={addQueryType}
                 onRemove={removeQueryType}
@@ -909,12 +924,14 @@ function NotificationEventCard({
 function QueryTypesCard({
     types,
     assignees,
+    assigneesLoading,
     onUpdate,
     onAdd,
     onRemove,
 }: {
     types: QueryTypeConfig[];
     assignees: AssigneeOption[];
+    assigneesLoading: boolean;
     onUpdate: (index: number, patch: Partial<QueryTypeConfig>) => void;
     onAdd: () => void;
     onRemove: (index: number) => void;
@@ -930,14 +947,16 @@ function QueryTypesCard({
                 <CardTitle>Query types</CardTitle>
                 <CardDescription>
                     The categories a learner can pick when raising a query (e.g. Doubt, Technical
-                    Issue, Payment Issue). Each type routes to its own default handler. The Doubt
-                    type is built-in and can’t be removed.
+                    Issue, Payment Issue). Each type routes to its own default handler — including
+                    the built-in Doubt type, which you can point at a teacher, a role, or specific
+                    staff. The Doubt type can’t be renamed or removed.
                 </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
                 <div className="space-y-3">
                     {types.map((t, i) => {
-                        const source = t.assignee?.source ?? 'SUBJECT_TEACHER';
+                        const source: RouteSelectValue = t.assignee?.source ?? INHERIT_DEFAULT;
+                        const pickedStaff = t.assignee?.user_ids ?? [];
                         return (
                             <div
                                 key={i}
@@ -994,24 +1013,21 @@ function QueryTypesCard({
                                     <span className="text-xs font-semibold text-neutral-600">
                                         Route to
                                     </span>
-                                    {t.is_system && (
-                                        <span className="text-xs italic text-neutral-500">
-                                            uses “Default auto-assignment” above
-                                        </span>
-                                    )}
                                     <select
-                                        className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm text-neutral-800 focus:border-primary-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                                        className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm text-neutral-800 focus:border-primary-400 focus:outline-none"
                                         value={source}
-                                        disabled={t.is_system}
-                                        onChange={(e) =>
+                                        onChange={(e) => {
+                                            const next = e.target.value as RouteSelectValue;
+                                            // The sentinel isn't a source — clear the override so
+                                            // the type falls back to the global default again.
+                                            if (next === INHERIT_DEFAULT) {
+                                                onUpdate(i, { assignee: null });
+                                                return;
+                                            }
                                             onUpdate(i, {
-                                                assignee: {
-                                                    ...t.assignee,
-                                                    source: e.target
-                                                        .value as QueryTypeAssigneeSource,
-                                                },
-                                            })
-                                        }
+                                                assignee: { ...t.assignee, source: next },
+                                            });
+                                        }}
                                     >
                                         {ASSIGNEE_SOURCE_OPTIONS.map((o) => (
                                             <option key={o.value} value={o.value}>
@@ -1041,7 +1057,21 @@ function QueryTypesCard({
                                             ))}
                                         </select>
                                     )}
+
+                                    {source === INHERIT_DEFAULT && (
+                                        <span className="text-xs italic text-neutral-500">
+                                            follows “Default auto-assignment” above
+                                        </span>
+                                    )}
                                 </div>
+
+                                {t.is_system && source !== INHERIT_DEFAULT && (
+                                    <p className="text-xs text-neutral-500">
+                                        This only changes who is auto-assigned and notified. Teacher
+                                        inbox visibility still follows “Default auto-assignment”
+                                        above.
+                                    </p>
+                                )}
 
                                 {source === 'SPECIFIC_USERS' && (
                                     <div className="space-y-1">
@@ -1051,7 +1081,7 @@ function QueryTypesCard({
                                         <SelectChips
                                             options={assigneeOptions}
                                             selected={assigneeOptions.filter((o) =>
-                                                (t.assignee?.user_ids ?? []).includes(o.value)
+                                                pickedStaff.includes(o.value)
                                             )}
                                             onChange={(
                                                 picked: { label: string; value: string }[]
@@ -1066,7 +1096,7 @@ function QueryTypesCard({
                                                         // silently dropped on save.
                                                         user_ids: [
                                                             ...picked.map((p) => p.value),
-                                                            ...(t.assignee?.user_ids ?? []).filter(
+                                                            ...pickedStaff.filter(
                                                                 (id) =>
                                                                     !assigneeOptions.some(
                                                                         (o) => o.value === id
@@ -1080,6 +1110,21 @@ function QueryTypesCard({
                                             hasClearFilter={false}
                                             className="min-w-60"
                                         />
+                                        {assigneesLoading ? (
+                                            <p className="text-xs text-neutral-500">
+                                                Loading staff…
+                                            </p>
+                                        ) : assigneeOptions.length === 0 ? (
+                                            <p className="text-xs text-warning-600">
+                                                No active staff found. Add team members under Teams
+                                                first, then pick them here.
+                                            </p>
+                                        ) : pickedStaff.length === 0 ? (
+                                            <p className="text-xs text-neutral-500">
+                                                Nobody picked yet — until you add someone, these
+                                                queries fall back to the institute’s admins.
+                                            </p>
+                                        ) : null}
                                     </div>
                                 )}
                             </div>

--- a/frontend-admin-dashboard/src/routes/settings/-components/__tests__/doubt-query-type-routing/test.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/__tests__/doubt-query-type-routing/test.tsx
@@ -1,0 +1,169 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DoubtManagementSettings from '@/routes/settings/-components/DoubtManagementSettings';
+
+const STORED_SETTINGS = {
+    default_assignee_source: 'BATCH_TEACHER',
+    fallback_to_batch_when_no_subject_teacher: true,
+    // The built-in type as every existing institute has it stored: no per-type assignee, so it
+    // rides on default_assignee_source.
+    query_types: [
+        { key: 'DOUBT', label: 'Doubt', enabled: true, is_system: true, learner_selectable: true },
+        {
+            key: 'TECHNICAL',
+            label: 'Technical Issue',
+            enabled: true,
+            learner_selectable: true,
+            assignee: { source: 'ROLE', role: 'ADMIN' },
+        },
+    ],
+};
+
+const axiosGet = vi.fn<unknown[], Promise<{ data: unknown }>>(async () => ({ data: [] }));
+const axiosPost = vi.fn<unknown[], Promise<{ data: unknown }>>(async () => ({ data: {} }));
+const axiosCall = vi.fn<unknown[], Promise<{ data: unknown }>>(async () => ({
+    data: { data: structuredClone(STORED_SETTINGS) },
+}));
+
+// Lazy wrappers: the mock factory runs while the module graph is still loading, before the consts
+// above are initialized.
+vi.mock('@/lib/auth/axiosInstance', () => ({
+    __esModule: true,
+    default: Object.assign((...args: unknown[]) => axiosCall(...args), {
+        get: (...args: unknown[]) => axiosGet(...args),
+        post: (...args: unknown[]) => axiosPost(...args),
+    }),
+}));
+
+vi.mock('@/lib/auth/instituteUtils', () => ({
+    getCurrentInstituteId: () => 'inst-1',
+}));
+
+vi.mock('@/hooks/usePushNotifications', () => ({
+    usePushNotifications: () => ({ ensurePermission: vi.fn(async () => true) }),
+}));
+
+vi.mock('@/routes/dashboard/-hooks/useInstituteAssignees', () => ({
+    useInstituteAssignees: () => ({
+        assignees: [
+            { id: 'u-1', name: 'Asha Rao', subtitle: 'Teacher' },
+            { id: 'u-2', name: 'Vikram Shah', subtitle: 'Evaluator' },
+        ],
+        isLoading: false,
+    }),
+}));
+
+vi.mock('@/components/common/layout-container/sidebar/utils', () => ({
+    getTerminology: (term: string) => term,
+}));
+
+vi.mock('@/routes/settings/-components/NamingSettings', () => ({
+    OtherTerms: { SubOrg: 'Sub-organization' },
+    SystemTerms: { SubOrg: 'Sub-organization' },
+}));
+
+const renderScreen = () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <QueryClientProvider client={client}>
+            <DoubtManagementSettings />
+        </QueryClientProvider>
+    );
+};
+
+/** The Query-types row whose name input holds `label`. */
+const typeCard = (label: string): HTMLElement => {
+    const input = screen.getByDisplayValue(label);
+    const card = input.closest('div.rounded-lg');
+    if (!card) throw new Error(`no card for ${label}`);
+    return card as HTMLElement;
+};
+
+const routeSelect = (label: string): HTMLSelectElement =>
+    within(typeCard(label)).getAllByRole('combobox')[0] as HTMLSelectElement;
+
+const savedPayload = () =>
+    (axiosPost.mock.calls[0]?.[1] as { setting_data: { query_types: Record<string, unknown>[] } })
+        ?.setting_data;
+
+const savedType = (key: string) =>
+    savedPayload().query_types.find((t) => t.key === key) as {
+        assignee?: { source?: string; user_ids?: string[] };
+    };
+
+const save = async () => {
+    fireEvent.click(screen.getByText('Save settings'));
+    await waitFor(() => expect(axiosPost).toHaveBeenCalledTimes(1));
+};
+
+describe('Query types — built-in Doubt routing', () => {
+    beforeAll(() => {
+        // jsdom has no layout engine; cmdk scrolls its active item into view when the staff
+        // picker opens.
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('lets the admin re-route the built-in Doubt type instead of locking the picker', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        const select = routeSelect('Doubt');
+        expect(select).not.toBeDisabled();
+        // A stored type with no assignee shows as inheriting, not as a fake "Subject teacher".
+        expect(select.value).toBe('DEFAULT');
+        expect(
+            within(typeCard('Doubt')).getByText(/follows .Default auto-assignment. above/)
+        ).toBeInTheDocument();
+
+        fireEvent.change(select, { target: { value: 'SUBJECT_TEACHER' } });
+        await save();
+        expect(savedType('DOUBT').assignee).toEqual({ source: 'SUBJECT_TEACHER' });
+    });
+
+    it('keeps the payload free of a Doubt assignee while it inherits the global default', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        // Change something else so Save is enabled without touching Doubt's routing.
+        fireEvent.change(routeSelect('Technical Issue'), { target: { value: 'BATCH_TEACHER' } });
+        await save();
+        expect(savedType('DOUBT').assignee).toBeUndefined();
+    });
+
+    it('reverting to the default clears a previously saved Doubt override', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        const select = routeSelect('Doubt');
+        fireEvent.change(select, { target: { value: 'SPECIFIC_USERS' } });
+        fireEvent.change(select, { target: { value: 'DEFAULT' } });
+        await save();
+        expect(savedType('DOUBT').assignee).toBeUndefined();
+    });
+
+    it('offers the staff picker on the Doubt type and saves the picked handlers', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        fireEvent.change(routeSelect('Doubt'), { target: { value: 'SPECIFIC_USERS' } });
+
+        const card = typeCard('Doubt');
+        expect(within(card).getByText('Staff handlers')).toBeInTheDocument();
+        // Empty selection is spelled out rather than silently routing to admins.
+        expect(within(card).getByText(/Nobody picked yet/)).toBeInTheDocument();
+
+        fireEvent.click(within(card).getByText('Select...'));
+        fireEvent.click(await screen.findByText(/Asha Rao/));
+
+        await save();
+        expect(savedType('DOUBT').assignee).toMatchObject({
+            source: 'SPECIFIC_USERS',
+            user_ids: ['u-1'],
+        });
+    });
+});


### PR DESCRIPTION
… staff

The Doubt row's "Route to" picker was disabled and handleSave dropped its assignee outright, so the greyed-out "Subject teacher" was cosmetic — doubts actually routed via the global default_assignee_source. The backend already honors a per-type assignee for DOUBT (DoubtsManager.resolveAssigneesForDoubt), so only the UI was holding it back.

- Route to is editable for every type, with a new "Default auto-assignment (set above)" option that persists no assignee and keeps the inherit behavior
- Specific staff opens the same handler multi-select on the Doubt type
- A stored type with no assignee now renders as inheriting instead of a fake "Subject teacher" the save path never persisted
- Staff picker states are spelled out: loading, no active staff, and the empty-selection fallback to institute admins
- Note that per-type routing changes assignment/notification only — teacher inbox visibility still follows the global setting

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
