### PR TITLE
fix(super-admin): :: cast broke the calls summary endpoint

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/super_admin/service/SuperAdminCallService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/super_admin/service/SuperAdminCallService.java
@@ -362,11 +362,11 @@ public class SuperAdminCallService {
                                           AND r.duration_seconds > 0
                                          THEN (r.duration_seconds + 59) / 60 ELSE 0 END), 0),
                        COALESCE(sum(CASE WHEN r.diagnostics->'tts'->>'cacheHits' ~ '^[0-9]+$'
-                                         THEN (r.diagnostics->'tts'->>'cacheHits')::bigint END), 0),
+                                         THEN CAST(r.diagnostics->'tts'->>'cacheHits' AS bigint) END), 0),
                        COALESCE(sum(CASE WHEN r.diagnostics->'tts'->>'cacheMisses' ~ '^[0-9]+$'
-                                         THEN (r.diagnostics->'tts'->>'cacheMisses')::bigint END), 0),
+                                         THEN CAST(r.diagnostics->'tts'->>'cacheMisses' AS bigint) END), 0),
                        COALESCE(sum(CASE WHEN r.diagnostics->'tts'->>'cacheCharsSaved' ~ '^[0-9]+$'
-                                         THEN (r.diagnostics->'tts'->>'cacheCharsSaved')::bigint END), 0),
+                                         THEN CAST(r.diagnostics->'tts'->>'cacheCharsSaved' AS bigint) END), 0),
                        count(*) FILTER (WHERE r.diagnostics->'tts'->>'cacheHits' ~ '^[0-9]+$')
                 """ + BASE_FROM + " GROUP BY 1");
         bind(q, instituteId, from, to, health, disposition, agentId);


### PR DESCRIPTION
/super-admin/v1/calls/summary has been returning 511 since the speech-cache summary columns landed. I wrote the jsonb casts as ::bigint. In a JPA NATIVE query Hibernate parses ':' as a named-parameter marker, so it consumed one colon and shipped Postgres ":bigint" -- "syntax error at or near ':'".

CAST(x AS bigint) instead. The rest of this very query already uses CAST(? AS text) for the same reason; I added the one construct the file was avoiding.

Verified by running the corrected SQL against the production database rather than trusting a compile: it returns 67 smallest_pro calls with hits=2 misses=7 charsSaved=195 -- 191 for the opening plus 4 for the filler, which is exactly the two blobs the bot has stored.

A compile could never have caught this: the query is a text block, so it is only parsed at execution. That is the argument for running new native SQL against a real database before shipping it, which I did not do.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
