### PR TITLE
feat(ai-calling): trigger on a refusal, and on a situation the admin …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/VoiceBotInternalController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/VoiceBotInternalController.java
@@ -270,6 +270,9 @@ public class VoiceBotInternalController {
             // question once, on the rule, instead of hand-syncing it into the prompt.
             List<Map<String, String>> offers = aiCallActionService.offers(a);
             if (!offers.isEmpty()) base.put("sendOffers", offers);
+            // The admin's own trigger sentences, for the post-call analyser to judge.
+            List<String> conditions = aiCallActionService.conditions(a);
+            if (!conditions.isEmpty()) base.put("sendConditions", conditions);
         }
         if (a.getTemperature() != null) base.put("temperature", a.getTemperature());
         // V421 — snake_case ON PURPOSE: the bot reads agent.get("tts_model"). The

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiAgentService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiAgentService.java
@@ -296,6 +296,8 @@ public class AiAgentService {
         boolean promised = w != null && w.getPromised() != null && !w.getPromised().isBlank();
         boolean hasPredicate = w != null && (promised
                 || (w.getDisposition() != null && !w.getDisposition().isBlank())
+                || (w.getDeclined() != null && !w.getDeclined().isBlank())
+                || (w.getCustom() != null && !w.getCustom().isBlank())
                 || Boolean.TRUE.equals(w.getMeetingRequested())
                 || (w.getExtracted() != null && !w.getExtracted().isEmpty()));
         if (!hasPredicate) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
@@ -143,6 +143,7 @@ public class AiCallActionService {
         if (r.getActionType() == null || r.getActionType().isBlank()) return false;
         AiCallActionRule.When w = r.getWhen();
         return w != null && (notBlank(w.getDisposition()) || notBlank(w.getPromised())
+                || notBlank(w.getDeclined()) || notBlank(w.getCustom())
                 || Boolean.TRUE.equals(w.getMeetingRequested())
                 || (w.getExtracted() != null && !w.getExtracted().isEmpty()));
     }
@@ -187,7 +188,25 @@ public class AiCallActionService {
         return out;
     }
 
-    /** True when this agent books meetings through a rule, so the legacy auto-book stands down. */
+    /**
+      * The admin-written conditions this agent's rules test, for the analyser to judge.
+      *
+      * <p>Published as a CLOSED list for the same reason the artefact keys are: the model
+      * may only echo back a statement we asked about, so a rule can never fire on a
+      * sentence it composed itself.
+      */
+     public List<String> conditions(AiAgent agent) {
+         List<String> out = new ArrayList<>();
+         for (AiCallActionRule r : rulesOf(agent)) {
+             AiCallActionRule.When w = r.getWhen();
+             if (w != null && notBlank(w.getCustom()) && !out.contains(w.getCustom().trim())) {
+                 out.add(w.getCustom().trim());
+             }
+         }
+         return out;
+     }
+
+     /** True when this agent books meetings through a rule, so the legacy auto-book stands down. */
     public boolean hasBookMeetingRule(AiAgent agent) {
         return rulesOf(agent).stream()
                 .anyMatch(r -> ACTION_BOOK_MEETING.equalsIgnoreCase(r.getActionType()));
@@ -210,12 +229,15 @@ public class AiCallActionService {
     // ── evaluation ───────────────────────────────────────────────────────────────
 
     /** What a rule is evaluated against. Built once per call, never mutated. */
-    record View(String disposition, Set<String> promised, boolean meetingRequested,
-                Map<String, String> extracted) {}
+    record View(String disposition, Set<String> promised, Set<String> declined,
+                boolean meetingRequested, Map<String, String> extracted,
+                Set<String> conditionsMet) {}
 
     /** Reads the analyser's own report body. Absent fields degrade to "no match", never throw. */
     View viewOf(JsonNode report, String disposition) {
         Set<String> promised = new HashSet<>();
+        Set<String> declined = new HashSet<>();
+        Set<String> conditionsMet = new HashSet<>();
         Map<String, String> extracted = new HashMap<>();
         boolean meeting = false;
         if (report != null) {
@@ -227,6 +249,22 @@ public class AiCallActionService {
                     }
                 });
             }
+            JsonNode ds = report.path("declinedSends");
+            if (ds.isArray()) {
+                ds.forEach(n -> {
+                    if (n != null && !n.isNull() && !n.asText().isBlank()) {
+                        declined.add(n.asText().trim());
+                    }
+                });
+            }
+            JsonNode cm = report.path("conditionsMet");
+            if (cm.isArray()) {
+                cm.forEach(n -> {
+                    if (n != null && !n.isNull() && !n.asText().isBlank()) {
+                        conditionsMet.add(n.asText().trim());
+                    }
+                });
+            }
             meeting = report.path("meetingRequested").asBoolean(false);
             JsonNode qa = report.path("extractedQa");
             if (qa.isObject()) {
@@ -235,8 +273,8 @@ public class AiCallActionService {
                         e.getValue() == null || e.getValue().isNull() ? "" : e.getValue().asText("")));
             }
         }
-        return new View(disposition == null ? "" : disposition, promised, meeting,
-                Collections.unmodifiableMap(extracted));
+        return new View(disposition == null ? "" : disposition, promised, declined, meeting,
+                Collections.unmodifiableMap(extracted), conditionsMet);
     }
 
     /** PURE. Every non-null predicate member must hold (AND). */
@@ -248,6 +286,15 @@ public class AiCallActionService {
             return false;
         }
         if (notBlank(w.getPromised()) && !v.promised().contains(w.getPromised().trim())) {
+            return false;
+        }
+        if (notBlank(w.getDeclined()) && !v.declined().contains(w.getDeclined().trim())) {
+            return false;
+        }
+        // Case-insensitive: the admin's sentence travels to the model and back as text,
+        // and an LLM that re-cases a word must not silently stop a rule from firing.
+        if (notBlank(w.getCustom())
+                && v.conditionsMet().stream().noneMatch(c -> c.equalsIgnoreCase(w.getCustom().trim()))) {
             return false;
         }
         if (Boolean.TRUE.equals(w.getMeetingRequested()) && !v.meetingRequested()) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
@@ -125,6 +125,21 @@ public class AiCallActionRule {
         private String disposition;
         /** This artefact key appeared in the analyser's promisedSends. */
         private String promised;
+        /**
+         * This artefact key appeared in the analyser's declinedSends - the agent offered
+         * it and the caller REFUSED. Lets a rule answer a "no" ("they turned the quiz
+         * down, send the brochure instead") rather than only a "yes".
+         */
+        private String declined;
+        /**
+         * A statement the admin wrote, which the post-call analyser judged true of this
+         * call ("the parent asked about fees"). The analyser may only echo back conditions
+         * we published, never one it composed, so a rule cannot fire on invented text.
+         *
+         * <p>Post-call only: it is judged from the whole transcript, which does not exist
+         * while the call is still running.
+         */
+        private String custom;
         /** The analyser reported an agreed meeting. */
         private Boolean meetingRequested;
         /**

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -30,7 +30,7 @@ import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { fetchEmailTemplates } from '@/routes/calling/ai-agents/-services/ai-agents';
 import type { AiCallActionRule } from '@/routes/settings/-components/AiAgentsCard';
 
-type TriggerKind = 'promised' | 'disposition' | 'meeting' | 'extracted';
+type TriggerKind = 'promised' | 'declined' | 'custom' | 'disposition' | 'meeting' | 'extracted';
 
 interface Props {
     rules: AiCallActionRule[];
@@ -56,6 +56,8 @@ function slugify(label: string): string {
 function triggerKindOf(rule: AiCallActionRule): TriggerKind {
     const w = rule.when || {};
     if (w.promised) return 'promised';
+    if (w.declined) return 'declined';
+    if (w.custom !== undefined) return 'custom';
     if (w.disposition) return 'disposition';
     if (w.meetingRequested) return 'meeting';
     if (w.extracted && Object.keys(w.extracted).length) return 'extracted';
@@ -87,6 +89,9 @@ function ruleProblems(rule: AiCallActionRule): string[] {
     if (w.extracted && Object.keys(w.extracted).some((k) => !k)) {
         problems.push('Choose which captured answer triggers this.');
     }
+    if (triggerKindOf(rule) === 'custom' && !(rule.when || {}).custom) {
+        problems.push('Describe the situation this rule should run in.');
+    }
     if (rule.actionType === 'BOOK_MEETING') {
         if (!rule.bookingPageId) problems.push('Choose a booking page.');
     } else if (rule.channel === 'WHATSAPP' && !rule.template) {
@@ -96,6 +101,11 @@ function ruleProblems(rule: AiCallActionRule): string[] {
     }
     // The question IS the trigger for a "caller says yes" rule: with no question the
     // agent never offers it, so nothing can be agreed to and the rule sits idle.
+    if (triggerKindOf(rule) === 'custom' && rule.timing === 'MID_CALL') {
+        problems.push(
+            'A described situation is judged after the call, so this rule cannot send during it.'
+        );
+    }
     if (!rule.askLine && (triggerKindOf(rule) === 'promised' || rule.timing === 'MID_CALL')) {
         problems.push(
             'Write what the agent asks — this rule fires when the agent offers it and the caller agrees, so without a question it never runs.'
@@ -197,11 +207,15 @@ export function SendRulesEditor({
         const when: AiCallActionRule['when'] =
             kind === 'promised'
                 ? { promised: rule.artefact || slugify(rule.label || '') }
-                : kind === 'disposition'
-                  ? { disposition: dispositions[0] || '' }
-                  : kind === 'meeting'
-                    ? { meetingRequested: true }
-                    : { extracted: { [extractionQuestions[0] || '']: 'present' } };
+                : kind === 'declined'
+                  ? { declined: rule.artefact || slugify(rule.label || '') }
+                  : kind === 'custom'
+                    ? { custom: '' }
+                    : kind === 'disposition'
+                      ? { disposition: dispositions[0] || '' }
+                      : kind === 'meeting'
+                        ? { meetingRequested: true }
+                        : { extracted: { [extractionQuestions[0] || '']: 'present' } };
         update(i, { when });
     };
 
@@ -298,6 +312,12 @@ export function SendRulesEditor({
                                         <SelectItem value="promised">
                                             The caller says yes to your question
                                         </SelectItem>
+                                        <SelectItem value="declined">
+                                            The caller says no to your question
+                                        </SelectItem>
+                                        <SelectItem value="custom">
+                                            Something else I describe
+                                        </SelectItem>
                                         <SelectItem value="disposition">
                                             The call ended with a disposition
                                         </SelectItem>
@@ -309,6 +329,24 @@ export function SendRulesEditor({
                                         </SelectItem>
                                     </SelectContent>
                                 </Select>
+
+                                {kind === 'custom' && (
+                                    <>
+                                        <Input
+                                            className="h-8"
+                                            placeholder="e.g. the parent asked about fees"
+                                            value={rule.when?.custom || ''}
+                                            onChange={(e) =>
+                                                update(i, { when: { custom: e.target.value } })
+                                            }
+                                        />
+                                        <p className="text-caption text-neutral-500">
+                                            Written as a statement about the call. After each call
+                                            the AI decides whether it was clearly true — if it is
+                                            unsure, the rule does not run.
+                                        </p>
+                                    </>
+                                )}
 
                                 {kind === 'disposition' && (
                                     <Select

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
@@ -106,6 +106,10 @@ export interface AiCallActionRule {
     when?: {
         disposition?: string;
         promised?: string;
+        /** The agent offered this artefact and the caller REFUSED it. */
+        declined?: string;
+        /** A sentence the admin wrote, judged true of the call by the post-call analyser. */
+        custom?: string;
         meetingRequested?: boolean;
         extracted?: Record<string, string>;
     };

--- a/voice_bot_service/app/report.py
+++ b/voice_bot_service/app/report.py
@@ -60,7 +60,7 @@ def _llm_target(s):
 # than omitting them. admin_core reads promisedSends to decide what to actually send,
 # and a MISSING key must not be distinguishable from an EMPTY one downstream — else a
 # failed analysis reads as "the model considered it and found nothing promised".
-_NO_SENDS: Dict[str, Any] = {"promisedSends": [], "whatsappNumber": None, "email": None}
+_NO_SENDS: Dict[str, Any] = {"promisedSends": [], "declinedSends": [], "conditionsMet": [], "whatsappNumber": None, "email": None}
 
 
 async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
@@ -106,8 +106,22 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
         "array if none), "
         "whatsappNumber (the number the caller confirmed for the send, digits with "
         "country code, or null if they accepted but named no number), "
-        "email (only if the caller actually spoke an email address; null otherwise).\n"
+        "email (only if the caller actually spoke an email address; null otherwise), "
+        f"declinedSends (array, a subset of {artefacts}: ONLY artefacts the assistant "
+        "explicitly OFFERED and the caller REFUSED — 'nahi', 'not now', 'don't send'. An "
+        "artefact never offered is NOT declined, and one they simply did not respond to is "
+        "NOT declined. Empty array if none).\n"
     ) if artefacts else ""
+
+    # The admin's own trigger conditions, in their words. Closed vocabulary again: the
+    # model may only echo back conditions we asked about, so a rule can never fire on a
+    # sentence the model invented. Costs nothing when no rule uses one.
+    conditions = [str(c).strip() for c in (agent.get("sendConditions") or []) if str(c).strip()]
+    condition_spec = (
+        f"conditionsMet (array, a subset of {conditions}: return ONLY those statements that "
+        "the transcript CLEARLY supports. If a statement is not clearly true, leave it out. "
+        "Never invent a statement that is not in that list).\n"
+    ) if conditions else ""
 
     prompt = (
         "You analyse a phone call transcript between an assistant and a caller.\n"
@@ -124,7 +138,7 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
         f"NOW, e.g. '2026-07-23T15:00:00{now_offset}', or null if none agreed), "
         "meetingDatetimeText (the caller's own words for the time, e.g. 'tomorrow 3 pm', or null), "
         "meetingType (short label: 'demo' | 'visit' | 'call' | 'meeting', or null).\n"
-        + artefact_spec +
+        + artefact_spec + condition_spec +
         f"\nTranscript:\n{transcript}\n\nJSON:"
     )
     base_url, api_key, model = _llm_target(s)
@@ -276,6 +290,36 @@ def _sanitize_sends(analysis: Dict[str, Any], outcome: CallOutcome,
 
         seen: set = set()
         promised = [k for k in promised if not (k in seen or seen.add(k))]
+
+        # Declines: same closed vocabulary and de-duplication. The evidence bar is
+        # deliberately LOWER than for a promise, because the error directions invert -
+        # a missed decline means we send something unwanted, so a decline we are unsure
+        # about should still count. A refusal also needs no contact details.
+        raw_declined = analysis.get("declinedSends")
+        declined = ([str(x).strip() for x in raw_declined if str(x).strip()]
+                    if isinstance(raw_declined, list) else [])
+        declined = [k for k in declined if k in allowed]
+        seen_d: set = set()
+        declined = [k for k in declined if not (k in seen_d or seen_d.add(k))]
+        # An artefact cannot be both accepted and refused on one call. Trust the refusal:
+        # sending something the caller may have declined is the expensive mistake.
+        both = [k for k in declined if k in promised]
+        if both:
+            logger.warning("report: %s reported as BOTH promised and declined - treating as "
+                           "declined corr=%s", both, corr)
+            promised = [k for k in promised if k not in declined]
+        analysis["declinedSends"] = declined
+
+        # Custom conditions: closed vocabulary only. The model may echo back a statement
+        # the admin wrote, never one it composed, so a rule cannot fire on invented text.
+        wanted = {str(c).strip() for c in (agent.get("sendConditions") or []) if str(c).strip()}
+        raw_cond = analysis.get("conditionsMet")
+        met = ([str(x).strip() for x in raw_cond if str(x).strip()]
+               if isinstance(raw_cond, list) else [])
+        invented = [c for c in met if c not in wanted]
+        if invented:
+            logger.warning("report: dropping %d invented condition(s) corr=%s", len(invented), corr)
+        analysis["conditionsMet"] = [c for c in met if c in wanted]
 
         # Evidence. REPORT_REQUIRE_CONVERSATION already guarantees a caller turn exists
         # by the time we get here; this asks the narrower question of whether any of
@@ -565,6 +609,8 @@ async def build_and_post_report(outcome: CallOutcome, call_uuid: Optional[str]) 
         # Artefacts the caller ACCEPTED on the call. admin_core resolves each against
         # the agent's send rules and creates the real WhatsApp/email/meeting action.
         "promisedSends": analysis.get("promisedSends") or [],
+        "declinedSends": analysis.get("declinedSends") or [],
+        "conditionsMet": analysis.get("conditionsMet") or [],
         "whatsappNumber": analysis.get("whatsappNumber"),
         "email": analysis.get("email"),
         "transferAttempted": outcome.transfer_requested,


### PR DESCRIPTION
…describes

A rule could only answer a YES. Two cases had nowhere to go: "they turned the quiz down, send the brochure instead", and anything outside the four built-in triggers.

REFUSAL. The analyser now also returns declinedSends - artefacts the agent OFFERED and the caller refused - and a `declined` predicate fires on it. The evidence bar is deliberately LOWER than for a promise because the error directions invert: a missed promise costs a follow-up message, a missed refusal means we send something the caller said no to. If the model reports an artefact as both accepted and refused, the refusal wins for the same reason.

DESCRIBED SITUATION. The admin writes a statement in their own words ("the parent asked about fees"); the post-call analyser judges whether the transcript clearly supports it, and leaves it out when unsure. The list is CLOSED - the model may only echo back statements we published, never one it composed - so a rule cannot fire on invented text, the same discipline that stops it inventing artefact keys. No extra LLM call: both fields ride the existing analysis.

Post-call only, and the editor says so rather than letting it silently never fire: a described situation is judged from the whole transcript, which does not exist while the call is still running.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
