### PR TITLE
feat(ai-calling): teach every cached agent the wording rules, not jus…

### DIFF
--- a/voice_bot_service/app/bot.py
+++ b/voice_bot_service/app/bot.py
@@ -2103,6 +2103,33 @@ def build_system_prompt(context: Dict[str, Any], sink=None) -> str:
                 "'Assessment', 'Foundation Batch' — NEVER 'लाइव क्लासेस', 'असेसमेंट'. Devanagari is "
                 "for Hindi words ONLY; if a word is English, spell it in English."
             )
+
+        # WORDING CONSISTENCY — only for agents whose speech cache is ON.
+        #
+        # The cache keys on the exact sentence, so one line said two ways is two
+        # renders and neither is ever reused. Measured on live agent shreya-v3:
+        # SEVEN of its most-spoken sentences were near-duplicate PAIRS, each half
+        # sitting at count 1 instead of one entry at count 2 — so the longest,
+        # most-repeated lines in the call (86-172 chars) never cached at all.
+        # Every pair was one of three drifts: रमन/Raman, class/क्लास, and an
+        # optional leading "सर,".
+        #
+        # GATED, because it tightens delivery for a reason that only exists when
+        # the cache is on. An agent not using the cache keeps today's freedom —
+        # this feature has no business changing how 26 other agents speak.
+        if str(agent.get("speech_cache_mode") or "OFF").strip().upper() != "OFF":
+            script_rule += (
+                "\n- SAY A RECURRING LINE THE SAME WAY EVERY TIME — same words, same "
+                "order, same spelling. Three things drift and must not:"
+                "\n  * the student's NAME is always in DEVANAGARI — रमन, never Raman; "
+                "आर्यन, never Aryan. In this conversation the name is a Hindi word, not an "
+                "English one."
+                "\n  * an English word is never in Devanagari — write 'class', never "
+                "'क्लास'."
+                "\n  * सर/मैम goes exactly where the script puts it and nowhere else. "
+                "Never add one to a line that does not already open with it."
+            )
+
     # REGISTER. Founder, after hearing live calls: "everything is highly formal
     # Hindi... words that in general are not used". Measured across two days of
     # calls: 198 uses of literary vocabulary — प्रदर्शन 37x, पूछताछ 28x, अकादमिक

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -655,3 +655,48 @@ def test_every_live_engine_resolves_to_a_concrete_model(engine):
     """A blank here silently recreates the mismatch above for that engine."""
     providers = pytest.importorskip("app.providers")
     assert providers.default_engine_model(engine).strip(), engine
+
+
+# ── the wording-consistency prompt rule (bot.build_system_prompt) ────────────
+
+def _prompt_for(mode, language="hinglish"):
+    pytest.importorskip("pipecat.frames.frames")
+    # build_system_prompt fills date placeholders with glibc-only strftime
+    # directives (%-d). They work on the Linux container and raise on Windows,
+    # which is the same reason several existing tests here cannot run locally.
+    import datetime as _dt
+    try:
+        _dt.datetime.now().strftime("%-d")
+    except ValueError:
+        pytest.skip("%-d strftime is glibc-only; this asserts in CI")
+    from app import bot
+    agent = {"id": "a1", "name": "T", "language": language, "voice": "mrunal",
+             "tts_model": "smallest_pro", "systemPrompt": "SCRIPT BODY",
+             "openingLine": "नमस्ते जी।", "speech_cache_mode": mode}
+    return bot.build_system_prompt({"agent": agent, "instituteName": "X",
+                                    "direction": "OUTBOUND", "leadName": "P"})
+
+
+def test_consistency_rule_is_absent_for_an_agent_with_the_cache_off():
+    """It tightens delivery for a reason that only exists when the cache is on.
+    26 agents are OFF and this feature has no business changing how they speak."""
+    for mode in ("OFF", "", None):
+        assert "SAY A RECURRING LINE THE SAME WAY" not in _prompt_for(mode), mode
+
+
+def test_consistency_rule_is_present_once_the_cache_is_on():
+    """The three drifts measured on shreya-v3, now told to every cached agent
+    instead of being fixed one prompt at a time."""
+    for mode in ("FIXED", "FULL"):
+        p = _prompt_for(mode)
+        assert "SAY A RECURRING LINE THE SAME WAY" in p, mode
+        assert "never Raman" in p, mode
+        assert "never 'क्लास'" in p, mode
+        assert "सर/मैम goes exactly where the script puts it" in p, mode
+
+
+def test_consistency_rule_never_forces_devanagari_on_an_english_agent():
+    """An en-IN agent is told to write Latin only; a Devanagari name rule there
+    would contradict its own SCRIPT rule."""
+    p = _prompt_for("FULL", language="en")
+    assert "never Raman" not in p


### PR DESCRIPTION
…t one

The four script fixes that recovered shreya-v3's near-duplicates were edits to that one agent's system_prompt column. Every other agent will drift the same way the moment its cache is turned on, and fixing them one prompt at a time does not scale -- so the three GENERIC ones move into build_system_prompt, where the bot already assembles its own script rules on top of whatever the agent authored.

What the live ledger showed: SEVEN of shreya-v3's most-spoken sentences were near-duplicate PAIRS, each half sitting at count 1 instead of one entry at count 2. So its longest, most-repeated lines -- 86 to 172 characters, the ones actually worth caching -- never cached at all. Every pair was one of three drifts: रमन/Raman, class/क्लास, or an optional leading "सर,".

GATED on speech_cache_mode != OFF. The rule tightens delivery for a reason that only exists when the cache is on, and 26 agents are OFF. This feature has no business changing how they speak, and a test asserts the rule is absent for them.

Also carved out of the English branch: an en-IN agent is told to write Latin only, so a "name always in Devanagari" rule there would contradict its own SCRIPT rule two lines above. Tested.

The fourth fix stays per-agent: "do not prefix the name/class question with क्या मैं जान सकती हूँ कि" names a specific question in shreya-v3's own script and means nothing to another agent.

The three new tests skip on Windows for the same glibc-only strftime (%-d) that several existing tests here already cannot run past locally. They assert in CI.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
