### PR TITLE
fix(voice-bot): duplicate on_reply_start in SentinelGate.__init__

### DIFF
--- a/voice_bot_service/app/bot.py
+++ b/voice_bot_service/app/bot.py
@@ -1120,7 +1120,6 @@ class SentinelGate(FrameProcessor):
 
     def __init__(self, outcome: CallOutcome, on_activity, set_bot_speaking,
                  on_reply_start=None, on_send=None,
-                 on_reply_start=None,
                  transfer_closing: str = "Ek moment, main aapko connect kar rahi hoon.",
                  end_closing: str = "Theek hai, dhanyavaad. Aapka din shubh ho!",
                  transfer_fail_closing: str = ("Mujhe abhi connect karne mein dikkat aa "


### PR DESCRIPTION
Adding the on_send hook inserted a new parameter line instead of extending the existing one, so on_reply_start was declared twice and bot.py failed to import — collection aborted before any test ran.

Missed locally because ast.parse() only runs the parser, not the symbol table pass, so it never raises on a duplicate argument. compile(src, f, "exec") does, and is what this should have been checked with. pipecat is not installed locally, so test_call_behavior.py could not have run here either; the other three modules pass (124 tests).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
