### PR TITLE
Let a workflow ask for a readable short-link code

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/shortlink/service/ShortLinkIntegrationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/shortlink/service/ShortLinkIntegrationService.java
@@ -72,6 +72,29 @@ public class ShortLinkIntegrationService {
      */
     public String getOrCreateShortLink(String source, String sourceId, String destinationUrl,
             String instituteId) {
+        return getOrCreateShortLink(source, sourceId, destinationUrl, instituteId, null);
+    }
+
+    /**
+     * As above, but asks media_service for a specific code.
+     *
+     * <p>The hint is a request, not a guarantee. media_service slugifies it and uses
+     * it only if it is still free; otherwise it appends a random suffix, and a blank
+     * hint means a random code — which is exactly the behaviour of the four-argument
+     * form, so existing callers are unaffected.</p>
+     *
+     * <p>It also only applies the first time. A learner who already has a link keeps
+     * it, because media_service matches on (source, sourceId) before it ever looks
+     * at the hint.</p>
+     *
+     * @param shortCodeHint desired code, e.g. a mobile number so the link reads
+     *                      {@code u.suchbliss.com/s/919829227181}. Anything readable
+     *                      here is also guessable — do not pass a hint that would let
+     *                      someone enumerate learners where the destination is not
+     *                      itself behind a login.
+     */
+    public String getOrCreateShortLink(String source, String sourceId, String destinationUrl,
+            String instituteId, String shortCodeHint) {
         if (destinationUrl == null || destinationUrl.isBlank()) {
             return null;
         }
@@ -80,6 +103,7 @@ public class ShortLinkIntegrationService {
                 .sourceId(sourceId)
                 .destinationUrl(destinationUrl)
                 .instituteId(instituteId)
+                .shortCode(shortCodeHint == null || shortCodeHint.isBlank() ? null : shortCodeHint.trim())
                 .build();
         try {
             ResponseEntity<String> response = internalClientUtils.makeHmacRequest(

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
@@ -64,6 +64,10 @@ public class WorkflowAiCatalogController {
                 "params: sessionId, sourceId (the packageSessionId), sourceType ('BATCH' uppercase, or 'USER').",
                 "getOrCreateShortLink",
                 "params: destinationUrl (required — the long URL), source (e.g. 'LEARNER_JOIN'), sourceId "
+                        + "(optional shortCode asks for a readable code, e.g. the learner's mobile number, "
+                        + "giving u.<host>/s/919829227181; ignored once a link exists, and a taken code "
+                        + "gets a random suffix. Only use it where the destination needs a login — a "
+                        + "readable code is a guessable one.) "
                         + "(e.g. the learner's userId), instituteId (pass #ctx['instituteId'] explicitly inside "
                         + "an iterator). Idempotent per (source,sourceId): the same learner keeps the same URL "
                         + "across daily runs instead of minting a code per send. OUTPUT: shortUrl — inside an "

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
@@ -710,9 +710,13 @@ public class QueryServiceImpl implements QueryNodeHandler.QueryService {
         String source = params.get("source") == null ? "WORKFLOW" : String.valueOf(params.get("source"));
         String sourceId = params.get("sourceId") == null ? null : String.valueOf(params.get("sourceId"));
         String instituteId = params.get("instituteId") == null ? null : String.valueOf(params.get("instituteId"));
+        // Optional. Lets a workflow ask for a readable code — a learner's mobile
+        // number, say — instead of a random one. Ignored when the learner already
+        // has a link, and falls back to a random code if the value is taken.
+        String shortCode = params.get("shortCode") == null ? null : String.valueOf(params.get("shortCode"));
 
         String shortUrl = shortLinkIntegrationService.getOrCreateShortLink(
-                source, sourceId, destinationUrl, instituteId);
+                source, sourceId, destinationUrl, instituteId, shortCode);
 
         Map<String, Object> result = new HashMap<>();
         if (shortUrl == null || shortUrl.isBlank()) {


### PR DESCRIPTION
Short links were always random, so a learner's join link read u.suchbliss.com/s/24EANYL5. A workflow can now suggest the code — a mobile number, giving u.suchbliss.com/s/919829227181 — which is recognisable to the learner receiving it on WhatsApp.

media_service already accepted the hint and already handles the awkward cases: it slugifies the value, uses it only while it is free, appends a random suffix when it is taken, and falls back to a random code when no hint is given. Only admin_core was dropping the parameter on the floor, so this threads it through the prebuilt and the integration service. The four-argument method now delegates with null, leaving every existing caller on random codes.

It applies to new links only. media_service matches on (source, sourceId) before it looks at a hint, so learners who already have a link keep it, and the ones already sent on WhatsApp keep working.

Note the trade-off, which is why the catalog entry spells it out: a readable code is a guessable one. It suits a destination that is behind a login, where the worst case is confirming somebody is a learner — not one where the link itself grants access.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
