### PR TITLE
feat(doubts): additive per-type routing — a base route plus fixed han…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtNotificationService.java
@@ -1,6 +1,7 @@
 package vacademy.io.admin_core_service.features.doubts.manager;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,7 +105,12 @@ public class DoubtNotificationService {
      *  {@code admin.<domain>} / {@code learner.<domain>} naming convention. */
     private static final String FALLBACK_ADMIN_SUBDOMAIN = "admin";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    /**
+     * Lenient on purpose — see DoubtsManager. An unknown key written by a newer frontend must not
+     * cost this institute its notification preferences.
+     */
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /**
      * @param assigneeUserIds recipients for push/email. For "raised" event these are the auto- or

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtsManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtsManager.java
@@ -1,5 +1,6 @@
 package vacademy.io.admin_core_service.features.doubts.manager;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +74,14 @@ public class DoubtsManager {
     @Autowired
     SubOrgStaffLookupService subOrgStaffLookupService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    /**
+     * Lenient on purpose: this mapper reads a settings blob the admin frontend owns and extends.
+     * Jackson's default is to THROW on an unknown property, and the caller swallows that into
+     * "no setting" — so one field written by a newer frontend would silently drop the institute's
+     * whole doubt-routing config back to defaults. Unknown keys are ignored instead.
+     */
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /** Role name as configured in auth_service for institute-level admins. */
     private static final String ADMIN_ROLE = "ADMIN";
@@ -408,7 +416,8 @@ public class DoubtsManager {
         String typeKey = StringUtils.hasText(doubt.getType()) ? doubt.getType() : DEFAULT_TYPE;
         DoubtManagementSettingDataDto.QueryTypeConfig typeConfig = findTypeConfig(setting, typeKey);
         if (typeConfig != null && typeConfig.getAssignee() != null
-                && StringUtils.hasText(typeConfig.getAssignee().getSource())) {
+                && (StringUtils.hasText(typeConfig.getAssignee().getSource())
+                    || hasAdditionalHandlers(typeConfig.getAssignee()))) {
             return resolveTypeAssignees(typeConfig.getAssignee(), doubt.getPackageSessionId(),
                     subjectId, instituteId, setting);
         }
@@ -437,7 +446,12 @@ public class DoubtsManager {
                     || !StringUtils.hasText(typeConfig.getAssignee().getSource())) {
                 return false;
             }
-            return parseSource(typeConfig.getAssignee().getSource()) == DoubtDefaultAssigneeSourceEnum.NONE;
+
+            if (parseSource(typeConfig.getAssignee().getSource()) != DoubtDefaultAssigneeSourceEnum.NONE) {
+                return false;
+            }
+            // NONE plus additive handlers that resolved to nobody is a failed lookup, not a choice.
+            return !hasAdditionalHandlers(typeConfig.getAssignee());
         } catch (Exception e) {
             // Can't confirm the empty result was intentional → treat it as a real drop and log it.
             return false;
@@ -527,6 +541,11 @@ public class DoubtsManager {
         }
     }
 
+    private boolean hasAdditionalHandlers(DoubtManagementSettingDataDto.QueryTypeAssignee assignee) {
+        return (assignee.getAlsoUserIds() != null && !assignee.getAlsoUserIds().isEmpty())
+                || (assignee.getAlsoRoles() != null && !assignee.getAlsoRoles().isEmpty());
+    }
+
     private DoubtManagementSettingDataDto.QueryTypeConfig findTypeConfig(
             DoubtManagementSettingDataDto setting, String typeKey) {
         if (setting == null || setting.getQueryTypes() == null) return null;
@@ -536,21 +555,60 @@ public class DoubtsManager {
     }
 
     /**
-     * Resolves assignees for a type whose {@code assignee.source} is set:
-     *   SPECIFIC_USERS → the configured user ids; ROLE → all users holding that role;
-     *   SUBJECT/BATCH/BOTH → the faculty cascade; NONE → no implicit assignee (manual triage from
-     *   the institute-scoped admin inbox). SPECIFIC_USERS/ROLE fall back to admin when they resolve
-     *   to nobody so the query isn't dropped.
+     * Resolves assignees for a type whose {@code assignee.source} is set. The result is the UNION of
+     * two independent parts, which is what lets one type route to "subject teacher AND these three
+     * people" rather than forcing a single winner:
+     *
+     * <ul>
+     *   <li>the base route — SPECIFIC_USERS → the configured user ids; ROLE → all users holding that
+     *       role; SUBJECT/BATCH/BOTH → the faculty cascade; NONE → nobody;</li>
+     *   <li>the additive handlers — {@code also_user_ids} plus everyone holding an {@code also_roles}
+     *       role, always added on top of the base.</li>
+     * </ul>
+     *
+     * <p>The admin safety net now fires only when the whole union comes out empty. Once an institute
+     * has named additive handlers they ARE the safety net, and adding every admin on top of them
+     * would notify exactly the people the admin routed around. A per-type {@code NONE} with no
+     * additive handlers still means "assign nobody" — deliberate manual triage from the inbox.</p>
      */
     private List<String> resolveTypeAssignees(DoubtManagementSettingDataDto.QueryTypeAssignee assignee,
                                               String packageSessionId, String subjectId, String instituteId,
                                               DoubtManagementSettingDataDto setting) {
-        DoubtDefaultAssigneeSourceEnum source = parseSource(assignee.getSource());
+        // A blank source means the type never overrode the institute default — keep that cascade as
+        // the base so "default auto-assignment PLUS these two people" is expressible.
+        DoubtDefaultAssigneeSourceEnum source = StringUtils.hasText(assignee.getSource())
+                ? parseSource(assignee.getSource())
+                : parseAssigneeSource(setting);
+        List<String> additional = resolveAdditionalAssignees(assignee, instituteId);
+        // With additive handlers configured, the base route must not drag in its own admin fallback.
+        boolean allowAdminFallback = additional.isEmpty();
+
+        Set<String> assignees = new LinkedHashSet<>(resolveBaseTypeAssignees(
+                assignee, source, packageSessionId, subjectId, instituteId, setting, allowAdminFallback));
+        assignees.addAll(additional);
+
+        // Only needed when the base route's own safety net was suppressed above. With no additive
+        // handlers the base already applied it, and repeating the identical (retrying) ADMIN lookup
+        // here would double its cost for a guaranteed-identical result.
+        if (assignees.isEmpty() && !allowAdminFallback
+                && source != DoubtDefaultAssigneeSourceEnum.NONE) {
+            assignees.addAll(resolveAdminFallback(instituteId));
+        }
+        return new ArrayList<>(assignees);
+    }
+
+    /** The {@code assignee.source} leg of {@link #resolveTypeAssignees}, minus the additive handlers. */
+    private List<String> resolveBaseTypeAssignees(DoubtManagementSettingDataDto.QueryTypeAssignee assignee,
+                                                  DoubtDefaultAssigneeSourceEnum source, String packageSessionId,
+                                                  String subjectId, String instituteId,
+                                                  DoubtManagementSettingDataDto setting,
+                                                  boolean allowAdminFallback) {
         switch (source) {
             case SPECIFIC_USERS: {
                 List<String> ids = assignee.getUserIds() == null ? List.of()
                         : assignee.getUserIds().stream().filter(StringUtils::hasText).distinct().toList();
-                return ids.isEmpty() ? resolveAdminFallback(instituteId) : ids;
+                if (!ids.isEmpty()) return ids;
+                return allowAdminFallback ? resolveAdminFallback(instituteId) : List.of();
             }
             case ROLE: {
                 String role = StringUtils.hasText(assignee.getRole()) ? assignee.getRole() : ADMIN_ROLE;
@@ -559,13 +617,35 @@ public class DoubtsManager {
                 // lookup — which now carries its own retries — for a guaranteed-identical result.
                 // Skip it so an empty admin role costs the same attempts as any other empty role.
                 if (!ids.isEmpty() || ADMIN_ROLE.equalsIgnoreCase(role)) return ids;
-                return resolveAdminFallback(instituteId);
+                return allowAdminFallback ? resolveAdminFallback(instituteId) : List.of();
             }
             case NONE:
                 return List.of();
             default:
-                return resolveImplicitAssignees(source, packageSessionId, subjectId, instituteId, setting);
+                return resolveImplicitAssignees(source, packageSessionId, subjectId, instituteId,
+                        setting, allowAdminFallback);
         }
+    }
+
+    /**
+     * The additive handlers for a type: {@code also_user_ids} verbatim, plus every user holding one
+     * of {@code also_roles}. Order is preserved (explicit ids first) and duplicates collapse, so a
+     * person named both explicitly and via a role is assigned once. Empty when neither is configured
+     * — the overwhelmingly common case, and it costs zero lookups.
+     */
+    private List<String> resolveAdditionalAssignees(DoubtManagementSettingDataDto.QueryTypeAssignee assignee,
+                                                    String instituteId) {
+        Set<String> additional = new LinkedHashSet<>();
+        if (assignee.getAlsoUserIds() != null) {
+            assignee.getAlsoUserIds().stream().filter(StringUtils::hasText).forEach(additional::add);
+        }
+        if (assignee.getAlsoRoles() != null) {
+            assignee.getAlsoRoles().stream()
+                    .filter(StringUtils::hasText)
+                    .distinct()
+                    .forEach(role -> additional.addAll(resolveUsersByRole(instituteId, role)));
+        }
+        return new ArrayList<>(additional);
     }
 
     /**
@@ -581,19 +661,32 @@ public class DoubtsManager {
     List<String> resolveImplicitAssignees(DoubtDefaultAssigneeSourceEnum source, String packageSessionId,
                                           String subjectId, String instituteId,
                                           DoubtManagementSettingDataDto setting) {
+        return resolveImplicitAssignees(source, packageSessionId, subjectId, instituteId, setting, true);
+    }
+
+    /**
+     * @param allowAdminFallback false only when the caller has its own guaranteed recipients (a
+     *        type's additive handlers). The cascade then returns empty instead of widening to every
+     *        admin, so "batch teacher + these two people" doesn't quietly become "+ all admins" on a
+     *        batch with no faculty mapped.
+     */
+    List<String> resolveImplicitAssignees(DoubtDefaultAssigneeSourceEnum source, String packageSessionId,
+                                          String subjectId, String instituteId,
+                                          DoubtManagementSettingDataDto setting,
+                                          boolean allowAdminFallback) {
         // NONE → skip teachers entirely, go straight to admin so the doubt is still routed.
         if (source == DoubtDefaultAssigneeSourceEnum.NONE) {
-            return resolveAdminFallback(instituteId);
+            return adminFallbackIfAllowed(instituteId, allowAdminFallback);
         }
         // ROLE / SPECIFIC_USERS are only meaningful as a per-type choice, not a global cascade — if
         // one reaches here, route to admin rather than nobody.
         if (source == DoubtDefaultAssigneeSourceEnum.ROLE
                 || source == DoubtDefaultAssigneeSourceEnum.SPECIFIC_USERS) {
-            return resolveAdminFallback(instituteId);
+            return adminFallbackIfAllowed(instituteId, allowAdminFallback);
         }
         // The faculty cascade needs a batch. GENERAL queries (no batch) → admin fallback.
         if (packageSessionId == null || packageSessionId.isEmpty()) {
-            return resolveAdminFallback(instituteId);
+            return adminFallbackIfAllowed(instituteId, allowAdminFallback);
         }
 
         // Step 1: SUBJECT_TEACHER → try the subject-specific faculty first.
@@ -609,7 +702,7 @@ public class DoubtsManager {
             if (!fallback) {
                 // Strict subject-only mode: skip batch but still keep the admin safety net so
                 // the doubt isn't dropped on the floor.
-                return resolveAdminFallback(instituteId);
+                return adminFallbackIfAllowed(instituteId, allowAdminFallback);
             }
         }
 
@@ -620,7 +713,11 @@ public class DoubtsManager {
         if (!batchFaculty.isEmpty()) return batchFaculty;
 
         // Step 3: final fallback — institute admin(s).
-        return resolveAdminFallback(instituteId);
+        return adminFallbackIfAllowed(instituteId, allowAdminFallback);
+    }
+
+    private List<String> adminFallbackIfAllowed(String instituteId, boolean allowAdminFallback) {
+        return allowAdminFallback ? resolveAdminFallback(instituteId) : List.of();
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/dto/settings/doubt_management/DoubtManagementSettingDataDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/dto/settings/doubt_management/DoubtManagementSettingDataDto.java
@@ -157,6 +157,20 @@ public class DoubtManagementSettingDataDto {
         private String role;
         /** Explicit handler user ids when {@code source=SPECIFIC_USERS}. */
         private List<String> userIds;
+
+        /**
+         * Role names whose holders are assigned IN ADDITION to whatever {@link #source} resolved —
+         * this is what lets a type route to "subject teacher AND admin". {@code null}/empty ⇒ the
+         * base route alone, i.e. every config written before this field existed behaves unchanged.
+         */
+        private List<String> alsoRoles;
+
+        /**
+         * User ids assigned IN ADDITION to whatever {@link #source} resolved, so a type can keep its
+         * faculty cascade and still always land on a fixed set of handlers. {@code null}/empty ⇒ the
+         * base route alone.
+         */
+        private List<String> alsoUserIds;
     }
 
     @Data

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtsManagerAdditiveRoutingTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/doubts/manager/DoubtsManagerAdditiveRoutingTest.java
@@ -1,0 +1,243 @@
+package vacademy.io.admin_core_service.features.doubts.manager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.doubts.dtos.DoubtsDto;
+import vacademy.io.admin_core_service.features.doubts.entity.Doubts;
+import vacademy.io.admin_core_service.features.doubts.repository.DoubtsAssigneeRepository;
+import vacademy.io.admin_core_service.features.doubts.service.DoubtService;
+import vacademy.io.admin_core_service.features.faculty.entity.FacultySubjectPackageSessionMapping;
+import vacademy.io.admin_core_service.features.faculty.repository.FacultySubjectPackageSessionMappingRepository;
+import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
+import vacademy.io.admin_core_service.features.slide.service.SlideMetaDataService;
+import vacademy.io.admin_core_service.features.suborg.service.SubOrgStaffLookupService;
+import vacademy.io.admin_core_service.features.workflow.service.WorkflowTriggerService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Per-type routing used to pick a single winner: choosing "subject teacher" meant the institute
+ * could not ALSO pin a fixed set of handlers on the type. {@code also_user_ids} / {@code also_roles}
+ * make the result a union of the base route plus those handlers, which is what these tests pin.
+ *
+ * <p>The subtle part is the admin safety net. It exists so a doubt is never dropped, but once an
+ * admin has named explicit additional handlers, widening to every admin would notify exactly the
+ * people they routed around — so the net only fires when the whole union is empty.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DoubtsManagerAdditiveRoutingTest {
+
+    private static final String PS = "ps-1";
+    private static final String INST = "inst-1";
+    private static final String LEARNER = "learner-1";
+    private static final String DOUBT_ID = "doubt-1";
+    private static final String SETTING_KEY = "DOUBT_MANAGEMENT_SETTING";
+    private static final String ADMIN_ROLE = "ADMIN";
+    private static final String TEACHER = "teacher-1";
+    private static final String STAFF_A = "staff-a";
+    private static final String STAFF_B = "staff-b";
+    private static final String ADMIN_A = "admin-a";
+
+    @Mock private DoubtService doubtService;
+    @Mock private FacultySubjectPackageSessionMappingRepository facultyMappingRepository;
+    @Mock private InstituteSettingService instituteSettingService;
+    @Mock private SlideMetaDataService slideMetaDataService;
+    @Mock private DoubtNotificationService doubtNotificationService;
+    @Mock private DoubtsAssigneeRepository doubtsAssigneeRepository;
+    @Mock private AuthService authService;
+    @Mock private WorkflowTriggerService workflowTriggerService;
+    @Mock private SubOrgStaffLookupService subOrgStaffLookupService;
+
+    @InjectMocks private DoubtsManager manager;
+
+    private DoubtsDto slideDoubtRequest(String type) {
+        return DoubtsDto.builder()
+                .source("SLIDE").sourceId("slide-1").type(type)
+                .userId(LEARNER).batchId(PS).htmlText("please help")
+                .build();
+    }
+
+    private void wireCommon() {
+        when(facultyMappingRepository.findInstituteIdByPackageSessionId(PS)).thenReturn(Optional.of(INST));
+        when(doubtService.updateOrCreateDoubt(any(Doubts.class))).thenAnswer(inv -> {
+            Doubts d = inv.getArgument(0);
+            d.setId(DOUBT_ID);
+            return d;
+        });
+        when(slideMetaDataService.getSlideMetadataForAdmin(any())).thenReturn(Optional.empty());
+        when(subOrgStaffLookupService.resolveLearnerSubOrgIds(LEARNER, INST, PS)).thenReturn(List.of());
+    }
+
+    private void wireSetting(String defaultSource, List<Map<String, Object>> queryTypes) {
+        Map<String, Object> setting = new HashMap<>();
+        if (defaultSource != null) setting.put("default_assignee_source", defaultSource);
+        if (queryTypes != null) setting.put("query_types", queryTypes);
+        when(instituteSettingService.getSettingByInstituteIdAndKey(INST, SETTING_KEY)).thenReturn(setting);
+    }
+
+    /** A query type whose assignee block carries any mix of source / also_user_ids / also_roles. */
+    private static Map<String, Object> queryType(String key, String source,
+                                                 List<String> alsoUserIds, List<String> alsoRoles) {
+        Map<String, Object> assignee = new HashMap<>();
+        if (source != null) assignee.put("source", source);
+        if (alsoUserIds != null) assignee.put("also_user_ids", alsoUserIds);
+        if (alsoRoles != null) assignee.put("also_roles", alsoRoles);
+        Map<String, Object> type = new HashMap<>();
+        type.put("key", key);
+        type.put("assignee", assignee);
+        return type;
+    }
+
+    private void wireBatchTeacher() {
+        FacultySubjectPackageSessionMapping mapping = new FacultySubjectPackageSessionMapping();
+        mapping.setUserId(TEACHER);
+        mapping.setStatus("ACTIVE");
+        when(facultyMappingRepository.findRealTeachersByPackageSessionId(PS)).thenReturn(List.of(mapping));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> captureRaisedRecipients() {
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(doubtNotificationService).notifyDoubtRaised(any(Doubts.class), captor.capture(), eq(INST));
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("batch teacher AND the named staff are both assigned")
+    void facultyCascadeUnionsWithNamedStaff() {
+        wireCommon();
+        wireBatchTeacher();
+        wireSetting("SUBJECT_TEACHER",
+                List.of(queryType("DOUBT", "BATCH_TEACHER", List.of(STAFF_A, STAFF_B), null)));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        assertEquals(List.of(TEACHER, STAFF_A, STAFF_B), captureRaisedRecipients());
+    }
+
+    @Test
+    @DisplayName("also_roles adds everyone holding that role on top of the base route")
+    void roleHoldersAreAddedOnTop() {
+        wireCommon();
+        wireBatchTeacher();
+        when(authService.getUserIdsByRole(INST, ADMIN_ROLE)).thenReturn(List.of(ADMIN_A));
+        wireSetting("BATCH_TEACHER",
+                List.of(queryType("TECHNICAL", "BATCH_TEACHER", null, List.of(ADMIN_ROLE))));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("TECHNICAL"));
+
+        assertEquals(List.of(TEACHER, ADMIN_A), captureRaisedRecipients());
+    }
+
+    @Test
+    @DisplayName("a person named both explicitly and via a role is assigned once")
+    void duplicatesCollapse() {
+        wireCommon();
+        wireBatchTeacher();
+        when(authService.getUserIdsByRole(INST, ADMIN_ROLE)).thenReturn(List.of(STAFF_A, ADMIN_A));
+        wireSetting("BATCH_TEACHER",
+                List.of(queryType("DOUBT", "BATCH_TEACHER", List.of(STAFF_A), List.of(ADMIN_ROLE))));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        assertEquals(List.of(TEACHER, STAFF_A, ADMIN_A), captureRaisedRecipients());
+    }
+
+    @Test
+    @DisplayName("no faculty mapped: the named staff carry it alone, admins are NOT pulled in")
+    void namedStaffSuppressTheAdminSafetyNet() {
+        wireCommon();
+        when(facultyMappingRepository.findRealTeachersByPackageSessionId(PS)).thenReturn(List.of());
+        wireSetting("BATCH_TEACHER",
+                List.of(queryType("DOUBT", "BATCH_TEACHER", List.of(STAFF_A), null)));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        assertEquals(List.of(STAFF_A), captureRaisedRecipients());
+        verify(authService, never()).getUserIdsByRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("a blank source keeps the institute default as the base and adds the staff to it")
+    void blankSourceKeepsGlobalDefaultAsBase() {
+        wireCommon();
+        wireBatchTeacher();
+        wireSetting("BATCH_TEACHER", List.of(queryType("DOUBT", null, List.of(STAFF_A), null)));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        assertEquals(List.of(TEACHER, STAFF_A), captureRaisedRecipients());
+    }
+
+    @Test
+    @DisplayName("SPECIFIC_USERS still means only those users when nothing additive is configured")
+    void legacySpecificUsersUnchanged() {
+        wireCommon();
+        wireBatchTeacher();
+        Map<String, Object> type = queryType("PAYMENT", "SPECIFIC_USERS", null, null);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> assignee = (Map<String, Object>) type.get("assignee");
+        assignee.put("user_ids", List.of(STAFF_A));
+        wireSetting("BATCH_TEACHER", List.of(type));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("PAYMENT"));
+
+        // The teacher must NOT leak in — the union only widens when also_* is configured.
+        assertEquals(List.of(STAFF_A), captureRaisedRecipients());
+        verify(authService, never()).getUserIdsByRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("an unknown key written by a newer frontend does not cost the institute its routing")
+    void unknownSettingKeyIsIgnored() {
+        wireCommon();
+        wireBatchTeacher();
+        Map<String, Object> type = queryType("DOUBT", "BATCH_TEACHER", List.of(STAFF_A), null);
+        type.put("some_future_flag", true);
+        Map<String, Object> setting = new HashMap<>();
+        setting.put("default_assignee_source", "BATCH_TEACHER");
+        setting.put("query_types", List.of(type));
+        setting.put("another_future_block", Map.of("x", 1));
+        when(instituteSettingService.getSettingByInstituteIdAndKey(INST, SETTING_KEY)).thenReturn(setting);
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        // Strict Jackson would throw here, the caller would swallow it as "no setting", and the
+        // whole per-type config would vanish — the named handler is the proof it survived.
+        assertEquals(List.of(TEACHER, STAFF_A), captureRaisedRecipients());
+    }
+
+    @Test
+    @DisplayName("everything resolves to nobody: the admin safety net still fires")
+    void emptyUnionFallsBackToAdmins() {
+        wireCommon();
+        when(facultyMappingRepository.findRealTeachersByPackageSessionId(PS)).thenReturn(List.of());
+        when(authService.getUserIdsByRole(INST, "EVALUATOR")).thenReturn(List.of());
+        when(authService.getUserIdsByRole(INST, ADMIN_ROLE)).thenReturn(List.of(ADMIN_A));
+        wireSetting("BATCH_TEACHER",
+                List.of(queryType("DOUBT", "BATCH_TEACHER", null, List.of("EVALUATOR"))));
+
+        manager.updateOrCreateDoubt(null, null, slideDoubtRequest("DOUBT"));
+
+        assertEquals(List.of(ADMIN_A), captureRaisedRecipients());
+    }
+}

--- a/frontend-admin-dashboard/src/routes/settings/-components/DoubtManagementSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/DoubtManagementSettings.tsx
@@ -31,9 +31,14 @@ type QueryTypeAssigneeSource =
     | 'NONE';
 
 interface QueryTypeAssignee {
-    source: QueryTypeAssigneeSource;
+    /** Absent = no override; the institute-wide "Default auto-assignment" is the base. */
+    source?: QueryTypeAssigneeSource;
     role?: string | null;
     user_ids?: string[];
+    /** Roles assigned IN ADDITION to whatever `source` resolves to. */
+    also_roles?: string[];
+    /** Staff assigned IN ADDITION to whatever `source` resolves to. */
+    also_user_ids?: string[];
 }
 
 interface QueryTypeConfig {
@@ -146,6 +151,8 @@ const DEFAULT_QUERY_TYPES: QueryTypeConfig[] = [
 // Roles offered when a type routes by ROLE.
 const ROLE_OPTIONS = ['ADMIN', 'TEACHER', 'EVALUATOR', 'CONTENT CREATOR', 'ASSESSMENT CREATOR'];
 
+const ROLE_CHIP_OPTIONS = ROLE_OPTIONS.map((r) => ({ label: r, value: r }));
+
 /**
  * Frontend-only sentinel for "no per-type override" — the type defers to the institute-wide
  * "Default auto-assignment" radio above. It is never persisted as a source string: picking it
@@ -163,6 +170,24 @@ const ASSIGNEE_SOURCE_OPTIONS: { value: RouteSelectValue; label: string }[] = [
     { value: 'SPECIFIC_USERS', label: 'Specific staff' },
     { value: 'NONE', label: 'No one (no notifications sent)' },
 ];
+
+/**
+ * Strips empty additive arrays and collapses an assignee that no longer says anything to
+ * `undefined`. Sending `also_user_ids: []` would be harmless but writes noise into every institute's
+ * settings blob, and an assignee of `{}` reads as "configured" while behaving as "not configured".
+ */
+const normalizeAssignee = (assignee: QueryTypeAssignee | null | undefined) => {
+    if (!assignee) return undefined;
+    const alsoRoles = (assignee.also_roles ?? []).filter(Boolean);
+    const alsoUsers = (assignee.also_user_ids ?? []).filter(Boolean);
+    const next: QueryTypeAssignee = { ...assignee };
+    delete next.also_roles;
+    delete next.also_user_ids;
+    if (alsoRoles.length) next.also_roles = alsoRoles;
+    if (alsoUsers.length) next.also_user_ids = alsoUsers;
+    if (!next.source && !next.also_roles && !next.also_user_ids) return undefined;
+    return next;
+};
 
 /** UPPER_SNAKE slug used as a stable type key when the admin adds a new type. */
 const slugifyKey = (label: string): string =>
@@ -468,10 +493,10 @@ export default function DoubtManagementSettings() {
                 ...t,
                 key,
                 label: label || t.label,
-                // Every type — the built-in DOUBT included — may carry its own routing. A null
-                // assignee means the admin chose "Default auto-assignment", so it's dropped from
-                // the payload and the backend keeps falling back to default_assignee_source.
-                assignee: t.assignee ?? undefined,
+                // Every type — the built-in DOUBT included — may carry its own routing. An
+                // assignee that says nothing (no source, no additive handlers) is dropped so the
+                // backend keeps falling back to default_assignee_source for that type.
+                assignee: normalizeAssignee(t.assignee),
             });
         }
         save({ ...settings, query_types: normalizedTypes });
@@ -957,6 +982,11 @@ function QueryTypesCard({
                     {types.map((t, i) => {
                         const source: RouteSelectValue = t.assignee?.source ?? INHERIT_DEFAULT;
                         const pickedStaff = t.assignee?.user_ids ?? [];
+                        const alsoStaff = t.assignee?.also_user_ids ?? [];
+                        const alsoRoles = t.assignee?.also_roles ?? [];
+                        // With SPECIFIC_USERS the base list already IS a staff picker; a second one
+                        // would just be two lists doing the same job.
+                        const showAlsoStaff = source !== 'SPECIFIC_USERS';
                         return (
                             <div
                                 key={i}
@@ -1019,9 +1049,17 @@ function QueryTypesCard({
                                         onChange={(e) => {
                                             const next = e.target.value as RouteSelectValue;
                                             // The sentinel isn't a source — clear the override so
-                                            // the type falls back to the global default again.
+                                            // the type falls back to the global default again,
+                                            // keeping any additive handlers on top of it.
                                             if (next === INHERIT_DEFAULT) {
-                                                onUpdate(i, { assignee: null });
+                                                const keep =
+                                                    alsoRoles.length || alsoStaff.length
+                                                        ? {
+                                                              also_roles: alsoRoles,
+                                                              also_user_ids: alsoStaff,
+                                                          }
+                                                        : null;
+                                                onUpdate(i, { assignee: keep });
                                                 return;
                                             }
                                             onUpdate(i, {
@@ -1127,6 +1165,66 @@ function QueryTypesCard({
                                         ) : null}
                                     </div>
                                 )}
+
+                                <div className="space-y-2 rounded-md bg-neutral-50 p-2">
+                                    <span className="text-xs font-semibold text-neutral-600">
+                                        Also always assign
+                                    </span>
+                                    <p className="text-xs text-neutral-500">
+                                        Added on top of “Route to” — pick a teacher route and still
+                                        keep these people on every query of this type.
+                                    </p>
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        <SelectChips
+                                            placeholder="Roles…"
+                                            options={ROLE_CHIP_OPTIONS}
+                                            selected={ROLE_CHIP_OPTIONS.filter((o) =>
+                                                alsoRoles.includes(o.value)
+                                            )}
+                                            onChange={(picked) =>
+                                                onUpdate(i, {
+                                                    assignee: {
+                                                        ...t.assignee,
+                                                        also_roles: picked.map((p) => p.value),
+                                                    },
+                                                })
+                                            }
+                                            multiSelect={true}
+                                            hasClearFilter={true}
+                                            className="min-w-44"
+                                        />
+                                        {showAlsoStaff && (
+                                            <SelectChips
+                                                placeholder="Staff…"
+                                                options={assigneeOptions}
+                                                selected={assigneeOptions.filter((o) =>
+                                                    alsoStaff.includes(o.value)
+                                                )}
+                                                onChange={(picked) =>
+                                                    onUpdate(i, {
+                                                        assignee: {
+                                                            ...t.assignee,
+                                                            // Keep ids that aren't in the loaded
+                                                            // staff page so they aren't dropped.
+                                                            also_user_ids: [
+                                                                ...picked.map((p) => p.value),
+                                                                ...alsoStaff.filter(
+                                                                    (id) =>
+                                                                        !assigneeOptions.some(
+                                                                            (o) => o.value === id
+                                                                        )
+                                                                ),
+                                                            ],
+                                                        },
+                                                    })
+                                                }
+                                                multiSelect={true}
+                                                hasClearFilter={true}
+                                                className="min-w-60"
+                                            />
+                                        )}
+                                    </div>
+                                </div>
                             </div>
                         );
                     })}

--- a/frontend-admin-dashboard/src/routes/settings/-components/__tests__/doubt-query-type-routing/test.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/__tests__/doubt-query-type-routing/test.tsx
@@ -146,6 +146,55 @@ describe('Query types — built-in Doubt routing', () => {
         expect(savedType('DOUBT').assignee).toBeUndefined();
     });
 
+    it('keeps a teacher route AND adds named staff on top of it', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        const card = typeCard('Doubt');
+        fireEvent.change(routeSelect('Doubt'), { target: { value: 'SUBJECT_TEACHER' } });
+
+        fireEvent.click(within(card).getByText('Staff…'));
+        fireEvent.click(await screen.findByText(/Asha Rao/));
+        fireEvent.click(await screen.findByText(/Vikram Shah/));
+
+        await save();
+        expect(savedType('DOUBT').assignee).toEqual({
+            source: 'SUBJECT_TEACHER',
+            also_user_ids: ['u-1', 'u-2'],
+        });
+    });
+
+    it('adds a role on top of the route without replacing it', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        const card = typeCard('Technical Issue');
+        fireEvent.click(within(card).getByText('Roles…'));
+        // Scope to the popover — the card's ROLE <select> also carries an "ADMIN" option.
+        fireEvent.click(within(await screen.findByRole('listbox')).getByText('ADMIN'));
+
+        await save();
+        expect(savedType('TECHNICAL').assignee).toMatchObject({
+            source: 'ROLE',
+            also_roles: ['ADMIN'],
+        });
+    });
+
+    it('additive handlers survive switching the route back to the default', async () => {
+        renderScreen();
+        await screen.findByText('Query types');
+
+        const card = typeCard('Doubt');
+        fireEvent.click(within(card).getByText('Staff…'));
+        fireEvent.click(await screen.findByText(/Asha Rao/));
+        fireEvent.change(routeSelect('Doubt'), { target: { value: 'BATCH_TEACHER' } });
+        fireEvent.change(routeSelect('Doubt'), { target: { value: 'DEFAULT' } });
+
+        await save();
+        // No source override, but the named handler still rides on the institute default.
+        expect(savedType('DOUBT').assignee).toEqual({ also_user_ids: ['u-1'] });
+    });
+
     it('offers the staff picker on the Doubt type and saves the picked handlers', async () => {
         renderScreen();
         await screen.findByText('Query types');


### PR DESCRIPTION
…dlers

Per-type routing picked a single winner, so choosing "subject teacher" meant the institute could not ALSO pin a fixed set of handlers on the type. A type's assignee now carries also_roles / also_user_ids, and the recipient list is the union of the base route and those handlers, de-duplicated.

- blank source keeps the institute default as the base, so "default auto-assignment PLUS these two people" is expressible
- the admin safety net fires only when the whole union is empty: once explicit handlers are named they ARE the net, and widening to every admin would notify exactly the people the admin routed around
- admin UI gains an "Also always assign" row (roles + staff) on every query type, which survives changing the route
- configs without also_* behave exactly as before, including the single ADMIN role lookup

Also fixes a latent hazard on the same path: both settings ObjectMappers used Jackson's default of throwing on an unknown property, and the caller swallows that as "no setting" — so one field written by a newer frontend would have silently dropped an institute's whole doubt config back to defaults.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
