### PR TITLE
fix(app-status): wire community.server.baseurl for the app-status feature

### DIFF
--- a/admin_core_service/src/main/resources/application-dev.properties
+++ b/admin_core_service/src/main/resources/application-dev.properties
@@ -18,6 +18,7 @@ notification.server.baseurl=${NOTIFICATION_SERVER_BASE_URL}
 media.server.baseurl=${MEDIA_SERVER_BASE_URL:http://localhost:8075}
 media.service.baseurl=${MEDIA_SERVER_BASE_URL:http://localhost:8075}
 assessment.server.baseurl=${ASSESSMENT_SERVER_BASE_URL}
+community.server.baseurl=${COMMUNITY_SERVICE_BASE_URL:http://localhost:8073}
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 logging.level.org.springframework.security=DEBUG

--- a/admin_core_service/src/main/resources/application-k8s-local.properties
+++ b/admin_core_service/src/main/resources/application-k8s-local.properties
@@ -22,6 +22,7 @@ spring.mvc.dispatch-options-request=true
 auth.server.baseurl=http://auth-service.vacademy.svc.cluster.local:8071
 notification.server.baseurl=http://notification-service.vacademy.svc.cluster.local:8076
 assessment.server.baseurl=http://assessment-service.vacademy.svc.cluster.local:8074
+community.server.baseurl=http://community-service.vacademy.svc.cluster.local:8073
 
 ## File Upload
 spring.servlet.multipart.max-file-size=10MB

--- a/admin_core_service/src/main/resources/application-stage.properties
+++ b/admin_core_service/src/main/resources/application-stage.properties
@@ -30,6 +30,7 @@ notification.server.baseurl=${NOTIFICATION_SERVER_BASE_URL}
 media.server.baseurl=${MEDIA_SERVER_BASE_URL}
 media.service.baseurl=${MEDIA_SERVER_BASE_URL}
 assessment.server.baseurl=${ASSESSMENT_SERVER_BASE_URL:https://backend-stage.vacademy.io}
+community.server.baseurl=${COMMUNITY_SERVICE_BASE_URL:http://community-service:8073}
 # SCORM zips routinely exceed 10MB; keep in sync with the ingress
 # proxy-body-size (200m) in vacademy_devops/vacademy-services/templates/ingress.yaml
 spring.servlet.multipart.max-file-size=150MB


### PR DESCRIPTION
## Summary
- Follow-up to #2650. `CommunityAppRegistryClient` referenced `community.server.baseurl`, which had no matching property in any environment — it was silently falling back to `localhost`, so `admin_core_service` could never actually reach `community_service` in prod/stage.
- Bridges it via `application-{dev,stage,k8s-local}.properties` to the already-running `COMMUNITY_SERVICE_BASE_URL` env var, matching the exact pattern used for assessment/auth/media/notification.

## Test plan
- [x] Verified `COMMUNITY_SERVICE_BASE_URL=http://community-service:8073` is already set on the live `admin-core-service` deployment
- [x] Confirmed prod runs `-Dspring.profiles.active=stage`, so `application-stage.properties` is the file that needed the bridge