### PR TITLE
fix(admin): stop the browser autofilling credential fields that are n…

### DIFF
--- a/frontend-admin-dashboard/src/components/common/students/enroll-manually/forms/step-five-form.tsx
+++ b/frontend-admin-dashboard/src/components/common/students/enroll-manually/forms/step-five-form.tsx
@@ -17,6 +17,7 @@ import { StudentTable, StudentCredentialsType } from '@/types/student-table-type
 import { useReEnrollStudent } from '@/hooks/student-list-section/enroll-student-manually/useReEnrollStudent';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
 export const StepFiveForm = ({
     initialValues,
     handleNextButtonDisable,
@@ -169,6 +170,10 @@ export const StepFiveForm = ({
                         onSubmit={form.handleSubmit(onSubmit)}
                         className="flex flex-col gap-8"
                     >
+                        {/* These are the LEARNER's generated credentials, not a login —
+                            the decoy absorbs any autofill Chrome forces past the
+                            autocomplete hints MyInput sets. */}
+                        <AutofillDecoy />
                         <FormItemWrapper<StepFiveData> control={form.control} name="username">
                             <FormStepHeading stepNumber={5} heading="Generate Login Credentials" />
                         </FormItemWrapper>

--- a/frontend-admin-dashboard/src/components/design-system/autofill-decoy.tsx
+++ b/frontend-admin-dashboard/src/components/design-system/autofill-decoy.tsx
@@ -1,0 +1,16 @@
+/**
+ * Hidden username + password pair that absorbs the browser's autofill.
+ *
+ * Chrome fills the FIRST credential-shaped pair it finds in a form, so putting a
+ * throwaway pair above the real fields keeps the real ones empty even when the
+ * heuristics override `autocomplete`. Render it once, as the first child of any
+ * dialog/form that asks for a username and password that are not a login.
+ *
+ * Pair it with `noAutofillProps()` on the real inputs — see `@/lib/no-autofill`.
+ */
+export const AutofillDecoy = () => (
+    <div aria-hidden className="pointer-events-none size-0 overflow-hidden opacity-0">
+        <input type="text" tabIndex={-1} autoComplete="username" name="fake-username" />
+        <input type="password" tabIndex={-1} autoComplete="current-password" name="fake-password" />
+    </div>
+);

--- a/frontend-admin-dashboard/src/components/design-system/input.tsx
+++ b/frontend-admin-dashboard/src/components/design-system/input.tsx
@@ -5,6 +5,7 @@ import { FormInputProps } from './utils/types/input-types';
 import { InputErrorProps } from './utils/types/input-types';
 import { Label } from '../ui/label';
 import { EyeSlash, WarningCircle, Eye } from '@phosphor-icons/react';
+import { isAutofillSuppressed, passwordManagerIgnoreAttrs } from '@/lib/no-autofill';
 
 const inputSizeVariants = {
     large: 'w-full sm:w-60 h-10 py-2 px-3 text-subtitle',
@@ -37,11 +38,21 @@ export const MyInput = React.forwardRef<HTMLInputElement, FormInputProps>(
             disabled,
             label,
             labelStyle,
+            autoComplete,
             ...props
         },
         ref
     ) => {
         const [showPassword, setShowPassword] = useState(false);
+
+        // Default to "never autofill this". Nearly every MyInput in the admin app
+        // is a data-entry field (learner credentials, provider API keys, config)
+        // where the browser dropping the admin's own saved login is wrong — and
+        // for password fields Chrome only honours `new-password`, not `off`.
+        // Screens that genuinely want autofill (the login form) pass an explicit
+        // token, which wins here and also drops the password-manager opt-outs.
+        const resolvedAutoComplete =
+            autoComplete ?? (inputType === 'password' ? 'new-password' : 'off');
 
         const togglePasswordVisibility = () => {
             setShowPassword((prev) => !prev);
@@ -78,6 +89,10 @@ export const MyInput = React.forwardRef<HTMLInputElement, FormInputProps>(
                             value={input}
                             onChange={onChangeFunction}
                             required={required}
+                            autoComplete={resolvedAutoComplete}
+                            {...(isAutofillSuppressed(resolvedAutoComplete)
+                                ? passwordManagerIgnoreAttrs
+                                : {})}
                             {...props}
                         />
                         {inputType === 'password' && (

--- a/frontend-admin-dashboard/src/lib/__tests__/no-autofill/test.tsx
+++ b/frontend-admin-dashboard/src/lib/__tests__/no-autofill/test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { MyInput } from '@/components/design-system/input';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
+
+// MyInput renders its <Label> unassociated with the input, so query by element.
+const inputOf = (container: HTMLElement) => container.querySelector('input') as HTMLInputElement;
+
+describe('MyInput autofill defaults', () => {
+    it('suppresses autofill on password fields', () => {
+        const { container } = render(
+            <MyInput inputType="password" input="secret" onChangeFunction={() => {}} />
+        );
+        const el = inputOf(container);
+        // Chrome ignores `off` on credential fields; `new-password` is the token
+        // that actually stops the saved-credential dropdown.
+        expect(el.getAttribute('autocomplete')).toBe('new-password');
+        expect(el.getAttribute('data-lpignore')).toBe('true');
+        expect(el.getAttribute('data-1p-ignore')).toBe('true');
+    });
+
+    it('suppresses autofill on plain text fields', () => {
+        const { container } = render(
+            <MyInput inputType="text" input="" onChangeFunction={() => {}} />
+        );
+        expect(inputOf(container).getAttribute('autocomplete')).toBe('off');
+    });
+
+    it('lets the login form opt back in, without the manager opt-outs', () => {
+        const { container } = render(
+            <MyInput
+                inputType="password"
+                input=""
+                onChangeFunction={() => {}}
+                autoComplete="current-password"
+            />
+        );
+        const el = inputOf(container);
+        expect(el.getAttribute('autocomplete')).toBe('current-password');
+        expect(el.getAttribute('data-lpignore')).toBeNull();
+    });
+
+    it('still fills normally: value renders and typing propagates', () => {
+        const onChange = vi.fn();
+        const { container } = render(
+            <MyInput inputType="text" input="Ada" onChangeFunction={onChange} />
+        );
+        const el = inputOf(container);
+        expect(el.value).toBe('Ada');
+        fireEvent.change(el, { target: { value: 'Ada L' } });
+        expect(onChange).toHaveBeenCalled();
+    });
+
+    it('keeps other passed-through props intact', () => {
+        const { container } = render(
+            <MyInput
+                inputType="text"
+                input=""
+                onChangeFunction={() => {}}
+                name="learner_username_0"
+                disabled
+            />
+        );
+        const el = inputOf(container);
+        expect(el.name).toBe('learner_username_0');
+        expect(el.disabled).toBe(true);
+    });
+});
+
+describe('AutofillDecoy', () => {
+    it('renders an inert username/password pair the browser can fill instead', () => {
+        const { container } = render(<AutofillDecoy />);
+        const inputs = container.querySelectorAll('input');
+        expect(inputs.length).toBe(2);
+        inputs.forEach((i) => expect(i.getAttribute('tabindex')).toBe('-1'));
+        expect(container.querySelector('[aria-hidden]')).not.toBeNull();
+    });
+});

--- a/frontend-admin-dashboard/src/lib/no-autofill.ts
+++ b/frontend-admin-dashboard/src/lib/no-autofill.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+/**
+ * Browser / password-manager autofill suppression.
+ *
+ * Admin screens are full of credential-shaped fields that are NOT logins — the
+ * learner username + password we generate on "Enroll", the "Edit credentials"
+ * dialog, provider API keys under Settings. Chrome happily drops the admin's own
+ * saved vacademy password into those, which then gets saved onto the learner.
+ *
+ * Two things are needed to stop it:
+ *
+ *  1. `autocomplete`. Chrome ignores `off` on anything it classifies as a
+ *     credential field; the only token it honours is `new-password`, which marks
+ *     the field as part of a "create account" form rather than a login, so the
+ *     saved-credential dropdown never appears. Plain text fields sitting next to
+ *     one still take `off`.
+ *  2. `data-*` opt-outs. 1Password / LastPass / Dashlane / Bitwarden ignore the
+ *     standard attribute entirely and go by their own flags.
+ *
+ * Use `noAutofillProps()` on every credential-shaped input that is not the real
+ * login form. The real login form must keep `username` / `current-password` so
+ * password managers still work there.
+ */
+
+/** Flags the third-party password managers look for. */
+export const passwordManagerIgnoreAttrs = {
+    'data-lpignore': 'true',
+    'data-1p-ignore': 'true',
+    'data-bwignore': 'true',
+    'data-form-type': 'other',
+} as const;
+
+/**
+ * Full attribute bundle for an input that must never be autofilled.
+ *
+ * @param kind `'password'` for anything rendered as `type="password"` (or a
+ *  reveal-toggled secret), `'text'` for the plain fields beside it.
+ */
+export const noAutofillProps = (kind: 'text' | 'password' = 'text') => ({
+    autoComplete: kind === 'password' ? 'new-password' : 'off',
+    ...passwordManagerIgnoreAttrs,
+    spellCheck: false,
+});
+
+/**
+ * `true` when the given autocomplete token means "do not fill this", i.e. when
+ * the password-manager opt-out flags should ride along.
+ */
+export const isAutofillSuppressed = (token?: string) => token === 'off' || token === 'new-password';
+
+/**
+ * Hardest guard available: Chrome will not autofill a `readonly` input, so the
+ * field stays read-only until the user actually focuses it. Spread the result
+ * onto an input. Only worth reaching for on a real username+password pair, where
+ * Chrome's heuristics are most aggressive. Callers that need their own
+ * focus/blur handlers must compose them with the ones returned here.
+ */
+export const useAutofillGuard = () => {
+    const [readOnly, setReadOnly] = useState(true);
+    return {
+        readOnly,
+        onFocus: () => setReadOnly(false),
+        onBlur: () => setReadOnly(true),
+    };
+};

--- a/frontend-admin-dashboard/src/routes/dashboard/-components/AccountDetailsEdit.tsx
+++ b/frontend-admin-dashboard/src/routes/dashboard/-components/AccountDetailsEdit.tsx
@@ -13,6 +13,8 @@ import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { getUserId, getUserName } from '@/utils/userDetails';
 import { removeCookiesAndLogout } from '@/lib/auth/sessionUtility';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { noAutofillProps } from '@/lib/no-autofill';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
 
 // Validation schemas
 const accountDetailsSchema = z
@@ -153,6 +155,9 @@ export default function AccountDetailsEdit({ open, setOpen, onClose }: AccountDe
                 {/* Form Content */}
                 <div className="space-y-6 p-4">
                     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                        {/* Change-credentials form, not a login: without this Chrome
+                            drops the saved password straight into "New Password". */}
+                        <AutofillDecoy />
                         {/* Username Section */}
                         <div className="space-y-4">
                             <div className="flex items-center gap-2 text-sm font-medium text-gray-700">
@@ -166,6 +171,7 @@ export default function AccountDetailsEdit({ open, setOpen, onClose }: AccountDe
                                 </Label>
                                 <Input
                                     id="username"
+                                    {...noAutofillProps('text')}
                                     {...register('username')}
                                     placeholder="Enter your username"
                                     className="h-11 text-sm"
@@ -200,6 +206,7 @@ export default function AccountDetailsEdit({ open, setOpen, onClose }: AccountDe
                                     <Input
                                         id="newPassword"
                                         type={showNewPassword ? 'text' : 'password'}
+                                        {...noAutofillProps('password')}
                                         {...register('newPassword')}
                                         placeholder="Enter your new password"
                                         className="h-11 pr-10 text-sm"
@@ -252,6 +259,7 @@ export default function AccountDetailsEdit({ open, setOpen, onClose }: AccountDe
                                     <Input
                                         id="confirmPassword"
                                         type={showConfirmPassword ? 'text' : 'password'}
+                                        {...noAutofillProps('password')}
                                         {...register('confirmPassword')}
                                         placeholder="Confirm your new password"
                                         className="h-11 pr-10 text-sm"

--- a/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/EmailOtpForm.tsx
+++ b/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/EmailOtpForm.tsx
@@ -297,6 +297,9 @@ export function EmailLogin({
                                                         required={true}
                                                         size="large"
                                                         label="Email Address"
+                                                        // Real login identifier
+                                                        // — keep browser fill.
+                                                        autoComplete="email"
                                                         {...field}
                                                         className="w-[348px]"
                                                     />

--- a/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/forgot-password-form.tsx
+++ b/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/forgot-password-form.tsx
@@ -102,6 +102,8 @@ export function ForgotPassword() {
                                                     required={true}
                                                     size="large"
                                                     label="Email"
+                                                    // Account identifier — keep browser fill.
+                                                    autoComplete="email"
                                                     {...field}
                                                 />
                                             </FormControl>

--- a/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/login-form.tsx
+++ b/frontend-admin-dashboard/src/routes/login/-components/LoginPages/sections/login-form.tsx
@@ -730,6 +730,12 @@ export function LoginForm() {
                                                                         autoCapitalize="none"
                                                                         autoCorrect="off"
                                                                         spellCheck={false}
+                                                                        // This is the real login,
+                                                                        // so opt back in to the
+                                                                        // saved-credential fill
+                                                                        // MyInput suppresses by
+                                                                        // default everywhere else.
+                                                                        autoComplete="username"
                                                                         {...field}
                                                                         className="w-full sm:w-full"
                                                                     />
@@ -758,6 +764,7 @@ export function LoginForm() {
                                                                             required={true}
                                                                             size="large"
                                                                             label="Password"
+                                                                            autoComplete="current-password"
                                                                             {...field}
                                                                             className="w-full sm:w-full"
                                                                         />

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/enroll-bulk/components/ManualUserEntry.tsx
@@ -15,6 +15,8 @@ import { useUserIdentifierSetting } from '@/services/user-identifier-setting';
 import { getPreferredPhoneCountries } from '@/services/domain-routing';
 import { getTerminology } from '@/components/common/layout-container/sidebar/utils';
 import { RoleTerms, SystemTerms } from '@/routes/settings/-components/NamingSettings';
+import { noAutofillProps } from '@/lib/no-autofill';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
 
 interface Props {
     onAdd: (rows: NewUserRow[]) => void;
@@ -317,6 +319,10 @@ export const ManualUserEntry = ({ onAdd, editingRow, onEditSave, onEditCancel }:
 
     return (
         <div className="flex flex-col gap-4">
+            {/* These username/password fields set the LEARNER's credentials, not the
+                admin's — the decoy pair soaks up any autofill Chrome insists on
+                doing so the real rows stay blank (auto-generated server side). */}
+            <AutofillDecoy />
             <div className="flex flex-col gap-3">
                 {rows.map((row, idx) => (
                     <div
@@ -419,12 +425,14 @@ export const ManualUserEntry = ({ onAdd, editingRow, onEditSave, onEditCancel }:
                                     Username (optional)
                                 </Label>
                                 <Input
+                                    name={`learner_username_${idx}`}
                                     placeholder="auto-generated if blank"
                                     value={row.username}
                                     // Usernames cannot contain spaces — strip whitespace as it's typed/pasted
                                     onChange={(e) =>
                                         update(idx, 'username', e.target.value.replace(/\s/g, ''))
                                     }
+                                    {...noAutofillProps('text')}
                                 />
                             </div>
                             <div>
@@ -433,9 +441,11 @@ export const ManualUserEntry = ({ onAdd, editingRow, onEditSave, onEditCancel }:
                                 </Label>
                                 <Input
                                     type="password"
+                                    name={`learner_password_${idx}`}
                                     placeholder="auto-generated if blank"
                                     value={row.password}
                                     onChange={(e) => update(idx, 'password', e.target.value)}
+                                    {...noAutofillProps('password')}
                                 />
                             </div>
                         </div>

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-portal-access/edit-credentials-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-portal-access/edit-credentials-dialog.tsx
@@ -9,6 +9,7 @@ import { Warning, EnvelopeSimple, WhatsappLogo } from '@phosphor-icons/react';
 import { MyButton } from '@/components/design-system/button';
 import { MyInput } from '@/components/design-system/input';
 import { MyDialog } from '@/components/design-system/dialog';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
 import {
     updateStudentCredentials,
@@ -164,6 +165,8 @@ export const EditCredentialsDialog = ({
                 {/* No padding here: MyDialog already wraps children in p-6, and
                     adding our own stacked a second inset on every side. */}
                 <form className="flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+                    {/* Sets the LEARNER's credentials — never fill the admin's own. */}
+                    <AutofillDecoy />
                     <div className="flex items-center gap-2 rounded-md bg-warning-50 px-3 py-2">
                         <Warning className="size-4 shrink-0 text-warning-600" />
                         <p className="text-caption text-neutral-600">

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiCallingSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiCallingSettings.tsx
@@ -21,6 +21,7 @@ import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { Link } from '@tanstack/react-router';
 import { fetchAiVoiceCarrier } from '@/routes/settings/telephony/-services/ai-voice-carrier';
 import { AiAgentsCard } from './AiAgentsCard';
+import { noAutofillProps } from '@/lib/no-autofill';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 // Stored under the institute's AI_CALLING_SETTING JSON. The backend EVALUATE
@@ -707,6 +708,7 @@ export default function AiCallingSettings() {
                         <Input
                             id="ai-token"
                             type="password"
+                            {...noAutofillProps('password')}
                             value={apiToken}
                             placeholder={
                                 cfg?.hasToken
@@ -721,6 +723,7 @@ export default function AiCallingSettings() {
                         <Input
                             id="ai-webhook-secret"
                             type="password"
+                            {...noAutofillProps('password')}
                             value={webhookSecret}
                             placeholder={
                                 cfg?.hasWebhookSecret

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiSettings.tsx
@@ -121,6 +121,7 @@ interface ActivityLogResponse {
 import { useAIModelsList } from '@/hooks/useAiModels';
 import KnowledgeBase from './KnowledgeBase';
 import { StudentAiSettingsSection } from './StudentAiSettingsSection';
+import { noAutofillProps } from '@/lib/no-autofill';
 
 const AI_SETTINGS_SECTIONS: SettingsSectionGroup[] = [
     {
@@ -615,6 +616,7 @@ const AiSettings: React.FC<AiSettingsProps> = ({ isTab }) => {
                                 <Input
                                     id="openaiKey"
                                     type="password"
+                                    {...noAutofillProps('password')}
                                     value={openaiKey}
                                     onChange={(e) => setOpenaiKey(e.target.value)}
                                     placeholder="sk-..."
@@ -662,6 +664,7 @@ const AiSettings: React.FC<AiSettingsProps> = ({ isTab }) => {
                                 <Input
                                     id="geminiKey"
                                     type="password"
+                                    {...noAutofillProps('password')}
                                     value={geminiKey}
                                     onChange={(e) => setGeminiKey(e.target.value)}
                                     placeholder="AIza..."

--- a/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/PaymentGatewaySettings.tsx
@@ -44,6 +44,7 @@ import {
 import { MyButton } from '@/components/design-system/button';
 import { getInstituteId } from '@/constants/helper';
 import { BACKEND_BASE_URL } from '@/config/baseUrl';
+import { noAutofillProps } from '@/lib/no-autofill';
 import {
     PaymentGatewayMapping,
     PaymentVendor,
@@ -577,8 +578,10 @@ const GatewayDialog = ({
                                         onChange={(e) => updateField(f.key, e.target.value)}
                                         placeholder={f.placeholder}
                                         className={isSecret ? 'pr-10' : undefined}
-                                        autoComplete="off"
-                                        spellCheck={false}
+                                        // Gateway keys and the webhook username/password
+                                        // are the PROVIDER's credentials — `off` alone
+                                        // does not stop Chrome offering the admin's own.
+                                        {...noAutofillProps(isSecret ? 'password' : 'text')}
                                     />
                                     {isSecret && (
                                         <button

--- a/frontend-admin-dashboard/src/routes/settings/-components/WhatsAppSettings/WhatsAppSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/WhatsAppSettings/WhatsAppSettings.tsx
@@ -17,6 +17,7 @@ import {
     type CredentialField,
 } from '@/services/whatsapp-provider-service';
 import { WebhookSetup } from './WebhookSetup';
+import { noAutofillProps } from '@/lib/no-autofill';
 
 type Props = { isTab?: boolean };
 
@@ -351,6 +352,7 @@ export default function WhatsAppSettings({ isTab = false }: Props) {
                                                     <Input
                                                         id={`${providerName}-${field.key}`}
                                                         type="text"
+                                                        {...noAutofillProps('text')}
                                                         placeholder={field.placeholder}
                                                         value={
                                                             credentials[field.key] || ''

--- a/frontend-admin-dashboard/src/routes/settings/-components/zoom/AddZoomAccountDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/zoom/AddZoomAccountDialog.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { noAutofillProps } from '@/lib/no-autofill';
 import {
     createZoomAccount,
     updateZoomAccount,
@@ -374,6 +375,7 @@ const SecretField = forwardRef<HTMLInputElement, SecretFieldProps>(function Secr
                     id={id}
                     ref={ref}
                     type={visible ? 'text' : 'password'}
+                    {...noAutofillProps('password')}
                     {...rest}
                     className="h-9 pr-9"
                 />

--- a/frontend-admin-dashboard/src/routes/settings/telephony/-components/telephony-config-card.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/telephony/-components/telephony-config-card.tsx
@@ -5,6 +5,8 @@ import { Phone, CheckCircle, WarningCircle } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { noAutofillProps, useAutofillGuard } from '@/lib/no-autofill';
+import { AutofillDecoy } from '@/components/design-system/autofill-decoy';
 import {
     Select,
     SelectContent,
@@ -160,15 +162,7 @@ export function TelephonyConfigCard() {
     return (
         <div className="rounded-lg border border-neutral-200 bg-white p-5">
             {/* Decoy fields absorb browser autofill so the real credential inputs stay empty. */}
-            <div aria-hidden className="pointer-events-none size-0 overflow-hidden opacity-0">
-                <input type="text" tabIndex={-1} autoComplete="username" name="fake-username" />
-                <input
-                    type="password"
-                    tabIndex={-1}
-                    autoComplete="current-password"
-                    name="fake-password"
-                />
-            </div>
+            <AutofillDecoy />
 
             <div className="mb-4 flex items-start justify-between">
                 <div className="flex items-center gap-2">
@@ -330,7 +324,7 @@ function SecretField({
     helper?: string;
 }) {
     // Block browser autofill: fresh random name per render + readOnly-until-focus.
-    const [readOnly, setReadOnly] = useState(true);
+    const autofillGuard = useAutofillGuard();
     const [fieldName] = useState(() => `tel-${Math.random().toString(36).slice(2)}-tok`);
     return (
         <div className="space-y-1.5">
@@ -352,15 +346,9 @@ function SecretField({
                 id={fieldName}
                 value={value}
                 onChange={(e) => set(e.target.value)}
-                onFocus={() => setReadOnly(false)}
-                onBlur={() => setReadOnly(true)}
-                readOnly={readOnly}
                 placeholder={isSet ? 'Leave blank to keep the saved one' : 'Paste your key here'}
-                autoComplete="new-password"
-                data-lpignore="true"
-                data-1p-ignore="true"
-                data-form-type="other"
-                spellCheck={false}
+                {...noAutofillProps('password')}
+                {...autofillGuard}
             />
             {helper && <p className="text-xs text-neutral-500">{helper}</p>}
         </div>

--- a/frontend-admin-dashboard/src/routes/study-library/ai-copilot/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/ai-copilot/index.lazy.tsx
@@ -77,6 +77,7 @@ import { Loader2 } from 'lucide-react';
 import { useAIModelsList } from '@/hooks/useAiModels';
 import { useInstituteDetailsStore } from '@/stores/students/students-list/useInstituteDetailsStore';
 import { getAiProductName } from '@/config/branding';
+import { noAutofillProps } from '@/lib/no-autofill';
 
 export const Route = createLazyFileRoute('/study-library/ai-copilot/')({
     component: RouteComponent,
@@ -1667,7 +1668,7 @@ function RouteComponent() {
                                     placeholder="sk-..."
                                     className="flex-1"
                                     disabled={userKeysStatus.hasOpenAI}
-                                    autoComplete="new-password"
+                                    {...noAutofillProps('password')}
                                 />
                                 {!userKeysStatus.hasOpenAI ? (
                                     <Button
@@ -1710,7 +1711,7 @@ function RouteComponent() {
                                     placeholder="AIza..."
                                     className="flex-1"
                                     disabled={userKeysStatus.hasGemini}
-                                    autoComplete="new-password"
+                                    {...noAutofillProps('password')}
                                 />
                                 {!userKeysStatus.hasGemini ? (
                                     <Button


### PR DESCRIPTION
…ot logins

The "Enroll <learner>" dialog's manual-entry rows asked for a username and a password with no autofill hints, so Chrome classified the pair as a login and dropped the admin's own saved vacademy credentials in — which then got saved onto the learner. The same gap existed on every other credential-shaped screen in the admin app.

`autocomplete="off"` alone does not fix this: Chrome ignores it on fields it classifies as credentials, and the third-party managers (1Password, LastPass, Dashlane, Bitwarden) ignore the standard attribute entirely. The working combination is `autocomplete="new-password"` on password fields, `off` on the plain fields beside them, the four manager-specific `data-*` opt-outs, and a hidden decoy pair to absorb any fill the heuristics still force through.

That pattern already existed inline in the telephony config card; this lifts it into `@/lib/no-autofill` + `<AutofillDecoy />` and applies it everywhere:

- MyInput now defaults to no-autofill (`new-password` for password inputs, `off` otherwise) plus the manager opt-outs. An explicit `autoComplete` from a caller still wins and drops the opt-outs, so opting in stays possible.
- The real login, OTP and forgot-password forms opt back in explicitly with `username` / `current-password` / `email`, so password managers keep working where they should.
- Raw <Input> credential fields fixed on: enroll manual entry, dashboard account details, AI keys, AI calling token/webhook secret, payment gateway keys and webhook credentials, WhatsApp provider credentials, Zoom S2S credentials and the AI copilot keys.
- Decoy pairs added to the three real username+password dialogs (enroll step 5, edit credentials, account details).

Telephony config card refactored onto the shared helpers with no behaviour change. Covered by a render test asserting the tokens, that opting back in wins, and that ordinary typing still propagates.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
