### PR TITLE
fix(tts-cache): export the ledger rows that predate per-agent provenance

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/super_admin/service/TtsCacheAnalyticsService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/super_admin/service/TtsCacheAnalyticsService.java
@@ -168,7 +168,7 @@ public class TtsCacheAnalyticsService {
         Map<String, Double> card = callService.rateCard();
         List<Object[]> rows = em.createNativeQuery("""
                 SELECT e.agent_id,
-                       COALESCE(a.name, '(deleted agent)'),
+                       COALESCE(a.name, e.agent_id),
                        e.institute_id,
                        i.name,
                        max(e.engine), max(e.voice),

--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -204,6 +204,14 @@ def _num(v) -> str:
         return str(v)
 
 
+#: Ledger rows written before per-agent provenance existed have no owner and
+#: cannot gain one retroactively. They are reported under these sentinels so the
+#: analytics screens show them for what they are, rather than silently losing
+#: them to a join — which is exactly what happened on the first rollout.
+UNATTRIBUTED = "(unattributed)"
+UNATTRIBUTED_NAME = "(before per-agent tracking)"
+
+
 def cache_key(*, engine: str, model: str, voice: str, pace, temperature,
               sample_rate: int, term_map_version: str, text: str,
               salt: Optional[str] = None) -> str:
@@ -614,20 +622,33 @@ class SpeechCache:
         answer to "what is not cached yet" — the misses screen is exactly these
         rows. Bounded, because a report is not a reason to load an unbounded
         result set into memory on a box that is also carrying live calls.
+
+        LEFT JOIN on seen_agent for the same reason, learned the hard way: this
+        was an INNER JOIN, and seen_agent is only written for a candidate that
+        carries an agent_id. Every sentence laddered before per-agent tracking
+        existed therefore had no provenance row, so a ledger holding 73 real
+        sentences exported ZERO and the analytics table stayed empty with no
+        error anywhere. Those rows are reported under a sentinel agent instead
+        of being dropped: their sightings are real (seen.count), their hits are
+        not knowable per agent and so read 0. Labelling what we do not know
+        beats both discarding it and inventing an owner for it.
         """
         try:
             with self._connect() as db:
                 rows = db.execute(
-                    "SELECT s.key, sa.agent_id, sa.agent_name, sa.institute_id,"
+                    "SELECT s.key,"
+                    "       COALESCE(sa.agent_id, ?), COALESCE(sa.agent_name, ?),"
+                    "       sa.institute_id,"
                     " s.engine, s.model, s.voice, s.text, s.chars, s.fixed,"
-                    " sa.sightings, sa.hits, sa.last_hit_at,"
+                    "       COALESCE(sa.sightings, s.count), COALESCE(sa.hits, 0),"
+                    "       sa.last_hit_at,"
                     " s.first_seen, s.last_seen,"
                     " b.key IS NOT NULL, b.nbytes, b.duration_ms"
                     " FROM seen s"
-                    " JOIN seen_agent sa ON sa.key = s.key"
+                    " LEFT JOIN seen_agent sa ON sa.key = s.key"
                     " LEFT JOIN blob b ON b.key = s.key"
-                    " ORDER BY sa.hits DESC, s.chars DESC LIMIT ?",
-                    (limit,)).fetchall()
+                    " ORDER BY COALESCE(sa.hits, 0) DESC, s.chars DESC LIMIT ?",
+                    (UNATTRIBUTED, UNATTRIBUTED_NAME, limit)).fetchall()
             out = []
             for r in rows:
                 out.append({

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -870,3 +870,51 @@ async def test_report_now_pushes_what_the_reporter_would(routes, cache, monkeypa
     cache.ladder([c]); cache.store(c, _pcm(800))
     out = await routes.tts_cache_report_now(_Req())
     assert out["pushed"] == 1 and out["ok"] is True and sent["n"] == 1
+
+
+def test_export_reports_rows_that_predate_per_agent_tracking(cache):
+    """THE bug that made the first rollout look like a dead reporter.
+
+    seen_agent is only written for a candidate carrying an agent_id, so every
+    sentence laddered by the pre-analytics build had no provenance row. With an
+    INNER JOIN a ledger holding real sentences exported ZERO, the push was a
+    silent no-op, and the analytics table stayed empty with no error anywhere.
+    """
+    c = _cand("Namaste ji.", fixed=True)          # no agent_id at all
+    cache.ladder([c]); cache.store(c, _pcm(800))
+
+    out = cache.export_for_report()
+    assert len(out) == 1, "an unowned row must still be reported, not dropped"
+    e = out[0]
+    assert e["agentId"] == ttscache.UNATTRIBUTED
+    assert e["agentName"] == ttscache.UNATTRIBUTED_NAME
+    assert e["sentence"] == "Namaste ji."
+    assert e["rendered"] is True
+    # Sightings are real; per-agent hits were never recorded, so they must read
+    # 0 rather than be invented from the call-level counters.
+    assert e["sightings"] == 1 and e["hits"] == 0
+
+
+def test_export_still_prefers_real_provenance_when_it_exists(cache):
+    c = _acand("Theek hai.", "agent-a", fixed=True)
+    cache.ladder([c])
+    e = cache.export_for_report()[0]
+    assert e["agentId"] == "agent-a" and e["agentName"] == "AGENT-A"
+
+
+async def test_report_now_pushes_unattributed_history(routes, cache, monkeypatch):
+    """The backfill case end to end: an old ledger with no provenance must
+    still reach admin-core."""
+    from app import admin_core
+    sent = {}
+
+    async def _fake(entries):
+        sent["ids"] = [x["agentId"] for x in entries]
+        return True
+
+    monkeypatch.setattr(admin_core, "post_tts_cache_report", _fake)
+    c = _cand("Namaste ji.", fixed=True)
+    cache.ladder([c]); cache.store(c, _pcm(800))
+    out = await routes.tts_cache_report_now(_Req())
+    assert out["pushed"] == 1 and out["ok"] is True
+    assert sent["ids"] == [ttscache.UNATTRIBUTED]


### PR DESCRIPTION
The first backfill on the live box returned "ledger is empty" while the same box's stats route reported 73 sentences, 19 blobs and 92 sightings. Both were telling the truth: they read different tables.

export_for_report did `FROM seen s JOIN seen_agent sa`, an INNER JOIN, and seen_agent is only written for a candidate that carries an agent_id. Every sentence laddered before per-agent tracking existed therefore had no provenance row, so a ledger full of real data exported ZERO rows. The reporter's own `if entries:` guard then made the push a silent no-op, and the analytics table stayed empty with no error logged anywhere — indistinguishable from a reporter that never started, which is precisely what we spent the rollout chasing.

Nor would it have healed on its own: an old row only gains provenance if that exact sentence is spoken again.

Now a LEFT JOIN, with unowned rows reported under an explicit sentinel rather than dropped. Their sightings are real (seen.count); their per-agent hits were never recorded, so they read 0 instead of being back-derived from call-level counters. Labelling what we do not know beats discarding it or inventing an owner for it.

admin-core stops rendering an unresolvable agent_id as "(deleted agent)", which would have mislabelled that bucket. It shows the id itself — "(unattributed)" for these, and the uuid for an agent that really was deleted, which is the more useful answer in both cases.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
