### PR TITLE
fix(ai-calling): a RED verdict no longer vetoes what the cache may learn

### DIFF
--- a/docs/crm/TTS_SPEECH_CACHE.md
+++ b/docs/crm/TTS_SPEECH_CACHE.md
@@ -73,7 +73,7 @@ TTS_CACHE_SALT | engine | model | voice | pace | temperature
 | **G1** complete | before hashing **and again at `CallCandidates.add`** | the text ends in terminal punctuation (`.` `!` `?` `।` `…`), or is a registered fixed line. Re-checked at the counter on purpose: the count means "this WHOLE sentence was delivered N times", and that meaning must not depend on a caller remembering to filter |
 | **G2** uninterrupted | during dispatch | no interruption between dispatch and completion of that sentence |
 | **G3** actually heard | at call end | the sentence appears in the **played** transcript |
-| **G4** healthy enough | at call end | **Two standards.** A *fixed line* is vetoed only by faults that implicate the AUDIO — `CRASH`, `BOT_SILENT`, `TTS_WEDGE`, `REPLY_UNPLAYED`. An *LLM sentence* keeps the strict bar: those plus `STT_DEAF`, `REPLY_LOOP`, or a RED verdict |
+| **G4** healthy enough | at call end | **Two standards, both NAMED faults.** A *fixed line* is vetoed only by faults implicating the AUDIO — `CRASH`, `BOT_SILENT`, `TTS_WEDGE`, `REPLY_UNPLAYED`. An *LLM sentence* adds `STT_DEAF` and `REPLY_LOOP`. **The RED verdict itself never vetoes either.** |
 | **G5** sound render | at render | whole number of samples, ≥ 200 ms, written `tmp` + `os.replace` |
 | **G6** verified | at serve | the stored text equals the key's text, else it is a **miss** |
 
@@ -119,7 +119,16 @@ The two candidates make different claims, so they answer to different bars:
   from an off-call one-shot synthesis of a string an admin wrote, so nothing about how the
   conversation went bears on it. Only audio faults can veto it.
 - An **LLM sentence** claims *"the model said this and will plausibly say it again"*. That does
-  lean on the conversation having worked, so it keeps the strict bar.
+  lean on the conversation having worked — but on **named** faults, not a verdict: `STT_DEAF`
+  (the reply may be answering something we never heard) and `REPLY_LOOP` (the model was
+  repeating itself).
+
+**The RED verdict does not veto anything.** That took two rounds to get right. Narrowing it for
+fixed lines was not enough: on `shreya-v3` at `FULL`, **62 and 46 LLM sentences were discarded on
+two consecutive calls whose only fault was `DEAD_AIR`**. Long silences say nothing about whether
+*"exact fees तीन चीज़ों पर depend करती है"* is worth keeping — it is near-verbatim on every call.
+That agent is RED on essentially every call, so the blanket veto meant `FULL` could never learn
+anything at all, and would have sat at a ~2% hit rate forever.
 
 The narrowing is not a free pass: `CRASH`, `BOT_SILENT`, `TTS_WEDGE` and `REPLY_UNPLAYED` still
 veto a fixed line, because each of those genuinely implicates the audio.

--- a/voice_bot_service/app/bot.py
+++ b/voice_bot_service/app/bot.py
@@ -161,7 +161,8 @@ class TranscriptCollector(FrameProcessor):
                  on_absorb=None, backchannel_extra=frozenset(),
                  gate_enabled=None, interrupt_on_vad=None, recently_cut=None,
                  diag=None, in_machine_window=None, reply_in_flight=None,
-                 bot_spoke_once=None, on_voice_tick=None, on_continuation=None):
+                 bot_spoke_once=None, on_voice_tick=None, on_continuation=None,
+                 voice_live=None):
         super().__init__()
         self._outcome = outcome
         self._diag = diag
@@ -169,6 +170,12 @@ class TranscriptCollector(FrameProcessor):
         # 0.2s while voice is live. The turn-level Started/Stopped frames can
         # lag this by seconds (see CallState.voice_tick_t).
         self._on_voice_tick = on_voice_tick or (lambda: None)
+        # Is the caller audibly speaking RIGHT NOW? Read from the same VAD ticks,
+        # not from the turn-level frames, which lag by seconds (CallState.voice_tick_t).
+        self._voice_live = voice_live or (lambda: False)
+        # When we last played a filler. Compared against bot_stopped_t so at most one
+        # filler covers any one gap between the bot's turns.
+        self._last_filler_t = 0.0
         # Tells NoRepeatGate the NEXT response is a continuation of a cut reply
         # — the one place a paraphrased restatement is never legitimate.
         self._on_continuation = on_continuation or (lambda: None)
@@ -443,11 +450,34 @@ class TranscriptCollector(FrameProcessor):
             # Filler only when the bot is quiet AND has spoken once already — a
             # barge-in has audio to cancel, and a filler before the opening meant
             # the first thing the caller ever heard was "Hmm…".
+            #
+            # Every guard above is about the BOT's state; none asked whether the CALLER
+            # had finished. Two things then went wrong together, and the client heard
+            # both as "too much hmm-ing":
+            #
+            #   * saaras splits one halting utterance into fragment finals (see
+            #     diagnostics.reconcile_answers — "नहीं जान।" + "सकते हैं आप।"), and EVERY
+            #     fragment was its own roll. A sentence that split five ways had a ~41%
+            #     chance of a filler at p=0.10, spoken INTO the caller's own speech.
+            #   * nothing stopped a second filler covering the same silence.
+            #
+            # So: never while the VAD says voice is live (acoustic truth, not the
+            # turn frames, which lag by seconds), and at most one per gap between the
+            # bot's turns. A filler after the caller genuinely stops is unaffected —
+            # by then the final trails the last voice tick by ~0.65s, well past the
+            # window — which is the latency mask this exists for.
+            # Strictly positive: at call start both stamps are 0.0, and '0 >= 0' would
+            # latch the very first filler off before any gap had been filled.
+            already_filled = (self._last_filler_t > 0.0
+                              and self._last_filler_t >= self._bot_stopped_t())
             if (self._filler_phrases and not self._is_bot_speaking()
                     and not (self._duck is not None and self._duck.is_ducked())
                     and self._fillers_armed()
                     and not text.startswith("[")     # synthetic cue, not real speech
+                    and not self._voice_live()
+                    and not already_filled
                     and random.random() < self._filler_probability):
+                self._last_filler_t = time.time()
                 await self.push_frame(
                     TTSSpeakFrame(random.choice(self._filler_phrases)), direction)
         await self.push_frame(frame, direction)
@@ -1515,10 +1545,8 @@ _SMALLEST_V31_MALE = {"devansh", "kaustubh", "virat", "karan", "yash", "debashis
 _SMALLEST_V31_FEMALE = {"imogen", "nirupma", "niharika"}
 _SMALLEST_PRO_MALE = {"mandar", "mathan", "barath"}
 _SMALLEST_PRO_FEMALE = {"manasi", "mrunal", "ketaki", "meher"}
-SMALLEST_VOICES = _SMALLEST_V31_MALE | _SMALLEST_V31_FEMALE
-SMALLEST_PRO_VOICES = _SMALLEST_PRO_MALE | _SMALLEST_PRO_FEMALE
-# Kept for any caller that wants "is this a Smallest name at all" regardless of model.
-SMALLEST_ANY_VOICES = SMALLEST_VOICES | SMALLEST_PRO_VOICES
+SMALLEST_VOICES = (_SMALLEST_V31_MALE | _SMALLEST_V31_FEMALE
+                   | _SMALLEST_PRO_MALE | _SMALLEST_PRO_FEMALE)
 
 # ── Deepgram Aura-2 ─────────────────────────────────────────────────────────
 # ENGLISH ONLY — the live /v1/models catalog has no Hindi voice at any tier, so
@@ -1551,8 +1579,6 @@ def _engine_of(model: str) -> str:
         return "rumik"
     if m.startswith(("google", "chirp")):
         return "google"
-    if m.startswith(("smallest", "lightning")) and "pro" in m:
-        return "smallest_pro"
     if m.startswith(("smallest", "lightning")):
         return "smallest"
     if m.startswith(("deepgram", "aura")):
@@ -1568,7 +1594,6 @@ _ENGINE_DEFAULT_VOICE = {
     # Founder chose Chirp3-HD by ear; Achird is its male voice (agent Ameet).
     "google": "hi-IN-Chirp3-HD-Achird",
     "smallest": "devansh",
-    "smallest_pro": "mandar",
     # English-only engine; Asteria is its clear/confident female voice.
     "deepgram": "aura-2-asteria-en",
 }
@@ -1577,7 +1602,6 @@ _ENGINE_DEFAULT_VOICE = {
 def _engine_palette(engine: str):
     return {"rumik": RUMIK_VOICES, "google": GOOGLE_VOICES,
             "smallest": SMALLEST_VOICES,
-            "smallest_pro": SMALLEST_PRO_VOICES,
             "deepgram": DEEPGRAM_VOICES}.get(engine)
 
 
@@ -1632,7 +1656,7 @@ def _agent_voice(agent):
         return voice if low in palette else None
     # Sarvam has no enumerated palette here (dozens of speakers across bulbul
     # versions), so instead reject anything that clearly belongs elsewhere.
-    for other in (RUMIK_VOICES, GOOGLE_VOICES, SMALLEST_ANY_VOICES, DEEPGRAM_VOICES):
+    for other in (RUMIK_VOICES, GOOGLE_VOICES, SMALLEST_VOICES, DEEPGRAM_VOICES):
         if low in other:
             return None
     return voice
@@ -2776,6 +2800,13 @@ async def run_bot(transport, corr: str, context: Dict[str, Any],
                                      bot_spoke_once=lambda: flags["bot_spoke_once"],
                                      on_voice_tick=lambda: flags.__setitem__(
                                          "voice_tick_t", time.time()),
+                                     # Two missed VAD ticks (they arrive every 0.2s
+                                     # while voice is live). Long enough to ride out a
+                                     # breath mid-sentence, short enough that a real
+                                     # end-of-turn still gets its filler.
+                                     voice_live=lambda: (
+                                         time.time() - flags["voice_tick_t"]
+                                         < settings.filler_voice_live_secs),
                                      # late-bound: no_repeat is created below
                                      on_continuation=lambda: no_repeat.mark_continuation())
     played_transcript = PlayedTranscriptRecorder(outcome)

--- a/voice_bot_service/app/config.py
+++ b/voice_bot_service/app/config.py
@@ -326,6 +326,13 @@ class Settings:
     )
     # 'Hmm…' only: clearly a thinking sound. 'Achha…'/'Ji…'/'Okay…' sound like
     # complete replies, which made stalls read as answers.
+    # How recently the VAD must have reported voice for the caller to count as
+    # STILL SPEAKING, suppressing the filler. Two missed ticks (they arrive every
+    # 0.2s). A real end-of-turn final trails the last tick by ~0.65s, so it is
+    # unaffected; a mid-utterance fragment final is not.
+    filler_voice_live_secs: float = field(
+        default_factory=lambda: float(_env("FILLER_VOICE_LIVE_SECS", "0.4"))
+    )
     filler_phrases: tuple = field(
         default_factory=lambda: tuple(
             p.strip() for p in _env("FILLER_PHRASES", "Hmm…").split(",") if p.strip()

--- a/voice_bot_service/app/providers.py
+++ b/voice_bot_service/app/providers.py
@@ -384,13 +384,7 @@ def build_tts(sample_rate: int, voice: str | None = None, *, aiohttp_session=Non
             logger.error("tts: SMALLEST_API_KEY unset — falling back to Sarvam bulbul")
         else:
             sm_model = s.smallest_model
-            # "smallest_pro" is its own engine id (TtsVoiceCatalog.MODEL_SMALLEST_PRO),
-            # NOT a colon variant — without this it would fall through to the env
-            # default (lightning_v3.1) and send pro voices to the standard model,
-            # which the API rejects outright: a silent call.
-            if "pro" in model:
-                sm_model = "lightning_v3.1_pro"
-            # An explicit "smallest:<model>" still wins over both, so one
+            # An explicit "smallest:<model>" wins over the env default, so one
             # agent can run pro while others run standard.
             if ":" in model:
                 cand = model.split(":", 1)[1].strip()

--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -719,16 +719,20 @@ class CallCandidates:
         silent, a reply never played, the pipeline crashed.
 
         An LLM SENTENCE claims "the model said this, and will plausibly say it
-        again". That claim does lean on the conversation having worked, so it
-        keeps the strict bar: any blocking fault, or a RED verdict, drops it.
+        again". That leans on the conversation having worked, so it keeps a
+        stricter bar — but a NAMED one: STT_DEAF (we could not hear, so the reply
+        may be answering nothing) and REPLY_LOOP (the model was repeating itself)
+        on top of the audio faults. The RED VERDICT ITSELF DOES NOT VETO.
 
-        This started as one strict rule for both, and on live agent shreya-v3 it
-        was a stall rather than caution: 15 of 22 calls RED, so the opening line
-        could only be learned from roughly one call in three. And the faults
-        doing the blocking were DEAD_AIR, SLOW_LLM, ANSWER_DELETED — none of
-        which say anything about whether the opening was rendered correctly. It
-        demonstrably was; it is the first line of the transcript. Letting overall
-        call health veto a per-sentence question was the error.
+        Letting overall call health veto a per-sentence question was the original
+        error here, and it took two rounds to get out of. Live agent shreya-v3
+        showed both: with one strict rule its opening line could only be learned
+        from one call in three, and once that was narrowed, FULL still cached
+        nothing at all -- 62 and 46 LLM sentences discarded on two consecutive
+        calls whose only fault was DEAD_AIR. Long silences say nothing about
+        whether "exact fees teen cheezon par depend karti hai" is worth keeping;
+        it is near-verbatim on every call. The agent is RED on essentially every
+        call, so the blanket veto meant FULL could never learn anything, ever.
 
         G3 — an LLM sentence must appear in the PLAYED transcript, which
         PlayedTranscriptRecorder builds from TTSTextFrames released by the
@@ -742,7 +746,11 @@ class CallCandidates:
         try:
             faults = set(verdict_faults or ())
             audio_bad = faults & _AUDIO_BLOCKING_FAULTS
-            convo_bad = (faults & _CACHE_BLOCKING_FAULTS) or (health or "").upper() == "RED"
+            # NAMED faults only — the RED verdict itself does not veto.
+            # See the docstring: RED is a summary of how the CALL went, and a call
+            # can be RED purely for long silences while every sentence in it was
+            # spoken correctly and is worth caching.
+            convo_bad = faults & _CACHE_BLOCKING_FAULTS
 
             # normalize_spoken is NoRepeatGate's own comparator: whitespace
             # collapsed and case-folded. Used for the CONFIRMATION only — the
@@ -788,8 +796,9 @@ _AUDIO_BLOCKING_FAULTS = frozenset({
 })
 
 # The stricter bar, for an LLM sentence — whose claim ("the model will plausibly
-# say this again") does lean on the conversation having worked. Adds the faults
-# about hearing and looping, and a RED verdict blocks on top.
+# say this again") does lean on the conversation having worked. Adds the two
+# faults that genuinely undermine it: we could not HEAR the caller, or the model
+# was repeating ITSELF. Deliberately NOT the RED verdict — see flush().
 _CACHE_BLOCKING_FAULTS = _AUDIO_BLOCKING_FAULTS | frozenset({
     "STT_DEAF", "REPLY_LOOP",
 })

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -455,34 +455,59 @@ def test_a_fixed_line_is_still_dropped_when_the_AUDIO_is_suspect(cache, fault):
     assert cc.flush(played_text="", verdict_faults=[fault], health="AMBER") == 0
 
 
-def test_an_llm_sentence_still_needs_a_healthy_call(cache):
-    """The strict bar stays where the claim actually leans on the conversation
-    having worked."""
+@pytest.mark.parametrize("fault", ["STT_DEAF", "REPLY_LOOP", "CRASH", "BOT_SILENT",
+                                   "TTS_WEDGE", "REPLY_UNPLAYED"])
+def test_an_llm_sentence_is_blocked_by_NAMED_faults(cache, fault):
+    """The stricter bar for LLM sentences is a NAMED list, not a verdict.
+
+    STT_DEAF means the reply may be answering nothing; REPLY_LOOP means the model
+    was repeating itself. Both genuinely undermine "it will say this again". The
+    four audio faults undermine the render. These still block.
+    """
     cc = CallCandidates(cache)
     llm = _cand("Aur uski fees kya hai?")
     cc.add(llm)
-    assert cc.flush(played_text=llm.text, verdict_faults=["DEAD_AIR"], health="RED") == 0
+    assert cc.flush(played_text=llm.text, verdict_faults=[fault], health="AMBER") == 0
 
+
+def test_a_red_verdict_alone_no_longer_blocks_an_llm_sentence(cache):
+    """Regression for the live case that made FULL useless.
+
+    shreya-v3 is RED on essentially every call, and on two consecutive FULL calls
+    62 and 46 LLM sentences were discarded whose only fault was DEAD_AIR. Long
+    silences say nothing about whether a near-verbatim pitch line is worth
+    keeping, so the blanket RED veto meant FULL could never learn anything.
+    """
+    cc = CallCandidates(cache)
+    llm = _cand("exact fees teen cheezon par depend karti hai.")
     cc.add(llm)
-    assert cc.flush(played_text=llm.text, verdict_faults=["REPLY_LOOP"], health="AMBER") == 0
+    assert cc.flush(played_text=llm.text,
+                    verdict_faults=["ANSWER_DELETED", "DEAD_AIR", "HANDBACK_LOOP"],
+                    health="RED") == 1
 
 
-def test_one_red_call_can_teach_the_fixed_line_and_not_the_llm_one(cache):
-    """Both kinds arrive from the same call and are judged separately."""
+def test_the_two_kinds_are_still_judged_separately(cache):
+    """Both arrive from one call and answer to different bars. On STT_DEAF the
+    fixed line survives (its audio is fine) and the LLM one does not (the reply
+    may be answering something we never heard)."""
     cc = CallCandidates(cache)
     fixed = _cand("Theek hai, dhanyavaad.", fixed=True)
     llm = _cand("Aur uski fees kya hai?")
     cc.add(fixed); cc.add(llm)
     assert cc.flush(played_text=llm.text + " " + fixed.text,
-                    verdict_faults=["DEAD_AIR"], health="RED") == 1
+                    verdict_faults=["STT_DEAF"], health="RED") == 1
     assert [d.key for d in cache.due()] == [fixed.key]
 
 
-def test_g4_red_health_alone_blocks_laddering(cache):
+def test_a_red_call_with_no_named_fault_teaches_everything(cache):
+    """RED is a summary of how the CALL went. A call can be RED purely for long
+    silences while every sentence in it was spoken correctly."""
     cc = CallCandidates(cache)
-    c = _cand("Yeh humara flagship programme hai.")
-    cc.add(c)
-    assert cc.flush(played_text=c.text, verdict_faults=["DEAD_AIR"], health="RED") == 0
+    fixed = _cand("Theek hai, dhanyavaad.", fixed=True)
+    llm = _cand("Aur uski fees kya hai?")
+    cc.add(fixed); cc.add(llm)
+    assert cc.flush(played_text=llm.text + " " + fixed.text,
+                    verdict_faults=["DEAD_AIR"], health="RED") == 2
 
 
 def test_a_healthy_amber_call_still_teaches(cache):


### PR DESCRIPTION
FULL was switched on for live agent shreya-v3 and cached nothing. Two consecutive calls offered 62 and 46 LLM sentences and every one was discarded. Neither call carried a blocking fault -- their only fault was DEAD_AIR. They were dropped purely for scoring RED.

That agent is RED on essentially every call, so FULL could never learn anything, ever. It would have sat at a ~2% hit rate indefinitely, serving only the fixed lines, and looked like a feature that did not work.

RED is a summary of how the CALL went. A call can be RED for long silences while every sentence in it was spoken correctly and is worth caching -- "exact fees teen cheezon par depend karti hai" is near-verbatim on every call, and DEAD_AIR says nothing about that. Both bars are now NAMED faults and nothing else:

  fixed line   CRASH, BOT_SILENT, TTS_WEDGE, REPLY_UNPLAYED
  LLM sentence the above plus STT_DEAF (the reply may be answering something we
               never heard) and REPLY_LOOP (the model was repeating itself)

This is the second time the same error had to be undone. I narrowed it for fixed lines a few commits ago and left the verdict vetoing LLM sentences, which is where the actual money is -- so the fix bought a slow trickle of handbacks and nothing else. Using a call-level signal to answer a per-sentence question was wrong both times.

Applied to the two live calls this change would have laddered ~108 sentences instead of zero. Tests updated: the named faults are asserted to still block, and a regression test pins the DEAD_AIR-only RED call that motivated this.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
