### PR TITLE
Stop the class restarting itself; show a record dot, not "LIVE"

### DIFF
--- a/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/study-library/level-material/subject-material/module-material/chapter-material/slide-material/youtube-player.tsx
@@ -1552,14 +1552,33 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
     }
 
     try {
-      const videoDuration = await safeGetNumber(player.getDuration());
+      // A player that has not finished loading metadata reports a duration of 0,
+      // and briefly does so right after onReady. Clamping against that turned
+      // EVERY seek into a seek to 0 — which is how a live class that had already
+      // run its course appeared to start itself over. Wait for a real duration
+      // instead of trusting the first answer.
+      let videoDuration = await safeGetNumber(player.getDuration());
+      for (let i = 0; i < 10 && !(videoDuration > 0); i++) {
+        await new Promise((r) => setTimeout(r, 300));
+        if (!isMountedRef.current) return false;
+        videoDuration = await safeGetNumber(player.getDuration());
+      }
+      if (!(videoDuration > 0)) {
+        // Still unknown. There is nothing safe to clamp against, and seeking to 0
+        // would restart the class, so leave the player where it is.
+        console.warn("Seek skipped: video duration unavailable");
+        return false;
+      }
 
       let finalSeekTime = totalSecondsToSeek;
       // Ensure timestamp is within valid range
       if (finalSeekTime <= 0) {
         finalSeekTime = 0;
       } else if (finalSeekTime >= videoDuration) {
-        finalSeekTime = videoDuration;
+        // Land just short of the end rather than exactly on it: seeking to the
+        // duration itself fires ENDED, and the replay that follows is the same
+        // restart under a different name.
+        finalSeekTime = Math.max(0, videoDuration - 1);
       }
 
       const success = await safePlayerOperation(
@@ -1688,7 +1707,16 @@ export const YouTubePlayerComp: React.FC<YouTubePlayerProps> = ({
             // zero, so the class appears to restart itself just as it finishes.
             // Past the end there is nothing left to sync to, so leave the player
             // where it is and let it finish.
-            const duration = await safeGetNumber(playerRef.current?.getDuration());
+            // Same trap as in seekToTimestamp: a duration of 0 means "not loaded
+            // yet", not "zero-length". Waiting for it is what makes the check below
+            // meaningful — reading it once let the guard skip itself and hand an
+            // out-of-range target to the seek.
+            let duration = await safeGetNumber(playerRef.current?.getDuration());
+            for (let i = 0; i < 10 && !(duration > 0); i++) {
+              await new Promise((r) => setTimeout(r, 300));
+              if (!isMountedRef.current) return;
+              duration = await safeGetNumber(playerRef.current?.getDuration());
+            }
             if (duration > 0 && elapsedSeconds >= duration - 1) {
               console.log(
                 `Live class is ${elapsedSeconds}s in but the video is only ${duration}s long — not seeking.`

--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
@@ -622,9 +622,25 @@ function EmbedComponent() {
           <h1 className="min-w-0 text-subtitle font-bold leading-tight xs:text-h3 md-tablets:text-h2">
             {sessionDetails?.title || getTerminology(ContentTerms.Session, SystemTerms.Session)}
           </h1>
-          <span className={`rounded px-3 py-1 text-sm font-semibold uppercase text-white shadow ${sessionId ? "bg-red-600" : "bg-primary-300"}`}>
-            {sessionId ? "Live" : "SESSION"}
-          </span>
+          {/* A recording dot rather than the word "Live". These classes are a
+              scheduled playback, not a broadcast, and "LIVE" alongside YouTube's
+              own chrome read as a claim the class could not keep. The dot is
+              shrink-0 so the title truncates against it instead of squashing it. */}
+          {sessionId ? (
+            <span
+              className="flex shrink-0 items-center gap-2 rounded px-3 py-1 text-sm font-semibold uppercase text-neutral-600 shadow"
+              role="status"
+              aria-label="Recording"
+              title="Recording"
+            >
+              <span className="size-2 shrink-0 rounded-full bg-red-600" aria-hidden="true" />
+              Rec
+            </span>
+          ) : (
+            <span className="shrink-0 rounded bg-primary-300 px-3 py-1 text-sm font-semibold uppercase text-white shadow">
+              SESSION
+            </span>
+          )}
         </div>
         <div className="flex-grow relative flex items-center justify-center p-2">
           {renderEmbeddedSession()}


### PR DESCRIPTION
The restart was my own earlier fix falling into the trap it was meant to close. seekToTimestamp clamps the target against getDuration(), and a player that has not finished loading metadata reports a duration of 0 — briefly, right after onReady. Clamping against 0 turns EVERY seek into a seek to 0, so the live-class sync restarted the class instead of skipping past its end. The guard I added read the duration once and, seeing 0, skipped itself and handed the out-of-range target straight to that clamp.

Both places now wait for a real duration before deciding: up to ~3s, and if it never arrives the seek is abandoned rather than sent to 0, because leaving the player alone is always safer than restarting a class. A target past the end now lands one second short of it — seeking exactly to the duration fires ENDED, and the replay after that is the same restart under another name.

The badge becomes a red recording dot. These classes are scheduled playback, not a broadcast, so "LIVE" next to YouTube's own chrome claimed something the class could not keep. It carries role=status and an aria-label so it still announces itself, and shrink-0 so the title truncates against it rather than squashing it.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
