### PR TITLE
feat(voice-bot): export, push-now and flush routes for the speech-cac…

### DIFF
--- a/docs/crm/TTS_CACHE_API.md
+++ b/docs/crm/TTS_CACHE_API.md
@@ -340,6 +340,68 @@ Five added fields alongside the existing cost/margin ones:
 | **Screens 1–4 are empty until the new bot build deploys** | they read a table only that build populates. `/summary` and the `/calls` fields work today |
 | **`/tts-cache/summary` SQL is unverified against prod** | it compiles, but a Java text block is only parsed at execution — the same way the `::bigint` bug reached production. The ssh tunnel has been down; worth one run before relying on it |
 
+## Appendix — operator routes on the voice bot
+
+Separate surface from everything above: these live on the **bot**, not admin-core,
+and are gated by the shared internal secret rather than a super-admin token.
+
+```
+-H 'x-voice-bot-token: <INTERNAL_CLIENT_SECRET>'
+```
+
+They exist because the ledger is SQLite plus audio files on **one box's local
+disk**. Until now the only way to read or clear it was a shell on that box, which
+made an empty analytics table impossible to diagnose remotely — a reporter that
+never started and a ledger with nothing in it look identical from Postgres.
+
+**Export the whole ledger** — the same payload the 120s reporter pushes:
+
+```bash
+curl -H 'x-voice-bot-token: <secret>'   'https://voice-bot-in.vacademy.io/voice-bot-service/internal/tts-cache/export?limit=2000'
+```
+
+```json
+{ "ready": true, "blobs": 13, "count": 56, "truncated": false, "entries": [ … ] }
+```
+
+`ready` and `blobs` are returned *beside* the rows on purpose: a cache still
+opening returns zero entries, which is not the same answer as an open cache that
+genuinely holds nothing. Optional `agentId` filters; `limit` defaults 2000, caps
+5000, and `truncated` tells you when you hit it.
+
+**Push to admin-core now**, instead of waiting for the tick — this is the backfill:
+
+```bash
+curl -X POST -H 'x-voice-bot-token: <secret>'   'https://voice-bot-in.vacademy.io/voice-bot-service/internal/tts-cache/report-now'
+```
+
+```json
+{ "ready": true, "pushed": 56, "ok": true }
+```
+
+An empty ledger returns `{"pushed": 0, "ok": null, "note": "ledger is empty — nothing to push"}`
+rather than a bare 200 — "pushed nothing" and "pushed successfully" must not look
+alike. Safe to repeat: admin-core upserts on `(cache_key, agent_id)`.
+
+**Flush** — `dryRun` defaults **true**, and it refuses a request naming neither an
+agent nor a key (that is not "flush everything"):
+
+```bash
+curl -X POST -H 'x-voice-bot-token: <secret>' -H 'content-type: application/json'   -d '{"agentId":"b759218d-…","dryRun":true}'   'https://voice-bot-in.vacademy.io/voice-bot-service/internal/tts-cache/flush'
+```
+
+```json
+{ "dryRun": true, "entriesRemoved": 3, "bytesRemoved": 412800,
+  "result": "DRY RUN — 3 entries, 2 shared with another agent and kept" }
+```
+
+Audio another agent still references is kept — the key is global, so agents on the
+same voice share one blob.
+
+> Point these at the box that actually serves calls. `voice-bot-in.vacademy.io`
+> resolves to the Linode Mumbai host; the Hetzner `voice-bot-service` pods take no
+> call traffic and declare no volumes, so their ledger is always empty.
+
 ## Conventions
 
 - **`null` never means zero.** `hit_rate`, `inr_saved`, `inr_wasted` and the `tts_cache_*`

--- a/voice_bot_service/app/main.py
+++ b/voice_bot_service/app/main.py
@@ -361,6 +361,112 @@ async def tts_cache_stats(request: Request):
     }
 
 
+@router.get("/internal/tts-cache/export")
+async def tts_cache_export(request: Request):
+    """The whole ledger, as JSON — the same payload the 120s reporter pushes.
+
+    Exists because the ledger lives on ONE box's local disk, so until now the
+    only way to read it was a shell on that box. That made an empty analytics
+    table impossible to diagnose remotely: a reporter that never started and a
+    ledger with nothing in it look identical from Postgres.
+
+    `ready` is returned separately from the rows for the same reason. A cache
+    still opening returns ready=false with zero entries, which is NOT the same
+    answer as an open cache that genuinely holds nothing, and a caller that
+    cannot tell those apart will "fix" the wrong thing.
+    """
+    if not _internal_ok(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    cache = ttscache.get_cache()
+    try:
+        limit = min(max(int(request.query_params.get("limit") or 2000), 1), 5000)
+    except ValueError:
+        return JSONResponse({"error": "limit must be an integer"}, status_code=400)
+    agent_id = (request.query_params.get("agentId") or "").strip()
+    try:
+        entries = await asyncio.to_thread(cache.export_for_report, limit)
+    except Exception:
+        logger.exception("tts-cache: export route failed")
+        return JSONResponse({"error": "export failed"}, status_code=502)
+    if agent_id:
+        entries = [e for e in entries if e.get("agentId") == agent_id]
+    return {
+        "ready": cache.ready,
+        "blobs": cache.size,
+        "count": len(entries),
+        "truncated": len(entries) >= limit,
+        "entries": entries,
+    }
+
+
+@router.post("/internal/tts-cache/report-now")
+async def tts_cache_report_now(request: Request):
+    """Push the ledger to admin-core immediately instead of waiting for the tick.
+
+    The reporter already does this every 120s; this is the same call, on demand,
+    for the case where the analytics table needs filling right now — a box that
+    was redeployed late, or a first rollout where nobody wants to watch a clock.
+
+    Safe to repeat: admin-core upserts on (cache_key, agent_id), so a second
+    push updates the same rows rather than duplicating them.
+    """
+    if not _internal_ok(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    cache = ttscache.get_cache()
+    try:
+        entries = await asyncio.to_thread(cache.export_for_report)
+    except Exception:
+        logger.exception("tts-cache: report-now export failed")
+        return JSONResponse({"error": "export failed"}, status_code=502)
+    if not entries:
+        # The reporter's own `if entries:` guard makes this case silent. Say it
+        # out loud here, because "pushed nothing" and "pushed successfully" are
+        # the same HTTP 200 otherwise.
+        return {"ready": cache.ready, "pushed": 0, "ok": None,
+                "note": "ledger is empty — nothing to push"}
+    ok = await admin_core.post_tts_cache_report(entries)
+    logger.info("tts-cache: report-now pushed %s entries ok=%s", len(entries), ok)
+    return {"ready": cache.ready, "pushed": len(entries), "ok": ok}
+
+
+@router.post("/internal/tts-cache/flush")
+async def tts_cache_flush(request: Request):
+    """Drop one cached sentence, or everything one agent contributed.
+
+    dryRun defaults TRUE — it reports what WOULD go and deletes nothing. The
+    destructive reading of an ambiguous request is the wrong one, and this route
+    deletes audio we paid a vendor to render.
+
+    Audio another agent still references is kept: the cache key is global, so
+    agents on the same voice share one blob and flushing one must not take
+    somebody else's. The returned note says how many were kept for that reason.
+    """
+    if not _internal_ok(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    agent_id = (body.get("agentId") or "").strip()
+    cache_key = (body.get("cacheKey") or "").strip()
+    if not agent_id and not cache_key:
+        return JSONResponse(
+            {"error": "pass agentId or cacheKey — refusing to flush everything"},
+            status_code=400)
+    dry_run = bool(body.get("dryRun", True))
+    cache = ttscache.get_cache()
+    try:
+        entries, freed, note = await asyncio.to_thread(
+            cache.forget, agent_id=agent_id, cache_key=cache_key, dry_run=dry_run)
+    except Exception:
+        logger.exception("tts-cache: flush route failed")
+        return JSONResponse({"error": "flush failed"}, status_code=502)
+    logger.info("tts-cache: flush agent=%s key=%s dryRun=%s -> %s",
+                agent_id or "-", cache_key or "-", dry_run, note)
+    return {"dryRun": dry_run, "entriesRemoved": entries,
+            "bytesRemoved": freed, "result": note}
+
+
 def _cache_write(path: str, data: bytes) -> bool:
     """Atomic cache write; False means "serve inline instead" (never 500)."""
     try:

--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -345,7 +345,7 @@ class SpeechCache:
                     idx[key] = Entry(key, path, nbytes, duration_ms, text)
             self._index = idx
             self._ready = True
-            logger.info("tts-cache: %d entries loaded from %s", len(idx), self.root)
+            logger.info("tts-cache: {} entries loaded from {}", len(idx), self.root)
         except Exception:
             logger.exception("tts-cache: open failed — cache disabled for this process")
             self._ready = False
@@ -389,7 +389,7 @@ class SpeechCache:
         if entry is None:
             return None
         if entry.text != text:
-            logger.warning("tts-cache: text mismatch for key %s… — treating as miss", key[:12])
+            logger.warning("tts-cache: text mismatch for key {}… — treating as miss", key[:12])
             return None
         return entry
 
@@ -403,12 +403,12 @@ class SpeechCache:
         try:
             data = await asyncio.to_thread(self._read_blob, entry.path)
         except Exception:
-            logger.exception("tts-cache: read failed for %s", entry.key[:12])
+            logger.exception("tts-cache: read failed for {}", entry.key[:12])
             return None
         if data is None:
             return None
         if len(data) != entry.nbytes or len(data) % (SAMPLE_WIDTH * CHANNELS):
-            logger.warning("tts-cache: blob %s… is %d bytes, expected %d — dropping",
+            logger.warning("tts-cache: blob {}… is {} bytes, expected {} — dropping",
                            entry.key[:12], len(data), entry.nbytes)
             await self.discard(entry.key)
             return None
@@ -469,14 +469,14 @@ class SpeechCache:
         """
         try:
             if not pcm or len(pcm) % (SAMPLE_WIDTH * CHANNELS):
-                logger.warning("tts-cache: refusing ragged render for %r", cand.text[:40])
+                logger.warning("tts-cache: refusing ragged render for {!r}", cand.text[:40])
                 return False
             duration_ms = int(len(pcm) * 1000 / _BYTES_PER_SEC)
             if duration_ms < get_settings().tts_cache_min_blob_ms:
                 # Too short to be a spoken sentence: a silent stub or a vendor
                 # error page decoded to noise. Either would be dead air on a
                 # real call.
-                logger.warning("tts-cache: refusing %dms render for %r",
+                logger.warning("tts-cache: refusing {}ms render for {!r}",
                                duration_ms, cand.text[:40])
                 return False
 
@@ -510,11 +510,11 @@ class SpeechCache:
                     " duration_ms=excluded.duration_ms, text=excluded.text",
                     (cand.key, len(pcm), duration_ms, cand.text, now, now))
             self._index[cand.key] = Entry(cand.key, path, len(pcm), duration_ms, cand.text)
-            logger.info("tts-cache: stored %dms (%d chars) %s/%s %r",
+            logger.info("tts-cache: stored {}ms ({} chars) {}/{} {!r}",
                         duration_ms, cand.chars, cand.engine, cand.voice, cand.text[:48])
             return True
         except Exception:
-            logger.exception("tts-cache: store failed for %r", cand.text[:40])
+            logger.exception("tts-cache: store failed for {!r}", cand.text[:40])
             return False
 
     # -- ledger -------------------------------------------------------------
@@ -741,7 +741,7 @@ class SpeechCache:
                 total -= nbytes or 0
                 removed += 1
             if removed:
-                logger.warning("tts-cache: evicted %d entries (budget %d bytes)", removed, budget)
+                logger.warning("tts-cache: evicted {} entries (budget {} bytes)", removed, budget)
             return removed
         except Exception:
             logger.exception("tts-cache: eviction failed")
@@ -836,7 +836,7 @@ class CallCandidates:
         if not self._enabled:
             return
         if not is_complete(cand.text):
-            logger.warning("tts-cache: refusing incomplete candidate %r", cand.text[:48])
+            logger.warning("tts-cache: refusing incomplete candidate {!r}", cand.text[:48])
             return
         # Bounded: a runaway generation must not grow this without limit.
         if len(self._items) < 400:
@@ -913,10 +913,10 @@ class CallCandidates:
                     unheard += 1
             self._items = []
             if dropped:
-                logger.info("tts-cache: dropped %d candidate(s) — health=%s audio_faults=%s",
+                logger.info("tts-cache: dropped {} candidate(s) — health={} audio_faults={}",
                             dropped, health, sorted(audio_bad) or "none")
             if unheard:
-                logger.info("tts-cache: %d candidate(s) never reached the caller — not laddered",
+                logger.info("tts-cache: {} candidate(s) never reached the caller — not laddered",
                             unheard)
             return self._cache.ladder(heard)
         except Exception:
@@ -1002,8 +1002,8 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
     can_serve_anything = ((mode_allows(cache_mode, True) and s.tts_cache_speech_enabled)
                           or (mode_allows(cache_mode, False) and s.tts_cache_llm_enabled))
     if not (can_serve_anything and in_rollout):
-        logger.info("tts-cache: NOT installed engine=%s agent=%s mode=%s rollout=%s "
-                    "kill_speech=%s kill_llm=%s — call is untouched",
+        logger.info("tts-cache: NOT installed engine={} agent={} mode={} rollout={} "
+                    "kill_speech={} kill_llm={} — call is untouched",
                     engine_l, agent_id or agent_name or "?",
                     (cache_mode or MODE_OFF).upper(), "in" if in_rollout else "OUT",
                     s.tts_cache_speech_enabled, s.tts_cache_llm_enabled)
@@ -1074,19 +1074,19 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
             # The ordering guard, not the cache, refused this one. Worth its own
             # wording: it looks identical to a cold cache from the outside, and
             # chasing a "miss" that was really a deferral wastes a rollout.
-            logger.info("tts-cache: MISS (vendor in flight, ordering) %r", norm[:48])
+            logger.info("tts-cache: MISS (vendor in flight, ordering) {!r}", norm[:48])
 
         if may_serve:
             entry = cache.lookup(key, norm)          # G6 verifies the stored text
             if entry is None and s.tts_cache_debug:
-                logger.info("tts-cache: MISS (not stored) key=%s %r", key[:12], norm[:48])
+                logger.info("tts-cache: MISS (not stored) key={} {!r}", key[:12], norm[:48])
             if entry is not None:
                 blob = await cache.read(entry)       # G5 re-checks the length
                 if blob:
                     _bump("note_tts_cache_hit", entry.duration_ms, len(norm))
                     cache.note_hit(key)
                     cache.note_hit_for_agent(key, agent_id)
-                    logger.info("tts-cache: HIT %dms %r", entry.duration_ms, norm[:48])
+                    logger.info("tts-cache: HIT {}ms {!r}", entry.duration_ms, norm[:48])
 
                     # Emit the turn brackets ONLY if the base class is not already
                     # doing it, or the caller hears two of everything.
@@ -1163,8 +1163,8 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
     tts.run_tts = run_tts
     # One line per call saying exactly which gates are open. Without it, "why did
     # this call not hit the cache" is a guess between four different switches.
-    logger.info("tts-cache: installed engine=%s voice=%s agent=%s mode=%s rollout=%s "
-                "kill_speech=%s kill_llm=%s async_arrival=%s entries=%d",
+    logger.info("tts-cache: installed engine={} voice={} agent={} mode={} rollout={} "
+                "kill_speech={} kill_llm={} async_arrival={} entries={}",
                 engine_l, voice, agent_id or agent_name or "?",
                 (cache_mode or MODE_OFF).upper(), "in" if in_rollout else "OUT",
                 s.tts_cache_speech_enabled, s.tts_cache_llm_enabled,

--- a/voice_bot_service/app/ttswarm.py
+++ b/voice_bot_service/app/ttswarm.py
@@ -78,10 +78,10 @@ async def synthesize(*, engine: str, model: str, voice: str, pace, temperature,
             raw = await _main._synth_audio(text, voice or s.sarvam_tts_voice,
                                            model or s.sarvam_tts_model, "hi-IN")
         else:
-            logger.warning("tts-warm: no one-shot renderer for engine %r", eng)
+            logger.warning("tts-warm: no one-shot renderer for engine {!r}", eng)
             return None
     except Exception:
-        logger.exception("tts-warm: %s synthesis failed for %r", eng, text[:40])
+        logger.exception("tts-warm: {} synthesis failed for {!r}", eng, text[:40])
         return None
     if not raw:
         return None
@@ -140,9 +140,9 @@ async def warm(*, engine: str, model: str, voice: str, pace, temperature,
             else:
                 failed += 1
         except Exception:
-            logger.exception("tts-warm: failed on %r", t[:40])
+            logger.exception("tts-warm: failed on {!r}", t[:40])
             failed += 1
-    logger.info("tts-warm: %s/%s warmed=%d skipped=%d failed=%d",
+    logger.info("tts-warm: {}/{} warmed={} skipped={} failed={}",
                 engine, voice, done, skipped, failed)
     return {"warmed": done, "skipped": skipped, "failed": failed}
 

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -772,3 +772,101 @@ def test_flushing_the_last_agent_does_remove_the_audio(cache):
     assert entries == 1 and freed > 0
     assert cache.lookup(c.key, c.text) is None
     assert cache.export_for_report() == []
+
+
+# ── the internal routes (export / report-now / flush) ───────────────────────
+#
+# These exist because the ledger lives on ONE box's local disk. Reading or
+# clearing it used to need a shell on that box, which made an empty analytics
+# table impossible to diagnose remotely. Handlers are called directly with a
+# stub Request so the suite needs no HTTP client.
+
+class _Req:
+    def __init__(self, token="s3cret", query=None, body=None):
+        self.headers = {"x-voice-bot-token": token} if token else {}
+        self.query_params = query or {}
+        self._body = body
+
+    async def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+@pytest.fixture
+def routes(cache, monkeypatch):
+    """app.main wired to the test cache and a known internal secret."""
+    pytest.importorskip("fastapi")
+    import dataclasses
+    from app import main as m
+    from app import ttscache as tc
+    monkeypatch.setattr(tc, "get_cache", lambda: cache)
+    # Settings is a frozen dataclass, so swap the accessor rather than the field.
+    stub = dataclasses.replace(m.get_settings(), internal_client_secret="s3cret")
+    monkeypatch.setattr(m, "get_settings", lambda: stub)
+    return m
+
+
+async def test_export_and_flush_refuse_a_bad_token(routes):
+    for call in (routes.tts_cache_export(_Req(token="")),
+                 routes.tts_cache_flush(_Req(token="wrong", body={"agentId": "a"})),
+                 routes.tts_cache_report_now(_Req(token=None))):
+        assert (await call).status_code == 401
+
+
+async def test_export_returns_the_ledger_and_says_whether_it_is_ready(routes, cache):
+    c = _acand("Namaste ji.", "agent-a", fixed=True)
+    cache.ladder([c]); cache.store(c, _pcm(800))
+    out = await routes.tts_cache_export(_Req())
+    assert out["count"] == 1 and out["truncated"] is False
+    assert out["entries"][0]["sentence"] == "Namaste ji."
+    # ready/blobs travel separately from the rows: a cache still opening returns
+    # zero entries, which is NOT the same answer as an open, empty one.
+    assert "ready" in out and out["blobs"] == 1
+
+
+async def test_export_filters_by_agent(routes, cache):
+    a = _acand("Namaste ji.", "agent-a", fixed=True)
+    cache.ladder([a]); cache.ladder([_acand("Theek hai.", "agent-b", fixed=True)])
+    out = await routes.tts_cache_export(_Req(query={"agentId": "agent-b"}))
+    assert out["count"] == 1
+    assert out["entries"][0]["agentId"] == "agent-b"
+
+
+async def test_flush_defaults_to_a_dry_run(routes, cache):
+    """The destructive reading of an ambiguous request is the wrong one."""
+    c = _acand("Namaste ji.", "agent-a", fixed=True)
+    cache.ladder([c]); cache.store(c, _pcm(800))
+    out = await routes.tts_cache_flush(_Req(body={"agentId": "agent-a"}))
+    assert out["dryRun"] is True
+    assert "DRY RUN" in out["result"]
+    assert cache.lookup(c.key, c.text) is not None, "a dry run must delete nothing"
+
+
+async def test_flush_refuses_to_wipe_everything(routes):
+    """No agentId and no cacheKey is not 'flush the whole cache'."""
+    r = await routes.tts_cache_flush(_Req(body={"dryRun": False}))
+    assert r.status_code == 400
+
+
+async def test_report_now_is_explicit_about_an_empty_ledger(routes, monkeypatch):
+    """The reporter's own `if entries:` guard makes this silent; the route must
+    not return the same 200 for 'pushed nothing' and 'pushed successfully'."""
+    out = await routes.tts_cache_report_now(_Req())
+    assert out["pushed"] == 0 and out["ok"] is None
+    assert "empty" in out["note"]
+
+
+async def test_report_now_pushes_what_the_reporter_would(routes, cache, monkeypatch):
+    from app import admin_core
+    sent = {}
+
+    async def _fake(entries):
+        sent["n"] = len(entries)
+        return True
+
+    monkeypatch.setattr(admin_core, "post_tts_cache_report", _fake)
+    c = _acand("Namaste ji.", "agent-a", fixed=True)
+    cache.ladder([c]); cache.store(c, _pcm(800))
+    out = await routes.tts_cache_report_now(_Req())
+    assert out["pushed"] == 1 and out["ok"] is True and sent["n"] == 1


### PR DESCRIPTION
…he ledger

The ledger is SQLite plus audio files on ONE box's local disk, so reading or clearing it needed a shell on that box. That left the analytics table undiagnosable from outside: a reporter that never started and a ledger with nothing in it produce the identical empty table, because the reporter's own `if entries:` guard makes an empty push silent.

Three routes, on the existing x-voice-bot-token gate:

  GET  /internal/tts-cache/export      the whole ledger, as the reporter sends it
  POST /internal/tts-cache/report-now  push immediately instead of on the tick
  POST /internal/tts-cache/flush       drop one key, or one agent's entries

export returns `ready` and `blobs` beside the rows, and report-now answers an empty ledger with an explicit note rather than a bare 200 — in both cases "still opening", "genuinely empty" and "working" would otherwise be the same response, which is the ambiguity that made this hard to chase in the first place. flush keeps dryRun defaulting true and refuses a request that names neither an agent nor a key, since that is not a request to wipe everything.

Also fixes 21 log lines in ttscache.py and ttswarm.py that used printf placeholders against loguru, which formats with str.format: every one printed a literal %d/%s and dropped its arguments, so the logs on the box were useless for exactly the diagnosis these routes are meant to support. %r becomes {!r}, not {}, to keep the repr quoting that shows truncation and stray whitespace. main.py is deliberately untouched there — it uses stdlib logging and its %s lines are correct as they stand.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
