### PR TITLE
feat(ai-calling): let a workflow re-call leads a counsellor already owns

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadStatusService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/service/LeadStatusService.java
@@ -213,7 +213,7 @@ public class LeadStatusService {
                 .build());
 
         logStatusChangeToTimeline(saved, oldStatusId, target, actorUserId, source);
-        emitStatusChanged(saved, instituteId, oldStatusId, target);
+        emitStatusChanged(saved, instituteId, oldStatusId, target, source, actorUserId);
 
         // Keep the user's profile conversion_status (what the side-view reads) in sync with this
         // per-response change, so the leads list and the side-view never disagree. Best-effort —
@@ -282,7 +282,8 @@ public class LeadStatusService {
         }
     }
 
-    private void emitStatusChanged(AudienceResponse lead, String instituteId, String oldStatusId, LeadStatus target) {
+    private void emitStatusChanged(AudienceResponse lead, String instituteId, String oldStatusId, LeadStatus target,
+                                   String source, String actorUserId) {
         if (instituteId == null || instituteId.isBlank()) return;
         try {
             String oldKey = oldStatusId == null ? null
@@ -291,6 +292,13 @@ public class LeadStatusService {
             leadTriggerContextBuilder.put(ctx, "changeType", "LEAD_STATUS");
             leadTriggerContextBuilder.put(ctx, "oldStatus", oldKey);
             leadTriggerContextBuilder.put(ctx, "newStatus", target.getStatusKey());
+            // WHO moved the status — the same token written to lead_status_history.source
+            // ("MANUAL" | "MANUAL_DISPOSITION" | "AI_CALLING" | "AI_WORKFLOW" | ...). Without
+            // it a workflow on this event cannot tell a human's change from one the workflow
+            // itself caused, and a graph that reacts to a status by writing another status
+            // re-triggers itself (this event has no idempotency dedup — strategy UUID).
+            leadTriggerContextBuilder.put(ctx, "statusChangeSource", source != null ? source : "MANUAL");
+            leadTriggerContextBuilder.put(ctx, "statusChangedByUserId", actorUserId);
             workflowTriggerService.handleTriggerEvents(
                     WorkflowTriggerEvent.LEAD_STATUS_CHANGED.name(), lead.getId(), instituteId, ctx);
         } catch (Exception ex) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallNodeDispatcher.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallNodeDispatcher.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import vacademy.io.admin_core_service.features.telephony.core.dto.AiCallRequestDTO;
+import vacademy.io.admin_core_service.features.telephony.enums.CallTrigger;
 
 import java.util.concurrent.Executor;
 
@@ -45,9 +46,21 @@ public class AiCallNodeDispatcher {
 
     /** Place this AI call on the paced background worker; returns immediately. */
     public void enqueue(AiCallRequestDTO req) {
+        enqueue(req, CallTrigger.AUTOMATION);
+    }
+
+    /**
+     * As {@link #enqueue(AiCallRequestDTO)}, but with the caller declaring WHICH
+     * throttle profile applies. The trigger is chosen by the calling code from the
+     * node's authored config — never read off the request body — so a workflow can
+     * opt out of the already-assigned guard only when an admin explicitly built it
+     * that way. Everything else still enqueues as {@link CallTrigger#AUTOMATION}.
+     */
+    public void enqueue(AiCallRequestDTO req, CallTrigger trigger) {
+        CallTrigger effective = trigger == null ? CallTrigger.AUTOMATION : trigger;
         executor.execute(() -> {
             try {
-                aiCallService.placeCall(req, null);
+                aiCallService.placeCall(req, null, effective);
             } catch (Exception e) {
                 log.warn("ai-call queue: failed to place call for lead {} (response {}): {}",
                         req.getUserId(), req.getResponseId(), e.getMessage());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/enums/CallTrigger.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/enums/CallTrigger.java
@@ -27,7 +27,21 @@ public enum CallTrigger {
      * these leads deliberately — but KEEPS the daily cap and the duplicate window,
      * because a fan-out is exactly what those two are there to bound.
      */
-    BULK_MANUAL;
+    BULK_MANUAL,
+
+    /**
+     * A workflow whose CALL_AI node was explicitly authored with
+     * {@code ignoreAssignedGuard = true}. Same throttle profile as
+     * {@link #BULK_MANUAL}: the already-assigned guard is skipped because an admin
+     * deliberately built a graph that targets leads a counsellor already owns (e.g.
+     * "when a manual call is dispositioned DNP, let the bot try again"), but the
+     * daily cap and the duplicate window still apply — this path IS automation and
+     * can loop, so the two throttles that bound fan-out must stay on.
+     *
+     * <p>Distinct from {@link #AUTOMATION} so the skip is visible in logs and can
+     * never be the default: a node without the flag still comes in as AUTOMATION.
+     */
+    WORKFLOW_EXPLICIT;
 
     /** True when the lead already having a counsellor should block the dial. */
     public boolean enforcesAssignedLeadGuard() {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowCatalogController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowCatalogController.java
@@ -342,6 +342,10 @@ public class WorkflowCatalogController {
                 ctxVar("changeType", "Change type (CONVERSION_STATUS / TIER / ENQUIRY_STATUS / LEAD_STATUS)"),
                 ctxVar("oldStatus", "Previous status"),
                 ctxVar("newStatus", "New status"),
+                // Only emitted by the per-lead LEAD_STATUS path (LeadStatusService); the
+                // profile-level conversion/tier emitters don't set them.
+                ctxVar("statusChangeSource", "Who changed it: MANUAL | MANUAL_DISPOSITION | AI_CALLING | AI_WORKFLOW"),
+                ctxVar("statusChangedByUserId", "User ID of whoever changed it (blank for system changes)"),
                 ctxVar("conversionStatus", "Conversion status")));
 
         // Assessment events. Emitted cross-service by assessment_service's

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/CallAiNodeHandler.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/engine/CallAiNodeHandler.java
@@ -15,6 +15,7 @@ import vacademy.io.admin_core_service.features.telephony.core.AiCallOutcomeProce
 import vacademy.io.admin_core_service.features.telephony.core.AiCallingSettingsService;
 import vacademy.io.admin_core_service.features.telephony.core.dto.AiCallRequestDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.AiCallingSettingsPojo;
+import vacademy.io.admin_core_service.features.telephony.enums.CallTrigger;
 import vacademy.io.admin_core_service.features.workflow.entity.NodeTemplate;
 import vacademy.io.admin_core_service.features.workflow.entity.WorkflowExecutionState;
 import vacademy.io.admin_core_service.features.workflow.enums.WorkflowExecutionStatus;
@@ -116,6 +117,13 @@ public class CallAiNodeHandler implements NodeHandler {
         // falls back to the institute's AI_CALLING_SETTING default). Lets one builder pick
         // the provider for this node without touching global settings.
         String provider = firstNonBlank(readConfig(nodeConfigJson, "provider"), str(context.get("provider")));
+        // Opt-in escape from the already-assigned guard. OFF by default: automation that
+        // re-dials leads a counsellor already owns is exactly what the guard exists to stop.
+        // Turned ON only for graphs deliberately built to target owned leads — the canonical
+        // case being "a counsellor manually called and dispositioned this lead DNP, now let
+        // the bot try again", where the lead is assigned BY DEFINITION and the guard would
+        // silently stop every dial. The daily cap and duplicate window still apply.
+        boolean ignoreAssignedGuard = readConfigBool(nodeConfigJson, "ignoreAssignedGuard");
         // Arbitrary call metadata handed to the AI agent (e.g. studentName, sessionName,
         // courseName — whatever the conversation needs). Static keys come from the node
         // config's "metadata" object; dynamic per-run values from the context's
@@ -152,7 +160,7 @@ public class CallAiNodeHandler implements NodeHandler {
             return out;   // routes to next node via normal traversal; does NOT pause/dial; does NOT call giveUpAfterRetries
         }
 
-        Plan plan = plan(instituteId, userId, attempts, callsToday, callsDay, provider);
+        Plan plan = plan(instituteId, userId, attempts, callsToday, callsDay, provider, ignoreAssignedGuard);
 
         switch (plan.action()) {
             case STOP -> {
@@ -184,7 +192,11 @@ public class CallAiNodeHandler implements NodeHandler {
                 req.setSubjectId(subjectId);
                 if (!callMetadata.isEmpty()) req.setMetadata(callMetadata);
 
-                aiCallDispatcher.enqueue(req); // paced; placeCall guards already-assigned leads
+                // paced; placeCall re-applies the same guards server-side. The trigger must
+                // match the decision plan() just made, or placeCall would refuse a dial the
+                // node already counted as an attempt.
+                aiCallDispatcher.enqueue(req, ignoreAssignedGuard
+                        ? CallTrigger.WORKFLOW_EXPLICIT : CallTrigger.AUTOMATION);
 
                 int newAttempts = attempts + 1;
                 String today = LocalDate.now(IST).toString();
@@ -245,6 +257,19 @@ public class CallAiNodeHandler implements NodeHandler {
             return v == null || v.isNull() ? null : v.asText();
         } catch (Exception e) {
             return null;
+        }
+    }
+
+    /** Read a boolean flag from the node config; absent / unparseable ⇒ false. */
+    private boolean readConfigBool(String json, String key) {
+        if (json == null || json.isBlank()) return false;
+        try {
+            JsonNode v = mapper.readTree(json).get(key);
+            // asBoolean() also accepts the string "true", which is what the builder's
+            // config panel writes for a checkbox.
+            return v != null && !v.isNull() && v.asBoolean(false);
+        } catch (Exception e) {
+            return false;
         }
     }
 
@@ -392,10 +417,12 @@ public class CallAiNodeHandler implements NodeHandler {
     private record Plan(Action action, Instant resumeAt, String reason) {}
 
     private Plan plan(String instituteId, String userId, int attempts, int callsToday, String callsDay,
-                      String provider) {
+                      String provider, boolean ignoreAssignedGuard) {
         AiCallingSettingsPojo s = settingsService.get(instituteId);
         if (s == null || !s.isEnabled()) return new Plan(Action.STOP, null, "ai_calling_disabled");
-        if (leadAlreadyAssigned(userId, instituteId)) return new Plan(Action.STOP, null, "assigned");
+        if (!ignoreAssignedGuard && leadAlreadyAssigned(userId, instituteId)) {
+            return new Plan(Action.STOP, null, "assigned");
+        }
         if (attempts >= Math.max(1, s.getMaxRetries())) return new Plan(Action.STOP, null, "exhausted");
 
         ZoneId tz = resolveZone(s.getTimezone());

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/node-config-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/node-config-panel.tsx
@@ -1366,6 +1366,31 @@ export function NodeConfigPanel() {
                                 )}
                             </select>
                         </div>
+                        <div className="flex items-start gap-2 rounded-md border border-input p-3">
+                            <input
+                                id="ignore-assigned-guard"
+                                type="checkbox"
+                                className="mt-0.5"
+                                checked={data.config.ignoreAssignedGuard === true}
+                                onChange={(e) =>
+                                    handleConfigChange('ignoreAssignedGuard', e.target.checked)
+                                }
+                            />
+                            <div>
+                                <Label
+                                    htmlFor="ignore-assigned-guard"
+                                    className="cursor-pointer text-xs"
+                                >
+                                    Also call leads that already have a counsellor
+                                </Label>
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    Off by default: the bot skips leads a counsellor already owns.
+                                    Turn this on for workflows that deliberately target owned leads
+                                    — e.g. re-calling a lead a counsellor just marked DNP — or the
+                                    node will stop without dialling. Daily call caps still apply.
+                                </p>
+                            </div>
+                        </div>
                         <div>
                             <Label className="text-xs">Extra metadata for the agent (JSON, optional)</Label>
                             <textarea

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.ts
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.ts
@@ -193,7 +193,9 @@ function makeChannelSendNodes(
 //   1. `on` must evaluate to a List of Maps (not Strings)
 //   2. Each Map must have an `email` (or `to`, `parentsEmail` etc.) field
 //   3. `forEach.eval` must evaluate to a Map (the same item)
-//   4. DELAY nodes >60s require the Quartz resume job (currently disabled)
+//   4. DELAY nodes >60s pause and resume via the Quartz resume job, which runs
+//      every 2 min (QuartzConfig.workflowResumeTrigger) — it is ENABLED. The same
+//      job drives the CALL_AI retry loop.
 // ═══════════════════════════════════════════════════
 
 export const USE_CASE_TEMPLATES: UseCaseTemplate[] = [
@@ -287,6 +289,149 @@ export const USE_CASE_TEMPLATES: UseCaseTemplate[] = [
                 workflowName: 'AI-call new leads',
                 workflowDescription:
                     'Place an AI call when a lead is submitted, then route on the call disposition: callOutcome == ASSIGN sets the interested status, otherwise the follow-up status.',
+            };
+        },
+    },
+
+    // ─── 0b. AI re-call a lead after a manual status change ───
+    // The counsellor calls a lead, dispositions it (DNP / not reachable / call back),
+    // and the bot picks it up from there. Two things make this work that are easy to
+    // miss, so they are baked into the generated graph rather than left to the admin:
+    //   * ignoreAssignedGuard — the lead is assigned to the counsellor who just called
+    //     it, and CALL_AI refuses assigned leads by default (CallTrigger.AUTOMATION).
+    //     Without the flag the node stops with reason="assigned" and never dials.
+    //   * the source guard — LEAD_STATUS_CHANGED has no idempotency dedup (strategy
+    //     UUID), and the AI's own outcome writes a status back through the same path.
+    //     Matching on the status alone re-enters the graph off its own write.
+    {
+        id: 'ai_recall_on_status',
+        name: 'AI re-calls leads on a status',
+        description:
+            'When a lead is moved to a chosen status (e.g. DNP) by a person — from the leads list or a post-call disposition — the AI voice agent calls them back after a delay. Retries, calling hours and the counsellor handoff all follow Settings → AI Calling.',
+        icon: '🔁',
+        triggerEvents: ['LEAD_STATUS_CHANGED'],
+        workflowType: 'EVENT_DRIVEN',
+        questions: [
+            {
+                id: 'statusKey',
+                label: 'Which lead status should start the AI call?',
+                helpText:
+                    'The status KEY exactly as it appears in Settings → Lead Statuses (e.g. DNP, NOT_REACHABLE, CALL_BACK). The status must already exist for this institute — the workflow can only fire on a status a person can actually set.',
+                type: 'text',
+                required: true,
+                defaultValue: 'DNP',
+            },
+            {
+                id: 'campaignName',
+                label: 'AI agent (optional)',
+                helpText:
+                    'Name of the AI agent/campaign from Settings → AI Calling → Campaigns. Leave blank to use the institute default.',
+                type: 'text',
+                required: false,
+            },
+            {
+                id: 'delayMinutes',
+                label: 'Wait how long before the bot calls?',
+                helpText:
+                    'Minutes between the status change and the AI call, so the bot never rings seconds after the counsellor hung up. The call still only goes out inside the calling hours set in Settings → AI Calling.',
+                type: 'number',
+                required: false,
+                defaultValue: 30,
+            },
+        ],
+        generateWorkflow: (answers) => {
+            const statusKey = ((answers.statusKey as string) || 'DNP').trim().toUpperCase();
+            const campaignName = ((answers.campaignName as string) || '').trim();
+            const delayMinutes = Number(answers.delayMinutes ?? 30) || 0;
+
+            // CONDITION — fire only on the chosen status AND only when a PERSON set it.
+            // statusChangeSource carries the same token as lead_status_history.source:
+            // MANUAL (leads list) / MANUAL_DISPOSITION (post-call outcome) are human;
+            // AI_CALLING / AI_WORKFLOW are this system writing back, and must not
+            // re-enter the graph. Written as an explicit allow-list so an unknown future
+            // source defaults to NOT calling.
+            const gateNode = makeNode(
+                'CONDITION',
+                `Manually set to ${statusKey}?`,
+                {
+                    condition:
+                        `#ctx['newStatus'] == '${statusKey}' and ` +
+                        "(#ctx['statusChangeSource'] == 'MANUAL' or #ctx['statusChangeSource'] == 'MANUAL_DISPOSITION')",
+                    trueLabel: 'Yes — hand to the bot',
+                    falseLabel: 'No — ignore',
+                },
+                250,
+                80,
+                true
+            );
+
+            const delayNode = makeNode(
+                'DELAY',
+                `Wait ${delayMinutes} min`,
+                // The engine reads { delay: { value, unit } } (DelayNodeHandler) — a flat
+                // delayMinutes key parses to 0 and silently skips the wait.
+                { delay: { value: delayMinutes, unit: 'MINUTES' } },
+                250,
+                220
+            );
+
+            // CALL_AI — ignoreAssignedGuard is the whole point of this template.
+            const callNode = makeNode(
+                'CALL_AI',
+                'AI Call',
+                campaignName
+                    ? { campaignName, ignoreAssignedGuard: true }
+                    : { ignoreAssignedGuard: true },
+                250,
+                360
+            );
+
+            // Branch on the AI's verdict. The true branch is left with a blank statusKey
+            // on purpose so the builder's validation makes the admin pick their own
+            // status — the same convention as the 'AI-call new leads' template.
+            const outcomeNode = makeNode(
+                'CONDITION',
+                'Interested?',
+                {
+                    condition: "#ctx['callOutcome'] == 'ASSIGN'",
+                    trueLabel: 'Interested / assign',
+                    falseLabel: 'Still no luck',
+                },
+                250,
+                500
+            );
+
+            const interestedNode = makeNode(
+                'SET_LEAD_STATUS',
+                'Set status: interested',
+                { statusKey: '' },
+                80,
+                640
+            );
+
+            const nodes = [gateNode, delayNode, callNode, outcomeNode, interestedNode];
+            const edges = [
+                makeEdge(gateNode.id, delayNode.id, 'true'),
+                makeEdge(delayNode.id, callNode.id),
+                makeEdge(callNode.id, outcomeNode.id),
+                makeEdge(outcomeNode.id, interestedNode.id, 'true'),
+            ];
+
+            // A zero-minute wait means "call immediately" — drop the DELAY node rather
+            // than persisting a no-op pause the resume job still has to service.
+            if (delayMinutes <= 0) {
+                nodes.splice(nodes.indexOf(delayNode), 1);
+                edges.splice(0, 2, makeEdge(gateNode.id, callNode.id, 'true'));
+                callNode.position = { x: 250, y: 220 };
+            }
+
+            return {
+                nodes,
+                edges,
+                workflowName: `AI re-calls ${statusKey} leads`,
+                workflowDescription:
+                    `When a person moves a lead to ${statusKey} — from the leads list or a post-call disposition — ` +
+                    `wait ${delayMinutes} minutes, then have the AI agent call them. Statuses set by the AI itself are ignored, so the workflow cannot re-trigger off its own writes.`,
             };
         },
     },


### PR DESCRIPTION
"When a counsellor manually marks a lead DNP, have the AI bot call it back" could not be built before: the lead is assigned to the counsellor who just called it, and CALL_AI dials as CallTrigger.AUTOMATION, the only trigger that enforces the already-assigned guard. The node stopped with reason="assigned" and never dialled.

- CallTrigger.WORKFLOW_EXPLICIT: skips the already-assigned guard but keeps the daily cap and duplicate window, since this path is still automation and can loop. Distinct from AUTOMATION so the skip is visible in logs and can never become the default.
- AiCallNodeDispatcher.enqueue(req, trigger): the trigger is chosen by the calling code from authored node config, never read off the request body.
- CALL_AI node config "ignoreAssignedGuard" (default false) drives both the node's own plan() gate and the trigger it dials with, so the two can't disagree and burn a retry on a call placeCall would refuse.
- LEAD_STATUS_CHANGED now carries statusChangeSource + statusChangedByUserId. The event has no idempotency dedup (strategy UUID) and the AI's own outcome writes a status back through changeLeadStatus, so without the source a graph reacting to a status re-enters off its own write.
- Builder: a checkbox for the flag, and a one-click template "AI re-calls leads on a status" wiring the status gate, source allow-list, delay and outcome branch. Also corrects a stale comment claiming the Quartz resume job is disabled - it runs every 2 min and is what drives the CALL_AI retry loop.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
