### PR TITLE
fix(white-label): serve the institute favicon, not the Vacademy mark

### DIFF
--- a/frontend-learner-dashboard-app/functions/_middleware.ts
+++ b/frontend-learner-dashboard-app/functions/_middleware.ts
@@ -318,6 +318,67 @@ async function serveManifest(
   });
 }
 
+/**
+ * Per-institute /favicon.ico.
+ *
+ * The crawler branch below rewrites the icon <link> tags in the HTML, but that
+ * only helps consumers that (a) send a crawler UA we recognise and (b) read the
+ * markup at all. Google's favicon fetcher does neither reliably, and a browser
+ * with no icon link requests /favicon.ico by convention. That path used to be
+ * excluded from Functions in public/_routes.json, so every white-labelled
+ * domain served the static Vacademy "V" — which is what Google indexed and
+ * showed next to e.g. readonrent.in.
+ *
+ * Resolve the institute from the hostname and redirect to its own mark instead.
+ * A redirect (rather than proxying the bytes) reuses /branding-image, which
+ * already fixes the wrong content-type S3 hands back for branding uploads.
+ */
+async function serveFavicon(
+  context: Parameters<PagesFunction>[0],
+  url: URL
+): Promise<Response> {
+  const hostname = url.hostname;
+  const backendBase = getBackendBase(hostname);
+  const { domain, subdomain } = parseDomainParts(hostname);
+  const branding = await fetchBranding(domain, subdomain, backendBase);
+
+  // Prefer the dedicated tab icon for the same reason the manifest does: the
+  // main logo is often a wide lockup, and a favicon slot is square.
+  const iconFileId = branding
+    ? nonEmpty(branding.tabIconFileId) || nonEmpty(branding.instituteLogoFileId)
+    : "";
+  const iconSource = iconFileId ? await resolveLogoUrl(iconFileId, backendBase) : "";
+
+  if (iconSource) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: `${url.origin}/branding-image?u=${encodeURIComponent(iconSource)}`,
+        // Short enough that a branding change propagates the same day. The old
+        // immutable year-long rule on *.ico pinned the wrong mark for far longer
+        // than any fix could undo.
+        "cache-control": "public, max-age=3600, must-revalidate",
+      },
+    });
+  }
+
+  // Vacademy's own hosts legitimately want the Vacademy mark.
+  if (isVacademyHost(hostname)) return context.next();
+
+  // Unresolved white-label host: no icon beats someone else's icon. Same
+  // reasoning as the cold-cache branch of the inline script in index.html.
+  return new Response(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"></svg>',
+    {
+      status: 200,
+      headers: {
+        "content-type": "image/svg+xml",
+        "cache-control": "public, max-age=300, must-revalidate",
+      },
+    }
+  );
+}
+
 export const onRequest: PagesFunction = async (context) => {
   const { request } = context;
   const ua = request.headers.get("user-agent") || "";
@@ -327,6 +388,13 @@ export const onRequest: PagesFunction = async (context) => {
   // one is for real browsers, not bots.
   if (url.pathname === "/manifest.webmanifest") {
     return serveManifest(context, url);
+  }
+
+  // Per-institute favicon. Also handled before the crawler check: the whole
+  // point is that the callers that ask for it (browsers, Google's favicon
+  // fetcher) do not identify as crawlers.
+  if (url.pathname === "/favicon.ico") {
+    return serveFavicon(context, url);
   }
 
   // Only intercept for crawlers
@@ -447,8 +515,16 @@ export const onRequest: PagesFunction = async (context) => {
       /<link\s+rel="(?:shortcut )?icon"[^>]*\/>/g,
       `<link rel="icon" href="${escapedLogo}" />`
     );
-    // Also add a favicon link if none existed
-    if (!html.includes('rel="icon"')) {
+    // Also add a favicon link if none existed.
+    //
+    // This MUST test for a real <link> tag, not the bare substring `rel="icon"`.
+    // index.html has no icon link at all (only apple-touch-icon), but its inline
+    // branding script contains the selector string 'link[rel="icon"]' — so a
+    // substring check matched the JS source and silently skipped the injection
+    // on every white-labelled domain. Crawlers then found no icon link, fell
+    // back to /favicon.ico, and Google listed those domains with the Vacademy
+    // mark.
+    if (!/<link[^>]+rel="(?:shortcut )?icon"/.test(html)) {
       html = html.replace(
         "</head>",
         `    <link rel="icon" href="${escapedLogo}" />\n  </head>`

--- a/frontend-learner-dashboard-app/public/_headers
+++ b/frontend-learner-dashboard-app/public/_headers
@@ -84,8 +84,13 @@
 /*.gif
   Cache-Control: public, max-age=31536000, immutable
 
-/*.ico
-  Cache-Control: public, max-age=31536000, immutable
+# NOTE: deliberately NO blanket rule for .ico.
+#
+# /favicon.ico is answered per-institute by functions/_middleware.ts, which sets
+# its own short cache-control. The old `/*.ico immutable` rule matched the
+# REQUEST path (see the warning at the top of this file), so it pinned whichever
+# mark a visitor first received for a year — on white-label domains that was the
+# Vacademy "V", and no deploy could dislodge it.
 
 /*.svg
   Cache-Control: public, max-age=31536000, immutable

--- a/frontend-learner-dashboard-app/public/_routes.json
+++ b/frontend-learner-dashboard-app/public/_routes.json
@@ -7,7 +7,6 @@
     "/svgs/*",
     "/vendor/*",
     "/badge-library/*",
-    "/favicon.ico",
     "/robots.txt",
     "/styles.css",
     "/sw.js",


### PR DESCRIPTION
## Summary of Changes

Every white-labelled domain was serving the Vacademy "V" as its favicon. Reported by the ReadOnRent client ("main page still shows your logo"), but the defect was never tenant-specific — it affected all white-label hosts, and it is what Google indexed and displayed next to `readonrent.in` in search results.

Two independent causes, both fixed here:

**Frontend (Cloudflare Pages edge):**
- `functions/_middleware.ts` — the crawler branch injects a `<link rel="icon">` when the page has none, guarded by `if (!html.includes('rel="icon"'))`. `index.html` has no icon link at all (only `apple-touch-icon`), but its inline branding script contains the literal selector string `'link[rel="icon"]'`. The substring matched that JS source, so the guard was always true and **the injection never ran on any white-label domain**. Now tests for a real tag: `/<link[^>]+rel="(?:shortcut )?icon"/`.
- `functions/_middleware.ts` — new `serveFavicon()`, mirroring the existing `serveManifest()`. `/favicon.ico` is now resolved per-host: institute mark via a 302 to `/branding-image`, the Vacademy mark on Vacademy hosts, and a blank SVG on an unresolved white-label host (no icon beats someone else's icon — same reasoning as the cold-cache branch in `index.html`).
- `public/_routes.json` — dropped `/favicon.ico` from the Pages Functions `exclude` list; while excluded, the handler was unreachable.
- `public/_headers` — removed the blanket `/*.ico` `max-age=31536000, immutable` rule. That rule matches the *request* path, so it pinned whichever mark a visitor first received for a year; no deploy could dislodge it. `/favicon.ico` now sets its own short cache-control.

Fixing only the first cause would not have fixed the search listing: Google's favicon fetcher does not send a UA matched by `CRAWLER_UA_REGEX`, so it never reaches the crawler branch and falls back to `/favicon.ico` regardless.

## Related Issue

Client report (ReadOnRent / Sanskar), 2026-08-24.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

Verified locally against the real middleware under `wrangler pages dev`, sending a `Host:` header per case (branding is resolved from the hostname, so a `*.pages.dev` preview deploy resolves to no institute and **cannot** exercise this path):

- `/favicon.ico` with `Host: readonrent.in` → `302 → /branding-image?u=<their mark>`, `max-age=3600`.
- Googlebot UA with `Host: readonrent.in` → `<link rel="icon">` present with the institute icon (absent on production today).
- `/favicon.ico` with `Host: learner.vacademy.io` → still resolves to `vacademy_short_logo.png`; no regression on our own hosts.
- `/favicon.ico` with an unresolved white-label host → blank SVG, never the Vacademy V.
- Negative control: stashed the fix and re-ran — 3 of the 4 assertions fail, with the unresolved-host case dumping the raw Vacademy `.ico` bytes. Confirms the tests detect the actual defect rather than passing vacuously.
- End-to-end against production APIs: `resolve?domain=readonrent.in&subdomain=` returns 404 and the existing `"*"` retry succeeds; `get-public-url` for their `tabIconFileId` returns the CloudFront object; `/branding-image` already serves it as `image/jpeg` 200.
- `tsc --strict --skipLibCheck` clean with `@cloudflare/workers-types`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
