### PR TITLE
feat(app-registry): registry API for the App Registration module

### DIFF
--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistryProviderController.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistryProviderController.java
@@ -1,0 +1,59 @@
+package vacademy.io.community_service.feature.appregistry.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.auth.util.SuperAdminAuthUtil;
+
+import java.util.Map;
+
+/**
+ * Server-side half of the dashboard's StoreProvider abstraction.
+ *
+ * <p>This endpoint exists so the store credential never has to reach a browser: signing an App
+ * Store Connect JWT or holding a Google service-account key client-side would expose the private
+ * key to anyone with devtools.
+ *
+ * <p>No store integration is wired up yet, so every operation answers <b>501 Not Implemented</b>
+ * with a plain explanation. That is a deliberate choice over returning a plausible-looking status:
+ * a dashboard that invents "Live" is worse than one that says "go and look". The client renders
+ * this as "Manual action required" and links to the right console.
+ *
+ * <p>When a provider is implemented, it must use the official API and documented auth only —
+ * Play Developer API via a service account, App Store Connect via a JWT-signed .p8, Partner Center
+ * via Azure AD. Never a scraped console session, a reused browser cookie, or an undocumented
+ * endpoint.
+ */
+@RestController
+@RequestMapping("/community-service/super-admin/v1/app-registry/providers")
+public class AppRegistryProviderController {
+
+    private static final Map<String, String> CONSOLES = Map.of(
+            "android", "https://play.google.com/console",
+            "ios", "https://appstoreconnect.apple.com",
+            "windows", "https://partner.microsoft.com/dashboard",
+            "macos", "https://appstoreconnect.apple.com");
+
+    @GetMapping("/{platform}/{appId}/{operation}")
+    public ResponseEntity<Map<String, Object>> operation(@RequestAttribute("user") CustomUserDetails user,
+                                                         @PathVariable String platform,
+                                                         @PathVariable String appId,
+                                                         @PathVariable String operation) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+
+        String console = CONSOLES.get(platform == null ? "" : platform.toLowerCase());
+        if (console == null) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "manual", false,
+                    "message", "Unknown platform: " + platform));
+        }
+
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(Map.of(
+                "manual", true,
+                "operation", operation,
+                "consoleUrl", console,
+                "message", "The server-side store integration for this platform isn't configured yet. "
+                        + "Check the store console and record the result in the dashboard."));
+    }
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistrySuperAdminController.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistrySuperAdminController.java
@@ -1,0 +1,63 @@
+package vacademy.io.community_service.feature.appregistry.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.auth.util.SuperAdminAuthUtil;
+import vacademy.io.community_service.feature.appregistry.service.AppRegistryService;
+
+import java.util.List;
+
+/**
+ * App Registration &amp; Store Management registry, consumed by the health-check dashboard's
+ * App Registration module.
+ *
+ * <p>Mirrors exactly the five operations the dashboard's storage adapter expects, so turning on
+ * {@code VITE_APP_REGISTRY_REMOTE=true} moves the team off per-browser localStorage and onto
+ * shared storage with no other client change.
+ */
+@RestController
+@RequestMapping("/community-service/super-admin/v1/app-registry")
+public class AppRegistrySuperAdminController {
+
+    @Autowired
+    private AppRegistryService service;
+
+    @GetMapping("/apps")
+    public ResponseEntity<List<JsonNode>> list(@RequestAttribute("user") CustomUserDetails user) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+        return ResponseEntity.ok(service.listAll());
+    }
+
+    @GetMapping("/apps/{id}")
+    public ResponseEntity<JsonNode> get(@RequestAttribute("user") CustomUserDetails user,
+                                        @PathVariable String id) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    @PutMapping("/apps/{id}")
+    public ResponseEntity<JsonNode> upsert(@RequestAttribute("user") CustomUserDetails user,
+                                           @PathVariable String id,
+                                           @RequestBody JsonNode record) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+        return ResponseEntity.ok(service.upsert(id, record));
+    }
+
+    @DeleteMapping("/apps/{id}")
+    public ResponseEntity<Void> delete(@RequestAttribute("user") CustomUserDetails user,
+                                       @PathVariable String id) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/apps/import")
+    public ResponseEntity<List<JsonNode>> importAll(@RequestAttribute("user") CustomUserDetails user,
+                                                    @RequestBody List<JsonNode> records) {
+        SuperAdminAuthUtil.requireSuperAdmin(user);
+        return ResponseEntity.ok(service.replaceAll(records));
+    }
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/entity/AppRegistration.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/entity/AppRegistration.java
@@ -1,0 +1,69 @@
+package vacademy.io.community_service.feature.appregistry.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Date;
+
+/**
+ * One white-label application tracked by the App Registration &amp; Store Management module.
+ *
+ * <p>The whole client-side {@code AppRecord} is kept verbatim in {@link #payload} as jsonb rather
+ * than normalised into a dozen child tables. That is deliberate: the record's shape is driven by
+ * the platform-requirements catalogue, which changes every time Google, Apple or Microsoft move a
+ * goalpost. Normalising it would mean a schema change per store policy update, for data that is
+ * only ever read and written as a whole document.
+ *
+ * <p>The scalar columns beside it are the fields that are stable identity/search keys, denormalised
+ * so listing and searching stay index-friendly. Note what is deliberately absent: no rolled-up
+ * status column. That rollup is business logic the dashboard already owns, and duplicating it here
+ * would only create two versions that drift apart.
+ */
+@Entity
+@Table(name = "app_registration", schema = "public",
+        indexes = {
+                @Index(name = "idx_app_registration_package", columnList = "package_name"),
+                @Index(name = "idx_app_registration_archived", columnList = "archived")
+        })
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class AppRegistration {
+
+    /** Client-generated UUID; the dashboard owns app identity so records survive export/import. */
+    @Id
+    @Column(name = "id")
+    private String id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "client_name")
+    private String clientName;
+
+    @Column(name = "package_name")
+    private String packageName;
+
+    @Column(name = "archived", nullable = false)
+    private Boolean archived;
+
+    /** The complete AppRecord document as sent by the dashboard. */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
+    private String payload;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Date updatedAt;
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/repository/AppRegistrationRepository.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/repository/AppRegistrationRepository.java
@@ -1,0 +1,11 @@
+package vacademy.io.community_service.feature.appregistry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vacademy.io.community_service.feature.appregistry.entity.AppRegistration;
+
+import java.util.List;
+
+public interface AppRegistrationRepository extends JpaRepository<AppRegistration, String> {
+
+    List<AppRegistration> findAllByOrderByNameAsc();
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/AppRegistryService.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/AppRegistryService.java
@@ -1,0 +1,131 @@
+package vacademy.io.community_service.feature.appregistry.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.common.exceptions.VacademyException;
+import vacademy.io.community_service.feature.appregistry.entity.AppRegistration;
+import vacademy.io.community_service.feature.appregistry.repository.AppRegistrationRepository;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Storage for the app registry.
+ *
+ * <p>Records are passed through as raw JSON in both directions. The dashboard is the only client
+ * and it owns the document shape, so re-declaring ~40 nested fields as Java DTOs would buy nothing
+ * but a second place to update whenever a store adds a question — and a silent data-loss bug the
+ * first time the two drift.
+ */
+@Service
+public class AppRegistryService {
+
+    @Autowired
+    private AppRegistrationRepository repository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional(readOnly = true)
+    public List<JsonNode> listAll() {
+        List<JsonNode> out = new ArrayList<>();
+        for (AppRegistration row : repository.findAllByOrderByNameAsc()) {
+            out.add(parse(row.getPayload(), row.getId()));
+        }
+        return out;
+    }
+
+    @Transactional(readOnly = true)
+    public JsonNode get(String id) {
+        AppRegistration row = repository.findById(id)
+                .orElseThrow(() -> new VacademyException(HttpStatus.NOT_FOUND, "App not found: " + id));
+        return parse(row.getPayload(), id);
+    }
+
+    @Transactional
+    public JsonNode upsert(String id, JsonNode record) {
+        return parse(save(id, record).getPayload(), id);
+    }
+
+    @Transactional
+    public void delete(String id) {
+        if (!repository.existsById(id)) {
+            throw new VacademyException(HttpStatus.NOT_FOUND, "App not found: " + id);
+        }
+        repository.deleteById(id);
+    }
+
+    /**
+     * Bulk replace, backing the dashboard's Import button. Destructive by contract — the whole
+     * registry becomes exactly what was uploaded — so it runs in one transaction: a bad payload
+     * rolls back rather than leaving the team with a half-imported registry.
+     */
+    @Transactional
+    public List<JsonNode> replaceAll(List<JsonNode> records) {
+        if (records == null) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "Expected an array of app records");
+        }
+        repository.deleteAllInBatch();
+        List<JsonNode> out = new ArrayList<>();
+        for (JsonNode record : records) {
+            String id = textAt(record, "id", null);
+            if (id == null || id.isBlank()) {
+                throw new VacademyException(HttpStatus.BAD_REQUEST, "Every app record needs an id");
+            }
+            out.add(parse(save(id, record).getPayload(), id));
+        }
+        return out;
+    }
+
+    /* ------------------------------------------------------------------ internals */
+
+    private AppRegistration save(String id, JsonNode record) {
+        if (record == null || !record.isObject()) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "Expected an app record object");
+        }
+
+        ObjectNode node = ((ObjectNode) record).deepCopy();
+        // The path is authoritative, so a body whose id disagrees can't silently write elsewhere.
+        node.put("id", id);
+        // The server owns the clock; a client with a skewed one must not win a last-write race.
+        node.put("updatedAt", Instant.now().toString());
+
+        JsonNode basics = node.path("basics");
+        AppRegistration row = repository.findById(id).orElseGet(() -> AppRegistration.builder().id(id).build());
+        row.setName(textAt(basics, "name", ""));
+        row.setClientName(textAt(basics, "client", ""));
+        row.setPackageName(textAt(basics, "packageName", ""));
+        row.setArchived(node.path("archived").asBoolean(false));
+        row.setPayload(write(node));
+        return repository.save(row);
+    }
+
+    private static String textAt(JsonNode node, String field, String fallback) {
+        if (node == null) return fallback;
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? fallback : value.asText(fallback);
+    }
+
+    private JsonNode parse(String payload, String id) {
+        try {
+            return objectMapper.readTree(payload);
+        } catch (JsonProcessingException e) {
+            throw new VacademyException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Stored app record for " + id + " is not valid JSON");
+        }
+    }
+
+    private String write(JsonNode node) {
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new VacademyException(HttpStatus.BAD_REQUEST, "App record could not be serialised");
+        }
+    }
+}


### PR DESCRIPTION
Backs the health-check dashboard's App Registration module with shared storage instead of per-browser localStorage.

The AppRecord is stored as jsonb with only name/client/package_name/archived denormalised for indexing. The document's shape is driven by the platform requirements catalogue, so normalising it would mean a schema change every time a store moves a goalpost. No rolled-up status column: that rollup is dashboard logic and a second copy would drift.

Provider endpoints return 501 with manual=true rather than a fabricated status, so the dashboard says 'manual action required' and links to the right console. Store credentials stay server-side; official APIs only.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
