### PR TITLE
test(ttscache): assert the English branch with a language the code re…

### DIFF
--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -697,9 +697,20 @@ def test_consistency_rule_is_present_once_the_cache_is_on():
 
 def test_consistency_rule_never_forces_devanagari_on_an_english_agent():
     """An en-IN agent is told to write Latin only; a Devanagari name rule there
-    would contradict its own SCRIPT rule."""
-    p = _prompt_for("FULL", language="en")
-    assert "never Raman" not in p
+    would contradict its own SCRIPT rule.
+
+    Both spellings a real agent is configured with. NOT bare "en": that is not a
+    key in _STT_LANGS and has no hyphen, so _agent_language returns tag=None and
+    the agent silently takes the HINDI branch — which is what this test asserted
+    against before, passing an English expectation through a Hindi prompt.
+    """
+    for language in ("english", "en-IN"):
+        p = _prompt_for("FULL", language=language)
+        # Prove we actually reached the English branch, so the assertion below
+        # cannot pass for the wrong reason a second time.
+        assert "Write every reply in English (Latin letters) only" in p, language
+        assert "never Raman" not in p, language
+        assert "SAY A RECURRING LINE THE SAME WAY" not in p, language
 
 
 # ── provenance + flush (the analytics dimension) ────────────────────────────


### PR DESCRIPTION
…cognises

The test asked for an English agent with language="en" and then asserted the Devanagari name rule was absent. It was present, and the production code was right: "en" is not a key in _STT_LANGS and has no hyphen, so _agent_language returns tag=None, is_english is False, and the agent takes the HINDI branch. The test was checking an English expectation against a Hindi prompt.

A real agent is configured "english" or "en-IN", so it now runs both, which is the coverage the test was meant to have.

It also asserts the English SCRIPT rule is present before asserting the Devanagari rule is absent. Without that, the test passes whenever the prompt happens not to contain the string — including when the language value silently routes to the wrong branch again, which is exactly how this one went green locally and red in CI.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
