### PR TITLE
fix(ai-calling): a RED call can still teach the cache its fixed lines

### DIFF
--- a/docs/crm/TTS_SPEECH_CACHE.md
+++ b/docs/crm/TTS_SPEECH_CACHE.md
@@ -73,7 +73,7 @@ TTS_CACHE_SALT | engine | model | voice | pace | temperature
 | **G1** complete | before hashing **and again at `CallCandidates.add`** | the text ends in terminal punctuation (`.` `!` `?` `।` `…`), or is a registered fixed line. Re-checked at the counter on purpose: the count means "this WHOLE sentence was delivered N times", and that meaning must not depend on a caller remembering to filter |
 | **G2** uninterrupted | during dispatch | no interruption between dispatch and completion of that sentence |
 | **G3** actually heard | at call end | the sentence appears in the **played** transcript |
-| **G4** healthy call | at call end | the verdict is not RED and carries none of `CRASH`, `BOT_SILENT`, `TTS_WEDGE`, `REPLY_UNPLAYED`, `STT_DEAF`, `REPLY_LOOP` |
+| **G4** healthy enough | at call end | **Two standards.** A *fixed line* is vetoed only by faults that implicate the AUDIO — `CRASH`, `BOT_SILENT`, `TTS_WEDGE`, `REPLY_UNPLAYED`. An *LLM sentence* keeps the strict bar: those plus `STT_DEAF`, `REPLY_LOOP`, or a RED verdict |
 | **G5** sound render | at render | whole number of samples, ≥ 200 ms, written `tmp` + `os.replace` |
 | **G6** verified | at serve | the stored text equals the key's text, else it is a **miss** |
 
@@ -104,7 +104,27 @@ The confirmation is whitespace-tolerant (`turntake.normalize_spoken`) because th
 space-joins per-word text frames. **The key itself stays byte-exact** — the two comparisons
 answer different questions.
 
-### Fixed lines are exempt from G3 and G4
+### Why G4 has two standards
+
+It started as one strict rule for both, and live agent `shreya-v3` showed that was a stall
+rather than caution: **15 of its 22 calls are RED**, so its opening line could only be learned
+from roughly one call in three. Worse, the faults doing the blocking were `DEAD_AIR`,
+`SLOW_LLM`, `ANSWER_DELETED` and `REPLY_LOOP` — none of which say anything about whether the
+opening was *rendered correctly*. It demonstrably was; it is the first line of the transcript.
+Letting overall call health veto a per-sentence question was the error.
+
+The two candidates make different claims, so they answer to different bars:
+
+- A **fixed line** claims only *"this authored string is worth rendering"*. Its audio comes
+  from an off-call one-shot synthesis of a string an admin wrote, so nothing about how the
+  conversation went bears on it. Only audio faults can veto it.
+- An **LLM sentence** claims *"the model said this and will plausibly say it again"*. That does
+  lean on the conversation having worked, so it keeps the strict bar.
+
+The narrowing is not a free pass: `CRASH`, `BOT_SILENT`, `TTS_WEDGE` and `REPLY_UNPLAYED` still
+veto a fixed line, because each of those genuinely implicates the audio.
+
+### Fixed lines are exempt from G3
 
 The opening, farewells, nudge, handbacks, fillers and transfer-fail closing are *authored by an
 admin*, not learned from a call. There is no call to have heard them on. They still face G1,

--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -708,12 +708,29 @@ class CallCandidates:
               health: str) -> int:
         """Apply G4 then G3, then ladder the survivors. Blocking; call at call end.
 
-        G4 — the call must have been healthy. A call where synthesis wedged, a
-        reply never played, or we went deaf is not evidence about anything, and
-        the whole batch is dropped rather than picked over. Cheap to be strict:
-        the sentence will come round again on a call that worked.
+        G4 — the call has to have been healthy enough for what this sentence
+        actually claims. TWO STANDARDS, because the two kinds of candidate make
+        different claims:
 
-        G3 — the sentence must appear in the PLAYED transcript, which
+        A FIXED line claims only "this authored string is worth rendering". Its
+        audio comes from an off-call one-shot synthesis of a string an admin
+        wrote; nothing about how the conversation went bears on it. So only the
+        faults that implicate AUDIO can veto it — synthesis wedged, the bot went
+        silent, a reply never played, the pipeline crashed.
+
+        An LLM SENTENCE claims "the model said this, and will plausibly say it
+        again". That claim does lean on the conversation having worked, so it
+        keeps the strict bar: any blocking fault, or a RED verdict, drops it.
+
+        This started as one strict rule for both, and on live agent shreya-v3 it
+        was a stall rather than caution: 15 of 22 calls RED, so the opening line
+        could only be learned from roughly one call in three. And the faults
+        doing the blocking were DEAD_AIR, SLOW_LLM, ANSWER_DELETED — none of
+        which say anything about whether the opening was rendered correctly. It
+        demonstrably was; it is the first line of the transcript. Letting overall
+        call health veto a per-sentence question was the error.
+
+        G3 — an LLM sentence must appear in the PLAYED transcript, which
         PlayedTranscriptRecorder builds from TTSTextFrames released by the
         transport at playout position, i.e. text the caller actually HEARD.
         This is the same test NoRepeatGate runs to un-record never-played
@@ -724,12 +741,8 @@ class CallCandidates:
             return 0
         try:
             faults = set(verdict_faults or ())
-            blocking = faults & _CACHE_BLOCKING_FAULTS
-            if blocking or (health or "").upper() == "RED":
-                logger.info("tts-cache: dropping %d candidate(s) — call health %s %s",
-                            len(self._items), health, sorted(blocking))
-                self._items = []
-                return 0
+            audio_bad = faults & _AUDIO_BLOCKING_FAULTS
+            convo_bad = (faults & _CACHE_BLOCKING_FAULTS) or (health or "").upper() == "RED"
 
             # normalize_spoken is NoRepeatGate's own comparator: whitespace
             # collapsed and case-folded. Used for the CONFIRMATION only — the
@@ -739,13 +752,23 @@ class CallCandidates:
             from .turntake import normalize_spoken
             played = normalize_spoken(played_text or "")
 
-            heard, unheard = [], 0
+            heard, unheard, dropped = [], 0, 0
             for c in self._items:
-                if c.fixed or (played and normalize_spoken(c.text) in played):
+                if c.fixed:
+                    if audio_bad:
+                        dropped += 1
+                    else:
+                        heard.append(c)
+                elif convo_bad:
+                    dropped += 1
+                elif played and normalize_spoken(c.text) in played:
                     heard.append(c)
                 else:
                     unheard += 1
             self._items = []
+            if dropped:
+                logger.info("tts-cache: dropped %d candidate(s) — health=%s audio_faults=%s",
+                            dropped, health, sorted(audio_bad) or "none")
             if unheard:
                 logger.info("tts-cache: %d candidate(s) never reached the caller — not laddered",
                             unheard)
@@ -756,10 +779,19 @@ class CallCandidates:
             return 0
 
 
-# A call carrying any of these did not deliver audio reliably, so nothing it saw
-# is trustworthy evidence. Names match diagnostics.py's fault codes.
-_CACHE_BLOCKING_FAULTS = frozenset({
-    "CRASH", "BOT_SILENT", "TTS_WEDGE", "REPLY_UNPLAYED", "STT_DEAF", "REPLY_LOOP",
+# Faults that implicate the AUDIO itself: synthesis stalled, the bot produced
+# nothing, a reply never reached the caller, the pipeline died. These are the only
+# ones that can say anything about whether a rendered string is trustworthy, so
+# they are the only ones that veto a FIXED line. Names match diagnostics.py.
+_AUDIO_BLOCKING_FAULTS = frozenset({
+    "CRASH", "BOT_SILENT", "TTS_WEDGE", "REPLY_UNPLAYED",
+})
+
+# The stricter bar, for an LLM sentence — whose claim ("the model will plausibly
+# say this again") does lean on the conversation having worked. Adds the faults
+# about hearing and looping, and a RED verdict blocks on top.
+_CACHE_BLOCKING_FAULTS = _AUDIO_BLOCKING_FAULTS | frozenset({
+    "STT_DEAF", "REPLY_LOOP",
 })
 
 

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -429,6 +429,55 @@ def test_the_counter_only_ever_counts_whole_sentences(cache):
     assert cache.due() == []
 
 
+def test_a_fixed_line_survives_a_red_call(cache):
+    """The change live agent shreya-v3 forced: 15 of its 22 calls are RED, so one
+    strict bar meant its opening line could only be learned from one call in
+    three. And the faults doing the blocking — DEAD_AIR, SLOW_LLM,
+    ANSWER_DELETED, REPLY_LOOP — say nothing about whether that opening was
+    rendered correctly. It demonstrably was; it is the first line of the
+    transcript."""
+    cc = CallCandidates(cache)
+    fixed = _cand("Namaste ji, main Shreya bol rahi hoon.", fixed=True)
+    cc.add(fixed)
+    n = cc.flush(played_text="",
+                 verdict_faults=["ANSWER_DELETED", "DEAD_AIR", "REPLY_LOOP", "SLOW_LLM"],
+                 health="RED")
+    assert n == 1
+    assert [d.key for d in cache.due()] == [fixed.key]
+
+
+@pytest.mark.parametrize("fault", ["CRASH", "BOT_SILENT", "TTS_WEDGE", "REPLY_UNPLAYED"])
+def test_a_fixed_line_is_still_dropped_when_the_AUDIO_is_suspect(cache, fault):
+    """The narrowing is not a free pass. These four implicate the audio itself,
+    and they must still veto a fixed line."""
+    cc = CallCandidates(cache)
+    cc.add(_cand("Theek hai, dhanyavaad.", fixed=True))
+    assert cc.flush(played_text="", verdict_faults=[fault], health="AMBER") == 0
+
+
+def test_an_llm_sentence_still_needs_a_healthy_call(cache):
+    """The strict bar stays where the claim actually leans on the conversation
+    having worked."""
+    cc = CallCandidates(cache)
+    llm = _cand("Aur uski fees kya hai?")
+    cc.add(llm)
+    assert cc.flush(played_text=llm.text, verdict_faults=["DEAD_AIR"], health="RED") == 0
+
+    cc.add(llm)
+    assert cc.flush(played_text=llm.text, verdict_faults=["REPLY_LOOP"], health="AMBER") == 0
+
+
+def test_one_red_call_can_teach_the_fixed_line_and_not_the_llm_one(cache):
+    """Both kinds arrive from the same call and are judged separately."""
+    cc = CallCandidates(cache)
+    fixed = _cand("Theek hai, dhanyavaad.", fixed=True)
+    llm = _cand("Aur uski fees kya hai?")
+    cc.add(fixed); cc.add(llm)
+    assert cc.flush(played_text=llm.text + " " + fixed.text,
+                    verdict_faults=["DEAD_AIR"], health="RED") == 1
+    assert [d.key for d in cache.due()] == [fixed.key]
+
+
 def test_g4_red_health_alone_blocks_laddering(cache):
     cc = CallCandidates(cache)
     c = _cand("Yeh humara flagship programme hai.")


### PR DESCRIPTION
G4 dropped a call's whole batch of candidates on any blocking fault or a RED verdict. Live agent shreya-v3 showed that is a stall, not caution: 15 of its 22 calls are RED, so its opening line could only be learned from roughly one call in three -- and on the two-sighting rule that is an expected wait of about nine calls to cache a single authored string.

The faults doing the blocking were DEAD_AIR, SLOW_LLM, ANSWER_DELETED and REPLY_LOOP. None of them says anything about whether the opening was RENDERED correctly. It demonstrably was; it is the first line of the transcript. Letting overall call health veto a per-sentence question was the error.

The two kinds of candidate make different claims, so they now answer to different bars:

  * A FIXED line claims only "this authored string is worth rendering". Its audio is an off-call one-shot synthesis of a string an admin wrote, so how the conversation went does not bear on it. Vetoed only by faults that implicate the audio: CRASH, BOT_SILENT, TTS_WEDGE, REPLY_UNPLAYED.
  * An LLM SENTENCE claims "the model said this and will plausibly say it again", which does lean on the conversation having worked. Keeps the strict bar -- those four plus STT_DEAF, REPLY_LOOP, or a RED verdict.

Not a free pass: the four audio faults still veto a fixed line, and a test asserts each one does. Another asserts a single RED call teaches the fixed line and not the LLM one, since both arrive from the same call and are judged apart.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
