### PR TITLE
fix(db): repair six native queries that throw at runtime

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/repository/RatingRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/common/repository/RatingRepository.java
@@ -31,7 +31,7 @@ public interface RatingRepository extends JpaRepository<Rating, String> {
             "    (r.source_id = :sourceId AND (:ratingStatuses IS NULL OR r.status IN (:ratingStatuses))) " +
             ")",
         countQuery = "SELECT COUNT(DISTINCT r.id) FROM rating r " +
-            "LEFT JOIN package_session ps ON ps.p.id = r.source_id " +
+            "LEFT JOIN package_session ps ON ps.id = r.source_id " +
             "AND (:packageSessionStatuses IS NULL OR ps.status IN (:packageSessionStatuses)) " +
             "WHERE ( " +
             "    ((:ratingStatuses IS NULL OR r.status IN (:ratingStatuses)) " +

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/repository/InstituteRepository.java
@@ -73,7 +73,7 @@ public interface InstituteRepository extends CrudRepository<Institute, String> {
     List<InstituteSearchProjection> searchByQuery(@Param("query") String query);
 
     @Query(value = """
-            SELECT i.* FROM institute i
+            SELECT i.* FROM institutes i
             JOIN student_session_institute_group_mapping ssigm ON ssigm.institute_id = i.id
             WHERE ssigm.user_id = :userId
             AND ssigm.package_session_id = :sessionId ORDER BY created_at DESC LIMIT 1

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_tracking/repository/ActivityLogRepository.java
@@ -714,9 +714,8 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, String
                 AND al.created_at BETWEEN :startDate AND :endDate
             )
             SELECT
-                slide_id,
                 COALESCE(total_minutes_spent, 0) / NULLIF((DATE(:endDate) - DATE(:startDate) + 1), 0) AS avg_daily_minutes_spent
-            FROM total_time_spent;
+            FROM total_time_spent
             """, nativeQuery = true)
     Double findAverageDailyTimeSpentByBatch(
             @Param("startDate") Date startDate,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/packages/repository/PackageRepository.java
@@ -1502,6 +1502,7 @@ public interface PackageRepository extends JpaRepository<PackageEntity, String> 
                     p.why_learn, p.who_should_learn, p.about_the_course, p.comma_separated_tags,
                     p.course_depth, p.course_html_description, p.package_type, p.created_at, p.created_by_user_id,
                     ps_read_time.total_read_time_minutes,
+                    ps.id, ps.session_id,
                     s.id, s.session_name
             """, countQuery = """
                 SELECT COUNT(DISTINCT ps.id)

--- a/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/StudentAttemptRepository.java
+++ b/assessment_service/src/main/java/vacademy/io/assessment_service/features/assessment/repository/StudentAttemptRepository.java
@@ -157,6 +157,9 @@ public interface StudentAttemptRepository extends CrudRepository<StudentAttempt,
             WITH RankedAttemptsRaw AS (
                                     SELECT
                                         sa.id AS attemptId,
+                                        aur.participant_name AS studentName,
+                                        sa.total_time_in_seconds AS completionTimeInSeconds,
+                                        sa.total_marks AS achievedMarks,
                                         ROW_NUMBER() OVER (PARTITION BY aur.user_id ORDER BY sa.created_at DESC) AS rn
                                     FROM student_attempt sa
                                     JOIN assessment_user_registration aur ON aur.id = sa.registration_id

--- a/common_service/src/main/java/vacademy/io/common/auth/repository/UserRepository.java
+++ b/common_service/src/main/java/vacademy/io/common/auth/repository/UserRepository.java
@@ -77,22 +77,12 @@ public interface UserRepository extends CrudRepository<User, String> {
                         @Param("roleStatus") List<String> roleStatus,
                         @Param("roleNames") List<String> roleNames);
 
-        @Query(value = """
-                        SELECT u.* FROM users u
-                        JOIN user_role ur ON u.id = ur.user_id
-                        JOIN roles r ON r.id = ur.role_id
-                        WHERE u.mobile = :mobile
-                          AND ur.status IN (:roleStatus)
-                          AND r.role_name IN (:roleNames)
-                        ORDER BY u.created_at DESC
-                        LIMIT 1
-                        """, nativeQuery = true)
-        Optional<User> findMostRecentUserByMobileAndRoleStatusAndRoleNames(
-                        @Param("mobile") String mobile,
-                        @Param("roleStatus") List<String> roleStatus,
-                        @Param("roleNames") List<String> roleNames);
-
-        // NEW METHOD: For WhatsApp OTP login - uses correct column name 'mobile_number'
+        // For WhatsApp OTP login - uses correct column name 'mobile_number'.
+        //
+        // This supersedes findMostRecentUserByMobileAndRoleStatusAndRoleNames, which was
+        // removed: it was byte-for-byte identical apart from filtering on a column named
+        // "mobile", which does not exist on users (the column is mobile_number). It had no
+        // callers and threw 42703 on every execution.
         @Query(value = """
                         SELECT u.* FROM users u
                         JOIN user_role ur ON u.id = ur.user_id


### PR DESCRIPTION
Spring Data does not validate native queries at startup, so each of these compiled fine and failed only when executed. Found by extracting every @Query(nativeQuery = true) string in the platform and planning it with EXPLAIN against the real schema.

Reachable from live endpoints:

  PackageRepository.getOpenCatalogPackageDetail -- the outer GROUP BY omitted
      ps.id and ps.session_id while the SELECT returns both, so Postgres raised
      42803. Its own countQuery is COUNT(DISTINCT ps.id), which confirms
      per-package-session granularity was the intended semantics, so adding
      ps.id makes the value and count queries agree. Reached from
      OpenPackageService in the else-branch of the search check, i.e. browsing
      the open catalog WITHOUT a search term.

  RatingRepository.getAllRatingsWithFilter -- the countQuery joined
      "ps.p.id" (42P01) where the value query correctly joins ps.id. The method
      returns Page<Rating>, so Spring runs both queries on every call. Hit by
      /rating/get-package-ratings and the public /open/rating variant.

  StudentAttemptRepository.findLeaderBoardForAssessmentAndInstituteIdWithSearch --
      the countQuery's first CTE selected only attemptId and rn, but downstream
      still referenced achievedMarks, completionTimeInSeconds (DENSE_RANK) and
      ra.studentName (the name filter), giving 42703. Its CTE now mirrors the
      value query's so the two cannot drift apart again.

Not currently reachable, fixed or removed so they cannot bite later:

  InstituteRepository.findInstitutesByUserIdAndPackageSessionId -- "FROM
      institute" (42P01); the table is institutes.
  ActivityLogRepository.findAverageDailyTimeSpentByBatch -- selected slide_id,
      which its CTE never exposes (42703), and returned two columns into a
      Double. Dropped the column, and the trailing semicolon with it.
  UserRepository.findMostRecentUserByMobileAndRoleStatusAndRoleNames -- REMOVED
      rather than fixed. It filtered on a column "mobile" that does not exist
      (the column is mobile_number) and was byte-for-byte identical to
      findUserByMobileNumberAndRoleStatusAndRoleNames directly below it, which
      already does it correctly. It had no callers.

Verified: all six now plan cleanly against the live schema, each checked with a marker unique to its own fix so the result cannot come from a neighbouring query. No behaviour is preserved by these changes because none of these queries could execute at all beforehand.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
