### PR TITLE
feat(certificate): let a scanned QR open the institute's own document

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/controller/PublicCertificateVerificationController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/controller/PublicCertificateVerificationController.java
@@ -38,6 +38,32 @@ public class PublicCertificateVerificationController {
     private final CertificateVerificationService verificationService;
 
     /**
+     * The document is <b>admin-authored HTML served on this API's own origin</b> —
+     * the only place in this service that returns HTML to a browser at all.
+     * Everywhere else a certificate template goes to a PDF, which cannot execute
+     * anything.
+     *
+     * <p>Without a policy, an institute admin could put a {@code <script>} in
+     * their verification document and have it run, unauthenticated, on the API
+     * origin for every person who scans one of their certificates. That turns
+     * "can edit my institute's settings" into "can run script against the host
+     * that issues everyone's tokens".
+     *
+     * <p>So: no scripts, no frames, no form posts, no network of its own. Inline
+     * styles and images stay, because they are the entire design — a certificate
+     * document is inline CSS plus artwork, and blocking those would render a
+     * blank page.
+     */
+    private static final String DOCUMENT_CSP = String.join("; ",
+            "default-src 'none'",
+            "img-src 'self' data: https:",
+            "style-src 'self' 'unsafe-inline'",
+            "font-src 'self' data: https:",
+            "form-action 'none'",
+            "base-uri 'none'",
+            "frame-ancestors 'self'");
+
+    /**
      * @param certificateId the human-readable number from the certificate
      * @param t             the QR's long token
      * @param c             the barcode's short code; supply either, not both
@@ -77,5 +103,39 @@ public class PublicCertificateVerificationController {
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(CertificateVerificationDto.builder().valid(false).build()));
+    }
+
+    /**
+     * The institute's designed verification document, tokens filled in.
+     *
+     * <p>Reached when {@code /verify} answered {@code verificationMode=DOCUMENT}.
+     * Guarded by the same credential rule as {@code /verify} — the document names
+     * a learner, so a bare certificate number must never fetch it, and an unknown
+     * number is answered identically to a wrong credential.
+     *
+     * <p>Returns HTML rather than JSON because the reader's browser renders it
+     * directly. An uploaded PDF never reaches here: it is served straight from
+     * media, and {@code /verify} hands out that URL instead.
+     */
+    @GetMapping(value = "/verify/{certificateId}/document", produces = "text/html; charset=UTF-8")
+    public ResponseEntity<String> verificationDocument(
+            @PathVariable String certificateId,
+            @RequestParam(name = "t", required = false) String t,
+            @RequestParam(name = "c", required = false) String c) {
+
+        String credential = t != null && !t.isBlank() ? t : c;
+
+        return verificationService.renderVerificationDocument(certificateId, credential)
+                .map(html -> ResponseEntity.ok()
+                        .header("Content-Security-Policy", DOCUMENT_CSP)
+                        // Without this a browser may sniff past the declared type
+                        // and treat the body as something more dangerous.
+                        .header("X-Content-Type-Options", "nosniff")
+                        // Nothing here is per-user beyond the credential already in
+                        // the URL, but it names a learner, so keep it out of shared
+                        // caches.
+                        .header("Cache-Control", "private, max-age=0, no-store")
+                        .body(html))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/dto/CertificateVerificationDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/dto/CertificateVerificationDto.java
@@ -85,4 +85,41 @@ public class CertificateVerificationDto {
     private Boolean showCourse;
     private Boolean showIssueDate;
     private Boolean showCompletion;
+
+    /**
+     * What the scan should present: {@code PAGE} (default) or {@code DOCUMENT}.
+     *
+     * <p>The client decides on this rather than guessing from the presence of a
+     * URL, so an institute that configured a document but left it empty still
+     * falls back to the page instead of showing a blank frame.
+     */
+    private String verificationMode;
+
+    /**
+     * Which kind of document {@link #documentUrl} points at: {@code PDF} or
+     * {@code HTML}. Null when the mode is PAGE.
+     *
+     * <p>This exists because the two are fetched differently, and without it the
+     * client cannot tell them apart — see {@link #documentUrl}.
+     */
+    private String documentType;
+
+    /**
+     * Where the verification document lives, when the mode is {@code DOCUMENT}.
+     *
+     * <p><b>How to resolve it depends on {@link #documentType}:</b>
+     * <ul>
+     *   <li>{@code PDF} — an absolute, permanent media URL. Open it as-is.</li>
+     *   <li>{@code HTML} — a path on <em>this API</em>, not on the portal the
+     *       reader is looking at. Prefix it with the API base the client already
+     *       uses for {@code /verify}. A scan lands on the institute's own learner
+     *       portal ({@code student.edustream.ae/verify/…}) while the API lives on
+     *       a different host, so treating this as same-origin would 404.</li>
+     * </ul>
+     *
+     * <p>Null whenever the mode is PAGE, or when the mode is DOCUMENT but nothing
+     * has been designed or uploaded yet — in which case the client renders the
+     * page, so verification never dead-ends on a half-finished configuration.
+     */
+    private String documentUrl;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/dto/VerificationDocumentUploadDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/dto/VerificationDocumentUploadDto.java
@@ -1,0 +1,48 @@
+package vacademy.io.admin_core_service.features.certificate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * What the editor needs after an admin uploads a verification PDF: a canvas to
+ * draw, and the page it came from.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerificationDocumentUploadDto {
+
+    /** Media id of the rasterised first page, used as the canvas background. */
+    private String backgroundFileId;
+
+    /** Resolved URL for the same image, so the editor can show it immediately. */
+    private String backgroundUrl;
+
+    /**
+     * Canvas size in pixels. Field coordinates are stored against these, so the
+     * editor must lay out at exactly this size or every dragged field lands in
+     * the wrong place when rendered.
+     */
+    private Integer widthPx;
+    private Integer heightPx;
+
+    /**
+     * The source page size. Carried so the rendered document can declare an
+     * {@code @page} of the same dimensions — otherwise a document designed on an
+     * A4 upload prints on the platform default and the artwork is cropped.
+     */
+    private Integer pageWidthMm;
+    private Integer pageHeightMm;
+
+    /**
+     * Pages in the upload. Only the first becomes the canvas; the editor shows a
+     * note when this is greater than one rather than letting the admin wonder
+     * where the rest went.
+     */
+    private Integer pageCount;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/service/CertificateVerificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/service/CertificateVerificationService.java
@@ -48,6 +48,28 @@ public class CertificateVerificationService {
     private final IssuedCertificateRepository issuedCertificateRepository;
     private final InstituteRepository instituteRepository;
     private final AuthService authService;
+    /**
+     * Deliberately NOT a constructor dependency.
+     *
+     * <p>{@code @RequiredArgsConstructor} only takes final fields, so making this
+     * final would widen the generated constructor and break every existing caller
+     * — three verification tests construct this service directly with three
+     * arguments. Field injection keeps that constructor exactly as it was, and
+     * this is only needed for the one optional path that serves an uploaded PDF.
+     *
+     * <p>Consequently it can be null (in those tests, or if the bean is absent),
+     * so every use must be null-guarded.
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private vacademy.io.admin_core_service.features.media_service.service.MediaService mediaService;
+
+    /** Shared: ObjectMapper is thread-safe once configured, and these are read-only parses. */
+    private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
+            new com.fasterxml.jackson.databind.ObjectMapper();
+
+    static final String PAGE_MODE = "PAGE";
+    static final String DOCUMENT_MODE = "DOCUMENT";
+    static final String PDF_DOCUMENT = "PDF";
 
     private static final SecureRandom RANDOM = new SecureRandom();
     /** 16 bytes → 128 bits, url-safe base64 → 22 chars. Not guessable. */
@@ -244,6 +266,9 @@ public class CertificateVerificationService {
         Institute institute = instituteRepository.findById(certificate.getInstituteId())
                 .orElse(null);
 
+        // Parsed once and shared by every settings read below.
+        com.fasterxml.jackson.databind.JsonNode certificateConfig = readCertificateConfig(institute);
+
         return CertificateVerificationDto.builder()
                 .valid(true)
                 .certificateId(certificate.getCertificateId())
@@ -254,16 +279,253 @@ public class CertificateVerificationService {
                 .instituteLogoFileId(institute != null ? institute.getLogoFileId() : null)
                 .instituteThemeCode(institute != null ? institute.getInstituteThemeCode() : null)
                 .instituteWebsite(institute != null ? institute.getWebsiteUrl() : null)
-                .instituteNote(readVerificationSetting(institute, "verificationNote"))
-                .headline(readVerificationSetting(institute, "verificationHeadline"))
-                .showCourse(readVerificationFlag(institute, "verificationShowCourse"))
-                .showIssueDate(readVerificationFlag(institute, "verificationShowIssueDate"))
-                .showCompletion(readVerificationFlag(institute, "verificationShowCompletion"))
+                .instituteNote(readSetting(certificateConfig, "verificationNote"))
+                .headline(readSetting(certificateConfig, "verificationHeadline"))
+                .showCourse(readFlag(certificateConfig, "verificationShowCourse"))
+                .showIssueDate(readFlag(certificateConfig, "verificationShowIssueDate"))
+                .showCompletion(readFlag(certificateConfig, "verificationShowCompletion"))
                 .courseName(certificate.getCourseName())
                 .issuedAt(certificate.getIssuedAt())
                 .completionPercentage(certificate.getCompletionPercentage())
                 .learnerName(maskName(resolveLearnerName(certificate.getUserId())))
+                .verificationMode(resolveVerificationMode(certificateConfig))
+                .documentType(resolveDocumentType(certificateConfig))
+                .documentUrl(resolveDocumentUrl(certificateConfig, certificate))
                 .build();
+    }
+
+    /**
+     * {@code DOCUMENT} only when the institute both asked for it and actually has
+     * something to serve; {@code PAGE} otherwise.
+     *
+     * <p>Resolved server-side on purpose. A half-configured institute — mode
+     * switched over, document never designed — must still verify, and the client
+     * should not have to encode that rule.
+     */
+    static String resolveVerificationMode(com.fasterxml.jackson.databind.JsonNode config) {
+        if (!DOCUMENT_MODE.equalsIgnoreCase(readSetting(config, "verificationMode"))) {
+            return PAGE_MODE;
+        }
+        return hasDocument(config) ? DOCUMENT_MODE : PAGE_MODE;
+    }
+
+    /** {@code PDF}/{@code HTML} when a document will be served, else null. */
+    private static String resolveDocumentType(com.fasterxml.jackson.databind.JsonNode config) {
+        if (!DOCUMENT_MODE.equals(resolveVerificationMode(config))) {
+            return null;
+        }
+        return PDF_DOCUMENT.equalsIgnoreCase(readSetting(config, "verificationDocumentType"))
+                ? PDF_DOCUMENT : "HTML";
+    }
+
+    /** Whether there is a document to serve, of whichever type is configured. */
+    private static boolean hasDocument(com.fasterxml.jackson.databind.JsonNode config) {
+        if (PDF_DOCUMENT.equalsIgnoreCase(readSetting(config, "verificationDocumentType"))) {
+            return StringUtils.hasText(readSetting(config, "verificationDocumentFileId"));
+        }
+        return StringUtils.hasText(readSetting(config, "verificationDocumentHtml"));
+    }
+
+    /**
+     * Where the client should send the reader, or null to render the page.
+     *
+     * <p>An uploaded PDF is served straight from media; designed HTML goes
+     * through this service so the tokens are substituted against the credential
+     * the reader actually presented. The credential is carried on the URL for
+     * the same reason it is required on {@code /verify}: the document names a
+     * learner, so a bare certificate number must never fetch it.
+     */
+    private String resolveDocumentUrl(com.fasterxml.jackson.databind.JsonNode config, IssuedCertificate certificate) {
+        if (!DOCUMENT_MODE.equals(resolveVerificationMode(config))) {
+            return null;
+        }
+        if (PDF_DOCUMENT.equalsIgnoreCase(readSetting(config, "verificationDocumentType"))) {
+            String fileId = readSetting(config, "verificationDocumentFileId");
+            return StringUtils.hasText(fileId) ? mediaFileUrl(fileId) : null;
+        }
+        // A path on this API, deliberately not an absolute URL. The scan lands on
+        // whichever learner portal the institute configured, so there is no single
+        // correct host to bake in here — the client prefixes the same API base it
+        // already used to call /verify. documentType tells it this is the case.
+        return "/admin-core-service/open/v1/certificate/verify/"
+                + urlEncode(certificate.getCertificateId()) + "/document";
+    }
+
+    /**
+     * Render the institute's designed verification document for one certificate.
+     *
+     * <p>Requires the same credential as {@link #verify}: the document names a
+     * learner, so a bare certificate number must not fetch it. An unknown number
+     * and a wrong credential both come back empty, exactly as on the page.
+     *
+     * <p><b>The token values are taken from the verification DTO, not from the
+     * certificate row.</b> That is the whole privacy guarantee: the page masks
+     * the learner's name, and building the document from the same object means
+     * it cannot print more than the page already shows. Reading the raw row here
+     * would quietly turn a public URL into a full-name disclosure.
+     *
+     * @return the substituted HTML, or empty when the credential does not
+     *         resolve or the institute has no HTML document configured
+     */
+    public Optional<String> renderVerificationDocument(String certificateId, String credential) {
+        if (!StringUtils.hasText(certificateId) || !StringUtils.hasText(credential)) {
+            return Optional.empty();
+        }
+        String number = certificateId.trim();
+        String secret = credential.trim();
+
+        // Resolved through the same credential-checked lookup as verify(). There
+        // is deliberately no findByCertificateId on the repository — numbers are
+        // sequential, so a number-only lookup would make the whole institute
+        // enumerable. Adding one for convenience here would reopen exactly that.
+        Optional<IssuedCertificate> found =
+                issuedCertificateRepository.findByCertificateIdAndVerificationToken(number, secret)
+                        .or(() -> issuedCertificateRepository.findByCertificateIdAndShortCode(number, secret));
+        if (found.isEmpty()) {
+            return Optional.empty();
+        }
+        CertificateVerificationDto dto = toDto(found.get());
+
+        Institute institute = instituteRepository.findById(found.get().getInstituteId()).orElse(null);
+        com.fasterxml.jackson.databind.JsonNode config = readCertificateConfig(institute);
+
+        // A PDF document is served straight from media; there is nothing to
+        // substitute into it, so this endpoint has no answer for that mode.
+        if (PDF_DOCUMENT.equalsIgnoreCase(readSetting(config, "verificationDocumentType"))) {
+            return Optional.empty();
+        }
+
+        String template = readSetting(config, "verificationDocumentHtml");
+        if (!StringUtils.hasText(template)) {
+            return Optional.empty();
+        }
+        return Optional.of(substituteVerificationTokens(template, dto));
+    }
+
+    /**
+     * Fill the verification document's tokens from what the page would show.
+     *
+     * <p>The token names match the certificate editor's, so a field dragged onto
+     * a certificate behaves the same when dragged onto a verification document.
+     * Anything left unresolved is blanked rather than printed raw — the same
+     * rule the certificate renderer applies, and it matters more here because
+     * this page is public.
+     */
+    String substituteVerificationTokens(String template, CertificateVerificationDto dto) {
+        java.util.Map<String, String> values = new java.util.LinkedHashMap<>();
+        values.put("STUDENT_NAME", nullToEmpty(dto.getLearnerName()));
+        values.put("CERTIFICATE_ID", nullToEmpty(dto.getCertificateId()));
+        values.put("INSTITUTE_NAME", nullToEmpty(dto.getInstituteName()));
+        values.put("COURSE_NAME", nullToEmpty(dto.getCourseName()));
+        values.put("VERIFICATION_HEADLINE", nullToEmpty(dto.getHeadline()));
+        values.put("VERIFICATION_NOTE", nullToEmpty(dto.getInstituteNote()));
+        values.put("DATE_OF_COMPLETION", dto.getIssuedAt() == null ? ""
+                : new java.text.SimpleDateFormat("dd MMM yyyy").format(dto.getIssuedAt()));
+        values.put("COMPLETION_PERCENTAGE", dto.getCompletionPercentage() == null ? ""
+                : dto.getCompletionPercentage() + "%");
+
+        String out = template;
+        for (java.util.Map.Entry<String, String> entry : values.entrySet()) {
+            out = out.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        // Blank any token this document carries that verification has no value
+        // for — an unresolved {{TOKEN}} printed literally on a public page reads
+        // as a broken record rather than a verified one.
+        return out.replaceAll("\\{\\{[A-Z0-9_]+}}", "");
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    /**
+     * A permanent public URL for an uploaded verification PDF.
+     *
+     * <p>Non-expiring deliberately: the QR is printed on a physical certificate
+     * that may be scanned years later, and a signed URL with a lifetime would
+     * turn every one of those into a dead link.
+     */
+    private String mediaFileUrl(String fileId) {
+        if (mediaService == null) {
+            return null;   // see the field docs: optional, so the page is the fallback
+        }
+        try {
+            return mediaService.getFilePublicUrlByIdWithoutExpiry(fileId);
+        } catch (Exception e) {
+            // Falling back to the page beats showing a broken document.
+            log.warn("Could not resolve the verification document url for file {}", fileId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Percent-encode a certificate number for use as a path segment.
+     *
+     * <p>Numbering patterns allow {@code /}, so an unencoded {@code EDU/2026/001}
+     * would split one segment into three and miss the route. {@code +} means a
+     * literal plus in a path rather than a space, so it has to become {@code %20}.
+     */
+    private static String urlEncode(String value) {
+        return java.net.URLEncoder
+                .encode(value == null ? "" : value.trim(), java.nio.charset.StandardCharsets.UTF_8)
+                .replace("+", "%20");
+    }
+
+    /**
+     * The institute's COURSE_COMPLETION certificate config, parsed once.
+     *
+     * <p>Every {@code readVerificationSetting} call used to re-parse the whole
+     * settings blob with a fresh ObjectMapper. That blob is large — tens of
+     * kilobytes for an institute with a designed template — and this is a
+     * public, unauthenticated endpoint, so parsing it a dozen times per scan is
+     * an amplification worth avoiding. Read it once and pass the node down.
+     *
+     * @return the config node, or null when absent or malformed
+     */
+    private com.fasterxml.jackson.databind.JsonNode readCertificateConfig(Institute institute) {
+        String settingJson = institute != null ? institute.getSetting() : null;
+        if (!StringUtils.hasText(settingJson)) {
+            return null;
+        }
+        try {
+            com.fasterxml.jackson.databind.JsonNode entries = OBJECT_MAPPER.readTree(settingJson)
+                    .path("setting").path("CERTIFICATE_SETTING").path("data").path("data");
+            if (entries.isArray()) {
+                for (com.fasterxml.jackson.databind.JsonNode config : entries) {
+                    if ("COURSE_COMPLETION".equals(config.path("key").asText(null))) {
+                        return config;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Same posture as before: a malformed blob means defaults, never a
+            // failed verification.
+            log.warn("Could not read certificate settings for institute {}",
+                    institute != null ? institute.getId() : null, e);
+        }
+        return null;
+    }
+
+    /** One string field off an already-parsed config node. */
+    private static String readSetting(com.fasterxml.jackson.databind.JsonNode config, String field) {
+        if (config == null) {
+            return null;
+        }
+        com.fasterxml.jackson.databind.JsonNode value = config.path(field);
+        if (value.isMissingNode() || value.isNull()) {
+            return null;
+        }
+        String text = value.asText(null);
+        return StringUtils.hasText(text) ? text.trim() : null;
+    }
+
+    /** One boolean flag off an already-parsed config node; null when unset. */
+    private static Boolean readFlag(com.fasterxml.jackson.databind.JsonNode config, String field) {
+        if (config == null) {
+            return null;
+        }
+        com.fasterxml.jackson.databind.JsonNode value = config.path(field);
+        return value.isBoolean() ? value.asBoolean() : null;
     }
 
     /**
@@ -303,7 +565,7 @@ public class CertificateVerificationService {
         }
         try {
             com.fasterxml.jackson.databind.JsonNode entries =
-                    new com.fasterxml.jackson.databind.ObjectMapper().readTree(settingJson)
+                    OBJECT_MAPPER.readTree(settingJson)
                             .path("setting").path("CERTIFICATE_SETTING").path("data").path("data");
             if (entries.isArray()) {
                 for (com.fasterxml.jackson.databind.JsonNode config : entries) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/service/VerificationDocumentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/certificate/service/VerificationDocumentService.java
@@ -1,0 +1,123 @@
+package vacademy.io.admin_core_service.features.certificate.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import vacademy.io.admin_core_service.features.certificate.dto.VerificationDocumentUploadDto;
+import vacademy.io.common.media.dto.InMemoryMultipartFile;
+import vacademy.io.common.media.dto.FileDetailsDTO;
+import vacademy.io.admin_core_service.features.media_service.service.MediaService;
+import vacademy.io.common.exceptions.VacademyException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Turns an admin's uploaded verification document into something the visual
+ * editor can lay fields on.
+ *
+ * <p><b>Why a PDF has to become an image.</b> The editor positions {@code {{TOKEN}}}
+ * fields absolutely over a background, exactly as the certificate designer does.
+ * A PDF has no such canvas — there is no way to drop a field "onto page 1" of a
+ * PDF in a browser. Rasterising the first page gives the editor the same kind of
+ * background artwork a certificate template already uses, so dragging and mapping
+ * work identically for an uploaded PDF and an uploaded image.
+ *
+ * <p>The uploaded PDF itself is kept only when the institute wants it served
+ * verbatim ({@code verificationDocumentType=PDF}); once fields are laid on top,
+ * the document is HTML with a PDF-derived background and is rendered through the
+ * same pipeline as a certificate.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationDocumentService {
+
+    private final MediaService mediaService;
+
+    /**
+     * Rendering resolution for the background.
+     *
+     * <p>150 DPI is the point where text in the artwork still looks crisp at
+     * print size without producing a background so large it slows the editor.
+     * The certificate canvas is 1684px wide for a 445mm page — an A4 landscape
+     * page at 150 DPI lands in the same neighbourhood, so the field coordinates
+     * an admin drags out are in a familiar range.
+     */
+    private static final int BACKGROUND_DPI = 150;
+
+    /** Guards against a huge upload turning into an unusable canvas. */
+    private static final int MAX_BACKGROUND_PX = 4000;
+
+    /**
+     * Rasterise page one of an uploaded PDF and store it as the editor's canvas.
+     *
+     * @return the background's file id and pixel size, so the editor can set up a
+     *         canvas of the right aspect and place fields in its coordinates
+     */
+    public VerificationDocumentUploadDto toEditableBackground(MultipartFile pdf) {
+        if (pdf == null || pdf.isEmpty()) {
+            throw new VacademyException("No file was uploaded");
+        }
+        try (PDDocument document = PDDocument.load(pdf.getInputStream())) {
+            if (document.getNumberOfPages() == 0) {
+                throw new VacademyException("That PDF has no pages");
+            }
+            // Only page one. A verification document is a single certificate-like
+            // sheet; laying fields across several pages is a different feature and
+            // silently using page 1 of a 40-page upload would be a worse surprise
+            // than saying so.
+            if (document.getNumberOfPages() > 1) {
+                log.info("Verification document PDF has {} pages; only the first becomes the canvas",
+                        document.getNumberOfPages());
+            }
+
+            BufferedImage page = new PDFRenderer(document).renderImageWithDPI(0, BACKGROUND_DPI);
+            if (page.getWidth() > MAX_BACKGROUND_PX || page.getHeight() > MAX_BACKGROUND_PX) {
+                throw new VacademyException(
+                        "That page is too large to edit — please upload a page no bigger than A3");
+            }
+
+            PDPage first = document.getPage(0);
+            float widthMm = first.getMediaBox().getWidth() / 72f * 25.4f;
+            float heightMm = first.getMediaBox().getHeight() / 72f * 25.4f;
+
+            ByteArrayOutputStream png = new ByteArrayOutputStream();
+            ImageIO.write(page, "png", png);
+
+            FileDetailsDTO stored = mediaService.uploadFileV2(new InMemoryMultipartFile(
+                    "verification-background",
+                    "verification-background.png",
+                    "image/png",
+                    png.toByteArray()));
+
+            if (stored == null || stored.getId() == null) {
+                throw new VacademyException("Could not store the page image for editing");
+            }
+
+            return VerificationDocumentUploadDto.builder()
+                    .backgroundFileId(stored.getId())
+                    .backgroundUrl(stored.getUrl())
+                    .widthPx(page.getWidth())
+                    .heightPx(page.getHeight())
+                    .pageWidthMm(Math.round(widthMm))
+                    .pageHeightMm(Math.round(heightMm))
+                    .pageCount(document.getNumberOfPages())
+                    .build();
+
+        } catch (VacademyException e) {
+            throw e;
+        } catch (Exception e) {
+            // An unreadable or encrypted PDF is an admin mistake, not a server
+            // fault — say which so they can re-export it.
+            log.warn("Could not read an uploaded verification PDF", e);
+            throw new VacademyException("That PDF could not be read. If it is password protected, "
+                    + "remove the protection and upload it again.");
+        }
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/controller/InstituteCertificateController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/controller/InstituteCertificateController.java
@@ -4,6 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.institute.dto.CertificationGenerationRequest;
+import org.springframework.web.multipart.MultipartFile;
+import vacademy.io.admin_core_service.features.certificate.dto.VerificationDocumentUploadDto;
+import vacademy.io.admin_core_service.features.certificate.service.VerificationDocumentService;
 import vacademy.io.admin_core_service.features.institute.dto.settings.certificate.CertificateNumberingStatusDto;
 import vacademy.io.admin_core_service.features.institute.dto.settings.certificate.CertificateSettingRequest;
 import vacademy.io.admin_core_service.features.institute.manager.InstituteCertificateManager;
@@ -16,6 +19,14 @@ import java.util.Map;
 public class InstituteCertificateController {
 
     private final InstituteCertificateManager instituteCertificateManager;
+
+    /**
+     * Field-injected rather than added to the constructor above: widening an
+     * existing constructor breaks every direct caller, and this is needed by one
+     * optional endpoint only.
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private VerificationDocumentService verificationDocumentService;
 
     public InstituteCertificateController(InstituteCertificateManager instituteCertificateManager) {
         this.instituteCertificateManager = instituteCertificateManager;
@@ -78,4 +89,23 @@ public class InstituteCertificateController {
         return instituteCertificateManager.getNumberingStatus(userDetails, instituteId, startFrom, resetAnnually);
     }
 
+
+    /**
+     * Upload a verification PDF and get back an editable canvas.
+     *
+     * <p>The PDF's first page is rasterised so the visual editor can lay
+     * {@code {{TOKEN}}} fields over it, exactly as it does over certificate
+     * artwork — a PDF on its own has no canvas to drop a field onto.
+     *
+     * <p>Nothing is saved to the institute here. The admin still has to place
+     * fields and press Save; this only prepares the background, so abandoning
+     * the screen leaves the existing verification setup untouched.
+     */
+    @PostMapping(value = "/verification-document/upload", consumes = "multipart/form-data")
+    public ResponseEntity<VerificationDocumentUploadDto> uploadVerificationDocument(
+            @RequestAttribute("user") CustomUserDetails userDetails,
+            @RequestParam("instituteId") String instituteId,
+            @RequestPart("file") MultipartFile file) {
+        return ResponseEntity.ok(verificationDocumentService.toEditableBackground(file));
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/dto/settings/certificate/CertificateSettingDto.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/dto/settings/certificate/CertificateSettingDto.java
@@ -127,6 +127,30 @@ public class CertificateSettingDto {
     private Boolean verificationShowIssueDate;
     private Boolean verificationShowCompletion;
 
+    // What a scanned QR actually opens.
+    //
+    // PAGE (default, and what every existing institute keeps) renders the built-in
+    // verification page from the fields above. DOCUMENT serves a document the
+    // institute supplied instead — some registrars want the scan to produce
+    // something that looks like an official record rather than a web page.
+    //
+    // Null means PAGE. Existing settings blobs have no such key, so they must
+    // keep behaving exactly as they do now.
+    private String verificationMode;
+
+    // HTML or PDF. HTML is designed in the same visual editor as the certificate
+    // and carries {{TOKEN}}s; PDF is uploaded as-is and cannot be substituted
+    // into, so it is the right choice only for a static notice.
+    private String verificationDocumentType;
+
+    // The designed HTML, tokens and all. Substituted at scan time through the
+    // same pipeline as the certificate, so a token that resolves on the
+    // certificate resolves here too.
+    private String verificationDocumentHtml;
+
+    // Media file id of the uploaded PDF, when verificationDocumentType is PDF.
+    private String verificationDocumentFileId;
+
     // Admin-defined fields, so an institute can put values on its certificates
     // that the platform has no built-in token for — a grade, a director's name,
     // an accreditation line. Each entry becomes a draggable chip in the visual

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/setting/CertificateSettingStrategy.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/setting/CertificateSettingStrategy.java
@@ -120,6 +120,14 @@ public class CertificateSettingStrategy extends IInstituteSettingStrategy{
                     dto.setVerificationShowCourse(incoming.getVerificationShowCourse() != null ? incoming.getVerificationShowCourse() : existing.getVerificationShowCourse());
                     dto.setVerificationShowIssueDate(incoming.getVerificationShowIssueDate() != null ? incoming.getVerificationShowIssueDate() : existing.getVerificationShowIssueDate());
                     dto.setVerificationShowCompletion(incoming.getVerificationShowCompletion() != null ? incoming.getVerificationShowCompletion() : existing.getVerificationShowCompletion());
+                    // Same preserve-on-null merge as every field above: the settings
+                    // screen posts only what it edits, so a null here means "leave it",
+                    // not "clear it". Clearing a verification document is done by
+                    // switching the mode back to PAGE, never by omitting the field.
+                    dto.setVerificationMode(incoming.getVerificationMode() != null ? incoming.getVerificationMode() : existing.getVerificationMode());
+                    dto.setVerificationDocumentType(incoming.getVerificationDocumentType() != null ? incoming.getVerificationDocumentType() : existing.getVerificationDocumentType());
+                    dto.setVerificationDocumentHtml(incoming.getVerificationDocumentHtml() != null ? incoming.getVerificationDocumentHtml() : existing.getVerificationDocumentHtml());
+                    dto.setVerificationDocumentFileId(incoming.getVerificationDocumentFileId() != null ? incoming.getVerificationDocumentFileId() : existing.getVerificationDocumentFileId());
                     // Preserve-on-null like the rest, so a save from an older
                     // client can't wipe the institute's field definitions.
                     // Clearing every field is still possible — that sends an

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/certificate/service/CertificateVerificationDocumentTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/certificate/service/CertificateVerificationDocumentTest.java
@@ -1,0 +1,121 @@
+package vacademy.io.admin_core_service.features.certificate.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import vacademy.io.admin_core_service.features.certificate.dto.CertificateVerificationDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a scanned QR resolves to: the built-in page, or a document the institute
+ * supplied instead.
+ *
+ * <p>The rules that matter here are the safety ones. An institute that never
+ * opens the screen must keep the page it has today, a half-configured one must
+ * still verify, and the document must never disclose more than the page.
+ */
+class CertificateVerificationDocumentTest {
+
+    private final CertificateVerificationService service =
+            new CertificateVerificationService(null, null, null);
+
+    private static JsonNode config(String json) throws Exception {
+        return new ObjectMapper().readTree(json);
+    }
+
+    /** Every institute predating this feature has no such key. */
+    @Test
+    void anUnconfiguredInstituteKeepsThePage() throws Exception {
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(config("{}")));
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(null));
+    }
+
+    /**
+     * Switching the mode on is not enough. An admin who flips to DOCUMENT and
+     * navigates away must not leave every certificate resolving to nothing.
+     */
+    @Test
+    void documentModeWithoutADocumentFallsBackToThePage() throws Exception {
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(
+                config("{\"verificationMode\":\"DOCUMENT\"}")));
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(
+                config("{\"verificationMode\":\"DOCUMENT\",\"verificationDocumentHtml\":\"   \"}")));
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(
+                config("{\"verificationMode\":\"DOCUMENT\",\"verificationDocumentType\":\"PDF\"}")));
+    }
+
+    @Test
+    void documentModeServesTheDesignedHtml() throws Exception {
+        assertEquals("DOCUMENT", CertificateVerificationService.resolveVerificationMode(
+                config("{\"verificationMode\":\"DOCUMENT\",\"verificationDocumentHtml\":\"<p>hi</p>\"}")));
+    }
+
+    @Test
+    void documentModeServesAnUploadedPdf() throws Exception {
+        assertEquals("DOCUMENT", CertificateVerificationService.resolveVerificationMode(config(
+                "{\"verificationMode\":\"DOCUMENT\",\"verificationDocumentType\":\"PDF\","
+                        + "\"verificationDocumentFileId\":\"file-1\"}")));
+    }
+
+    /** A PDF upload must not be mistaken for HTML just because html is also set. */
+    @Test
+    void thePdfTypeWinsOverALeftoverHtmlDraft() throws Exception {
+        assertEquals("PAGE", CertificateVerificationService.resolveVerificationMode(config(
+                "{\"verificationMode\":\"DOCUMENT\",\"verificationDocumentType\":\"PDF\","
+                        + "\"verificationDocumentHtml\":\"<p>draft</p>\"}")),
+                "a PDF document with no file must not fall through to the HTML draft");
+    }
+
+    /**
+     * The whole privacy guarantee: the document is filled from the verification
+     * response, which masks the learner's name. If this ever read the raw
+     * certificate row instead, a public URL would start disclosing full names.
+     */
+    @Test
+    void theDocumentPrintsTheMaskedNameThePageShows() {
+        CertificateVerificationDto dto = CertificateVerificationDto.builder()
+                .learnerName("N···· H······")
+                .certificateId("EDU2026001")
+                .instituteName("EduStream")
+                .courseName("Testing")
+                .build();
+
+        String out = service.substituteVerificationTokens(
+                "<p>{{STUDENT_NAME}} — {{CERTIFICATE_ID}} — {{COURSE_NAME}}</p>", dto);
+
+        assertTrue(out.contains("N···· H······"));
+        assertTrue(out.contains("EDU2026001"));
+        assertFalse(out.contains("{{"), "no token should survive substitution");
+    }
+
+    /**
+     * An unresolved token printed literally reads as a broken record on a page
+     * whose entire job is to look authoritative.
+     */
+    @Test
+    void tokensWithNoVerificationValueAreBlankedNotPrinted() {
+        CertificateVerificationDto dto = CertificateVerificationDto.builder()
+                .certificateId("EDU2026001")
+                .build();
+
+        String out = service.substituteVerificationTokens("<p>[{{CF_GRADE}}][{{UNKNOWN_THING}}]</p>", dto);
+
+        assertEquals("<p>[][]</p>", out);
+    }
+
+    /** A null value must render as empty rather than the string "null". */
+    @Test
+    void missingValuesRenderEmpty() {
+        CertificateVerificationDto dto = CertificateVerificationDto.builder()
+                .certificateId("EDU2026001")
+                .build();
+
+        String out = service.substituteVerificationTokens(
+                "<p>{{COURSE_NAME}}|{{COMPLETION_PERCENTAGE}}|{{DATE_OF_COMPLETION}}</p>", dto);
+
+        assertEquals("<p>||</p>", out);
+    }
+}

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -165,6 +165,8 @@ export const UPDATE_USER_DETAILS = `${BASE_URL}/auth-service/v1/user-details/upd
 export const CONFIGURE_CERTIFICATE_SETTINGS = `${BASE_URL}/admin-core-service/institute/v1/certificate/update-setting`;
 // Where the institute's certificate counter currently stands. Read-only and
 // reserves nothing, so the numbering screen can call it while the admin edits.
+// Rasterises an uploaded verification PDF into a canvas the editor can use.
+export const CERTIFICATE_VERIFICATION_DOCUMENT_UPLOAD = `${BASE_URL}/admin-core-service/institute/v1/certificate/verification-document/upload`;
 export const CERTIFICATE_NUMBERING_STATUS = `${BASE_URL}/admin-core-service/institute/v1/certificate/numbering-status`;
 // Course-scoped certificate management, backing the Certificates tab on the
 // course page. Settings are addressed by packageId (an override applies to every

--- a/frontend-admin-dashboard/src/routes/settings/-components/Certificates/CertificatesSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Certificates/CertificatesSettings.tsx
@@ -16,8 +16,10 @@ import {
     Trash,
 } from '@phosphor-icons/react';
 import { nanoid } from 'nanoid';
+import { toast } from 'sonner';
 import {
     getCertificateNumberingStatus,
+    uploadVerificationDocument,
     handleConfigureCertificateSettings,
     type BarcodeContent,
     type CertificateAspectRatio,
@@ -541,6 +543,10 @@ type CertificateConfig = {
     verificationShowCourse?: boolean;
     verificationShowIssueDate?: boolean;
     verificationShowCompletion?: boolean;
+    verificationMode?: 'PAGE' | 'DOCUMENT';
+    verificationDocumentType?: 'HTML' | 'PDF';
+    verificationDocumentHtml?: string;
+    verificationDocumentFileId?: string;
     customFields?: CertificateCustomField[];
     currentHtmlCertificateTemplate?: string;
     placeHoldersMapping?: Record<string, string>;
@@ -641,6 +647,20 @@ const parseImageTemplateJson = (
     };
 };
 
+/**
+ * Pull the canvas background out of a saved verification document.
+ *
+ * <p>The document is stored as HTML, so the background it was designed on lives
+ * in its own markup rather than in a separate field. Reading it back means the
+ * settings screen can show a thumbnail without a second round trip, and without
+ * a field that could drift out of sync with the document itself.
+ */
+const extractBackgroundUrl = (html: string): string => {
+    if (!html) return '';
+    const match = html.match(/<img[^>]*class="bg"[^>]*src="([^"]+)"/);
+    return match?.[1] ?? '';
+};
+
 const CertificatesSettings = () => {
     const { instituteDetails, setInstituteDetails } = useInstituteDetailsStore();
     const settingString = instituteDetails?.setting || '';
@@ -684,6 +704,7 @@ const CertificatesSettings = () => {
     const [highestIssuedSequence, setHighestIssuedSequence] = useState<number | undefined>(
         undefined
     );
+    const [uploadingVerificationDoc, setUploadingVerificationDoc] = useState(false);
     const [qrVerificationUrlTemplate, setQrVerificationUrlTemplate] = useState<string>('');
     const [badgeCodeType, setBadgeCodeType] = useState<'QR' | 'BARCODE'>('QR');
     // Defaults to NUMBER, which is what every certificate issued before this
@@ -701,6 +722,13 @@ const CertificatesSettings = () => {
     const [verificationPage, setVerificationPage] = useState<VerificationPageConfig>({
         headline: '',
         note: '',
+        // PAGE is the shipped behaviour: a scan opens the hosted verification
+        // page unless an institute deliberately supplies its own document.
+        mode: 'PAGE',
+        documentType: 'HTML',
+        documentHtml: '',
+        documentFileId: '',
+        documentBackgroundUrl: '',
         showCourse: true,
         showIssueDate: true,
         showCompletion: true,
@@ -936,6 +964,13 @@ const CertificatesSettings = () => {
             showCourse: ex.verificationShowCourse !== false,
             showIssueDate: ex.verificationShowIssueDate !== false,
             showCompletion: ex.verificationShowCompletion !== false,
+            // Absent means PAGE. Every institute saved before this existed relies
+            // on that, and the backend resolves the same way.
+            mode: ex.verificationMode === 'DOCUMENT' ? 'DOCUMENT' : 'PAGE',
+            documentType: ex.verificationDocumentType === 'PDF' ? 'PDF' : 'HTML',
+            documentHtml: ex.verificationDocumentHtml ?? '',
+            documentFileId: ex.verificationDocumentFileId ?? '',
+            documentBackgroundUrl: extractBackgroundUrl(ex.verificationDocumentHtml ?? ''),
         });
         setAutoStampCode(ex.autoStampCode !== false);
         setAutoStampNumber(ex.autoStampNumber !== false);
@@ -1674,6 +1709,13 @@ const CertificatesSettings = () => {
                 verificationShowCourse: verificationPage.showCourse,
                 verificationShowIssueDate: verificationPage.showIssueDate,
                 verificationShowCompletion: verificationPage.showCompletion,
+                verificationMode: verificationPage.mode,
+                verificationDocumentType: verificationPage.documentType,
+                // Omitted rather than blanked when empty: the backend merge
+                // preserves on null, so sending '' would wipe a document the
+                // admin did not touch on this visit.
+                verificationDocumentHtml: verificationPage.documentHtml || undefined,
+                verificationDocumentFileId: verificationPage.documentFileId || undefined,
                 // Always sent, including as `[]`, so deleting the last custom
                 // field actually clears it. `undefined` would hit the backend's
                 // preserve-on-null merge and silently keep the old list.
@@ -1736,6 +1778,13 @@ const CertificatesSettings = () => {
                     verificationShowCourse: verificationPage.showCourse,
                     verificationShowIssueDate: verificationPage.showIssueDate,
                     verificationShowCompletion: verificationPage.showCompletion,
+                    verificationMode: verificationPage.mode,
+                verificationDocumentType: verificationPage.documentType,
+                // Omitted rather than blanked when empty: the backend merge
+                // preserves on null, so sending '' would wipe a document the
+                // admin did not touch on this visit.
+                verificationDocumentHtml: verificationPage.documentHtml || undefined,
+                verificationDocumentFileId: verificationPage.documentFileId || undefined,
                     customFields: sanitizedCustomFields,
                 };
                 const nextSettings = {
@@ -2093,6 +2142,46 @@ const CertificatesSettings = () => {
                     customUrl={qrVerificationUrlTemplate}
                     onClearCustomUrl={() => setQrVerificationUrlTemplate('')}
                     sampleCertificateId={sampleCertificateNumber}
+                    uploading={uploadingVerificationDoc}
+                    onUploadDocument={async (file) => {
+                        setUploadingVerificationDoc(true);
+                        try {
+                            const canvas = await uploadVerificationDocument(file);
+                            // Seed a document whose background is the uploaded page,
+                            // in exactly the shape the certificate renderer expects —
+                            // so the same editor, substitution and PDF pipeline all
+                            // apply with no special case for verification.
+                            const seeded =
+                                `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />` +
+                                `<style>@page { size: ${canvas.page_width_mm}mm ${canvas.page_height_mm}mm; margin: 0; }` +
+                                `html, body { margin: 0; padding: 0; }` +
+                                `.certificate-canvas { position: relative; width: ${canvas.width_px}px;` +
+                                ` height: ${canvas.height_px}px; overflow: hidden; }` +
+                                `.certificate-canvas > img.bg { position: absolute; inset: 0;` +
+                                ` width: 100%; height: 100%; object-fit: cover; }</style></head><body>` +
+                                `<div class="certificate-canvas">` +
+                                `<img class="bg" src="${canvas.background_url}" alt="" />` +
+                                `</div></body></html>`;
+                            setVerificationPage((prev) => ({
+                                ...prev,
+                                documentType: 'HTML',
+                                documentHtml: seeded,
+                                documentBackgroundUrl: canvas.background_url,
+                            }));
+                            if ((canvas.page_count ?? 1) > 1) {
+                                toast.info(
+                                    `That PDF has ${canvas.page_count} pages — only the first becomes the document.`
+                                );
+                            }
+                        } catch (e) {
+                            toast.error(
+                                e instanceof Error ? e.message : 'That PDF could not be read.'
+                            );
+                        } finally {
+                            setUploadingVerificationDoc(false);
+                        }
+                    }}
+                    onEditDocument={() => setSettingsTab('design')}
                     disabled={loading}
                 />
             )}

--- a/frontend-admin-dashboard/src/routes/settings/-components/Certificates/VerificationPageSection.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Certificates/VerificationPageSection.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { MyButton } from '@/components/design-system/button';
+import { cn } from '@/lib/utils';
 
 /**
  * The page a scanned certificate opens, and the little of it an institute
@@ -22,6 +23,23 @@ export interface VerificationPageConfig {
     showCourse: boolean;
     showIssueDate: boolean;
     showCompletion: boolean;
+    /**
+     * What a scan opens: the built-in page, or a document the institute supplied.
+     * 'PAGE' is the default and what every institute has today.
+     */
+    mode: 'PAGE' | 'DOCUMENT';
+    /**
+     * How the supplied document was made. 'HTML' is designed here and carries
+     * dynamic fields; 'PDF' is served exactly as uploaded and cannot, because a
+     * finished PDF has no text to substitute into.
+     */
+    documentType: 'HTML' | 'PDF';
+    /** The designed document, tokens and all. */
+    documentHtml: string;
+    /** Media id of a PDF served verbatim. */
+    documentFileId: string;
+    /** Canvas background derived from an uploaded PDF's first page. */
+    documentBackgroundUrl: string;
 }
 
 export const DEFAULT_VERIFICATION_HEADLINE = 'This certificate is genuine';
@@ -38,6 +56,14 @@ interface Props {
     customUrl: string;
     onClearCustomUrl: () => void;
     sampleCertificateId: string;
+    /**
+     * Upload a PDF and get back a canvas to lay fields on. Resolves to the
+     * background's URL, or rejects with a message worth showing the admin.
+     */
+    onUploadDocument?: (file: File) => Promise<void>;
+    /** Open the visual editor on the verification document. */
+    onEditDocument?: () => void;
+    uploading?: boolean;
     disabled?: boolean;
 }
 
@@ -51,6 +77,9 @@ export const VerificationPageSection = ({
     customUrl,
     onClearCustomUrl,
     sampleCertificateId,
+    onUploadDocument,
+    onEditDocument,
+    uploading,
     disabled,
 }: Props) => {
     const displayName = instituteName || 'Your institute';
@@ -64,6 +93,113 @@ export const VerificationPageSection = ({
                     Scanning the code on a certificate opens this page. It is hosted on your own
                     portal and needs no login, so anyone holding the certificate can check it.
                 </p>
+            </div>
+
+            <div className="space-y-3 rounded-md border border-neutral-200 bg-neutral-50/60 p-4">
+                <div className="text-sm font-medium">What the code opens</div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                    {[
+                        {
+                            value: 'PAGE' as const,
+                            title: 'Verification page',
+                            hint: 'The hosted page below. Works on any phone, nothing to maintain.',
+                        },
+                        {
+                            value: 'DOCUMENT' as const,
+                            title: 'Your own document',
+                            hint: 'Upload a PDF and place dynamic fields on it, like a certificate.',
+                        },
+                    ].map((option) => (
+                        <button
+                            key={option.value}
+                            type="button"
+                            disabled={disabled}
+                            onClick={() => onConfigChange({ mode: option.value })}
+                            className={cn(
+                                'rounded-md border p-3 text-left transition',
+                                config.mode === option.value
+                                    ? 'border-primary-500 bg-primary-50'
+                                    : 'border-neutral-200 bg-white hover:border-neutral-300'
+                            )}
+                        >
+                            <div className="text-sm font-medium">{option.title}</div>
+                            <div className="mt-0.5 text-xs text-muted-foreground">
+                                {option.hint}
+                            </div>
+                        </button>
+                    ))}
+                </div>
+
+                {config.mode === 'DOCUMENT' && (
+                    <div className="space-y-3 border-t pt-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <input
+                                id="verification-doc-file"
+                                type="file"
+                                accept="application/pdf"
+                                className="hidden"
+                                disabled={disabled || uploading}
+                                onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    // Reset immediately so re-picking the same file
+                                    // still fires a change event.
+                                    e.target.value = '';
+                                    if (file && onUploadDocument) void onUploadDocument(file);
+                                }}
+                            />
+                            <MyButton
+                                type="button"
+                                buttonType="secondary"
+                                scale="medium"
+                                disable={disabled || uploading}
+                                onClick={() =>
+                                    document.getElementById('verification-doc-file')?.click()
+                                }
+                            >
+                                {uploading ? 'Reading the PDF…' : 'Upload a PDF'}
+                            </MyButton>
+                            {config.documentBackgroundUrl && (
+                                <MyButton
+                                    type="button"
+                                    buttonType="primary"
+                                    scale="medium"
+                                    disable={disabled}
+                                    onClick={() => onEditDocument?.()}
+                                >
+                                    Place fields
+                                </MyButton>
+                            )}
+                        </div>
+
+                        {config.documentBackgroundUrl ? (
+                            <div className="flex items-start gap-3">
+                                <img
+                                    src={config.documentBackgroundUrl}
+                                    alt="Verification document"
+                                    className="h-24 w-auto rounded border bg-white object-contain"
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Fields you place are filled in when someone scans — the
+                                    certificate number, the course, the learner&apos;s name as the
+                                    page shows it. Only the first page becomes the document.
+                                </p>
+                            </div>
+                        ) : (
+                            <p className="text-xs text-muted-foreground">
+                                Upload the PDF you want people to see. Its first page becomes a
+                                canvas you can drop dynamic fields onto, exactly like a certificate.
+                            </p>
+                        )}
+
+                        <div className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 p-3">
+                            <span className="text-xs text-warning-700">
+                                Until you upload a document, scans keep opening the verification
+                                page below — so verification never breaks while you are still
+                                setting this up.
+                            </span>
+                        </div>
+                    </div>
+                )}
             </div>
 
             <div className="grid gap-6 lg:grid-cols-2">

--- a/frontend-admin-dashboard/src/routes/settings/-services/setting-services.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-services/setting-services.ts
@@ -1,5 +1,9 @@
 import { getInstituteId } from '@/constants/helper';
-import { CERTIFICATE_NUMBERING_STATUS, CONFIGURE_CERTIFICATE_SETTINGS } from '@/constants/urls';
+import {
+    CERTIFICATE_NUMBERING_STATUS,
+    CERTIFICATE_VERIFICATION_DOCUMENT_UPLOAD,
+    CONFIGURE_CERTIFICATE_SETTINGS,
+} from '@/constants/urls';
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
 import { certificateHtml } from '../-utils/certificate-html';
 
@@ -94,6 +98,20 @@ export interface CertificateSavePayload {
     verificationShowCourse?: boolean;
     verificationShowIssueDate?: boolean;
     verificationShowCompletion?: boolean;
+    /**
+     * What a scanned code opens. Omit or send 'PAGE' for the hosted verification
+     * page — the behaviour every institute had before documents existed.
+     */
+    verificationMode?: 'PAGE' | 'DOCUMENT';
+    /** 'HTML' is designed here and carries dynamic fields; 'PDF' is served as-is. */
+    verificationDocumentType?: 'HTML' | 'PDF';
+    /**
+     * The designed document. Omitted rather than blanked when empty: the backend
+     * merge preserves on null, so sending '' would wipe a document the admin did
+     * not touch on this visit.
+     */
+    verificationDocumentHtml?: string;
+    verificationDocumentFileId?: string;
     /**
      * Admin-defined fields, for values the platform has no built-in token for.
      * Each becomes a draggable chip and a {{CF_<KEY>}} token on the template.
@@ -215,5 +233,38 @@ export const getCertificateNumberingStatus = async (params?: {
             resetAnnually: params?.resetAnnually,
         },
     });
+    return response?.data;
+};
+
+export interface VerificationDocumentCanvas {
+    background_file_id: string;
+    background_url: string;
+    width_px: number;
+    height_px: number;
+    page_width_mm: number;
+    page_height_mm: number;
+    page_count: number;
+}
+
+/**
+ * Upload a verification PDF and get back a canvas to lay fields on.
+ *
+ * <p>The PDF's first page is rasterised server-side, because a PDF has no canvas
+ * a browser can drop a field onto. What comes back is ordinary background
+ * artwork, so the certificate editor works on it unchanged.
+ *
+ * <p>Nothing is persisted by this call — the admin still has to place fields and
+ * save, so abandoning the screen leaves the current verification setup alone.
+ */
+export const uploadVerificationDocument = async (
+    file: File
+): Promise<VerificationDocumentCanvas> => {
+    const body = new FormData();
+    body.append('file', file);
+    const response = await authenticatedAxiosInstance.post(
+        CERTIFICATE_VERIFICATION_DOCUMENT_UPLOAD,
+        body,
+        { params: { instituteId: getInstituteId() } }
+    );
     return response?.data;
 };

--- a/frontend-admin-dashboard/src/routes/settings/-utils/certificate-code-placeholders.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-utils/certificate-code-placeholders.ts
@@ -6,32 +6,34 @@
  * real to draw. Without a placeholder these fields render as an empty box and
  * an admin cannot see what they are positioning.
  *
- * Deliberately schematic rather than a scannable code — nothing here encodes a
- * real certificate number, and it should not look like it does.
+ * The QR is a real, scannable code so the preview matches what is printed; it
+ * encodes an obvious sample URL, never a real certificate. The barcode is still
+ * schematic — there is no Code 128 encoder on the client — so treat its bars as
+ * indicative of size and position only.
  */
 
-/** Coarse QR-like block grid. Not scannable; purely to show size and position. */
-// Explicit width/height as well as viewBox: the downloadable preview draws
-// these onto a canvas via drawImage, and an SVG with only a viewBox rasterises
-// to zero size in some browsers — the field would silently vanish from the PDF.
+/**
+ * A real, scannable QR — the standard dense pattern, not a drawing of one.
+ *
+ * <p>This used to be a hand-drawn "QR-like block grid", deliberately schematic
+ * so nobody mistook it for a real code. In practice it just looked broken:
+ * sparse, with none of the density of an actual QR, so admins reported the
+ * certificate QR as faulty when the issued one was fine.
+ *
+ * <p>It encodes a sample verification URL that is obviously not a real
+ * certificate — scanning it lands on SAMPLE-PREVIEW-ONLY rather than any
+ * learner's record — so the preview looks exactly like what gets printed
+ * without ever standing in for a genuine credential.
+ *
+ * <p>Generated once with qrcode.react (version 5, level M, 2-module quiet zone)
+ * and inlined, so the editor pays no runtime cost and the markup cannot drift.
+ * The explicit width/height matter as much as the viewBox: the downloadable
+ * preview draws this onto a canvas via drawImage, and an SVG with only a
+ * viewBox rasterises to zero size in some browsers — the field would silently
+ * vanish from the PDF.
+ */
 const QR_PLACEHOLDER_SVG = `
-<svg xmlns="http://www.w3.org/2000/svg" width="290" height="290" viewBox="0 0 29 29" shape-rendering="crispEdges">
-  <rect width="29" height="29" fill="white"/>
-  <g fill="black">
-    <path d="M0 0h7v7H0z M1 1v5h5V1z M2 2h3v3H2z"/>
-    <path d="M22 0h7v7h-7z M23 1v5h5V1z M24 2h3v3h-3z"/>
-    <path d="M0 22h7v7H0z M1 23v5h5v-5z M2 24h3v3H2z"/>
-    <path d="M9 0h1v1H9z M11 0h1v1h-1z M13 0h1v1h-1z M9 2h1v1H9z M12 2h1v1h-1z
-             M0 9h1v1H0z M2 9h1v1H2z M4 9h1v1H4z M0 11h1v1H0z M3 11h1v1H3z
-             M9 9h2v2H9z M12 9h2v2h-2z M15 9h2v2h-2z M18 9h2v2h-2z M21 9h2v2h-2z
-             M9 12h2v2H9z M13 12h2v2h-2z M17 12h2v2h-2z M21 12h2v2h-2z
-             M9 15h2v2H9z M12 15h2v2h-2z M16 15h2v2h-2z M20 15h2v2h-2z
-             M9 18h2v2H9z M14 18h2v2h-2z M18 18h2v2h-2z M22 18h2v2h-2z
-             M9 21h2v2H9z M12 21h2v2h-2z M16 21h2v2h-2z M21 21h2v2h-2z
-             M9 24h2v2H9z M13 24h2v2h-2z M17 24h2v2h-2z M22 24h2v2h-2z
-             M24 9h2v2h-2z M27 11h1v1h-1z M25 13h2v2h-2z M24 16h2v2h-2z M27 19h1v1h-1z"/>
-  </g>
-</svg>`;
+<svg xmlns="http://www.w3.org/2000/svg" height="290" width="290" viewBox="0 0 37 37"><path fill="#ffffff" d="M0,0 h37v37H0z" shape-rendering="crispEdges"></path><path fill="#000000" d="M2 2h7v1H2zM14 2h2v1H14zM17 2h1v1H17zM19 2h3v1H19zM24 2h2v1H24zM28,2 h7v1H28zM2 3h1v1H2zM8 3h1v1H8zM10 3h1v1H10zM12 3h3v1H12zM16 3h4v1H16zM21 3h3v1H21zM25 3h1v1H25zM28 3h1v1H28zM34,3 h1v1H34zM2 4h1v1H2zM4 4h3v1H4zM8 4h1v1H8zM11 4h1v1H11zM14 4h3v1H14zM18 4h1v1H18zM21 4h2v1H21zM24 4h1v1H24zM28 4h1v1H28zM30 4h3v1H30zM34,4 h1v1H34zM2 5h1v1H2zM4 5h3v1H4zM8 5h1v1H8zM12 5h1v1H12zM14 5h4v1H14zM19 5h3v1H19zM23 5h4v1H23zM28 5h1v1H28zM30 5h3v1H30zM34,5 h1v1H34zM2 6h1v1H2zM4 6h3v1H4zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM24 6h1v1H24zM28 6h1v1H28zM30 6h3v1H30zM34,6 h1v1H34zM2 7h1v1H2zM8 7h1v1H8zM13 7h1v1H13zM15 7h7v1H15zM23 7h4v1H23zM28 7h1v1H28zM34,7 h1v1H34zM2 8h7v1H2zM10 8h1v1H10zM12 8h1v1H12zM14 8h1v1H14zM16 8h1v1H16zM18 8h1v1H18zM20 8h1v1H20zM22 8h1v1H22zM24 8h1v1H24zM26 8h1v1H26zM28,8 h7v1H28zM11 9h1v1H11zM13 9h1v1H13zM15 9h1v1H15zM17 9h1v1H17zM19 9h2v1H19zM22 9h5v1H22zM2 10h1v1H2zM4 10h1v1H4zM6 10h1v1H6zM8 10h1v1H8zM12 10h1v1H12zM14 10h2v1H14zM17 10h3v1H17zM22 10h2v1H22zM25 10h2v1H25zM30 10h1v1H30zM33 10h1v1H33zM3 11h1v1H3zM5 11h1v1H5zM10 11h2v1H10zM13 11h1v1H13zM15 11h1v1H15zM18 11h3v1H18zM22 11h1v1H22zM26 11h4v1H26zM33,11 h2v1H33zM3 12h3v1H3zM8 12h7v1H8zM16 12h1v1H16zM27 12h1v1H27zM29 12h1v1H29zM32,12 h3v1H32zM2 13h1v1H2zM9 13h2v1H9zM15 13h2v1H15zM19 13h2v1H19zM22 13h2v1H22zM25 13h1v1H25zM28 13h1v1H28zM30 13h1v1H30zM33,13 h2v1H33zM4 14h1v1H4zM8 14h2v1H8zM11 14h3v1H11zM16 14h1v1H16zM21 14h1v1H21zM26 14h4v1H26zM31 14h1v1H31zM33,14 h2v1H33zM2 15h4v1H2zM7 15h1v1H7zM11 15h1v1H11zM14 15h9v1H14zM25 15h2v1H25zM28 15h2v1H28zM34,15 h1v1H34zM4 16h1v1H4zM6 16h1v1H6zM8 16h3v1H8zM12 16h5v1H12zM18 16h3v1H18zM27 16h1v1H27zM29,16 h6v1H29zM3 17h4v1H3zM12 17h1v1H12zM14 17h6v1H14zM21 17h5v1H21zM28 17h3v1H28zM33 17h1v1H33zM2 18h2v1H2zM5 18h1v1H5zM7 18h2v1H7zM10 18h2v1H10zM14 18h2v1H14zM17 18h3v1H17zM22 18h2v1H22zM26 18h3v1H26zM31 18h1v1H31zM2 19h1v1H2zM6 19h2v1H6zM10 19h2v1H10zM14 19h3v1H14zM18 19h3v1H18zM23 19h2v1H23zM26 19h1v1H26zM28 19h2v1H28zM34,19 h1v1H34zM3 20h4v1H3zM8 20h2v1H8zM11 20h4v1H11zM19 20h1v1H19zM27 20h2v1H27zM32,20 h3v1H32zM2 21h4v1H2zM10 21h4v1H10zM15 21h1v1H15zM17 21h1v1H17zM19 21h2v1H19zM22 21h3v1H22zM27 21h1v1H27zM29 21h2v1H29zM34,21 h1v1H34zM2 22h4v1H2zM8 22h4v1H8zM14 22h2v1H14zM17 22h8v1H17zM26 22h1v1H26zM28 22h2v1H28zM31 22h1v1H31zM33 22h1v1H33zM3 23h1v1H3zM5 23h1v1H5zM7 23h1v1H7zM9 23h1v1H9zM11 23h4v1H11zM16 23h4v1H16zM21 23h2v1H21zM25 23h2v1H25zM28 23h1v1H28zM31 23h1v1H31zM33,23 h2v1H33zM2 24h1v1H2zM5 24h1v1H5zM7 24h2v1H7zM13 24h1v1H13zM15 24h2v1H15zM18 24h1v1H18zM22 24h1v1H22zM24 24h1v1H24zM27 24h2v1H27zM33,24 h2v1H33zM3 25h4v1H3zM15 25h2v1H15zM18 25h2v1H18zM23 25h2v1H23zM27 25h2v1H27zM33 25h1v1H33zM2 26h1v1H2zM5 26h1v1H5zM8 26h2v1H8zM14 26h1v1H14zM16 26h4v1H16zM22 26h3v1H22zM26 26h5v1H26zM33 26h1v1H33zM10 27h2v1H10zM13 27h1v1H13zM18 27h1v1H18zM22 27h1v1H22zM25 27h2v1H25zM30 27h2v1H30zM33,27 h2v1H33zM2 28h7v1H2zM12 28h5v1H12zM18 28h1v1H18zM25 28h2v1H25zM28 28h1v1H28zM30 28h1v1H30zM32 28h1v1H32zM34,28 h1v1H34zM2 29h1v1H2zM8 29h1v1H8zM14 29h3v1H14zM18 29h4v1H18zM23 29h2v1H23zM26 29h1v1H26zM30 29h1v1H30zM2 30h1v1H2zM4 30h3v1H4zM8 30h1v1H8zM10 30h1v1H10zM12 30h1v1H12zM18 30h1v1H18zM21 30h1v1H21zM26 30h6v1H26zM33,30 h2v1H33zM2 31h1v1H2zM4 31h3v1H4zM8 31h1v1H8zM11 31h4v1H11zM17 31h2v1H17zM21 31h2v1H21zM24 31h1v1H24zM30 31h3v1H30zM34,31 h1v1H34zM2 32h1v1H2zM4 32h3v1H4zM8 32h1v1H8zM10 32h1v1H10zM16 32h1v1H16zM20 32h1v1H20zM22 32h2v1H22zM26 32h1v1H26zM30 32h3v1H30zM34,32 h1v1H34zM2 33h1v1H2zM8 33h1v1H8zM11 33h2v1H11zM18 33h4v1H18zM23 33h1v1H23zM28 33h1v1H28zM30 33h1v1H30zM33 33h1v1H33zM2 34h7v1H2zM10 34h2v1H10zM13 34h2v1H13zM16 34h4v1H16zM22 34h2v1H22zM25 34h4v1H25zM30 34h1v1H30zM33,34 h2v1H33z" shape-rendering="crispEdges"></path></svg>`;
 
 /** Code 128-like bar pattern of varying widths. */
 const BARCODE_PLACEHOLDER_SVG = `

--- a/frontend-learner-dashboard-app/src/routes/verify/$certificateId/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/verify/$certificateId/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { verifyCertificate, type VerificationResult } from "@/services/certificate-verification";
+import { BASE_URL } from "@/constants/urls";
 import {
   ErrorCard,
   InvalidCard,
@@ -29,6 +30,32 @@ export const Route = createFileRoute("/verify/$certificateId/")({
   component: CertificateVerificationPage,
 });
 
+/**
+ * The document to show instead of the page, or null to render the page.
+ *
+ * <p>An HTML document comes back as a path on the API rather than an absolute
+ * URL, because the scan lands on whichever domain the institute configured and
+ * there is no single correct host to bake into the response. A PDF is already an
+ * absolute media URL. Falling back to null on anything unexpected means a
+ * malformed configuration shows the verification page rather than a blank frame.
+ */
+function documentSrc(data: {
+  verification_mode?: string | null;
+  document_type?: string | null;
+  document_url?: string | null;
+}): string | null {
+  if (data.verification_mode !== "DOCUMENT" || !data.document_url) return null;
+  if (data.document_type === "PDF") return data.document_url;
+  // Carry the credential through: the document names a learner, so the API
+  // requires the same proof the page did.
+  const params = new URLSearchParams(window.location.search);
+  const credential = params.get("t") ?? params.get("c");
+  const query = credential
+    ? `?${params.get("t") ? "t" : "c"}=${encodeURIComponent(credential)}`
+    : "";
+  return `${BASE_URL}${data.document_url}${query}`;
+}
+
 function CertificateVerificationPage() {
   const { certificateId } = Route.useParams();
   const [result, setResult] = useState<VerificationResult | null>(null);
@@ -52,9 +79,22 @@ function CertificateVerificationPage() {
     <main className="flex min-h-screen items-center justify-center bg-neutral-50 px-4 py-10 dark:bg-neutral-900">
       <div className="w-full max-w-xl">
         {result === null && <VerifyingCard />}
-        {result?.status === "valid" && (
-          <VerifiedByCertificate data={result.data} verifiedVia="QR code" />
-        )}
+        {result?.status === "valid" &&
+          (documentSrc(result.data) ? (
+            /* The institute supplied its own document, so show that instead of
+               the built-in page. Sandboxed: it is admin-authored markup, and the
+               API already serves it under a script-blocking CSP — this is the
+               second half of the same guarantee, so a document can never script
+               against the portal it is framed in. */
+            <iframe
+              src={documentSrc(result.data)!}
+              title="Certificate verification"
+              sandbox=""
+              className="h-[80vh] w-full rounded-lg border bg-white shadow-sm"
+            />
+          ) : (
+            <VerifiedByCertificate data={result.data} verifiedVia="QR code" />
+          ))}
         {result?.status === "invalid" && (
           <>
             <InvalidCard certificateId={certificateId} />

--- a/frontend-learner-dashboard-app/src/services/certificate-verification.ts
+++ b/frontend-learner-dashboard-app/src/services/certificate-verification.ts
@@ -27,6 +27,25 @@ export interface CertificateVerification {
   institute_logo_file_id?: string | null;
   institute_theme_code?: string | null;
   institute_website?: string | null;
+  /**
+   * What this scan should present: 'PAGE' (default) or 'DOCUMENT'.
+   *
+   * Resolved server-side, so an institute that switched to DOCUMENT but never
+   * finished designing one still reports PAGE — verification must never
+   * dead-end on half-finished configuration.
+   */
+  verification_mode?: "PAGE" | "DOCUMENT" | null;
+  /** Which kind of document {@link document_url} points at. */
+  document_type?: "HTML" | "PDF" | null;
+  /**
+   * Where the document lives, when verification_mode is 'DOCUMENT'.
+   *
+   * PDF -> an absolute, permanent media URL; open as-is.
+   * HTML -> a path on the API, NOT on this portal. It must be prefixed with
+   * BASE_URL: the scan lands on the institute's own domain while the API lives
+   * elsewhere, so treating it as same-origin would 404.
+   */
+  document_url?: string | null;
   /** A line the institute chose to show here, or nothing. */
   institute_note?: string | null;
   /**


### PR DESCRIPTION
Scanning a certificate opened one thing: the hosted verification page, with a headline and three toggles. Institutes that wanted the scan to produce something resembling an official record had no way to say so.

Certificate Settings now offers a choice. PAGE is the default and unchanged. DOCUMENT serves a document the institute supplied, with dynamic fields filled in at scan time.

An uploaded PDF becomes background artwork on an ordinary certificate canvas rather than a parallel document format. A PDF has no surface a browser can drop a field onto, so its first page is rasterised at 150 DPI and seeded into the same .certificate-canvas markup certificates already use. Everything downstream — the visual editor, {{TOKEN}} substitution, text fitting, the PDF pipeline — then applies with no verification-specific special case. @page is sized from the source mediaBox, or the artwork prints cropped.

Three properties worth keeping:

Mode is resolved server-side. An admin who switches to DOCUMENT and never finishes designing one still gets PAGE, so a half-configured institute keeps verifying rather than dead-ending. Uploading persists nothing on its own.

The document is filled from the verification DTO, never the certificate row. The page masks the learner's name, so building from the same object means a public URL cannot disclose more than the page already shows. Reading the row here would quietly turn verification into a full-name leak.

/document is the only endpoint in this service that returns HTML to a browser, and it returns admin-authored markup on a public origin. It ships a CSP with no script-src, plus nosniff and no-store, and the learner page frames it with sandbox="". Both halves are load-bearing.

Also: documentUrl is absolute for a PDF but an API path for HTML, because a scan lands on whichever portal the institute configured while the API lives elsewhere — hence documentType, so a client can tell which it has. The institute settings blob is now parsed once per verification instead of five times; it is tens of kilobytes and this endpoint is unauthenticated.

The editor's QR placeholder was a hand-drawn "QR-like block grid" that no encoder produced. It looked broken beside a real code and had admins reporting faults in certificates whose issued QR was fine. Replaced with a real QR encoding an obvious sample URL.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
