### PR TITLE
fix(institute): correct column name in renewal-scheduler candidate query

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteRepository.java
@@ -226,7 +226,7 @@ public interface InstituteRepository extends CrudRepository<Institute, String> {
      * JSON envelope and keeps only those with
      * packageSessionRenewalSchedulerEnabled = true. Returns [id, setting].
      */
-    @Query(value = "SELECT id, setting FROM institutes WHERE setting LIKE '%PAYMENT_SETTING%'",
+    @Query(value = "SELECT id, setting_json FROM institutes WHERE setting_json LIKE '%PAYMENT_SETTING%'",
             nativeQuery = true)
     List<Object[]> findIdAndSettingWithPaymentSetting();
 


### PR DESCRIPTION
findIdAndSettingWithPaymentSetting() selected `setting`, which is the Java field name on the Institute entity, not the column. The column is `setting_json` (@Column(name = "setting_json") private String setting), so the native query failed on every execution with:

  ERROR 42703: column "setting" does not exist

The call site in PackageSessionScheduler.processPackageSessionRenewals() sits above its own try-block, so the exception escaped the method rather than being caught and logged as a scan failure -- meaning the nightly 04:00 enrolment-policy scan has thrown on every run since b677ff9d2 and has never actually executed.

Verified against production: 1 institute has a PAYMENT_SETTING block and 0 have packageSessionRenewalSchedulerEnabled set, so the corrected query returns a single row that then fails the flag check and yields an empty list. The job now logs "No institutes have enabled the renewal scheduler" and returns cleanly. No dormant behaviour is activated by this fix.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
