### PR TITLE
feat(invoice): proforma invoices, numbered into the real series only …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceDTO.java
@@ -48,6 +48,12 @@ public class InvoiceDTO {
     // Admin-entered notes (from invoice_data_json), if any — used by the frontend
     // "Duplicate" action to prefill a new Create-Invoice dialog from this invoice.
     private String notes;
+    /**
+     * True while this document is still an unpaid PROFORMA — it carries a number from the
+     * institute's separate proforma series, not from its real invoice series, and only
+     * becomes a numbered invoice when it is paid.
+     */
+    private Boolean proforma;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<InvoiceLineItemDTO> lineItems;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceData.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceData.java
@@ -51,6 +51,12 @@ public class InvoiceData {
      */
     private Long seqNo;
     private String seqScopeKey;
+    /**
+     * Heading the PDF prints, via {@code {{document_title}}} — "INVOICE" for a real invoice,
+     * "PROFORMA INVOICE" while the document is still an unpaid proforma. Null renders as
+     * "INVOICE", which is what every existing caller wants.
+     */
+    private String documentTitle;
     private LocalDateTime invoiceDate;
     private LocalDateTime dueDate;
     

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceNumberContext.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/dto/InvoiceNumberContext.java
@@ -50,6 +50,22 @@ public class InvoiceNumberContext {
     /** {@code invoice.source} — USER_PLAN / ADMIN_INVOICE / LIVE_SESSION / fee receipt. */
     private String docType;
 
+    /**
+     * Optional counter namespace. When set, the allocation reads and writes
+     * {@code "<namespace>:<scopeKey>"} instead of the bare scope key, giving this kind of
+     * document its own independent sequence.
+     *
+     * <p>Used by proforma invoices: a proforma is not a tax document, so it must never
+     * consume a number out of the institute's real invoice series — a proforma that is
+     * cancelled or never paid would otherwise leave a permanent hole in a numbered tax
+     * series, which is exactly what tax authorities do not allow. It gets its own tidy
+     * {@code PRO:*} counter instead, and only draws a real number when it is paid and
+     * becomes an actual invoice.
+     *
+     * <p>Null (the default) means the document numbers out of the institute's main series.
+     */
+    private String seqNamespace;
+
     // ── Lazy: only invoked when the format needs them ───────────────────────
     private Supplier<String> enrollmentNumberSupplier;
     private Supplier<InvoicePackageContextProjection> packageContextSupplier;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceNumberService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceNumberService.java
@@ -201,9 +201,20 @@ public class InvoiceNumberService {
                 .build();
     }
 
+    /**
+     * The {@code invoice.seq_scope_key} this allocation counts within.
+     *
+     * <p>A context carrying a {@link InvoiceNumberContext#getSeqNamespace() seqNamespace}
+     * gets {@code "<namespace>:<scopeKey>"}, which is simply a scope key no date can ever
+     * produce — so that document kind counts on its own and leaves the institute's main
+     * series untouched. Every read of the counter goes through here, so preview,
+     * allocation and collision-retry all agree on which series they are in.
+     */
     private String scopeKeyFor(InvoiceNumberConfig config, InvoiceNumberContext context) {
         LocalDate date = context.getDate() != null ? context.getDate() : LocalDate.now();
-        return config.getSeqScope().scopeKey(date);
+        String scopeKey = config.getSeqScope().scopeKey(date);
+        String namespace = context.getSeqNamespace();
+        return StringUtils.hasText(namespace) ? namespace + ":" + scopeKey : scopeKey;
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceService.java
@@ -249,6 +249,22 @@ public class InvoiceService {
     private static final String DOC_TYPE_ADMIN = "ADM";
     private static final String DOC_TYPE_LIVE_SESSION = "LS";
 
+    /**
+     * Doc type and counter namespace for proforma invoices. The namespace is what keeps a
+     * proforma out of the institute's real invoice series — see
+     * {@code InvoiceNumberContext.seqNamespace}.
+     */
+    private static final String DOC_TYPE_PROFORMA = "PRO";
+
+    /** {@code invoice_data_json} keys carrying proforma state. See {@link #finalizeProformaOnPayment}. */
+    private static final String JSON_KEY_PROFORMA = "proforma";
+    private static final String JSON_KEY_PROFORMA_DOC_TYPE = "proformaDocType";
+    private static final String JSON_KEY_PROFORMA_NUMBER = "proformaNumber";
+    private static final String JSON_KEY_FINALIZED_AT = "finalizedAt";
+
+    private static final String DOCUMENT_TITLE_INVOICE = "INVOICE";
+    private static final String DOCUMENT_TITLE_PROFORMA = "PROFORMA INVOICE";
+
     private static final DateTimeFormatter DISPLAY_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     // ── Editable-placeholder support (admin invoice preview / overrides) ──────────────
@@ -1682,6 +1698,201 @@ public class InvoiceService {
                 buildInvoiceNumberContext(instituteId, institute, config, invoiceData, docType));
     }
 
+    // ── Proforma ─────────────────────────────────────────────────────────────
+
+    /**
+     * Whether this institute issues unpaid invoices as proformas
+     * ({@code INVOICE_SETTING.proformaEnabled}). Defaults to false, so nothing changes for
+     * an institute that has not opted in.
+     */
+    public boolean isProformaEnabled(String instituteId) {
+        try {
+            Institute institute = instituteRepository.findById(instituteId).orElse(null);
+            if (institute == null) {
+                return false;
+            }
+            return isProformaEnabled(institute);
+        } catch (Exception e) {
+            log.warn("Could not resolve proformaEnabled for institute {} — treating as off", instituteId, e);
+            return false;
+        }
+    }
+
+    private boolean isProformaEnabled(Institute institute) {
+        Object raw = getInvoiceSettings(institute).get("proformaEnabled");
+        return raw instanceof Boolean b ? b : Boolean.parseBoolean(String.valueOf(raw));
+    }
+
+    /**
+     * Allocate a PROFORMA number: its own series, never the institute's invoice series.
+     *
+     * <p>A proforma is a request for payment, not a tax document. Numbering it out of the
+     * real series would mean every cancelled or never-paid proforma leaves a permanent gap
+     * in a sequence that is supposed to be gapless — so it counts in its own {@code PRO:*}
+     * namespace and only draws a real number when it is paid (see
+     * {@link #finalizeProformaOnPayment}).
+     *
+     * <p>The institute's configured format is kept and simply prefixed, so
+     * {@code ACME/2026-27/0007} proformas read {@code PRO-ACME/2026-27/0007}. Formats that
+     * already carry {@code {{doc_type}}} render {@code PRO} through that token instead and
+     * are left alone.
+     *
+     * <p><b>Scope of the guarantee:</b> a proforma number is unique among OUTSTANDING
+     * proformas, not across all time. A row carries one {@code (seq_no, seq_scope_key)}
+     * pair, and finalization re-points that pair at the real series — so the proforma
+     * counter only ever sees proformas that have not yet been paid, and a number can be
+     * handed out again once its previous holder became an invoice. That is deliberate and
+     * harmless: nothing in tax law requires a proforma series to be gapless or permanent
+     * (which is the entire reason for this feature), the unique constraint still prevents
+     * two live documents sharing a number, and the number a paid invoice used to carry is
+     * preserved on it as {@code proformaNumber}. Strict lifetime-monotonic proforma numbers
+     * would need a dedicated column, since one row cannot record its position in two series.
+     */
+    private InvoiceNumberAllocation allocateProformaNumber(String instituteId, InvoiceData invoiceData) {
+        Institute institute = resolveInstituteForNumbering(instituteId, invoiceData);
+        InvoiceNumberConfig config = InvoiceNumberConfig.fromInvoiceSettings(
+                institute != null ? getInvoiceSettings(institute) : null);
+        if (!config.usesDocType()) {
+            config = config.withFormat(DOC_TYPE_PROFORMA + "-" + config.getFormat());
+        }
+        InvoiceNumberContext context = buildInvoiceNumberContext(
+                instituteId, institute, config, invoiceData, DOC_TYPE_PROFORMA);
+        context.setSeqNamespace(DOC_TYPE_PROFORMA);
+        InvoiceNumberAllocation allocation = invoiceNumberService.generate(config, context);
+        applyAllocation(invoiceData, allocation);
+        log.info("Allocated proforma number {} (seq {} in {}) for institute {}",
+                allocation.number(), allocation.seqNo(), allocation.scopeKey(), instituteId);
+        return allocation;
+    }
+
+    /** True when this invoice is still an unpaid proforma. */
+    private boolean isProforma(Invoice invoice) {
+        return Boolean.parseBoolean(
+                String.valueOf(readInvoiceDataJsonField(invoice.getInvoiceDataJson(), JSON_KEY_PROFORMA)));
+    }
+
+    /**
+     * Turn a paid proforma into a real invoice: allocate the actual invoice number NOW,
+     * re-render the PDF under it, and record what it used to be.
+     *
+     * <p>This is the moment the tax document comes into existence, which is the whole point
+     * of the feature — the institute's invoice series only ever advances for money that was
+     * actually received, so it stays gapless no matter how many proformas were raised and
+     * abandoned.
+     *
+     * <p>Called from both settlement paths ({@link #markInvoicePaidManually} and
+     * {@link #markAdminInvoicePaidByPaymentLog}) BEFORE the status flips to PAID. Idempotent:
+     * an invoice that is not a proforma — including one already finalized by an earlier
+     * delivery of the same webhook — returns untouched.
+     *
+     * <p>Best-effort on the PDF only. If re-rendering fails the invoice still gets its real
+     * number and the old proforma PDF is left in place rather than losing the number
+     * allocation; {@code resolveOrRegeneratePdfUrl} re-renders it on the next download.
+     */
+    private Invoice finalizeProformaOnPayment(Invoice invoice) {
+        if (!isProforma(invoice)) {
+            return invoice;
+        }
+        String proformaNumber = invoice.getInvoiceNumber();
+        String docType = readInvoiceDataJsonField(invoice.getInvoiceDataJson(), JSON_KEY_PROFORMA_DOC_TYPE);
+        if (!StringUtils.hasText(docType)) {
+            docType = DOC_TYPE_ADMIN;
+        }
+
+        UserDTO user = authService.getUsersFromAuthServiceByUserIds(List.of(invoice.getUserId()))
+                .stream().findFirst().orElse(UserDTO.builder().build());
+        Institute institute = instituteRepository.findById(invoice.getInstituteId()).orElse(null);
+        InvoiceData numberingData = numberingDataForAdminInvoice(
+                institute, user, invoice.getInvoiceDate(), invoice.getCurrency());
+        InvoiceNumberConfig config = InvoiceNumberConfig.fromInvoiceSettings(
+                institute != null ? getInvoiceSettings(institute) : null);
+
+        InvoiceNumberAllocation allocation =
+                allocateInvoiceNumber(invoice.getInstituteId(), numberingData, docType);
+
+        int maxAttempts = 4;
+        Invoice finalized;
+        for (int attempt = 0; ; attempt++) {
+            try {
+                finalized = self.saveFinalizedProformaNumber(
+                        invoice.getId(), allocation, proformaNumber);
+                break;
+            } catch (DataIntegrityViolationException e) {
+                if (attempt >= maxAttempts - 1) {
+                    throw e;
+                }
+                InvoiceNumberAllocation retry = invoiceNumberService.nextAfterCollision(config,
+                        buildInvoiceNumberContext(invoice.getInstituteId(), institute, config,
+                                numberingData, docType),
+                        attempt + 1);
+                log.warn("Invoice number {} collided while finalizing proforma {} for institute {} "
+                                + "— retrying as {} (attempt {}).",
+                        allocation.number(), proformaNumber, invoice.getInstituteId(),
+                        retry.number(), attempt + 1);
+                allocation = retry;
+            }
+        }
+
+        // The number was written by a DIFFERENT persistence context, so the instance the caller
+        // is holding still carries the proforma number. Copy the authoritative fields across —
+        // the caller saves this instance again to flip the status, and without this that save
+        // would write the stale number straight back over the one just allocated.
+        invoice.setInvoiceNumber(finalized.getInvoiceNumber());
+        invoice.setSeqNo(finalized.getSeqNo());
+        invoice.setSeqScopeKey(finalized.getSeqScopeKey());
+        invoice.setInvoiceDataJson(finalized.getInvoiceDataJson());
+
+        // Re-render under the real number. buildInvoiceDataFromPersistedInvoice reads the
+        // number off the row we just saved, so the new PDF (and its S3 object name) carry it.
+        try {
+            String pdfFileId = regenerateInvoicePdf(invoice);
+            if (StringUtils.hasText(pdfFileId)) {
+                invoice.setPdfFileId(pdfFileId);
+            }
+        } catch (Exception e) {
+            log.error("Proforma {} finalized as {} but PDF re-render failed — the stored PDF still "
+                            + "shows the proforma. It regenerates on next download.",
+                    proformaNumber, invoice.getInvoiceNumber(), e);
+        }
+
+        log.info("[ProformaFinalized] invoiceId={} proforma={} issuedAs={} seq={}",
+                invoice.getId(), proformaNumber, invoice.getInvoiceNumber(), invoice.getSeqNo());
+        return invoice;
+    }
+
+    /**
+     * Writes the real invoice number onto a proforma, in its own transaction.
+     *
+     * <p>MUST be invoked through {@code self} (the injected proxy), not directly: the whole
+     * point is the {@code REQUIRES_NEW} boundary. A duplicate-number write aborts the
+     * transaction it occurs in, so running this inline would leave the caller with a dead
+     * transaction and nothing to retry into.
+     *
+     * <p>Committing separately from the PAID flip is safe in both directions. If the caller
+     * rolls back afterwards, the invoice keeps its real number but stays PENDING_PAYMENT with
+     * {@code proforma=false} — and the retried webhook (or a repeated manual mark-paid,
+     * which still sees PENDING_PAYMENT) skips finalization as a no-op and just flips the
+     * status. No number is ever allocated twice.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Invoice saveFinalizedProformaNumber(String invoiceId, InvoiceNumberAllocation allocation,
+                                               String proformaNumber) {
+        Invoice invoice = invoiceRepository.findById(invoiceId)
+                .orElseThrow(() -> new VacademyException("Invoice not found: " + invoiceId));
+        invoice.setInvoiceNumber(allocation.number());
+        invoice.setSeqNo(allocation.seqNo());
+        invoice.setSeqScopeKey(allocation.scopeKey());
+
+        Map<String, Object> audit = new HashMap<>();
+        audit.put(JSON_KEY_PROFORMA, false);
+        audit.put(JSON_KEY_PROFORMA_NUMBER, proformaNumber);
+        audit.put(JSON_KEY_FINALIZED_AT, LocalDateTime.now().toString());
+        invoice.setInvoiceDataJson(mergeInvoiceDataJson(invoice.getInvoiceDataJson(), audit));
+        // saveAndFlush so a duplicate number surfaces HERE, inside this transaction, where the
+        // caller can catch it — a deferred flush would blow up in the caller instead.
+        return invoiceRepository.saveAndFlush(invoice);
+    }
+
     private Institute resolveInstituteForNumbering(String instituteId, InvoiceData invoiceData) {
         if (invoiceData != null && invoiceData.getInstitute() != null) {
             return invoiceData.getInstitute();
@@ -1878,6 +2089,12 @@ public class InvoiceService {
         // Basic invoice info
         filled = filled.replace("{{invoice_number}}",
                 ov.apply("invoice_number", invoiceData.getInvoiceNumber()));
+        // "PROFORMA INVOICE" while unpaid, "INVOICE" once it is a real one. Templates that
+        // predate this token keep their hardcoded heading — the PRO- number prefix still
+        // marks the document — so no institute's custom template breaks by not having it.
+        filled = filled.replace("{{document_title}}",
+                ov.apply("document_title", StringUtils.hasText(invoiceData.getDocumentTitle())
+                        ? invoiceData.getDocumentTitle() : DOCUMENT_TITLE_INVOICE));
         filled = filled.replace("{{invoice_date}}",
                 ov.apply("invoice_date", invoiceData.getInvoiceDate() != null
                         ? invoiceData.getInvoiceDate().format(DISPLAY_DATE_FORMATTER) : ""));
@@ -3843,6 +4060,8 @@ public class InvoiceService {
 
         // Read institute invoice settings once for all users in this bulk request
         Map<String, Object> invoiceSettings = getInvoiceSettings(institute);
+        // Proforma institutes raise these unpaid; the real invoice number is drawn on payment.
+        boolean proformaMode = isProformaEnabled(institute);
 
         // Subtotal = sum of (unitPrice * quantity) from line items
         BigDecimal subtotal = request.getLineItems().stream()
@@ -3919,9 +4138,13 @@ public class InvoiceService {
                     log.warn("Overridden invoice number '{}' already exists — generating a fresh number instead",
                             overrideNumber);
                 }
-                allocation = allocateInvoiceNumber(request.getInstituteId(),
-                        numberingDataForAdminInvoice(institute, user, invoiceDate, request.getCurrency()),
-                        DOC_TYPE_ADMIN);
+                InvoiceData numberingData =
+                        numberingDataForAdminInvoice(institute, user, invoiceDate, request.getCurrency());
+                // Proforma institutes raise unpaid invoices out of a separate PRO series; the
+                // real invoice number is only drawn when the money arrives.
+                allocation = proformaMode
+                        ? allocateProformaNumber(request.getInstituteId(), numberingData)
+                        : allocateInvoiceNumber(request.getInstituteId(), numberingData, DOC_TYPE_ADMIN);
             }
             String invoiceNumber = allocation.number();
 
@@ -3949,6 +4172,12 @@ public class InvoiceService {
                 Map<String, Object> dataJson = new HashMap<>();
                 if (StringUtils.hasText(effectiveNotes)) dataJson.put("notes", effectiveNotes);
                 if (!renderOverrides.isEmpty()) dataJson.put("overrides", renderOverrides);
+                if (proformaMode) {
+                    // Read back by finalizeProformaOnPayment: the flag says "still a proforma",
+                    // the doc type says which real series to draw from once it is paid.
+                    dataJson.put(JSON_KEY_PROFORMA, true);
+                    dataJson.put(JSON_KEY_PROFORMA_DOC_TYPE, DOC_TYPE_ADMIN);
+                }
                 if (!dataJson.isEmpty()) {
                     invoice.setInvoiceDataJson(INVOICE_JSON_MAPPER.writeValueAsString(dataJson));
                 }
@@ -4246,7 +4475,12 @@ public class InvoiceService {
             throw new VacademyException("Failed to promote payment log to SUCCESS: " + e.getMessage());
         }
 
-        // 3. Link PaymentLog → Invoice + flip status to PAID
+        // 3. A proforma becomes a real invoice at the moment it is paid — this is where the
+        // institute's actual invoice number gets drawn. Runs before the PAID flip so the
+        // number and the status land in the same transaction.
+        invoice = finalizeProformaOnPayment(invoice);
+
+        // Link PaymentLog → Invoice + flip status to PAID
         PaymentLog persistedLog = paymentLogRepository.findById(paymentLogId)
                 .orElseThrow(() -> new VacademyException(
                         "Payment log not found after creation: " + paymentLogId));
@@ -4660,9 +4894,14 @@ public class InvoiceService {
         BigDecimal subtotal = price.setScale(2, RoundingMode.HALF_UP);
         EffectiveTax tax = computeEffectiveTax(invoiceSettings, subtotal, null, null);
 
-        InvoiceNumberAllocation allocation = allocateInvoiceNumber(instituteId,
-                numberingDataForAdminInvoice(institute, user, LocalDateTime.now(), currency),
-                DOC_TYPE_LIVE_SESSION);
+        // Raised unpaid, so it follows the institute's proforma policy like an admin invoice:
+        // the real number is only drawn once the registration is actually paid for.
+        boolean proformaMode = isProformaEnabled(institute);
+        InvoiceData numberingData =
+                numberingDataForAdminInvoice(institute, user, LocalDateTime.now(), currency);
+        InvoiceNumberAllocation allocation = proformaMode
+                ? allocateProformaNumber(instituteId, numberingData)
+                : allocateInvoiceNumber(instituteId, numberingData, DOC_TYPE_LIVE_SESSION);
 
         Invoice invoice = new Invoice();
         invoice.setInvoiceNumber(allocation.number());
@@ -4682,6 +4921,13 @@ public class InvoiceService {
         invoice.setTaxIncluded(tax.taxIncluded());
         invoice.setSource(INVOICE_SOURCE_LIVE_SESSION);
         invoice.setSourceId(registrationId);
+        if (proformaMode) {
+            Map<String, Object> proformaState = new HashMap<>();
+            proformaState.put(JSON_KEY_PROFORMA, true);
+            proformaState.put(JSON_KEY_PROFORMA_DOC_TYPE, DOC_TYPE_LIVE_SESSION);
+            invoice.setInvoiceDataJson(
+                    mergeInvoiceDataJson(invoice.getInvoiceDataJson(), proformaState));
+        }
         invoice = invoiceRepository.save(invoice);
 
         AdminInvoiceLineItemRequestDTO lineReq = new AdminInvoiceLineItemRequestDTO();
@@ -4781,6 +5027,10 @@ public class InvoiceService {
             return;
         }
 
+        // A proforma becomes a real invoice at the moment it is paid — draw the institute's
+        // actual invoice number before flipping the status.
+        invoice = finalizeProformaOnPayment(invoice);
+
         invoice.setStatus(INVOICE_STATUS_PAID);
         invoiceRepository.saveAndFlush(invoice);
         log.info("Admin invoice {} marked as PAID via paymentLogId={}", invoice.getInvoiceNumber(), paymentLogId);
@@ -4865,6 +5115,9 @@ public class InvoiceService {
                 .user(user)
                 .institute(institute)
                 .invoiceNumber(invoice.getInvoiceNumber())
+                // Taken from the row rather than a parameter so the heading can never
+                // disagree with what the invoice actually is.
+                .documentTitle(isProforma(invoice) ? DOCUMENT_TITLE_PROFORMA : DOCUMENT_TITLE_INVOICE)
                 .invoiceDate(invoice.getInvoiceDate())
                 .dueDate(invoice.getDueDate())
                 .subtotal(subtotal)
@@ -5367,6 +5620,7 @@ public class InvoiceService {
                 .user(user)
                 .institute(institute)
                 .invoiceNumber(invoice.getInvoiceNumber())
+                .documentTitle(isProforma(invoice) ? DOCUMENT_TITLE_PROFORMA : DOCUMENT_TITLE_INVOICE)
                 .invoiceDate(invoice.getInvoiceDate())
                 .dueDate(invoice.getDueDate())
                 .subtotal(invoice.getSubtotal())
@@ -5505,6 +5759,7 @@ public class InvoiceService {
         return InvoiceDTO.builder()
                 .id(invoice.getId())
                 .invoiceNumber(invoice.getInvoiceNumber())
+                .proforma(isProforma(invoice))
                 .userPlanId(userPlanId) // Retrieved from payment log via mapping
                 .paymentLogId(primaryPaymentLogId) // Primary payment log ID (for backward compatibility)
                 .paymentLogIds(paymentLogIds) // All payment log IDs

--- a/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
+++ b/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
@@ -480,7 +480,7 @@
     <div class="invoice-container">
         <!-- Invoice Title - Top Right -->
         <div class="invoice-title-row">
-            <h1>INVOICE</h1>
+            <h1>{{document_title}}</h1>
         </div>
         
         <!-- Top Header: BILL TO (50%) and Invoice Details (50%) -->

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-payment-history/student-payment-history.tsx
@@ -336,6 +336,18 @@ const InvoicesList = ({
                                                 {shortInvoiceLabel(inv.invoice_number, inv.id)}
                                             </span>
                                             <span className="shrink-0">{getStatusBadge(inv.status)}</span>
+                                            {/* A proforma is not a tax invoice yet — it holds a
+                                                number from the separate PRO- series and gets a real
+                                                invoice number only once it is paid. Worth calling
+                                                out on the row so admins don't quote it as one. */}
+                                            {inv.proforma && (
+                                                <span
+                                                    className="inline-flex shrink-0 items-center rounded-full border border-neutral-300 bg-neutral-50 px-2 py-0.5 text-xs font-medium text-neutral-600"
+                                                    title="Proforma — becomes a numbered invoice when paid"
+                                                >
+                                                    PROFORMA
+                                                </span>
+                                            )}
                                         </div>
                                         <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-neutral-500">
                                             <span>{formatDate(inv.due_date || inv.invoice_date)}</span>

--- a/frontend-admin-dashboard/src/routes/settings/-components/Invoice/InvoiceSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Invoice/InvoiceSettings.tsx
@@ -652,6 +652,39 @@ export default function InvoiceSettings() {
                         )}
                     </div>
 
+                    <div className="space-y-3 rounded-lg border p-3">
+                        <div className="flex items-center justify-between">
+                            <div className="space-y-0.5">
+                                <Label htmlFor="invoice-proforma" className="cursor-pointer">
+                                    Issue unpaid invoices as proforma
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                    An invoice raised before payment is issued as a proforma,
+                                    numbered from a separate series. The real invoice number is
+                                    allocated only when it is paid, so a proforma that is cancelled
+                                    or never paid leaves no gap in your invoice series.
+                                </p>
+                            </div>
+                            <Switch
+                                id="invoice-proforma"
+                                checked={settings.proformaEnabled}
+                                onCheckedChange={(v) => update({ proformaEnabled: v })}
+                            />
+                        </div>
+                        {settings.proformaEnabled && (
+                            <p className="rounded-md bg-warning-50 p-2 text-xs text-warning-700">
+                                Invoices already issued keep their current numbers. Proformas are
+                                numbered{' '}
+                                <span className="font-medium">
+                                    {settings.numbering.format.includes('{{doc_type}}')
+                                        ? 'using PRO as the document type'
+                                        : `PRO-${settings.numbering.format}`}
+                                </span>{' '}
+                                and are renumbered into your invoice series on payment.
+                            </p>
+                        )}
+                    </div>
+
                     <div className="flex items-center justify-between rounded-lg border p-3">
                         <div className="space-y-0.5">
                             <Label htmlFor="invoice-manual-enroll" className="cursor-pointer">

--- a/frontend-admin-dashboard/src/routes/settings/-components/Invoice/invoice-settings-service.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Invoice/invoice-settings-service.ts
@@ -147,6 +147,16 @@ export interface InvoiceSettingsData {
     /** Which email carries the invoice PDF after a successful payment. */
     invoicePdfPlacement: InvoicePdfPlacement;
     /**
+     * Issue unpaid invoices as PROFORMA documents.
+     *
+     * When on, an invoice raised before payment is a proforma: it is numbered from a
+     * separate `PRO-` series and does NOT consume a number from the real invoice series.
+     * The real invoice number is allocated at the moment the invoice is paid, and the PDF
+     * is regenerated under it. A proforma that is cancelled or never paid therefore leaves
+     * no gap in the numbered tax series.
+     */
+    proformaEnabled: boolean;
+    /**
      * Generate an invoice when an admin enrolls learners manually / in bulk
      * (no payment gateway). Read by BulkAssignmentService.
      */
@@ -188,6 +198,7 @@ export const DEFAULT_INVOICE_SETTINGS: InvoiceSettingsData = {
     currency: 'INR',
     sendInvoiceEmail: false,
     invoicePdfPlacement: 'INVOICE_EMAIL',
+    proformaEnabled: false,
     generateInvoiceOnManualEnroll: false,
     sendAdminCopy: false,
     adminCopyUserIds: [],
@@ -304,6 +315,7 @@ const normalize = (raw: Partial<InvoiceSettingsData> | null | undefined): Invoic
             base.invoicePdfPlacement === 'PAYMENT_CONFIRMATION_EMAIL'
                 ? 'PAYMENT_CONFIRMATION_EMAIL'
                 : DEFAULT_INVOICE_SETTINGS.invoicePdfPlacement,
+        proformaEnabled: base.proformaEnabled ?? DEFAULT_INVOICE_SETTINGS.proformaEnabled,
         generateInvoiceOnManualEnroll:
             base.generateInvoiceOnManualEnroll ?? DEFAULT_INVOICE_SETTINGS.generateInvoiceOnManualEnroll,
         sendAdminCopy: base.sendAdminCopy ?? DEFAULT_INVOICE_SETTINGS.sendAdminCopy,

--- a/frontend-admin-dashboard/src/services/invoice-service.ts
+++ b/frontend-admin-dashboard/src/services/invoice-service.ts
@@ -47,6 +47,12 @@ export interface InvoiceDTO {
     tax_included: boolean;
     /** Admin-entered notes, if any — used to prefill "Duplicate". */
     notes?: string | null;
+    /**
+     * True while this is still an unpaid PROFORMA: it carries a number from the institute's
+     * separate proforma series and only becomes a numbered invoice when it is paid.
+     * Only set when the institute has `proformaEnabled` in its invoice settings.
+     */
+    proforma?: boolean | null;
     created_at: string;
     updated_at: string;
     line_items: InvoiceLineItemDTO[];


### PR DESCRIPTION
…on payment

Adds INVOICE_SETTING.proformaEnabled. When on, an invoice raised before payment is issued as a PROFORMA and does not consume a number from the institute's real invoice series; the real number is allocated at the moment it is paid, and the PDF is re-rendered under it.

The point is a gapless tax series. Numbering an unpaid invoice out of the real series means every proforma that is cancelled or simply never paid leaves a permanent hole in a sequence that is supposed to have none. Now the series only ever advances for money that actually arrived.

Numbering
  A proforma counts in its own namespace via the new
  InvoiceNumberContext.seqNamespace: the scope key becomes "PRO:20260821"
  instead of "20260821" - a key no date can produce, so the two series can
  never interfere. The institute's configured format is kept and prefixed
  (ACME/2026-27/0007 -> PRO-ACME/2026-27/0007); formats that already carry
  {{doc_type}} render PRO through that token and are left alone.

  A proforma number is unique among OUTSTANDING proformas, not across all
  time: a row carries one (seq_no, seq_scope_key) pair and finalization
  re-points it at the real series. That is deliberate and documented on
  allocateProformaNumber - nothing requires a proforma series to be gapless
  or permanent, the unique constraint still stops two live documents sharing
  a number, and the old number is preserved on the invoice as proformaNumber.

Finalization
  finalizeProformaOnPayment() runs in both settlement paths
  (markInvoicePaidManually, markAdminInvoicePaidByPaymentLog) before the
  status flips to PAID. Allocation moved from admin-paced (invoice creation)
  to webhook-paced (payment), which makes simultaneous collisions realistic,
  so the write goes through self.saveFinalizedProformaNumber in its OWN
  transaction and retries with nextAfterCollision - a duplicate-number write
  aborts the transaction it happens in, so without that boundary the first
  collision would poison the caller and leave nothing to retry into. The
  caller's entity is re-synced from the committed row afterwards, otherwise
  the status flip would write the stale proforma number back over it.

Scope
  Everything is behind the flag. Institutes without it are untouched: the two
  creation paths branch on it, finalization is a no-op for any invoice not
  marked proforma, and {{document_title}} falls back to "INVOICE". Existing
  invoices keep their numbers. A proforma outstanding when the flag is turned
  off still finalizes correctly on payment, since finalization reads the
  invoice's own marker rather than the current setting.

Applies to both paths that raise an invoice unpaid - admin-raised and live-session. Enrollment invoices are created after payment and are unaffected.

No migration: the flag lives in the settings JSON and the proforma marker in the existing invoice_data_json.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
