### PR TITLE
feat: institute-scoped app-status visibility + live App Store Connect…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/client/CommunityAppRegistryClient.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/client/CommunityAppRegistryClient.java
@@ -1,0 +1,70 @@
+package vacademy.io.admin_core_service.features.app_status.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import vacademy.io.common.core.internal_api_wrapper.InternalClientUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads app-registry records for an institute from community_service.
+ *
+ * <p>The registry lives in community_service's own database (institute-role membership tables do
+ * not — see {@code InternalAppRegistryController}'s javadoc on that side), so this institute's
+ * app status can only be fetched over the network, not joined in SQL. This class trusts the
+ * caller (AppStatusService) to have already verified the requesting user belongs to
+ * {@code instituteId} — the internal endpoint itself only checks HMAC service identity.
+ */
+@Component
+@Slf4j
+public class CommunityAppRegistryClient {
+
+    private final InternalClientUtils internalClientUtils;
+    private final ObjectMapper objectMapper;
+    private final String communityServiceBaseUrl;
+    private final String clientName;
+
+    public CommunityAppRegistryClient(
+            InternalClientUtils internalClientUtils,
+            ObjectMapper objectMapper,
+            @Value("${community.server.baseurl:http://localhost:8072}") String communityServiceBaseUrl,
+            @Value("${spring.application.name:admin_core_service}") String clientName) {
+        this.internalClientUtils = internalClientUtils;
+        this.objectMapper = objectMapper;
+        this.communityServiceBaseUrl = communityServiceBaseUrl;
+        this.clientName = clientName;
+    }
+
+    /**
+     * @return the institute's app records, or an empty list when the call fails. Empty-on-failure
+     *         (rather than propagating the error) is deliberate: this backs a read-only status
+     *         panel on an institute admin's settings page, and one flaky internal call must not
+     *         break page load for an unrelated feature on the same screen.
+     */
+    public List<JsonNode> fetchByInstitute(String instituteId) {
+        try {
+            String route = "/community-service/internal/v1/app-registry/by-institute?instituteId=" + instituteId;
+
+            ResponseEntity<String> response = internalClientUtils.makeHmacRequest(
+                    clientName, "GET", communityServiceBaseUrl, route, null);
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                List<JsonNode> out = new ArrayList<>();
+                objectMapper.readTree(response.getBody()).forEach(out::add);
+                return out;
+            }
+            log.warn("[app-status] community_service app-registry lookup returned {} for institute {}",
+                    response.getStatusCode(), instituteId);
+        } catch (Exception e) {
+            log.warn("[app-status] community_service app-registry lookup failed for institute {}: {}",
+                    instituteId, e.getMessage());
+        }
+        return List.of();
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/controller/AppStatusController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/controller/AppStatusController.java
@@ -1,0 +1,38 @@
+package vacademy.io.admin_core_service.features.app_status.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import vacademy.io.admin_core_service.features.app_status.dto.AppStatusResponse;
+import vacademy.io.admin_core_service.features.app_status.service.AppStatusService;
+import vacademy.io.common.auth.model.CustomUserDetails;
+
+/**
+ * Institute-admin-facing, read-only view of an institute's registered white-label apps.
+ *
+ * Deliberately NOT under /admin/* (same reasoning as WhiteLabelController) so the institute
+ * admin dashboard can call it without an elevated super-admin role — the service layer verifies
+ * the caller actually belongs to the instituteId being queried.
+ *
+ * Registration/editing stays exclusive to the health-check dashboard's App Registration module
+ * (SuperAdmin-only, in community_service) — this endpoint has no write path on purpose.
+ */
+@RestController
+@RequestMapping("/admin-core-service/institute/app-registry/v1")
+@RequiredArgsConstructor
+public class AppStatusController {
+
+    private final AppStatusService appStatusService;
+
+    @GetMapping("/status")
+    public ResponseEntity<AppStatusResponse> getStatus(
+            @RequestAttribute("user") CustomUserDetails user,
+            @RequestParam("instituteId") String instituteId) {
+
+        return ResponseEntity.ok(appStatusService.getStatus(user, instituteId));
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/dto/AppStatusResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/dto/AppStatusResponse.java
@@ -1,0 +1,76 @@
+package vacademy.io.admin_core_service.features.app_status.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Read-only view of an institute's registered white-label apps and their per-platform store
+ * status — returned by GET /admin-core-service/institute/app-registry/v1/status.
+ *
+ * <p>Registration itself (uploading icons, filling in store metadata, linking bundle/package
+ * ids) stays an ops-only workflow in the health-check dashboard's App Registration module —
+ * this endpoint is deliberately read-only so an institute admin can see where their app stands
+ * without being able to edit a record that belongs to the platform team.
+ */
+@Data
+@Builder
+public class AppStatusResponse {
+
+    @JsonProperty("institute_id")
+    private String instituteId;
+
+    @JsonProperty("apps")
+    private List<RegisteredApp> apps;
+
+    @Data
+    @Builder
+    public static class RegisteredApp {
+        @JsonProperty("id")
+        private String id;
+
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("display_name")
+        private String displayName;
+
+        @JsonProperty("package_name")
+        private String packageName;
+
+        @JsonProperty("platforms")
+        private List<PlatformStatus> platforms;
+    }
+
+    @Data
+    @Builder
+    public static class PlatformStatus {
+        /** ANDROID / IOS / WINDOWS / MACOS — matches the health-check dashboard's Platform enum. */
+        @JsonProperty("platform")
+        private String platform;
+
+        @JsonProperty("enabled")
+        private boolean enabled;
+
+        /** One of the health-check dashboard's StoreStatus values (e.g. LIVE, IN_REVIEW, REJECTED). */
+        @JsonProperty("status")
+        private String status;
+
+        @JsonProperty("store_url")
+        private String storeUrl;
+
+        @JsonProperty("current_version")
+        private String currentVersion;
+
+        @JsonProperty("current_build")
+        private String currentBuild;
+
+        @JsonProperty("released_at")
+        private String releasedAt;
+
+        @JsonProperty("last_synced_at")
+        private String lastSyncedAt;
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/service/AppStatusService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/app_status/service/AppStatusService.java
@@ -1,0 +1,110 @@
+package vacademy.io.admin_core_service.features.app_status.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import vacademy.io.admin_core_service.features.app_status.client.CommunityAppRegistryClient;
+import vacademy.io.admin_core_service.features.app_status.dto.AppStatusResponse;
+import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.auth.repository.UserRoleRepository;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppStatusService {
+
+    private static final String ROLE_NAME_ADMIN = "ADMIN";
+
+    private final CommunityAppRegistryClient communityAppRegistryClient;
+    private final InstituteRepository instituteRepository;
+    private final UserRoleRepository userRoleRepository;
+
+    public AppStatusResponse getStatus(CustomUserDetails user, String instituteId) {
+        assertInstituteAccess(user, instituteId);
+
+        List<AppStatusResponse.RegisteredApp> apps = new ArrayList<>();
+        for (JsonNode record : communityAppRegistryClient.fetchByInstitute(instituteId)) {
+            apps.add(toRegisteredApp(record));
+        }
+
+        return AppStatusResponse.builder()
+                .instituteId(instituteId)
+                .apps(apps)
+                .build();
+    }
+
+    private AppStatusResponse.RegisteredApp toRegisteredApp(JsonNode record) {
+        JsonNode basics = record.path("basics");
+
+        List<AppStatusResponse.PlatformStatus> platforms = new ArrayList<>();
+        JsonNode platformsNode = record.path("platforms");
+        platformsNode.fieldNames().forEachRemaining(platformKey -> {
+            JsonNode p = platformsNode.path(platformKey);
+            // An institute admin only cares about platforms actually turned on for this app —
+            // a disabled platform is registry bookkeeping, not something to show as "status".
+            if (!p.path("enabled").asBoolean(false)) {
+                return;
+            }
+            platforms.add(AppStatusResponse.PlatformStatus.builder()
+                    .platform(platformKey)
+                    .enabled(true)
+                    .status(textOrDefault(p, "status", "NOT_REGISTERED"))
+                    .storeUrl(textOrDefault(p, "storeUrl", ""))
+                    .currentVersion(textOrDefault(p, "currentVersion", ""))
+                    .currentBuild(textOrDefault(p, "currentBuild", ""))
+                    .releasedAt(textOrDefault(p, "releasedAt", ""))
+                    .lastSyncedAt(textOrDefault(p, "lastSyncedAt", ""))
+                    .build());
+        });
+
+        return AppStatusResponse.RegisteredApp.builder()
+                .id(textOrDefault(record, "id", ""))
+                .name(textOrDefault(basics, "name", ""))
+                .displayName(textOrDefault(basics, "displayName", ""))
+                .packageName(textOrDefault(basics, "packageName", ""))
+                .platforms(platforms)
+                .build();
+    }
+
+    private static String textOrDefault(JsonNode node, String field, String fallback) {
+        if (node == null) return fallback;
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? fallback : value.asText(fallback);
+    }
+
+    /**
+     * Same three-tier check as WhiteLabelService#assertInstituteAccess (root bypass → user_role
+     * ADMIN row → legacy staff-table fallback) — duplicated rather than shared because
+     * WhiteLabelService keeps it private, and this endpoint has the identical authorization
+     * requirement: only that institute's admins (or a root user) may read its data.
+     */
+    private void assertInstituteAccess(CustomUserDetails user, String instituteId) {
+        if (user == null) {
+            throw new VacademyException("Access denied: no authenticated user");
+        }
+
+        if (user.isRootUser()) {
+            return;
+        }
+
+        if (userRoleRepository.existsByUserIdAndInstituteIdAndRoleName(
+                user.getUserId(), instituteId, ROLE_NAME_ADMIN)) {
+            return;
+        }
+
+        boolean isStaff = instituteRepository.findInstitutesByUserId(user.getUserId())
+                .stream()
+                .anyMatch(i -> i.getId().equals(instituteId));
+        if (!isStaff) {
+            log.warn("[AppStatus] Unauthorized attempt by userId={} on instituteId={}",
+                    user.getUserId(), instituteId);
+            throw new VacademyException("Access denied: you are not a member of institute " + instituteId);
+        }
+    }
+}

--- a/community_service/src/main/java/vacademy/io/community_service/config/CommunityApplicationSecurityConfig.java
+++ b/community_service/src/main/java/vacademy/io/community_service/config/CommunityApplicationSecurityConfig.java
@@ -24,7 +24,10 @@ import vacademy.io.common.auth.filter.JwtAuthFilter;
 @EnableMethodSecurity
 public class CommunityApplicationSecurityConfig {
 
-    private static final String[] INTERNAL_PATHS = {};
+    private static final String[] INTERNAL_PATHS = {
+            // Service-to-service only (HMAC via InternalAuthFilter) — never exposed to browsers.
+            // admin_core_service's institute-facing app-status endpoint reads through this.
+            "/community-service/internal/**" };
 
     private static final String[] ALLOWED_PATHS = { "/community-service/engage/learner/**",
             "/community-service/engage/**", "/community-service/subject/**", "/community-service/chapter/**",

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistryProviderController.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/AppRegistryProviderController.java
@@ -5,8 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.auth.util.SuperAdminAuthUtil;
+import vacademy.io.community_service.feature.appregistry.service.StoreStatusSyncService;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Server-side half of the dashboard's StoreProvider abstraction.
@@ -15,12 +17,16 @@ import java.util.Map;
  * Store Connect JWT or holding a Google service-account key client-side would expose the private
  * key to anyone with devtools.
  *
- * <p>No store integration is wired up yet, so every operation answers <b>501 Not Implemented</b>
- * with a plain explanation. That is a deliberate choice over returning a plausible-looking status:
- * a dashboard that invents "Live" is worse than one that says "go and look". The client renders
- * this as "Manual action required" and links to the right console.
+ * <p>Live today: IOS and MACOS, via {@link StoreStatusSyncService} (App Store Connect API — the
+ * only store credential present in vacademy-secrets as of this writing). ANDROID (Play Developer
+ * API, needs a Google Cloud service-account key) and WINDOWS (Partner Center, needs Azure AD) have
+ * no credential configured, so they still answer <b>501 Not Implemented</b> with a plain
+ * explanation — a dashboard that invents "Live" for a store it can't actually reach is worse than
+ * one that says "go and look". The client renders that as "Manual action required" and links to
+ * the right console. The same 501 fallback covers iOS/macOS operations this sync doesn't cover
+ * yet ({@code getReviews}) and any request where the app record has no bundle id filled in.
  *
- * <p>When a provider is implemented, it must use the official API and documented auth only —
+ * <p>When a new provider is wired up, it must use the official API and documented auth only —
  * Play Developer API via a service account, App Store Connect via a JWT-signed .p8, Partner Center
  * via Azure AD. Never a scraped console session, a reused browser cookie, or an undocumented
  * endpoint.
@@ -35,6 +41,16 @@ public class AppRegistryProviderController {
             "windows", "https://partner.microsoft.com/dashboard",
             "macos", "https://appstoreconnect.apple.com");
 
+    /** Operations {@link StoreStatusSyncService#sync} can answer from one App Store Connect call. */
+    private static final Set<String> LIVE_OPERATIONS = Set.of(
+            "getAppStatus", "getLatestVersion", "getBuildStatus", "getReleaseStatus", "getSubmissionStatus");
+
+    private final StoreStatusSyncService storeStatusSyncService;
+
+    public AppRegistryProviderController(StoreStatusSyncService storeStatusSyncService) {
+        this.storeStatusSyncService = storeStatusSyncService;
+    }
+
     @GetMapping("/{platform}/{appId}/{operation}")
     public ResponseEntity<Map<String, Object>> operation(@RequestAttribute("user") CustomUserDetails user,
                                                          @PathVariable String platform,
@@ -42,18 +58,59 @@ public class AppRegistryProviderController {
                                                          @PathVariable String operation) {
         SuperAdminAuthUtil.requireSuperAdmin(user);
 
-        String console = CONSOLES.get(platform == null ? "" : platform.toLowerCase());
+        String platformKey = platform == null ? "" : platform.toLowerCase();
+        String console = CONSOLES.get(platformKey);
         if (console == null) {
             return ResponseEntity.badRequest().body(Map.of(
                     "manual", false,
                     "message", "Unknown platform: " + platform));
         }
 
+        if (LIVE_OPERATIONS.contains(operation)) {
+            Map<String, Object> full = storeStatusSyncService.sync(appId, platform);
+            if (full != null) {
+                return ResponseEntity.ok(sliceFor(operation, full));
+            }
+        }
+
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(Map.of(
                 "manual", true,
                 "operation", operation,
                 "consoleUrl", console,
-                "message", "The server-side store integration for this platform isn't configured yet. "
-                        + "Check the store console and record the result in the dashboard."));
+                "message", notConfiguredMessage(platformKey, operation)));
+    }
+
+    /**
+     * Each provider operation is a different slice of the same App Store Connect lookup — one API
+     * call already fetches everything {@code getAppStatus} needs, so the narrower operations just
+     * pick out the fields the frontend's {@code ProviderResult<T>} type expects for that call
+     * rather than re-fetching.
+     */
+    private static Map<String, Object> sliceFor(String operation, Map<String, Object> full) {
+        return switch (operation) {
+            case "getLatestVersion" -> Map.of("version", full.get("version"), "build", full.get("build"));
+            case "getBuildStatus" -> Map.of("status", full.get("status"));
+            case "getReleaseStatus" -> Map.of("status", full.get("status"), "releasedAt", full.get("releasedAt"));
+            case "getSubmissionStatus" -> Map.of("status", full.get("status"));
+            default -> full; // getAppStatus
+        };
+    }
+
+    private static String notConfiguredMessage(String platformKey, String operation) {
+        if ("android".equals(platformKey)) {
+            return "The Play Developer API isn't configured on the server yet — it needs a Google Cloud "
+                    + "service-account JSON key with Play Console API access. Check the store console and "
+                    + "record the result in the dashboard.";
+        }
+        if ("windows".equals(platformKey)) {
+            return "The Microsoft Partner Center API isn't configured on the server yet — it needs an "
+                    + "Azure AD app registration with Partner Center access. Check the store console and "
+                    + "record the result in the dashboard.";
+        }
+        if ("getReviews".equals(operation)) {
+            return "Review sync isn't implemented yet — check App Store Connect directly.";
+        }
+        return "This app's Bundle ID isn't filled in yet, or the App Store Connect credential isn't "
+                + "configured on the server. Check the store console and record the result in the dashboard.";
     }
 }

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/InternalAppRegistryController.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/controller/InternalAppRegistryController.java
@@ -1,0 +1,37 @@
+package vacademy.io.community_service.feature.appregistry.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import vacademy.io.community_service.feature.appregistry.service.AppRegistryService;
+
+import java.util.List;
+
+/**
+ * Service-to-service read path for the app registry, consumed by admin_core_service's
+ * institute-facing app-status endpoint.
+ *
+ * <p>community_service and admin_core_service run on separate databases (assessment_service vs
+ * admin_core_service), so the institute-membership check that gates this data cannot be a local
+ * JPA join against {@code user_role} here — that table doesn't exist in this service's database.
+ * admin_core_service already owns that check (see WhiteLabelService#assertInstituteAccess); this
+ * endpoint trusts it and only verifies HMAC service identity via {@link
+ * vacademy.io.common.auth.filter.InternalAuthFilter}, matched on {@code /community-service/internal/**}
+ * in {@code CommunityApplicationSecurityConfig}. It must never be exposed to browsers directly.
+ */
+@RestController
+@RequestMapping("/community-service/internal/v1/app-registry")
+public class InternalAppRegistryController {
+
+    @Autowired
+    private AppRegistryService service;
+
+    @GetMapping("/by-institute")
+    public ResponseEntity<List<JsonNode>> byInstitute(@RequestParam("instituteId") String instituteId) {
+        return ResponseEntity.ok(service.listByInstitute(instituteId));
+    }
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/entity/AppRegistration.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/entity/AppRegistration.java
@@ -27,7 +27,8 @@ import java.util.Date;
 @Table(name = "app_registration", schema = "public",
         indexes = {
                 @Index(name = "idx_app_registration_package", columnList = "package_name"),
-                @Index(name = "idx_app_registration_archived", columnList = "archived")
+                @Index(name = "idx_app_registration_archived", columnList = "archived"),
+                @Index(name = "idx_app_registration_institute", columnList = "institute_id")
         })
 @Getter
 @Setter
@@ -50,6 +51,15 @@ public class AppRegistration {
 
     @Column(name = "package_name")
     private String packageName;
+
+    /**
+     * Owning institute, denormalised out of {@link #payload} the same way {@link #packageName} is —
+     * nullable, because apps registered before this field existed (and any ops-only tooling app with
+     * no single owning institute) have none. A null institute_id simply never matches an institute
+     * filter; it is not an error state.
+     */
+    @Column(name = "institute_id")
+    private String instituteId;
 
     @Column(name = "archived", nullable = false)
     private Boolean archived;

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/repository/AppRegistrationRepository.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/repository/AppRegistrationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface AppRegistrationRepository extends JpaRepository<AppRegistration, String> {
 
     List<AppRegistration> findAllByOrderByNameAsc();
+
+    List<AppRegistration> findAllByInstituteIdAndArchivedFalseOrderByNameAsc(String instituteId);
 }

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/AppRegistryService.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/AppRegistryService.java
@@ -41,6 +41,20 @@ public class AppRegistryService {
         return out;
     }
 
+    /**
+     * Read path for the institute-admin-facing status view. Unlike {@link #listAll()} this never
+     * returns archived apps — an institute admin should not see a decommissioned registration and
+     * wonder why "their app" looks broken.
+     */
+    @Transactional(readOnly = true)
+    public List<JsonNode> listByInstitute(String instituteId) {
+        List<JsonNode> out = new ArrayList<>();
+        for (AppRegistration row : repository.findAllByInstituteIdAndArchivedFalseOrderByNameAsc(instituteId)) {
+            out.add(parse(row.getPayload(), row.getId()));
+        }
+        return out;
+    }
+
     @Transactional(readOnly = true)
     public JsonNode get(String id) {
         AppRegistration row = repository.findById(id)
@@ -101,6 +115,7 @@ public class AppRegistryService {
         row.setName(textAt(basics, "name", ""));
         row.setClientName(textAt(basics, "client", ""));
         row.setPackageName(textAt(basics, "packageName", ""));
+        row.setInstituteId(textAt(basics, "instituteId", null));
         row.setArchived(node.path("archived").asBoolean(false));
         row.setPayload(write(node));
         return repository.save(row);

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/StoreStatusSyncService.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/service/StoreStatusSyncService.java
@@ -1,0 +1,136 @@
+package vacademy.io.community_service.feature.appregistry.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vacademy.io.community_service.feature.appregistry.entity.AppRegistration;
+import vacademy.io.community_service.feature.appregistry.repository.AppRegistrationRepository;
+import vacademy.io.community_service.feature.appregistry.store.AppStoreConnectClient;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Live status sync for the two platforms with a real credential today — IOS and MACOS both go
+ * through App Store Connect (same API, same .p8 key). ANDROID (Play Developer API) and WINDOWS
+ * (Partner Center) have no service-account/Azure-AD credential configured anywhere in
+ * vacademy-secrets yet, so {@link #sync} simply isn't called for them — the controller keeps
+ * answering those with the existing "manual action required" 501.
+ *
+ * <p>A successful sync also writes the fetched status/version/build back into the stored
+ * {@code AppRegistration.payload}, so an institute admin reading the status endpoint sees the
+ * same freshly-synced data an ops person just pulled in health-check — not stale, manually-typed
+ * values from whenever someone last edited the record by hand.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreStatusSyncService {
+
+    private final AppRegistrationRepository repository;
+    private final AppStoreConnectClient appStoreConnectClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * @return the AppStatusResult-shaped fields for the dashboard's {@code getAppStatus} contract,
+     *         or null when this platform/appId combination can't be synced live — either no
+     *         credential is configured, the record/bundle id is missing, or the call to Apple
+     *         failed. The controller treats null as "fall back to manual".
+     */
+    @Transactional
+    public Map<String, Object> sync(String recordId, String platform) {
+        if (!"IOS".equalsIgnoreCase(platform) && !"MACOS".equalsIgnoreCase(platform)) {
+            return null;
+        }
+        if (!appStoreConnectClient.isConfigured()) {
+            return null;
+        }
+
+        AppRegistration row = repository.findById(recordId).orElse(null);
+        if (row == null) {
+            return null;
+        }
+
+        ObjectNode record;
+        try {
+            record = (ObjectNode) objectMapper.readTree(row.getPayload());
+        } catch (JsonProcessingException e) {
+            log.warn("[StoreStatusSync] Stored record {} is not valid JSON, skipping sync", recordId);
+            return null;
+        }
+
+        String platformKey = platform.toUpperCase(Locale.ROOT);
+        JsonNode platformNode = record.path("platforms").path(platformKey);
+        String bundleId = platformNode.path("fields").path("bundle_id").asText("");
+        if (bundleId.isBlank()) {
+            return null;
+        }
+
+        AppStoreConnectClient.AppStatus ascStatus = appStoreConnectClient.fetchStatus(bundleId);
+        String status = ascStatus == null ? "NOT_REGISTERED" : mapAppStoreState(ascStatus.appStoreState());
+        String version = ascStatus == null ? "" : ascStatus.versionString();
+        String build = ascStatus == null ? "" : ascStatus.buildNumber();
+        String storeUrl = ascStatus == null ? ""
+                : "https://appstoreconnect.apple.com/apps/" + ascStatus.ascAppId() + "/appstore";
+        String releasedAt = "LIVE".equals(status) && ascStatus != null ? ascStatus.createdDate() : "";
+        String syncedAt = Instant.now().toString();
+
+        persist(row, record, platformKey, status, version, build, storeUrl, releasedAt, syncedAt);
+
+        return Map.of(
+                "status", status,
+                "version", version,
+                "build", build,
+                "releasedAt", releasedAt,
+                // OTA (Capacitor bundle) rollout status is a separate system this integration has
+                // no visibility into — never fabricated, always reported as unknown.
+                "otaStatus", "NONE",
+                "storeUrl", storeUrl);
+    }
+
+    private void persist(AppRegistration row, ObjectNode record, String platformKey, String status,
+                          String version, String build, String storeUrl, String releasedAt, String syncedAt) {
+        ObjectNode platforms = (ObjectNode) record.path("platforms");
+        ObjectNode platformNode = (ObjectNode) platforms.path(platformKey);
+        platformNode.put("status", status);
+        if (!version.isBlank()) platformNode.put("currentVersion", version);
+        if (!build.isBlank()) platformNode.put("currentBuild", build);
+        if (!storeUrl.isBlank()) platformNode.put("storeUrl", storeUrl);
+        if (!releasedAt.isBlank()) platformNode.put("releasedAt", releasedAt);
+        platformNode.put("lastSyncedAt", syncedAt);
+        record.put("updatedAt", syncedAt);
+
+        try {
+            row.setPayload(objectMapper.writeValueAsString(record));
+            repository.save(row);
+        } catch (JsonProcessingException e) {
+            log.warn("[StoreStatusSync] Could not serialise synced record {}: {}", row.getId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Maps App Store Connect's {@code appStoreState} to the dashboard's StoreStatus enum. Unmapped
+     * / unrecognised states fall back to SUBMITTED rather than a guess in either direction — that
+     * reads as "something is in flight, go check" rather than falsely implying success or failure.
+     */
+    private static String mapAppStoreState(String appStoreState) {
+        return switch (appStoreState) {
+            case "READY_FOR_SALE" -> "LIVE";
+            case "PREPARE_FOR_SUBMISSION" -> "DRAFT";
+            case "WAITING_FOR_REVIEW", "WAITING_FOR_EXPORT_COMPLIANCE" -> "SUBMITTED";
+            case "IN_REVIEW" -> "IN_REVIEW";
+            case "PENDING_APPLE_RELEASE", "PENDING_DEVELOPER_RELEASE" -> "APPROVED";
+            case "REJECTED", "DEVELOPER_REJECTED", "METADATA_REJECTED", "INVALID_BINARY" -> "REJECTED";
+            case "DEVELOPER_REMOVED_FROM_SALE", "REMOVED_FROM_SALE" -> "REMOVED";
+            case "PENDING_CONTRACT" -> "SUSPENDED";
+            case "PROCESSING_FOR_APP_STORE" -> "BUILD_PROCESSING";
+            default -> "SUBMITTED";
+        };
+    }
+}

--- a/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/store/AppStoreConnectClient.java
+++ b/community_service/src/main/java/vacademy/io/community_service/feature/appregistry/store/AppStoreConnectClient.java
@@ -1,0 +1,216 @@
+package vacademy.io.community_service.feature.appregistry.store;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * App Store Connect API client for the app-registry "provider" status sync — read-only, and
+ * deliberately narrow: it answers exactly the questions {@code getAppStatus} needs (does an app
+ * exist for this bundle id, what's its latest version, and what review/release state is it in),
+ * not a general-purpose ASC SDK.
+ *
+ * <p>Credentials (issuer id, key id, the .p8 private key) arrive via env vars from the shared
+ * {@code vacademy-secrets} k8s secret, already wired into this service's deployment through
+ * {@code envFrom} — no new secret plumbing needed. When they're absent (e.g. local dev), every
+ * call returns {@code null} rather than throwing, so the caller falls back to the existing
+ * "manual action required" response instead of a raw 500.
+ */
+@Component
+@Slf4j
+public class AppStoreConnectClient {
+
+    private static final String BASE_URL = "https://api.appstoreconnect.apple.com";
+    /** Apple caps token lifetime at 20 minutes; stay comfortably inside that. */
+    private static final long TOKEN_TTL_SECONDS = 900;
+
+    private final String issuerId;
+    private final String keyId;
+    private final PrivateKey privateKey;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private volatile String cachedToken;
+    private volatile long cachedTokenExpiresAtEpochSeconds;
+
+    public AppStoreConnectClient(
+            @Value("${APP_STORE_CONNECT_ISSUER_ID:}") String issuerId,
+            @Value("${APP_STORE_CONNECT_KEY_ID:}") String keyId,
+            @Value("${APP_STORE_CONNECT_P8:}") String p8) {
+        this.issuerId = issuerId;
+        this.keyId = keyId;
+        this.privateKey = parsePrivateKey(p8);
+        if (!isConfigured()) {
+            log.info("[AppStoreConnect] Not configured (issuer/key/p8 missing) — getAppStatus for iOS/macOS "
+                    + "will fall back to the manual-action response until vacademy-secrets carries these.");
+        }
+    }
+
+    public boolean isConfigured() {
+        return StringUtils.hasText(issuerId) && StringUtils.hasText(keyId) && privateKey != null;
+    }
+
+    /** Result of a status lookup, or null if no app is registered in ASC for that bundle id. */
+    public record AppStatus(String ascAppId, String appStoreState, String versionString,
+                             String buildNumber, String createdDate) {
+    }
+
+    /**
+     * @return the latest app-store-version info for {@code bundleId}, or null if ASC has no app
+     *         with that bundle id (not yet registered) or the lookup failed.
+     */
+    public AppStatus fetchStatus(String bundleId) {
+        if (!isConfigured() || !StringUtils.hasText(bundleId)) {
+            return null;
+        }
+        try {
+            JsonNode appsBody = get("/v1/apps?filter[bundleId]=" + bundleId);
+            JsonNode apps = appsBody.path("data");
+            if (!apps.isArray() || apps.isEmpty()) {
+                return null;
+            }
+            String ascAppId = apps.get(0).path("id").asText(null);
+            if (ascAppId == null) {
+                return null;
+            }
+
+            // `sort` is rejected on this nested relationship route (verified against the live API
+            // — it 400s with PARAMETER_ERROR.ILLEGAL), unlike the top-level /v1/appStoreVersions
+            // collection where it's documented. So the "most recent" version is picked client-side
+            // by comparing createdDate across the page, not trusted to arrive in a given order.
+            // include=build resolves the CFBundleVersion in the same call; it's matched back to
+            // THIS version specifically via its build relationship id — with limit>1, `included`
+            // can contain builds for other versions too, so "first builds entry" would be wrong.
+            JsonNode versionsBody = get("/v1/apps/" + ascAppId + "/appStoreVersions?limit=50&include=build");
+            JsonNode versions = versionsBody.path("data");
+            if (!versions.isArray() || versions.isEmpty()) {
+                // App record exists but has never had a version submitted.
+                return new AppStatus(ascAppId, "PREPARE_FOR_SUBMISSION", "", "", "");
+            }
+
+            // "Most recently created version" is NOT the same question as "what's live right now" —
+            // verified against a real multi-version app (io.vacademy.student.app): its newest
+            // version by createdDate was an abandoned PREPARE_FOR_SUBMISSION draft, while an older
+            // entry was the actual READY_FOR_SALE version still serving users. Naively picking the
+            // newest createdDate would have reported a live, working app as "Draft" — actively
+            // wrong for the one audience (an institute admin) asking "is my app working right now".
+            //
+            // So: prefer the most recent version that is actually READY_FOR_SALE (what's live),
+            // and only fall back to the overall most recent version when nothing has ever gone
+            // live yet (a brand-new app still in its first submission).
+            JsonNode latest = mostRecentByState(versions, "READY_FOR_SALE");
+            if (latest == null) {
+                latest = mostRecentByState(versions, null);
+            }
+
+            JsonNode attrs = latest.path("attributes");
+            String buildRelId = latest.path("relationships").path("build").path("data").path("id").asText(null);
+            String buildNumber = "";
+            if (buildRelId != null) {
+                for (JsonNode included : versionsBody.path("included")) {
+                    if ("builds".equals(included.path("type").asText())
+                            && buildRelId.equals(included.path("id").asText())) {
+                        buildNumber = included.path("attributes").path("version").asText("");
+                        break;
+                    }
+                }
+            }
+            return new AppStatus(
+                    ascAppId,
+                    attrs.path("appStoreState").asText(""),
+                    attrs.path("versionString").asText(""),
+                    buildNumber,
+                    attrs.path("createdDate").asText(""));
+        } catch (Exception e) {
+            log.warn("[AppStoreConnect] Status lookup failed for bundleId={}: {}", bundleId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @param requiredState if non-null, only versions in this exact appStoreState are considered;
+     *                      if null, every version is a candidate. Ties broken by createdDate.
+     * @return the matching version with the latest createdDate, or null if none match.
+     */
+    private static JsonNode mostRecentByState(JsonNode versions, String requiredState) {
+        JsonNode best = null;
+        String bestCreatedDate = "";
+        for (JsonNode version : versions) {
+            if (requiredState != null
+                    && !requiredState.equals(version.path("attributes").path("appStoreState").asText(""))) {
+                continue;
+            }
+            String createdDate = version.path("attributes").path("createdDate").asText("");
+            if (best == null || createdDate.compareTo(bestCreatedDate) > 0) {
+                best = version;
+                bestCreatedDate = createdDate;
+            }
+        }
+        return best;
+    }
+
+    /* ------------------------------------------------------------------ internals */
+
+    private JsonNode get(String path) throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token());
+        RequestEntity<Void> request = new RequestEntity<>(headers, HttpMethod.GET, URI.create(BASE_URL + path));
+        ResponseEntity<String> response = restTemplate.exchange(request, String.class);
+        return objectMapper.readTree(response.getBody());
+    }
+
+    private synchronized String token() {
+        long now = System.currentTimeMillis() / 1000;
+        if (cachedToken != null && now < cachedTokenExpiresAtEpochSeconds - 30) {
+            return cachedToken;
+        }
+        long exp = now + TOKEN_TTL_SECONDS;
+        cachedToken = Jwts.builder()
+                .setHeaderParam("kid", keyId)
+                .setHeaderParam("typ", "JWT")
+                .setIssuer(issuerId)
+                .setIssuedAt(new Date(now * 1000))
+                .setExpiration(new Date(exp * 1000))
+                .claim("aud", "appstoreconnect-v1")
+                .signWith(privateKey, SignatureAlgorithm.ES256)
+                .compact();
+        cachedTokenExpiresAtEpochSeconds = exp;
+        return cachedToken;
+    }
+
+    private static PrivateKey parsePrivateKey(String p8) {
+        if (!StringUtils.hasText(p8)) {
+            return null;
+        }
+        try {
+            String cleaned = p8
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] der = Base64.getDecoder().decode(cleaned);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(der));
+        } catch (Exception e) {
+            log.warn("[AppStoreConnect] Could not parse APP_STORE_CONNECT_P8 as an EC private key: {}",
+                    e.getMessage());
+            return null;
+        }
+    }
+}

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -1351,6 +1351,12 @@ export const WHITE_LABEL_SETUP = `${BASE_URL}/admin-core-service/institute/white
 export const WHITE_LABEL_STATUS = (instituteId: string) =>
     `${BASE_URL}/admin-core-service/institute/white-label/v1/status?instituteId=${instituteId}`;
 
+// App Registry Status (read-only) — mobile/desktop app registration status for this institute,
+// sourced from the health-check dashboard's App Registration module. Registration itself stays
+// ops-only in that dashboard; this is a status view only.
+export const APP_REGISTRY_STATUS = (instituteId: string) =>
+    `${BASE_URL}/admin-core-service/institute/app-registry/v1/status?instituteId=${instituteId}`;
+
 // Institute Payment Gateway Admin CRUD
 export const INSTITUTE_PAYMENT_GATEWAYS = (instituteId: string) =>
     `${BASE_URL}/admin-core-service/v1/institute/payment-gateways?instituteId=${instituteId}`;

--- a/frontend-admin-dashboard/src/routes/settings/-components/AppStatusSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AppStatusSettings.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from 'react';
+import {
+    DeviceMobile,
+    AndroidLogo,
+    AppleLogo,
+    WindowsLogo,
+    ArrowSquareOut,
+    ArrowsClockwise,
+    CircleNotch,
+    Info,
+    Package,
+} from '@phosphor-icons/react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { MyButton } from '@/components/design-system/button';
+import { StatusChip, StatusType } from '@/components/design-system/status-chips';
+import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
+import { getInstituteId } from '@/constants/helper';
+import { APP_REGISTRY_STATUS } from '@/constants/urls';
+
+// ─── Types (mirrors community_service's AppRegistration payload, via admin_core_service's
+//      AppStatusResponse DTO) ───────────────────────────────────────────────────────────────
+
+type Platform = 'ANDROID' | 'IOS' | 'WINDOWS' | 'MACOS';
+
+interface PlatformStatus {
+    platform: Platform;
+    enabled: boolean;
+    status: string;
+    store_url: string;
+    current_version: string;
+    current_build: string;
+    released_at: string;
+    last_synced_at: string;
+}
+
+interface RegisteredApp {
+    id: string;
+    name: string;
+    display_name: string;
+    package_name: string;
+    platforms: PlatformStatus[];
+}
+
+interface AppStatusResponse {
+    institute_id: string;
+    apps: RegisteredApp[];
+}
+
+// ─── Presentation helpers ───────────────────────────────────────────────────────────────────
+
+const PLATFORM_META: Record<Platform, { label: string; Icon: typeof AndroidLogo }> = {
+    ANDROID: { label: 'Android', Icon: AndroidLogo },
+    IOS: { label: 'iOS', Icon: AppleLogo },
+    WINDOWS: { label: 'Windows', Icon: WindowsLogo },
+    MACOS: { label: 'macOS', Icon: AppleLogo },
+};
+
+/** Store-status strings come from the health-check dashboard's StoreStatus enum. */
+function statusTone(status: string): StatusType {
+    switch (status) {
+        case 'LIVE':
+        case 'APPROVED':
+            return 'SUCCESS';
+        case 'REJECTED':
+        case 'SUSPENDED':
+        case 'REMOVED':
+        case 'FAILED':
+            return 'DANGER';
+        case 'IN_REVIEW':
+        case 'SUBMITTED':
+        case 'BUILD_PROCESSING':
+        case 'UPDATE_AVAILABLE':
+            return 'WARNING';
+        default:
+            return 'INFO';
+    }
+}
+
+function statusLabel(status: string): string {
+    return status
+        .toLowerCase()
+        .split('_')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
+// ─── Main Component ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read-only view of this institute's registered apps and their store status, pulled from the
+ * health-check dashboard's App Registration module (community_service's app_registration table)
+ * via admin_core_service's institute-scoped proxy.
+ *
+ * Registration and status updates are ops-only, done by the platform team in health-check —
+ * there is intentionally no edit affordance here.
+ */
+export default function AppStatusSettings() {
+    const instituteId = getInstituteId();
+    const [data, setData] = useState<AppStatusResponse | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchStatus = async () => {
+        if (!instituteId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await authenticatedAxiosInstance.get<AppStatusResponse>(
+                APP_REGISTRY_STATUS(instituteId)
+            );
+            setData(res.data);
+        } catch (err) {
+            console.error('[AppStatus] Failed to load app status', err);
+            setError('Could not load app status right now. Try refreshing in a moment.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (instituteId) fetchStatus();
+    }, [instituteId]);
+
+    return (
+        <div className="max-w-3xl space-y-6">
+            <Card>
+                <CardHeader>
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="space-y-1">
+                            <CardTitle className="flex items-center gap-2 text-lg">
+                                <DeviceMobile className="size-5 text-primary-500" />
+                                App Status
+                            </CardTitle>
+                            <CardDescription>
+                                Your app&apos;s registration and store status on Android, iOS, Windows
+                                and macOS. Set up by the platform team — this view is read-only.
+                            </CardDescription>
+                        </div>
+                        <MyButton
+                            id="app-status-refresh-btn"
+                            buttonType="secondary"
+                            scale="small"
+                            layoutVariant="icon"
+                            onClick={fetchStatus}
+                            disable={loading}
+                            title="Refresh status"
+                        >
+                            {loading ? (
+                                <CircleNotch className="size-4 animate-spin" />
+                            ) : (
+                                <ArrowsClockwise className="size-4" />
+                            )}
+                        </MyButton>
+                    </div>
+                </CardHeader>
+            </Card>
+
+            {error && (
+                <Alert className="border-danger-400 bg-danger-100">
+                    <Info className="size-4 text-danger-600" />
+                    <AlertDescription className="text-danger-600">{error}</AlertDescription>
+                </Alert>
+            )}
+
+            {!error && loading && !data && (
+                <Card>
+                    <CardContent className="flex items-center justify-center gap-2 py-10 text-neutral-500">
+                        <CircleNotch className="size-4 animate-spin" />
+                        Loading app status…
+                    </CardContent>
+                </Card>
+            )}
+
+            {!error && !loading && data && data.apps.length === 0 && (
+                <Card>
+                    <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+                        <Package className="size-8 text-neutral-300" />
+                        <p className="text-body font-semibold text-neutral-600">
+                            No app registered yet
+                        </p>
+                        <p className="max-w-sm text-caption text-neutral-500">
+                            Once the platform team registers a mobile or desktop app for your
+                            institute, its status will show up here.
+                        </p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {data?.apps.map((app) => (
+                <Card key={app.id}>
+                    <CardHeader>
+                        <CardTitle className="text-body font-semibold">
+                            {app.display_name || app.name || 'Untitled app'}
+                        </CardTitle>
+                        {app.package_name && (
+                            <CardDescription className="font-mono text-caption">
+                                {app.package_name}
+                            </CardDescription>
+                        )}
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {app.platforms.length === 0 && (
+                            <p className="text-caption text-neutral-500">
+                                No platforms enabled for this app yet.
+                            </p>
+                        )}
+                        {app.platforms.map((p) => {
+                            const meta = PLATFORM_META[p.platform];
+                            return (
+                                <div
+                                    key={p.platform}
+                                    className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-neutral-200 p-3"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <meta.Icon className="size-5 text-neutral-500" />
+                                        <span className="text-body font-medium text-neutral-600">
+                                            {meta.label}
+                                        </span>
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        {(p.current_version || p.current_build) && (
+                                            <span className="text-caption text-neutral-500">
+                                                {p.current_version}
+                                                {p.current_build ? ` (${p.current_build})` : ''}
+                                            </span>
+                                        )}
+                                        <StatusChip
+                                            text={statusLabel(p.status)}
+                                            textSize="text-caption"
+                                            status={statusTone(p.status)}
+                                        />
+                                        {p.store_url && (
+                                            <a
+                                                href={p.store_url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="flex items-center gap-1 text-caption text-primary-500 hover:underline"
+                                            >
+                                                View in store
+                                                <ArrowSquareOut className="size-3.5" />
+                                            </a>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </CardContent>
+                </Card>
+            ))}
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/settings/-constants/terms.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-constants/terms.ts
@@ -137,6 +137,7 @@ export const enum SettingsTabs {
     ScheduledReports = 'scheduledReports',
     SchoolSettings = 'schoolSettings',
     WhiteLabel = 'whiteLabel',
+    AppStatus = 'appStatus',
     WhatsApp = 'whatsapp',
     LeadSettings = 'leadSettings',
     GuardianSettings = 'guardianSettings',

--- a/frontend-admin-dashboard/src/routes/settings/-utils/utils.ts
+++ b/frontend-admin-dashboard/src/routes/settings/-utils/utils.ts
@@ -15,6 +15,7 @@ import AiSettings from '../-components/AiSettings';
 import ScheduledReportsSettings from '../-components/ScheduledReportsSettings';
 import SchoolSettings from '../-components/School/SchoolSettings';
 import WhiteLabelSettings from '../-components/WhiteLabelSettings';
+import AppStatusSettings from '../-components/AppStatusSettings';
 import AssessmentSettings from '../-components/AssessmentSettings';
 import WhatsAppSettings from '../-components/WhatsAppSettings/WhatsAppSettings';
 import LeadSettings from '../-components/LeadSettings';
@@ -110,6 +111,13 @@ export const getAvailableSettingsTabs = (): SettingsTabEntry[] => {
             tab: SettingsTabs.WhiteLabel,
             value: 'White-Label Setup',
             component: WhiteLabelSettings,
+            domain: 'General',
+            group: 'Branding & Identity',
+        },
+        {
+            tab: SettingsTabs.AppStatus,
+            value: 'App Status',
+            component: AppStatusSettings,
             domain: 'General',
             group: 'Branding & Identity',
         },


### PR DESCRIPTION
… sync

- community_service: link app_registration rows to an institute, add an internal (HMAC) read endpoint for admin_core_service to call
- admin_core_service: institute-scoped, read-only /app-registry/v1/status endpoint reusing the existing WhiteLabel institute-access check
- frontend-admin-dashboard: new read-only "App Status" settings tab
- community_service: replace the getAppStatus/... 501 stubs with a real App Store Connect integration for iOS/macOS (Android/Windows still 501, no credential exists for either yet)

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
