### PR TITLE
fix(ai-calling): send only the parameters the WhatsApp template declares

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
@@ -18,6 +18,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -412,7 +413,7 @@ public class AiCallActionService {
         a.setStatus("OPEN");
         a.setTemplateName(blankToNull(rule.getTemplate()));
         a.setTemplateLanguage(blankToNull(rule.getTemplateLanguage()));
-        a.setVariablesJson(variablesJson(vars));
+        a.setVariablesJson(variablesJson(rule, channel, vars));
         a.setDraftBody(draftBody(rule, channel, leadName, vars));
         a.setRationale(rationale + " — rule "
                 + (notBlank(rule.getLabel()) ? rule.getLabel() : rule.getId()) + ".");
@@ -509,12 +510,52 @@ public class AiCallActionService {
         vars.putIfAbsent(camel.toString(), value.trim());
     }
 
-    private String variablesJson(Map<String, String> vars) {
+    /**
+     * WhatsApp gets POSITIONAL parameters and nothing else; email gets the full named map.
+     *
+     * <p>UnifiedSendService maps a variable name to a position only when the stored template
+     * DECLARES that name, and keeps every other key verbatim as a parameter of its own
+     * ("might be positional already"). So handing it our whole variable map padded the
+     * payload and Meta rejected the send on count alone:
+     * "(#132000) number of localizable_params (10) does not match the expected number of
+     * params (2)" - calls 09394294 and 42309d27, both dispositioned Quiz_Link_Sent with
+     * nothing sent. Keys "1".."N" pass straight through, so the count is exactly what the
+     * admin configured on the rule.
+     *
+     * <p>Email has no such constraint - it is substituted by name into the body text, and an
+     * unmatched placeholder is simply left as written.
+     */
+    private String variablesJson(AiCallActionRule rule, String channel, Map<String, String> vars) {
         try {
-            return mapper.writeValueAsString(vars == null ? Map.of() : vars);
+            if (!"WHATSAPP".equals(channel)) {
+                return mapper.writeValueAsString(vars == null ? Map.of() : vars);
+            }
+            Map<String, String> positional = new java.util.LinkedHashMap<>();
+            List<String> params = rule.getTemplateParams();
+            if (params != null) {
+                int i = 1;
+                for (String param : params) {
+                    positional.put(String.valueOf(i++), resolveParam(param, vars));
+                }
+            }
+            return mapper.writeValueAsString(positional);
         } catch (Exception e) {
             return "{}";
         }
+    }
+
+    /** A configured parameter is a variable name we can fill, or a literal to send as-is. */
+    private static String resolveParam(String param, Map<String, String> vars) {
+        if (param == null) return "";
+        String key = param.trim();
+        boolean braced = key.startsWith("{{") && key.endsWith("}}");
+        if (braced) key = key.substring(2, key.length() - 2).trim();
+        if (vars != null) {
+            String v = vars.get(key);
+            if (v != null && !v.isBlank()) return v;
+        }
+        // A {{placeholder}} we cannot fill must not travel to Meta as literal braces.
+        return braced ? "" : param.trim();
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
@@ -1,6 +1,7 @@
 package vacademy.io.admin_core_service.features.telephony.core.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -59,6 +60,23 @@ public class AiCallActionRule {
 
     /** Meta-approved template name for WhatsApp; the notification template for email. */
     private String template;
+
+    /**
+     * WhatsApp only: what goes into the template's placeholders, in order.
+     *
+     * <p>Each entry is either a variable name we can resolve for this lead (name, phone, a
+     * captured form field) or a literal to send as-is.
+     *
+     * <p>The count MUST equal the template's parameter count. Meta rejects the whole send
+     * otherwise - "(#132000) number of localizable_params (10) does not match the expected
+     * number of params (2)", which is what killed calls 09394294 and 42309d27. We used to
+     * hand UnifiedSendService the entire variable map, and anything it cannot match to a
+     * declared template name it keeps verbatim ("might be positional already"), so every
+     * extra key became an extra parameter.
+     *
+     * <p>Empty means the template takes no parameters.
+     */
+    private List<String> templateParams;
 
     /** Meta identifies a template by name + language, so both travel to the action row. */
     private String templateLanguage;

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -104,6 +104,28 @@ function ruleProblems(rule: AiCallActionRule): string[] {
     return problems;
 }
 
+/**
+ * How many placeholders a Meta template body declares, and the text around them.
+ *
+ * Meta parameters are POSITIONAL - {{1}}, {{2}} - and the send is rejected outright if the
+ * count we supply differs ("number of localizable_params (10) does not match the expected
+ * number of params (2)"). So the editor has to ask for exactly as many values as the chosen
+ * template declares, no more and no fewer.
+ */
+function templatePlaceholders(bodyText: string): number {
+    const found = new Set<number>();
+    const re = /\{\{\s*(\d+)\s*\}\}/g;
+    let m = re.exec(bodyText || '');
+    while (m !== null) {
+        found.add(Number(m[1]));
+        m = re.exec(bodyText || '');
+    }
+    return found.size;
+}
+
+/** The variables a call can always fill, offered as a hint next to each parameter. */
+const SUGGESTED_VARS = ['name', 'phone', 'email'];
+
 const BLANK: AiCallActionRule = {
     enabled: true,
     timing: 'POST_CALL',
@@ -494,6 +516,55 @@ Namaste {{name}}, ...`}
                                 )}
                             </div>
                         </div>
+
+                        {isWhatsApp && rule.template && (() => {
+                            const chosen = templates.find((t) => t.name === rule.template);
+                            const body =
+                                chosen?.components?.find((c) => c.type === 'BODY')?.text || '';
+                            const count = templatePlaceholders(body);
+                            if (!chosen) return null;
+                            if (count === 0) {
+                                return (
+                                    <p className="text-caption text-neutral-500">
+                                        This template takes no variables — nothing else to fill in.
+                                    </p>
+                                );
+                            }
+                            const params = rule.templateParams || [];
+                            return (
+                                <div className="space-y-1.5">
+                                    <Label className="text-caption">
+                                        What goes in the template&apos;s {count} blank
+                                        {count > 1 ? 's' : ''}
+                                    </Label>
+                                    {Array.from({ length: count }).map((_, n) => (
+                                        <Input
+                                            key={n}
+                                            className="h-8"
+                                            placeholder={
+                                                'Blank ' +
+                                                (n + 1) +
+                                                ' — a variable like ' +
+                                                SUGGESTED_VARS[n % SUGGESTED_VARS.length] +
+                                                ', or type fixed text'
+                                            }
+                                            value={params[n] || ''}
+                                            onChange={(e) => {
+                                                const next = Array.from({ length: count }).map(
+                                                    (_x, k) =>
+                                                        k === n ? e.target.value : params[k] || ''
+                                                );
+                                                update(i, { templateParams: next });
+                                            }}
+                                        />
+                                    ))}
+                                    <p className="text-caption text-neutral-500">
+                                        Meta fills these in order. Give exactly {count} — a
+                                        different number and the message is rejected.
+                                    </p>
+                                </div>
+                            );
+                        })()}
 
                         {!isMeeting && !isWhatsApp && (
                             <p className="text-caption text-neutral-500">

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
@@ -92,6 +92,11 @@ export interface AiCallActionRule {
     template?: string;
     templateLanguage?: string;
     /**
+     * WhatsApp only: what fills the template's {{1}}, {{2}}, ... in order. The count must
+     * equal the template's parameter count or Meta rejects the send outright (#132000).
+     */
+    templateParams?: string[];
+    /**
      * EMAIL only: the message the person receives. Email has no template layer — it is
      * sent verbatim and its FIRST LINE becomes the subject. Supports {{name}}.
      */


### PR DESCRIPTION
Meta rejected every send with (#132000): "number of localizable_params (10) does not match the expected number of params (2)". Calls 09394294 and 42309d27 both created the action correctly - marker fired, rule matched, source_ref right - and died at the vendor.

The 10 are ours. 31b8a31ba emits each variable in three spellings (as authored, snake_case, camelCase) to maximise NAMED matching, which is right for email. WhatsApp parameters are POSITIONAL, and UnifiedSendService maps a name to a position only when the stored template declares it - everything else it keeps verbatim as a parameter of its own ("might be positional already"). So each extra spelling became an extra parameter. That is precisely the padding UnifiedVariableAliases warns about: "we must not pad the payload with a dozen unused names."

- A rule now declares templateParams: what fills {{1}}, {{2}} in order, each an entry we resolve from the lead's data or send as a literal.
- WhatsApp sends ONLY those, keyed "1".."N" - which pass through untouched, by that same code's own comment - so the count is exactly what was configured.
- Email is untouched and still gets the full named map; it substitutes by name and leaves an unmatched placeholder alone.
- The editor reads the chosen template's body, counts its {{n}} placeholders and asks for exactly that many values, saying so.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
