### PR TITLE
feat(live-session): mark a learner present only if they actually atte…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceCriteriaConfigDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceCriteriaConfigDTO.java
@@ -1,0 +1,47 @@
+package vacademy.io.admin_core_service.features.live_session.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Minimum-attendance rule for a live session: a learner counts as PRESENT only
+ * if they were actually in the class for at least {@code minDurationPercent} of
+ * its scheduled length.
+ *
+ * <p>Copied onto each session from the institute's
+ * {@code LIVE_SESSION_SETTING.defaultAttendanceCriteria} when it is scheduled,
+ * so a class is judged by the rule it was created under. Disabled (or absent)
+ * means today's behaviour: the join click alone decides.
+ *
+ * <p>A learner who never appears in the provider's roster is treated as zero
+ * minutes attended, which is how "clicked Join but never entered the class"
+ * falls out of the same rule rather than needing one of its own.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AttendanceCriteriaConfigDTO {
+
+    private boolean enabled;
+
+    /**
+     * Share of the scheduled class length a learner must be present for, as a
+     * whole percentage (e.g. 60). The rule is inert without a positive value —
+     * at 0 everyone clears the bar, including learners who never showed up.
+     */
+    private Integer minDurationPercent;
+
+    /** Derived, not stored — without this Jackson writes a bogus "active" key into the persisted rule. */
+    @JsonIgnore
+    public boolean isActive() {
+        return enabled && minDurationPercent != null && minDurationPercent > 0;
+    }
+
+    public static AttendanceCriteriaConfigDTO off() {
+        return new AttendanceCriteriaConfigDTO(false, null);
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSession.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSession.java
@@ -146,6 +146,16 @@ public class LiveSession {
     @Column(name = "audience_push_config_json", columnDefinition = "text")
     private String audiencePushConfigJson;
 
+    /**
+     * Minimum-attendance rule this class was scheduled under:
+     * {enabled, minDurationPercent}. Copied from the institute's
+     * LIVE_SESSION_SETTING.defaultAttendanceCriteria at creation, never read
+     * from that setting later. NULL or disabled means the join click alone
+     * decides attendance. See AttendanceCriteriaService.
+     */
+    @Column(name = "attendance_criteria_json", columnDefinition = "text")
+    private String attendanceCriteriaJson;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Date createdAt;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSessionLogs.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSessionLogs.java
@@ -78,6 +78,15 @@ public class LiveSessionLogs {
     @Column(name = "provider_total_duration_minutes")
     private Integer providerTotalDurationMinutes;
 
+    /**
+     * Audit of the attendance-criteria evaluation for this row: verdict, reason,
+     * attendedMinutes, scheduledMinutes, requiredMinutes, thresholdPercent,
+     * previousStatus, evaluatedAt. Attendance is disputed data, so an absence
+     * must stay explainable after the fact.
+     */
+    @Column(name = "attendance_evaluation_json", columnDefinition = "TEXT")
+    private String attendanceEvaluationJson;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
@@ -56,6 +56,7 @@ public class LiveSessionProviderController {
     private final ProviderMeetingBatchService providerMeetingBatchService;
     private final vacademy.io.admin_core_service.features.live_session.service.RecordingAutoLinkService recordingAutoLinkService;
     private final vacademy.io.admin_core_service.core.security.InstituteAccessValidator instituteAccessValidator;
+    private final vacademy.io.admin_core_service.features.live_session.service.AttendanceCriteriaEvaluator attendanceCriteriaEvaluator;
 
     // -----------------------------------------------------------------------
     // OAuth connect / status
@@ -520,6 +521,18 @@ public class LiveSessionProviderController {
 
             String sessionId = schedule.getSessionId();
 
+            // Attendance criteria are opt-in per session, so everything here is
+            // skipped for a class that never enabled them. The admin snapshot
+            // must be read before the loop: processAnalyticsAttendee resets
+            // statusType to ONLINE when it upgrades a row, which would otherwise
+            // erase the evidence that an admin had marked this learner by hand.
+            vacademy.io.admin_core_service.features.live_session.entity.LiveSession criteriaSession =
+                    liveSessionRepository.findById(sessionId).orElse(null);
+            boolean criteriaActive = attendanceCriteriaEvaluator.isActiveFor(criteriaSession);
+            java.util.Set<String> adminMarked = criteriaActive
+                    ? attendanceCriteriaEvaluator.snapshotAdminMarked(scheduleId)
+                    : null;
+
             if (callback.getAttendees() != null) {
                 for (BbbAnalyticsCallbackDTO.Attendee attendee : callback.getAttendees()) {
                     if (attendee.getExtUserId() == null || attendee.getExtUserId().isBlank()) {
@@ -533,6 +546,23 @@ public class LiveSessionProviderController {
                                 attendee.getExtUserId(), e.getMessage());
                     }
                 }
+            }
+
+            // The roster is the only authoritative statement of who was actually
+            // in the room — our own attendance rows only record that someone
+            // opened the join link. Apply the class's rule now that durations
+            // have been merged.
+            if (criteriaActive) {
+                java.util.Map<String, Boolean> roster = new java.util.HashMap<>();
+                if (callback.getAttendees() != null) {
+                    for (BbbAnalyticsCallbackDTO.Attendee a : callback.getAttendees()) {
+                        if (a.getExtUserId() != null && !a.getExtUserId().isBlank()) {
+                            roster.merge(a.getExtUserId(), Boolean.TRUE.equals(a.getModerator()),
+                                    (x, y) -> x || y);
+                        }
+                    }
+                }
+                attendanceCriteriaEvaluator.evaluate(criteriaSession, schedule, roster, adminMarked);
             }
 
             schedule.setLastAttendanceSyncAt(new java.util.Date());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/service/zoom/ZoomAttendanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/service/zoom/ZoomAttendanceService.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Records learner attendance for Zoom sessions.
@@ -41,6 +42,8 @@ public class ZoomAttendanceService {
     private final ZoomMeetingManager zoomMeetingManager;
     private final LiveSessionParticipantRepository participantRepository;
     private final SessionScheduleRepository scheduleRepository;
+    private final vacademy.io.admin_core_service.features.live_session.repository.LiveSessionRepository liveSessionRepository;
+    private final vacademy.io.admin_core_service.features.live_session.service.AttendanceCriteriaEvaluator attendanceCriteriaEvaluator;
 
     /**
      * Polling fallback: pulls Zoom's post-meeting participant report and records
@@ -88,19 +91,38 @@ public class ZoomAttendanceService {
             }
         }
 
+        // Opt-in per session, so nothing here costs anything for a class that
+        // never enabled it. The admin snapshot must be taken before the upserts,
+        // which reset statusType to ONLINE and would erase a manual mark.
+        vacademy.io.admin_core_service.features.live_session.entity.LiveSession criteriaSession =
+                liveSessionRepository.findById(schedule.getSessionId()).orElse(null);
+        boolean criteriaActive = attendanceCriteriaEvaluator.isActiveFor(criteriaSession);
+        Set<String> adminMarked = criteriaActive
+                ? attendanceCriteriaEvaluator.snapshotAdminMarked(schedule.getId())
+                : null;
+
         Timestamp now = new Timestamp(System.currentTimeMillis());
         int upserts = 0;
+        // Zoom reports no host/moderator flag, so every attendee is scored as a
+        // participant.
+        Map<String, Boolean> roster = new LinkedHashMap<>();
         for (Map.Entry<String, Aggregate> entry : byEmail.entrySet()) {
             String email = entry.getKey();
             Aggregate agg = entry.getValue();
             List<String> userIds = participantRepository.findEnrolledUserIdByEmail(schedule.getSessionId(), email);
             if (!userIds.isEmpty()) {
                 upsertAttendance(schedule, "USER", userIds.get(0), agg, now);
+                roster.put(userIds.get(0), false);
             } else {
                 // Guest / email not matching any enrolled participant.
                 upsertAttendance(schedule, "PROVIDER_EMAIL", email, agg, now);
+                roster.put(email, false);
             }
             upserts++;
+        }
+
+        if (criteriaActive) {
+            attendanceCriteriaEvaluator.evaluate(criteriaSession, schedule, roster, adminMarked);
         }
 
         schedule.setLastAttendanceSyncAt(new Date());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaEvaluator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaEvaluator.java
@@ -1,0 +1,304 @@
+package vacademy.io.admin_core_service.features.live_session.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.live_session.dto.AttendanceCriteriaConfigDTO;
+import vacademy.io.admin_core_service.features.live_session.entity.LiveSession;
+import vacademy.io.admin_core_service.features.live_session.entity.LiveSessionLogs;
+import vacademy.io.admin_core_service.features.live_session.entity.SessionSchedule;
+import vacademy.io.admin_core_service.features.live_session.repository.LiveSessionLogsRepository;
+import vacademy.io.admin_core_service.features.live_session.scheduler.LiveSessionNotificationProcessor;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a session's minimum-attendance rule once the provider has told us who
+ * was really in the class and for how long.
+ *
+ * <p>Provider-neutral on purpose: BBB supplies the roster from its end-of-meeting
+ * analytics callback, Zoom from its past-meeting participants report. Google Meet
+ * cannot be supported — its API returns participants with no email
+ * ({@code GoogleConferenceService} sets {@code email(null)}), so a Meet
+ * participant cannot be tied back to a learner.
+ *
+ * <p>A learner missing from the roster counts as zero minutes, so "clicked Join
+ * and never arrived" is caught by the same comparison as "left after ten
+ * minutes" — no separate rule.
+ *
+ * <p>Two things it never does: it never touches a row an admin marked by hand
+ * ({@code statusType = OFFLINE}), because a teacher's judgement outranks the
+ * roster; and it never marks a moderator absent, because teachers run the class
+ * rather than attend it.
+ *
+ * <p>Every evaluation is written to {@code attendance_evaluation_json} — attendance
+ * is disputed data, so an absence must always be explainable after the fact.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AttendanceCriteriaEvaluator {
+
+    private static final String STATUS_PRESENT = "PRESENT";
+    private static final String STATUS_ABSENT = "ABSENT";
+    private static final String STATUS_TYPE_ADMIN = "OFFLINE";
+
+    private final LiveSessionLogsRepository liveSessionLogsRepository;
+    private final AttendanceCriteriaService attendanceCriteriaService;
+    private final vacademy.io.admin_core_service.features.live_session.repository.LiveSessionParticipantRepository participantRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Reaches back into session/institute services; @Lazy keeps that out of this
+     * bean's construction graph so an edge there cannot fail context startup.
+     */
+    @Autowired
+    @Lazy
+    private LiveSessionNotificationProcessor notificationProcessor;
+
+    /**
+     * Cheap gate so a session that never opted in pays nothing: reading the rule
+     * is a small JSON parse of a column we already hold, while the snapshot and
+     * evaluation below load every attendance row for the schedule.
+     */
+    public boolean isActiveFor(LiveSession session) {
+        return session != null && attendanceCriteriaService.resolve(session).isActive();
+    }
+
+    /**
+     * User ids an admin marked by hand, captured <i>before</i> the provider sync
+     * runs. Both the BBB and Zoom paths upgrade a non-PRESENT row to PRESENT and
+     * reset statusType to ONLINE, so by evaluation time the OFFLINE flag is
+     * already gone. Snapshotting first is what makes "a teacher's manual mark
+     * outranks the roster" actually true.
+     *
+     * @return null if the snapshot failed — the caller must then skip evaluation
+     *         rather than risk overwriting a mark it can no longer see.
+     */
+    public Set<String> snapshotAdminMarked(String scheduleId) {
+        try {
+            return liveSessionLogsRepository.findAllAttendanceByScheduleId(scheduleId).stream()
+                    .filter(l -> STATUS_TYPE_ADMIN.equalsIgnoreCase(l.getStatusType()))
+                    .map(LiveSessionLogs::getUserSourceId)
+                    .filter(StringUtils::hasText)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.warn("attendance_criteria.admin_snapshot_failed scheduleId={}: {}", scheduleId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @param roster      every user id the provider reported as present, mapped to
+     *                    whether they were a moderator. Must be the complete
+     *                    roster: anyone absent from it is judged to have attended
+     *                    zero minutes.
+     * @param adminMarked from {@link #snapshotAdminMarked}; null means the
+     *                    snapshot failed and nothing is changed.
+     */
+    public void evaluate(LiveSession session, SessionSchedule schedule,
+                         Map<String, Boolean> roster, Set<String> adminMarked) {
+        String scheduleId = schedule != null ? schedule.getId() : null;
+        try {
+            AttendanceCriteriaConfigDTO config = attendanceCriteriaService.resolve(session);
+            if (!config.isActive() || scheduleId == null) {
+                return;
+            }
+            if (adminMarked == null) {
+                log.warn("attendance_criteria.no_admin_snapshot scheduleId={} - skipping", scheduleId);
+                return;
+            }
+            if (roster == null || roster.isEmpty()) {
+                // An empty roster is indistinguishable from "the provider lost the
+                // attendee list". Marking a whole class absent off that is exactly
+                // the failure this must never cause.
+                log.warn("attendance_criteria.empty_roster scheduleId={} - skipping", scheduleId);
+                return;
+            }
+
+            roster = withEmailsResolved(session.getId(), roster);
+
+            Integer scheduledMinutes = scheduledMinutes(schedule);
+            if (scheduledMinutes == null || scheduledMinutes <= 0) {
+                log.warn("attendance_criteria.no_scheduled_duration scheduleId={} - skipping", scheduleId);
+                return;
+            }
+            double requiredMinutes = scheduledMinutes * (config.getMinDurationPercent() / 100.0);
+
+            List<LiveSessionLogs> rows =
+                    liveSessionLogsRepository.findAllAttendanceByScheduleId(scheduleId);
+
+            int changed = 0;
+            for (LiveSessionLogs row : rows) {
+                // Learners and guests both correlate: an authenticated learner
+                // joins with our userId as BBB's userID, and GuestController
+                // generates one guest-<uuid> used as both the BBB userID and the
+                // attendance row's userSourceId. PROVIDER_EMAIL rows are skipped —
+                // those are created by the Zoom sync itself for attendees who
+                // matched no learner, so there is nobody to mark absent.
+                if (!"USER".equalsIgnoreCase(row.getUserSourceType())
+                        && !"EXTERNAL_USER".equalsIgnoreCase(row.getUserSourceType())) {
+                    continue;
+                }
+                if (STATUS_TYPE_ADMIN.equalsIgnoreCase(row.getStatusType())
+                        || adminMarked.contains(row.getUserSourceId())) {
+                    continue;
+                }
+                if (Boolean.TRUE.equals(roster.get(row.getUserSourceId()))) {
+                    continue; // moderator — running the class, not attending it
+                }
+
+                boolean inRoster = roster.containsKey(row.getUserSourceId());
+                Integer reported = row.getProviderTotalDurationMinutes();
+                if (inRoster && reported == null) {
+                    // The provider says they were here but gave no minutes; we
+                    // cannot judge how long, and they demonstrably attended.
+                    writeAudit(row, config, STATUS_PRESENT, "NO_DURATION_DATA",
+                            null, scheduledMinutes, requiredMinutes);
+                    liveSessionLogsRepository.save(row);
+                    continue;
+                }
+
+                int attendedMinutes = inRoster ? reported : 0;
+                boolean meets = attendedMinutes >= requiredMinutes;
+                String verdict = meets ? STATUS_PRESENT : STATUS_ABSENT;
+                String reason = meets ? "MET_THRESHOLD" : (inRoster ? "BELOW_THRESHOLD" : "NO_SHOW");
+
+                // Read BEFORE writing the new audit, which overwrites it.
+                //
+                // Notify off the previous *verdict*, not the row's current status.
+                // Both provider paths reset status to PRESENT on every sync, and
+                // Zoom re-syncs an ended schedule every 15 minutes for two days —
+                // so "status changed" is true on every single run and would mail
+                // a below-threshold learner ~190 times. The verdict only moves
+                // when the underlying numbers do.
+                String previousVerdict = previousVerdict(row);
+                String previousStatus = row.getStatus();
+                boolean verdictMoved = !verdict.equalsIgnoreCase(
+                        previousVerdict != null ? previousVerdict : previousStatus);
+
+                writeAudit(row, config, verdict, reason, attendedMinutes, scheduledMinutes, requiredMinutes);
+
+                if (!verdict.equalsIgnoreCase(previousStatus)) {
+                    row.setStatus(verdict);
+                    changed++;
+                }
+                row.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+                liveSessionLogsRepository.save(row);
+
+                if (verdictMoved) {
+                    notify(session, row, verdict);
+                }
+            }
+
+            log.info("attendance_criteria.evaluated scheduleId={} pct={} scheduledMins={} requiredMins={} "
+                            + "roster={} rows={} statusChanged={}",
+                    scheduleId, config.getMinDurationPercent(), scheduledMinutes,
+                    Math.round(requiredMinutes), roster.size(), rows.size(), changed);
+
+        } catch (Exception e) {
+            log.error("attendance_criteria.failed scheduleId={}: {}", scheduleId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Scheduled class length, start to last-entry — the denominator the admin
+     * enters their percentage against. Note this is the booked slot, not how
+     * long the class actually ran: a class that finishes early still measures
+     * everyone against the full slot.
+     */
+    private Integer scheduledMinutes(SessionSchedule schedule) {
+        Time start = schedule.getStartTime();
+        Time end = schedule.getLastEntryTime();
+        if (start == null || end == null) {
+            return null;
+        }
+        long minutes = (end.getTime() - start.getTime()) / 60000L;
+        return minutes > 0 ? (int) minutes : null;
+    }
+
+    private void writeAudit(LiveSessionLogs row, AttendanceCriteriaConfigDTO config, String verdict,
+                            String reason, Integer attendedMinutes, Integer scheduledMinutes,
+                            double requiredMinutes) {
+        Map<String, Object> audit = new LinkedHashMap<>();
+        audit.put("verdict", verdict);
+        audit.put("reason", reason);
+        audit.put("attendedMinutes", attendedMinutes);
+        audit.put("scheduledMinutes", scheduledMinutes);
+        audit.put("thresholdPercent", config.getMinDurationPercent());
+        audit.put("requiredMinutes", Math.round(requiredMinutes));
+        if (attendedMinutes != null && scheduledMinutes != null && scheduledMinutes > 0) {
+            audit.put("attendedPercent", Math.round(attendedMinutes * 1000.0 / scheduledMinutes) / 10.0);
+        }
+        audit.put("previousStatus", row.getStatus());
+        audit.put("evaluatedAt", Instant.now().toString());
+        try {
+            row.setAttendanceEvaluationJson(objectMapper.writeValueAsString(audit));
+        } catch (Exception e) {
+            log.warn("attendance_criteria.audit_serialize_failed: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Some join paths identify a learner to the provider by email rather than by
+     * our user id — BBB's {@code getParticipantJoinLink} passes the email as the
+     * userID, and Zoom's report is email-keyed throughout. Left unresolved, such
+     * a learner is missing from the roster under their real id and would be
+     * marked absent for a class they sat through.
+     *
+     * <p>Adds the resolved user id alongside the email key, keeping both. Only
+     * email-shaped keys are looked up, so a normal roster costs no queries.
+     */
+    private Map<String, Boolean> withEmailsResolved(String sessionId, Map<String, Boolean> roster) {
+        Map<String, Boolean> resolved = new LinkedHashMap<>(roster);
+        for (Map.Entry<String, Boolean> e : roster.entrySet()) {
+            String key = e.getKey();
+            if (key == null || !key.contains("@")) {
+                continue;
+            }
+            try {
+                for (String userId : participantRepository
+                        .findEnrolledUserIdByEmail(sessionId, key.trim().toLowerCase())) {
+                    resolved.merge(userId, e.getValue(), (x, y) -> x || y);
+                }
+            } catch (Exception ex) {
+                log.warn("attendance_criteria.email_resolve_failed email={}: {}", key, ex.getMessage());
+            }
+        }
+        return resolved;
+    }
+
+    /** Verdict recorded by the last evaluation, or null if this row has never been evaluated. */
+    private String previousVerdict(LiveSessionLogs row) {
+        if (!StringUtils.hasText(row.getAttendanceEvaluationJson())) {
+            return null;
+        }
+        try {
+            var node = objectMapper.readTree(row.getAttendanceEvaluationJson()).path("verdict");
+            return node.isTextual() ? node.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void notify(LiveSession session, LiveSessionLogs row, String newStatus) {
+        try {
+            notificationProcessor.sendAttendanceNotification(
+                    session.getId(), row.getUserSourceId(), newStatus);
+        } catch (Exception e) {
+            log.warn("attendance_criteria.notify_failed userId={}: {}",
+                    row.getUserSourceId(), e.getMessage());
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaService.java
@@ -1,0 +1,92 @@
+package vacademy.io.admin_core_service.features.live_session.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
+import vacademy.io.admin_core_service.features.live_session.dto.AttendanceCriteriaConfigDTO;
+import vacademy.io.admin_core_service.features.live_session.entity.LiveSession;
+
+/**
+ * Resolves the attendance-criteria config for a session, from the session's own
+ * {@code attendance_criteria_json} and nothing else.
+ *
+ * <p>Deliberately <b>not</b> falling back to the institute setting at read time,
+ * unlike {@link RecordingAutoLinkService#resolveConfig}. The institute's
+ * {@code defaultAttendanceCriteria} is a scheduling-time default: the admin UI
+ * copies it onto each session as it is created (see
+ * {@code Step2Service.processAttendanceCriteria}), the same way
+ * {@code defaultNotifyOnAttendance} and {@code defaultBbbRecordEnabled} work.
+ *
+ * <p>A read-time fallback would mean switching the setting on retroactively
+ * re-decides attendance for every class already scheduled — including classes
+ * already taught whose callback simply hasn't landed yet, which for ~14% of
+ * classes is up to three days later. Attendance already recorded must not
+ * change because someone edited a setting afterwards.
+ *
+ * <p>Every failure path resolves to OFF rather than throwing. Attendance is
+ * disputed data: malformed config must leave the existing status alone, not
+ * take a guess at it.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AttendanceCriteriaService {
+
+    private static final String LIVE_SESSION_SETTING_KEY = "LIVE_SESSION_SETTING";
+    private static final String CRITERIA_NODE = "defaultAttendanceCriteria";
+
+    private final InstituteSettingService instituteSettingService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * The institute's current default, read <b>only</b> when a class is created
+     * so it can be stamped onto that class. Never called at evaluation time —
+     * see the class javadoc for why.
+     *
+     * <p>Deliberately server-side: seeding this through the scheduling form
+     * meant that if the settings request hadn't resolved when the form
+     * initialised, the class was created with the rule switched off and nothing
+     * anywhere reported a problem.
+     */
+    public AttendanceCriteriaConfigDTO resolveInstituteDefault(String instituteId) {
+        if (!StringUtils.hasText(instituteId)) {
+            return AttendanceCriteriaConfigDTO.off();
+        }
+        try {
+            Object rawData = instituteSettingService.getSettingByInstituteIdAndKey(
+                    instituteId, LIVE_SESSION_SETTING_KEY);
+            if (rawData == null) {
+                return AttendanceCriteriaConfigDTO.off();
+            }
+            var node = objectMapper.valueToTree(rawData).path(CRITERIA_NODE);
+            if (!node.isObject()) {
+                return AttendanceCriteriaConfigDTO.off();
+            }
+            AttendanceCriteriaConfigDTO config =
+                    objectMapper.treeToValue(node, AttendanceCriteriaConfigDTO.class);
+            return config != null ? config : AttendanceCriteriaConfigDTO.off();
+        } catch (Exception e) {
+            log.warn("attendance_criteria.institute_default_read_failed instituteId={}: {}",
+                    instituteId, e.getMessage());
+            return AttendanceCriteriaConfigDTO.off();
+        }
+    }
+
+    public AttendanceCriteriaConfigDTO resolve(LiveSession session) {
+        if (session == null || !StringUtils.hasText(session.getAttendanceCriteriaJson())) {
+            return AttendanceCriteriaConfigDTO.off();
+        }
+        try {
+            AttendanceCriteriaConfigDTO config = objectMapper.readValue(
+                    session.getAttendanceCriteriaJson(), AttendanceCriteriaConfigDTO.class);
+            return config != null ? config : AttendanceCriteriaConfigDTO.off();
+        } catch (Exception e) {
+            log.warn("attendance_criteria.session_config_parse_failed sessionId={}: {}",
+                    session.getId(), e.getMessage());
+            return AttendanceCriteriaConfigDTO.off();
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/Step2Service.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/Step2Service.java
@@ -14,6 +14,7 @@ import vacademy.io.admin_core_service.features.common.enums.CustomFieldTypeEnum;
 import vacademy.io.admin_core_service.features.common.repository.InstituteCustomFieldRepository;
 import vacademy.io.admin_core_service.features.common.repository.CustomFieldRepository;
 import vacademy.io.admin_core_service.features.common.service.InstituteCustomFiledService;
+import vacademy.io.admin_core_service.features.live_session.dto.AttendanceCriteriaConfigDTO;
 import vacademy.io.admin_core_service.features.live_session.dto.LiveSessionStep2RequestDTO;
 import vacademy.io.admin_core_service.features.live_session.entity.*;
 import vacademy.io.admin_core_service.features.live_session.enums.*;
@@ -33,7 +34,11 @@ import java.util.UUID;
 import java.util.List;
 
 @Service
+@lombok.extern.slf4j.Slf4j
 public class Step2Service {
+
+    @Autowired
+    private AttendanceCriteriaService attendanceCriteriaService;
 
     @Autowired
     private LiveSessionRepository sessionRepository;
@@ -91,6 +96,7 @@ public class Step2Service {
         liveSessionPaymentService.upsertPaymentConfig(session, request.getPaymentConfig());
         processRecordingAutoLinkConfig(request, session);
         processAudiencePushConfig(request, session);
+        processAttendanceCriteria(session, isEdit);
 
         session.setStatus(LiveSessionStatus.LIVE.name());
         sessionRepository.save(session);
@@ -467,6 +473,35 @@ public class Step2Service {
      * in Step1Service. Omitting the field on the request leaves the stored
      * config untouched (partial Step2 updates must not silently disable it).
      */
+    /**
+     * Stamps the institute's current minimum-attendance rule onto the class as
+     * it is created, so the class is judged by the rule in force when it was
+     * scheduled. Turning the institute setting on or off afterwards therefore
+     * affects later classes only, and never re-decides attendance for a class
+     * already scheduled or already taught.
+     *
+     * <p>Read here rather than sent by the scheduling form on purpose: if the
+     * settings request had not resolved when the form initialised, the form
+     * would post "disabled" and the class would silently be created with no rule.
+     *
+     * <p>Skipped on edit, so re-saving a class never rewrites its rule. Failures
+     * are swallowed — a class must still be created even if the setting cannot
+     * be read; it simply keeps today's behaviour.
+     */
+    private void processAttendanceCriteria(LiveSession session, boolean isEdit) {
+        if (isEdit) {
+            return;
+        }
+        try {
+            AttendanceCriteriaConfigDTO config =
+                    attendanceCriteriaService.resolveInstituteDefault(session.getInstituteId());
+            session.setAttendanceCriteriaJson(
+                    config.isActive() ? objectMapper.writeValueAsString(config) : null);
+        } catch (Exception e) {
+            log.warn("attendance_criteria.stamp_failed sessionId={}: {}", session.getId(), e.getMessage());
+        }
+    }
+
     private void processRecordingAutoLinkConfig(LiveSessionStep2RequestDTO request, LiveSession session) {
         if (request.getRecordingAutoLinkConfig() == null) {
             return;

--- a/admin_core_service/src/main/resources/db/migration/V461__attendance_criteria.sql
+++ b/admin_core_service/src/main/resources/db/migration/V461__attendance_criteria.sql
@@ -1,0 +1,34 @@
+-- Minimum-attendance rule: a learner counts as PRESENT only if they were
+-- actually in the class for at least N% of its scheduled length, instead of
+-- being marked present the moment they click Join.
+--
+-- A learner missing from the provider's roster counts as zero minutes, so
+-- "clicked Join but never entered" falls out of the same comparison. Measured
+-- on prod, of 290 such learners over 45 days, 41% never even requested a join
+-- URL and 67% show a ~12-minute retry-then-give-up pattern — all of them
+-- currently recorded PRESENT.
+--
+-- Vacademy Meet (roster from the analytics callback) and Zoom (roster from the
+-- past-meeting report). Google Meet returns participants with no email so they
+-- cannot be tied back to a learner; those classes are never evaluated.
+--
+-- Seeded onto each session from the institute's
+-- LIVE_SESSION_SETTING.defaultAttendanceCriteria at scheduling time, not read
+-- from that setting at evaluation time. A class is judged by the rule it was
+-- created under, so switching the setting on never retroactively re-decides
+-- classes already scheduled or already taught. NULL = disabled = today's
+-- behaviour, so no institute is affected until it opts in.
+ALTER TABLE live_session
+    ADD COLUMN IF NOT EXISTS attendance_criteria_json TEXT;
+
+-- Audit trail for every evaluation. Attendance is disputed data: this records
+-- why a learner was marked absent - the verdict, minutes attended, the
+-- scheduled length used as denominator, and the threshold applied.
+ALTER TABLE live_session_logs
+    ADD COLUMN IF NOT EXISTS attendance_evaluation_json TEXT;
+
+COMMENT ON COLUMN live_session.attendance_criteria_json IS
+    'Per-session minimum-attendance rule: {enabled, minDurationPercent}. Copied from the institute LIVE_SESSION_SETTING.defaultAttendanceCriteria when the class is scheduled. NULL or disabled = the join click alone decides attendance.';
+
+COMMENT ON COLUMN live_session_logs.attendance_evaluation_json IS
+    'Audit of the attendance-criteria evaluation: verdict, reason (MET_THRESHOLD/BELOW_THRESHOLD/NO_SHOW/NO_DURATION_DATA), attendedMinutes, scheduledMinutes, requiredMinutes, thresholdPercent, attendedPercent, previousStatus, evaluatedAt.';

--- a/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/LiveSessionSettings.tsx
@@ -15,6 +15,7 @@ import {
     BellRinging,
     MonitorPlay,
     PlugsConnected,
+    UserCheck,
 } from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
@@ -1113,6 +1114,84 @@ export default function LiveSessionSettings({ embedded = false }: LiveSessionSet
                         checked={settings.recordingTranscriptionEnabled}
                         onChange={(v) => togglePrimitive('recordingTranscriptionEnabled', v)}
                     />
+                </CardContent>
+            </Card>
+
+            {/* Minimum Attendance — present only if actually in the class long enough */}
+            <Card className="border-neutral-200 shadow-none">
+                <CardHeader className="flex-row items-start gap-3 space-y-0 p-5 pb-4">
+                    <div className="flex size-9 items-center justify-center rounded-md bg-primary-50 text-primary-500">
+                        <UserCheck size={18} />
+                    </div>
+                    <div className="flex-1">
+                        <CardTitle className="text-base">Minimum Attendance</CardTitle>
+                        <CardDescription>
+                            By default a learner is marked present the moment they click Join, even
+                            if they never actually reach the class or leave after a minute. Turn
+                            this on to require that they were genuinely in the class for a share of
+                            its scheduled length. Works for Vacademy Meet and Zoom; Google Meet
+                            doesn&apos;t report who was in the room, so those classes are
+                            unaffected. A teacher&apos;s manual mark always wins, and teachers are
+                            never marked absent.
+                        </CardDescription>
+                    </div>
+                </CardHeader>
+                <CardContent className="space-y-4 border-t border-neutral-100 p-5">
+                    <SettingRow
+                        title="Require a minimum attendance"
+                        description="Applies to classes scheduled from now on. Turning it off later returns new classes to the current behaviour and never re-decides a class that already happened."
+                        checked={settings.defaultAttendanceCriteria.enabled}
+                        onChange={(v) =>
+                            setSettings((prev) => ({
+                                ...prev,
+                                defaultAttendanceCriteria: {
+                                    ...prev.defaultAttendanceCriteria,
+                                    enabled: v,
+                                },
+                            }))
+                        }
+                    />
+
+                    {settings.defaultAttendanceCriteria.enabled && (
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                            <div className="flex-1">
+                                <div className="text-sm font-medium text-neutral-800">
+                                    Minimum share of the class
+                                </div>
+                                <div className="mt-0.5 text-xs text-neutral-500">
+                                    Measured against the scheduled class length. A learner below
+                                    this is marked absent — including anyone who clicked Join but
+                                    never entered. Note a class that finishes early still measures
+                                    everyone against the full scheduled slot.
+                                </div>
+                            </div>
+                            <Select
+                                value={String(
+                                    settings.defaultAttendanceCriteria.minDurationPercent || 60
+                                )}
+                                onValueChange={(v) =>
+                                    setSettings((prev) => ({
+                                        ...prev,
+                                        defaultAttendanceCriteria: {
+                                            ...prev.defaultAttendanceCriteria,
+                                            minDurationPercent: Number(v),
+                                        },
+                                    }))
+                                }
+                            >
+                                <SelectTrigger className="h-9 w-full sm:w-52">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {[25, 40, 50, 60, 70, 75, 80, 90].map((pct) => (
+                                        <SelectItem key={pct} value={String(pct)}>
+                                            {pct}% of the class
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    )}
                 </CardContent>
             </Card>
 

--- a/frontend-admin-dashboard/src/services/live-session-settings.ts
+++ b/frontend-admin-dashboard/src/services/live-session-settings.ts
@@ -120,6 +120,27 @@ export interface LiveSessionSettings {
      */
     recordingTranscriptionEnabled: boolean;
     /**
+     * "Minimum attendance" — a learner counts as present only if they were
+     * actually in the class for at least `minDurationPercent` of its scheduled
+     * length, rather than merely having clicked Join. Off means today's
+     * behaviour. A learner who never appears in the provider's roster counts as
+     * zero minutes, so click-and-never-arrive is caught by the same rule.
+     *
+     * Works for Vacademy Meet and Zoom, which both report who was in the room.
+     * Google Meet cannot be supported — its API returns participants with no
+     * email, so they can't be tied back to a learner; a Meet class carries the
+     * setting but is never evaluated.
+     *
+     * This is a scheduling-time default, not a live switch: the backend copies
+     * it onto each class as it is created. Turning it on affects classes
+     * scheduled from then on, and turning it off returns later classes to
+     * today's behaviour without re-deciding any class already held.
+     */
+    defaultAttendanceCriteria: {
+        enabled: boolean;
+        minDurationPercent: number;
+    };
+    /**
      * "LMS Connection" — bridges live classes into course content (the LMS).
      * `recordingAddToCourseEnabled` shows/hides the per-recording "Add to
      * course" action on the session view page; `classMaterialsEnabled`
@@ -286,6 +307,10 @@ export const DEFAULT_LIVE_SESSION_SETTINGS: LiveSessionSettings = {
     defaultDailyAttendanceCounting: false,
     descriptionEnabled: true,
     recordingTranscriptionEnabled: false,
+    defaultAttendanceCriteria: {
+        enabled: false,
+        minDurationPercent: 60,
+    },
     lmsConnection: {
         recordingAddToCourseEnabled: false,
         classMaterialsEnabled: false,
@@ -361,6 +386,10 @@ export const getLiveSessionSettings = async (): Promise<LiveSessionSettings> => 
             lmsConnection: {
                 ...DEFAULT_LIVE_SESSION_SETTINGS.lmsConnection,
                 ...(partial.lmsConnection ?? {}),
+            },
+            defaultAttendanceCriteria: {
+                ...DEFAULT_LIVE_SESSION_SETTINGS.defaultAttendanceCriteria,
+                ...(partial.defaultAttendanceCriteria ?? {}),
             },
         };
     } catch (err) {


### PR DESCRIPTION
…nded

A learner is currently marked PRESENT the moment they click Join. Measured on prod, of 290 learners over 45 days who hold an attendance row but never appear in the provider's roster, 41% never even requested a join URL and 67% show a ~12-minute retry-then-give-up pattern. All of them are recorded present.

Opt-in per institute under Settings -> Live Session Settings -> Minimum Attendance: a toggle plus the share of the scheduled class length a learner must actually be present for. Off is exactly today's behaviour, and every code path short-circuits before doing any work when a class did not opt in.

The rule is stamped onto each class as it is created (Step2Service reads the institute setting server-side) and read only from the class's own column when evaluating. Turning the setting on or off therefore affects classes scheduled from then on and never re-decides a class already scheduled or already taught - which is also what makes it safe to enable for a single pilot class.

Applied when the provider reports who was in the room: BBB's end-of-meeting analytics callback and Zoom's past-meeting sync. A learner absent from the roster counts as zero minutes, so click-and-never-arrive falls out of the same comparison. Google Meet cannot be supported - its API returns participants with no email, so they cannot be tied back to a learner.

Guards that matter, all learned the hard way:
- An empty roster aborts rather than marking a whole class absent, since it is indistinguishable from the provider losing the attendee list.
- Admin marks win. Both provider paths reset statusType to ONLINE when they upgrade a row, so the manual-mark set is snapshotted before that happens.
- Moderators are never marked absent.
- Notification fires on a change of verdict, not of status. Zoom re-syncs an ended schedule every 15 minutes for two days and resets status to PRESENT each time, which would otherwise have mailed a below-threshold learner ~190 times.
- Roster keys that are emails resolve through findEnrolledUserIdByEmail, so a learner whom the provider identifies by email is not judged a no-show.
- Fails open throughout: no scheduled duration, no roster, unreadable setting, or any exception leaves attendance exactly as it was.

Every evaluation writes attendance_evaluation_json (verdict, reason, minutes attended, scheduled minutes, required minutes, threshold, previous status), so a disputed absence can always be explained.

Note the denominator is the scheduled slot: a class that finishes early still measures everyone against its full booked length.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
