### PR TITLE
fix(payments): generate invoices after commit so a failed invoice can…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoSideViewService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/service/CpoSideViewService.java
@@ -345,19 +345,12 @@ public class CpoSideViewService {
         }
 
         if (req.isGenerateInvoice()) {
-            try {
-                PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
-                        .orElseThrow(() -> new VacademyException("Payment log not found: " + paymentLogId));
-                if (instituteId != null) {
-                    invoiceService.generateInvoice(plan, persistedLog, instituteId);
-                } else {
-                    log.warn("Skipping invoice generation for userPlan={} paymentLog={}: institute_id not resolvable",
-                            userPlanId, paymentLogId);
-                }
-            } catch (Exception e) {
-                log.warn("Failed to generate invoice for side-view offline payment userPlan={}, paymentLogId={}: {}",
-                        userPlanId, paymentLogId, e.getMessage());
-            }
+            // Deferred to after this transaction commits. Generating inline killed the payment:
+            // the invoice's REQUIRES_NEW transaction could not see this method's still-uncommitted
+            // PaymentLog, so invoice_payment_log_mapping failed its FK — and because catching that
+            // exception does not clear rollbackOnly, the commit died with "Transaction silently
+            // rolled back", discarding the payment log, the ledger credit and the allocation.
+            invoiceService.generateInvoiceAfterCommit(paymentLogId, instituteId);
         }
 
         return list(userPlanId);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -2870,6 +2870,82 @@ public class InvoiceService {
      * <p>MUST be invoked through {@code self} (the injected proxy), not directly: a private/
      * internal call bypasses the Spring proxy and the propagation would silently not apply.
      */
+    /**
+     * Generate an invoice for a payment once the caller's transaction has COMMITTED.
+     *
+     * <p>Callers that create the PaymentLog themselves — the CPO side-view offline payment, the
+     * bulk-assign enrolment payment — must use this rather than calling
+     * {@link #generateInvoice} inline, for two reasons:
+     *
+     * <ol>
+     *   <li>{@link #saveInvoiceWithMultiplePaymentLogs} runs REQUIRES_NEW on the assumption its
+     *       payment log is "already committed by the webhook". For an inline caller that is false:
+     *       the log is still pending in the caller's uncommitted transaction, so the new
+     *       transaction cannot see it and the insert dies on
+     *       {@code invoice_payment_log_mapping_payment_log_id_fkey}.</li>
+     *   <li>That failure then destroys the payment. Catching the exception does NOT clear the
+     *       transaction's rollbackOnly flag, so the caller returns normally and the commit fails
+     *       with "Transaction silently rolled back because it has been marked as rollback-only" —
+     *       taking the PaymentLog, the ledger credit and the FIFO allocation with it.</li>
+     * </ol>
+     *
+     * <p>Running after commit makes the REQUIRES_NEW assumption true and puts invoice failures
+     * strictly downstream of the money: the worst case becomes a recorded payment with no invoice,
+     * which can be regenerated, instead of a lost payment.
+     *
+     * <p>Falls through to running inline when no transaction is active, so a non-transactional
+     * caller still gets its invoice.
+     */
+    public void generateInvoiceAfterCommit(String paymentLogId, String instituteId) {
+        if (!StringUtils.hasText(paymentLogId)) {
+            return;
+        }
+        Runnable task = () -> {
+            try {
+                self.generateInvoiceForCommittedPayment(paymentLogId, instituteId);
+            } catch (Exception e) {
+                // Deliberately swallowed: the payment is already committed and must stand even if
+                // the invoice cannot be produced.
+                log.error("Invoice generation failed for paymentLog {} — the payment itself is "
+                        + "committed and unaffected: {}", paymentLogId, e.getMessage(), e);
+            }
+        };
+        if (org.springframework.transaction.support.TransactionSynchronizationManager.isSynchronizationActive()) {
+            org.springframework.transaction.support.TransactionSynchronizationManager.registerSynchronization(
+                    new org.springframework.transaction.support.TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            task.run();
+                        }
+                    });
+        } else {
+            task.run();
+        }
+    }
+
+    /**
+     * Reloads the committed payment log and its plan in one fresh transaction, so nothing is
+     * touched while detached, then generates the invoice.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void generateInvoiceForCommittedPayment(String paymentLogId, String instituteId) {
+        PaymentLog paymentLog = paymentLogRepository.findById(paymentLogId).orElse(null);
+        if (paymentLog == null) {
+            log.warn("Skipping post-commit invoice: payment log {} not found", paymentLogId);
+            return;
+        }
+        UserPlan userPlan = paymentLog.getUserPlan();
+        if (userPlan == null) {
+            log.warn("Skipping post-commit invoice: payment log {} has no user plan", paymentLogId);
+            return;
+        }
+        if (!StringUtils.hasText(instituteId)) {
+            log.warn("Skipping post-commit invoice for payment log {}: institute id not resolvable", paymentLogId);
+            return;
+        }
+        generateInvoice(userPlan, paymentLog, instituteId);
+    }
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Invoice saveInvoiceWithMultiplePaymentLogs(InvoiceData invoiceData, String invoiceNumber, String pdfFileId,
             List<PaymentLog> paymentLogs, String instituteId) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgLearnerService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgLearnerService.java
@@ -561,22 +561,19 @@ public class SubOrgLearnerService {
             }
         }
 
-        String invoiceId = null;
+        // Deferred to after enrollLearnerToSubOrg commits — see generateInvoiceAfterCommit.
+        // Generating inline handed the invoice's REQUIRES_NEW transaction a PaymentLog this
+        // (transactional) enrolment had not committed, so invoice_payment_log_mapping failed its
+        // FK; catching that did not clear rollbackOnly, so the whole sub-org enrolment was then
+        // discarded at commit rather than merely going without an invoice.
+        //
+        // invoiceId is consequently always null in the response now. It was already null whenever
+        // this failed — the catch left it unset — so nothing that used to be populated is lost;
+        // the invoice is still created, just after the enrolment is safely committed.
         if (request.isGenerateInvoice()) {
-            try {
-                PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
-                        .orElse(null);
-                if (persistedLog != null) {
-                    Invoice invoice = invoiceService.generateInvoice(
-                            learnerPlan, persistedLog, request.getInstituteId());
-                    if (invoice != null) invoiceId = invoice.getId();
-                }
-            } catch (Exception e) {
-                log.warn("Invoice generation failed for paymentLogId={}: {}",
-                        paymentLogId, e.getMessage());
-            }
+            invoiceService.generateInvoiceAfterCommit(paymentLogId, request.getInstituteId());
         }
-        return new ManualPaymentResult(paymentLogId, invoiceId);
+        return new ManualPaymentResult(paymentLogId, null);
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_management/service/BulkAssignmentService.java
@@ -803,15 +803,11 @@ public class BulkAssignmentService {
                 if (generateInvoiceOnManualEnroll
                         && StringUtils.hasText(paymentType)
                         && !PaymentOptionType.FREE.name().equalsIgnoreCase(paymentType)) {
-                    try {
-                        PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
-                                .orElseThrow(() -> new RuntimeException(
-                                        "Payment log not found: " + paymentLogId));
-                        invoiceService.generateInvoice(userPlan, persistedLog, instituteId);
-                    } catch (Exception e) {
-                        log.warn("Failed to generate invoice for userId={}, paymentLogId={}: {}",
-                                userId, paymentLogId, e.getMessage());
-                    }
+                    // After commit — see generateInvoiceAfterCommit. Inline, the invoice's
+                    // REQUIRES_NEW transaction cannot see this method's uncommitted PaymentLog,
+                    // and the resulting FK failure would roll the enrolment back rather than
+                    // merely skipping the invoice.
+                    invoiceService.generateInvoiceAfterCommit(paymentLogId, instituteId);
                 }
             } catch (Exception e) {
                 log.warn("Failed to create payment log for userId={}: {}", userId, e.getMessage());
@@ -1808,15 +1804,11 @@ public class BulkAssignmentService {
                     paymentLogId, amount, userPlan.getId());
 
             if (generateInvoiceOnManualEnroll) {
-                try {
-                    PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
-                            .orElseThrow(() -> new RuntimeException(
-                                    "Payment log not found: " + paymentLogId));
-                    invoiceService.generateInvoice(userPlan, persistedLog, instituteId);
-                } catch (Exception e) {
-                    log.warn("Failed to generate invoice for CPO offline payment userId={}, paymentLogId={}: {}",
-                            userId, paymentLogId, e.getMessage());
-                }
+                // After commit, not inline — see generateInvoiceAfterCommit. Generating here would
+                // hand the invoice's REQUIRES_NEW transaction a PaymentLog this transaction has not
+                // committed yet, failing invoice_payment_log_mapping's FK; and since catching that
+                // does not clear rollbackOnly, it would roll the enrolment payment back with it.
+                invoiceService.generateInvoiceAfterCommit(paymentLogId, instituteId);
             }
         } catch (Exception e) {
             log.error("Failed to record CPO offline payment for userPlan={}, amount={}: {}",


### PR DESCRIPTION
…'t destroy the payment

Recording an offline payment failed with "Transaction silently rolled back because it has been marked as rollback-only", losing the payment entirely.

Root cause: saveInvoiceWithMultiplePaymentLogs runs REQUIRES_NEW on the stated assumption that its payment log is "already committed by the webhook". True for the Razorpay path. False for every caller that creates the PaymentLog itself - the CPO side-view offline payment, both bulk-assign enrolment payment sites and the sub-org enrolment - which are @Transactional and had only save()d the log. The invoice's new transaction therefore could not see it:

  insert into invoice_payment_log_mapping violates foreign key constraint
  invoice_payment_log_mapping_payment_log_id_fkey
  Key (payment_log_id)=(09aa73a0-...) is not present in table "payment_log"

That alone would have been survivable, but each caller wrapped the invoice call in try/catch and logged a warning. Catching an exception does NOT clear the transaction's rollbackOnly flag, so the method returned normally and the commit blew up - discarding the PaymentLog, the ledger CREDIT_PAYMENT and the FIFO allocation along with the invoice. Silently, from the admin's point of view.

Adds InvoiceService.generateInvoiceAfterCommit(paymentLogId, instituteId), which registers a TransactionSynchronization and generates on afterCommit, reloading the payment log and its plan inside a fresh REQUIRES_NEW transaction so nothing is touched while detached. Runs inline when no transaction is active.

This makes the REQUIRES_NEW assumption true for these callers and puts invoice failures strictly downstream of the money: the worst case becomes a recorded payment with no invoice - regenerable - instead of a lost payment.

Applied to all four affected sites. The Razorpay webhook keeps its inline call: its payment log really is committed first.

Behaviour change worth noting: SubOrgLearnerService's response no longer carries invoiceId. It was already null whenever this failed (the catch left it unset), so nothing previously populated is lost - the invoice is now simply created after the enrolment is safely committed.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
