### PR TITLE
fix(ai-calling): a rule that cannot run now says so instead of failin…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiAgentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiAgentService.java
@@ -273,6 +273,59 @@ public class AiAgentService {
      * every lead whose call was later reprocessed. Minted here rather than trusted from the
      * client so a rule can never reach the ledger without one.
      */
+    /** A human label for error messages: the admin's name for the rule, else its key. */
+    private static String ruleName(AiCallActionRule r) {
+        if (r.getLabel() != null && !r.getLabel().isBlank()) return r.getLabel().trim();
+        if (r.getArtefact() != null && !r.getArtefact().isBlank()) return r.getArtefact().trim();
+        return "untitled";
+    }
+
+    /**
+     * Why this rule could never run, phrased for the admin, or null when it is fine.
+     *
+     * <p>Deliberately mirrors AiCallActionService.isUsable plus the per-channel needs that
+     * service checks at execution time. Both layers keep their checks: this one exists so a
+     * person is told, that one because a rule can also be broken by an edit made elsewhere.
+     */
+    private static String ruleProblem(AiCallActionRule r) {
+        if (r.getActionType() == null || r.getActionType().isBlank()) {
+            return "choose what to do (send a message or book a meeting).";
+        }
+        boolean booking = "BOOK_MEETING".equalsIgnoreCase(r.getActionType());
+        AiCallActionRule.When w = r.getWhen();
+        boolean promised = w != null && w.getPromised() != null && !w.getPromised().isBlank();
+        boolean hasPredicate = w != null && (promised
+                || (w.getDisposition() != null && !w.getDisposition().isBlank())
+                || Boolean.TRUE.equals(w.getMeetingRequested())
+                || (w.getExtracted() != null && !w.getExtracted().isEmpty()));
+        if (!hasPredicate) {
+            return "give it a name, so the AI has a key to refer to it by, and choose when it runs.";
+        }
+        if (promised && (r.getAskLine() == null || r.getAskLine().isBlank())) {
+            return "write what the agent asks on the call - this rule fires when the caller "
+                    + "agrees to that question, so without one it can never run.";
+        }
+        if (booking) {
+            if (r.getBookingPageId() == null || r.getBookingPageId().isBlank()) {
+                return "choose a booking page.";
+            }
+            return null;
+        }
+        String channel = r.getChannel() == null ? "" : r.getChannel().trim().toUpperCase();
+        if ("WHATSAPP".equals(channel)) {
+            if (r.getTemplate() == null || r.getTemplate().isBlank()) {
+                return "choose an approved WhatsApp template - proactive WhatsApp cannot be free text.";
+            }
+        } else if ("EMAIL".equals(channel)) {
+            if (r.getMessageBody() == null || r.getMessageBody().isBlank()) {
+                return "write the email message - it is sent exactly as written.";
+            }
+        } else {
+            return "choose a channel (WhatsApp or email).";
+        }
+        return null;
+    }
+
     private String writeRules(List<AiCallActionRule> rules) {
         List<AiCallActionRule> cleaned = new java.util.ArrayList<>();
         for (AiCallActionRule r : rules) {
@@ -281,6 +334,15 @@ public class AiAgentService {
                 r.setId(java.util.UUID.randomUUID().toString());
             }
             if (r.getArtefact() != null) r.setArtefact(r.getArtefact().trim());
+            String problem = ruleProblem(r);
+            if (problem != null) {
+                // Reject rather than store. A rule the engine can never execute used to be
+                // accepted here and then dropped silently by AiCallActionService.rulesOf, so
+                // the admin saw a saved rule, the agent offered the thing on a live call, and
+                // nothing was ever sent. Failing the save is the only point where a person is
+                // still looking at the screen.
+                throw new VacademyException("Action rule \"" + ruleName(r) + "\": " + problem);
+            }
             cleaned.add(r);
         }
         if (cleaned.isEmpty()) return null;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
@@ -107,8 +107,23 @@ public class AiCallActionService {
             List<AiCallActionRule> parsed = mapper.readValue(
                     agent.getSendRules(), new TypeReference<List<AiCallActionRule>>() {});
             List<AiCallActionRule> out = new ArrayList<>();
+            int unusable = 0;
             for (AiCallActionRule r : parsed) {
-                if (r != null && !Boolean.FALSE.equals(r.getEnabled()) && isUsable(r)) out.add(r);
+                if (r == null || Boolean.FALSE.equals(r.getEnabled())) continue;
+                if (!isUsable(r)) {
+                    // Saving now rejects these (AiAgentService.ruleProblem), but a row written
+                    // before that check, or edited straight in the database, still reaches here.
+                    // Dropping it silently is what made a configured-looking rule that never
+                    // sent anything so hard to diagnose from the outside.
+                    unusable++;
+                    continue;
+                }
+                out.add(r);
+            }
+            if (unusable > 0) {
+                log.warn("ai-call-actions: agent {} has {} unusable send rule(s) - each needs an "
+                        + "action type, a key and a trigger; they will never fire",
+                        agent.getId(), unusable);
             }
             return out;
         } catch (Exception e) {

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -62,6 +62,48 @@ function triggerKindOf(rule: AiCallActionRule): TriggerKind {
     return 'promised';
 }
 
+/**
+ * Why a rule would never fire, in the admin's words.
+ *
+ * This exists because the editor used to lie: triggerKindOf() falls back to
+ * 'promised' for DISPLAY when nothing is set, so the When dropdown showed a real
+ * selection while `when` was still {}. AiCallActionService.isUsable then rejected
+ * the rule (an empty predicate would fire on every call) and skipped it silently -
+ * the admin saw a configured rule, the agent offered the link on a live call, and
+ * nothing was ever sent.
+ */
+function ruleProblems(rule: AiCallActionRule): string[] {
+    const problems: string[] = [];
+    if (!rule.artefact || !rule.artefact.trim()) {
+        problems.push('Give this rule a name — the AI needs one to refer to it.');
+    }
+    const w = rule.when || {};
+    // A "caller says yes" rule derives its predicate from the key, so a missing key is
+    // already reported above and there is nothing separate to choose. The other kinds
+    // carry a value the admin has to pick.
+    if (w.disposition !== undefined && !w.disposition) {
+        problems.push('Choose which disposition triggers this.');
+    }
+    if (w.extracted && Object.keys(w.extracted).some((k) => !k)) {
+        problems.push('Choose which captured answer triggers this.');
+    }
+    if (rule.actionType === 'BOOK_MEETING') {
+        if (!rule.bookingPageId) problems.push('Choose a booking page.');
+    } else if (rule.channel === 'WHATSAPP' && !rule.template) {
+        problems.push('Choose an approved WhatsApp template.');
+    } else if (rule.channel === 'EMAIL' && !rule.messageBody) {
+        problems.push('Write the email message.');
+    }
+    // The question IS the trigger for a "caller says yes" rule: with no question the
+    // agent never offers it, so nothing can be agreed to and the rule sits idle.
+    if (!rule.askLine && (triggerKindOf(rule) === 'promised' || rule.timing === 'MID_CALL')) {
+        problems.push(
+            'Write what the agent asks — this rule fires when the agent offers it and the caller agrees, so without a question it never runs.'
+        );
+    }
+    return problems;
+}
+
 const BLANK: AiCallActionRule = {
     enabled: true,
     timing: 'POST_CALL',
@@ -110,7 +152,18 @@ export function SendRulesEditor({
     const [advancedOpen, setAdvancedOpen] = useState<Record<number, boolean>>({});
 
     const update = (i: number, patch: Partial<AiCallActionRule>) => {
-        const next = rules.map((r, n) => (n === i ? { ...r, ...patch } : r));
+        const next = rules.map((r, n) => {
+            if (n !== i) return r;
+            const merged = { ...r, ...patch };
+            // For the common rule - "the agent offers it, the caller says yes" - the
+            // QUESTION is the trigger, so the predicate is derived from the rule's key
+            // instead of being maintained separately. Hand-syncing the two is what let a
+            // rule show a When it did not actually have, look configured, and never fire.
+            if (triggerKindOf(merged) === 'promised') {
+                return { ...merged, when: { promised: (merged.artefact || '').trim() } };
+            }
+            return merged;
+        });
         onChange(next);
     };
 
@@ -130,7 +183,10 @@ export function SendRulesEditor({
         update(i, { when });
     };
 
-    const add = () => onChange([...rules, { ...BLANK, when: {} }]);
+    // Seed the predicate the UI is already showing. Adding a rule with when:{} made
+    // the dropdown display "The caller accepted this on the call" over an empty
+    // object, so a rule looked configured and could never run.
+    const add = () => onChange([...rules, { ...BLANK, when: { promised: '' } }]);
     const remove = (i: number) => onChange(rules.filter((_, n) => n !== i));
 
     return (
@@ -177,14 +233,9 @@ export function SendRulesEditor({
                                     // The key follows the label only until the rule is saved.
                                     // After that the backend owns the id and the key is part
                                     // of what the AI was told, so renaming must not move it.
+                                    // `when` is not touched here - update() derives it.
                                     const patch: Partial<AiCallActionRule> = { label };
-                                    if (!rule.id) {
-                                        const key = slugify(label);
-                                        patch.artefact = key;
-                                        if (triggerKindOf(rule) === 'promised') {
-                                            patch.when = { promised: key };
-                                        }
-                                    }
+                                    if (!rule.id) patch.artefact = slugify(label);
                                     update(i, patch);
                                 }}
                             />
@@ -216,14 +267,14 @@ export function SendRulesEditor({
 
                         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                             <div className="space-y-1.5">
-                                <Label className="text-caption">When</Label>
+                                <Label className="text-caption">When to do it</Label>
                                 <Select value={kind} onValueChange={(v) => setTrigger(i, v as TriggerKind)}>
                                     <SelectTrigger className="h-8">
                                         <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
                                         <SelectItem value="promised">
-                                            The caller accepted this on the call
+                                            The caller says yes to your question
                                         </SelectItem>
                                         <SelectItem value="disposition">
                                             The call ended with a disposition
@@ -480,6 +531,16 @@ Namaste {{name}}, ...`}
                             </div>
                             <div />
                         </div>
+
+                        {ruleProblems(rule).length > 0 && (
+                            <div className="rounded-md bg-warning-50 p-2">
+                                {ruleProblems(rule).map((problem) => (
+                                    <p key={problem} className="text-caption text-warning-600">
+                                        {problem}
+                                    </p>
+                                ))}
+                            </div>
+                        )}
 
                         <div>
                             <MyButton


### PR DESCRIPTION
…g silently

A live call offered the WhatsApp link and nothing was sent. The rule behind it had artefact=null, askLine=null and an all-null `when`, so it was skipped in three separate places - and every one of them skipped it QUIETLY.

The editor lied about its own state. triggerKindOf() falls back to 'promised' for DISPLAY when nothing is set, so the When dropdown showed a real selection over an empty `when`. The admin configured what the screen offered and got a rule the engine rejects.

- The predicate is now DERIVED, not hand-maintained: for a "caller says yes" rule, update() always sets when.promised from the rule's key. There is no longer a state where the screen and the data disagree. The label handler no longer patches `when` at all.
- The question IS the trigger, so the copy says so ("The caller says yes to your question") and a promised rule without one is an error, not just a mid-call warning: with no question the agent never offers it, so nothing can be agreed to.
- AiAgentService rejects an unrunnable rule at SAVE time, naming it and saying what is missing. That is the only moment a person is still looking.
- AiCallActionService.rulesOf now logs what it drops. Save-time validation cannot reach a row written before this shipped or edited in the database, and a silent drop there is exactly what made this so hard to see from outside.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
