### PR TITLE
feat(tts-cache): render a sentence on its first sighting, not its second

### DIFF
--- a/docs/crm/TTS_SPEECH_CACHE.md
+++ b/docs/crm/TTS_SPEECH_CACHE.md
@@ -168,7 +168,7 @@ sweeper defers when the box is at half its concurrent-call cap or above — synt
 network but the decode is real CPU on a 1 vCPU node, and background work must never be why a
 live caller hears a glitch. The periodic tick then catches up during a lull.
 
-**Admission:** an LLM sentence is rendered after `TTS_CACHE_MIN_SEEN` (default 2) qualifying
+**Admission:** an LLM sentence is rendered after `TTS_CACHE_MIN_SEEN` (default 1) qualifying
 sightings, so it first hits on its third. Break-even is 3 uses.
 
 **A fixed line is rendered after ONE sighting.** The threshold exists because an LLM sentence
@@ -343,7 +343,7 @@ LLM-sentence half earns its complexity.
 | `TTS_CACHE_LLM_ENABLED` | `true` | ops KILL switch for the LLM-sentence path |
 | `TTS_CACHE_AGENTS` | *(empty)* | optional extra ops restriction. Empty = no restriction |
 | `TTS_CACHE_SALT` | `v1` | bump to invalidate everything |
-| `TTS_CACHE_MIN_SEEN` | `2` | qualifying sightings before one render is spent |
+| `TTS_CACHE_MIN_SEEN` | `1` | qualifying sightings before one render is spent. 1 makes a line free from its SECOND use rather than its third |
 | `TTS_SPEECH_CACHE_MAX_BYTES` | 2 GB | own eviction budget |
 | `TTS_CACHE_MIN_BLOB_MS` | `200` | G5 floor |
 
@@ -454,7 +454,7 @@ priciest engine and the one whose renders are non-deterministic.
 |---|---|
 | Fixed lines | ~10–15% of TTS chars on a 5-min call. **Only the opening is pre-warmed**, and only if it has no `{{placeholder}}`; the farewells, handbacks, fillers and nudge reach the cache the same way an LLM sentence does — see the row below |
 | LLM sentences | **Unknown until the ledger runs.** `NoRepeatGate` needed *fuzzy* matching at 0.80 precisely because exact repeats were not frequent enough, and paraphrases of one question score ~0.6. Plan for 15–35%, not 60% |
-| **What hits on call 1** | Only a pre-warmed, placeholder-free opening. Everything else needs `TTS_CACHE_MIN_SEEN` sightings first, so its first hit is call 3 (or call 2 if the line is spoken twice in one call). A `hits=0` first call is the expected reading, not a broken cache — read `misses=N` and `laddered N` to confirm the plumbing works |
+| **What hits on call 1** | Only a pre-warmed, placeholder-free opening. Everything else needs `TTS_CACHE_MIN_SEEN` sightings first — at the default of 1 that means its first hit is call 2. A `hits=0` first call is the expected reading, not a broken cache — read `misses=N` and `laddered N` to confirm the plumbing works |
 | Ramp | starts near zero and climbs. G3/G4 make "qualifying" stricter than "spoken", so it climbs slower than a naive model predicts |
 | Where money is at stake | `sarvam` (₹2.34/min) and high-volume `google` (₹2.06/min past its 1M chars/month free tier ≈ 1,284 call-min). `edge` is free, `rumik` ₹0.45/min |
 | **The bigger lever** | not the cache — script determinism. `AI_CALL_ACTIONS.md` §10 flags the prompt at ~19k chars with the two-sentence turn cap not holding. A tighter script fixes that bug **and** raises the exact-match rate from the same edit |

--- a/voice_bot_service/app/config.py
+++ b/voice_bot_service/app/config.py
@@ -609,10 +609,23 @@ class Settings:
 
     # How many times a sentence must be seen — COMPLETE, uninterrupted, confirmed
     # played to the caller, on a call with a healthy verdict — before we spend one
-    # off-call render on it. Break-even is 3 uses. 2 catches recurring names and
-    # script lines early; raise it if the ledger shows a fat twice-only tail.
+    # off-call render on it.
+    #
+    # 1, because the arithmetic favours it. Counting vendor payments for a
+    # sentence spoken N times: no cache costs N; at 2 it costs 3 (two live plus
+    # the render) and is free from the third use; at 1 it costs 2 and is free
+    # from the SECOND. So 1 wins whenever a sentence recurs at all, and loses
+    # exactly one render for each that never does.
+    #
+    # Measured on shreya-v3's first day: 54 of 73 sentences sat at one sighting,
+    # so 2 was holding back the entire backlog. Rendering all 54 speculatively
+    # costs 4,237 chars — about Rs 7 — and happens off-call, where it buys no
+    # latency penalty. The hedge was costing more than it saved.
+    #
+    # Raise it if the ledger ever shows a fat never-recurring tail; that is the
+    # signal this trade has flipped.
     tts_cache_min_seen: int = field(
-        default_factory=lambda: int(_env("TTS_CACHE_MIN_SEEN", "2")))
+        default_factory=lambda: int(_env("TTS_CACHE_MIN_SEEN", "1")))
 
     # Own budget, because _evict_tts_cache only sweeps *.mp3 — this namespace
     # would otherwise grow until the volume is full. 8 kHz s16 = 16 KB/s, so

--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -588,7 +588,11 @@ class SpeechCache:
 
         TTS_CACHE_MIN_SEEN exists for ONE reason: an LLM sentence might be a
         one-off — "Namaste Rohan ji" for a name that never recurs — and rendering
-        it would buy nothing. Waiting for a second sighting is how we find out.
+        it buys nothing. It now defaults to 1, because that hedge turned out to
+        cost more than it saved: rendering on the first sighting makes a sentence
+        free from its SECOND use instead of its third, so it wins whenever the
+        line recurs at all and loses one cheap off-call render when it does not.
+        Raise it if the ledger ever shows a fat never-recurring tail.
 
         That reasoning is simply false for a fixed line. The opening, the
         farewells, the handbacks and the fillers are authored, and every one of

--- a/voice_bot_service/deploy/linode-mumbai/env.example
+++ b/voice_bot_service/deploy/linode-mumbai/env.example
@@ -50,7 +50,7 @@ TTS_PACE=1.1
 # Qualifying sightings before one off-call render is spent on a sentence.
 # "Qualifying" is strict: complete, uninterrupted, confirmed played to the
 # caller, on a call whose health verdict was not RED. Break-even is 3 uses.
-# TTS_CACHE_MIN_SEEN=2
+# TTS_CACHE_MIN_SEEN=1
 
 # Its own budget — the existing sweep only evicts *.mp3, so this namespace would
 # otherwise grow until the volume is full. 8 kHz s16 = 16 KB/s, so 2 GB is about

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -332,6 +332,9 @@ def test_a_row_whose_file_vanished_is_not_indexed(cache):
 # ── the ledger ──────────────────────────────────────────────────────────────
 
 def test_render_is_due_only_after_min_seen_sightings(cache):
+    """The knob still works when raised — _Settings pins it to 2, while the
+    shipped default is 1. This is the way back if the ledger ever shows a fat
+    never-recurring tail, so it has to keep being exercised."""
     c = _cand("Yeh humara flagship programme hai.")
     cache.ladder([c])
     assert cache.due() == []                    # once seen is not evidence
@@ -918,3 +921,21 @@ async def test_report_now_pushes_unattributed_history(routes, cache, monkeypatch
     out = await routes.tts_cache_report_now(_Req())
     assert out["pushed"] == 1 and out["ok"] is True
     assert sent["ids"] == [ttscache.UNATTRIBUTED]
+
+
+def test_min_seen_defaults_to_one(monkeypatch):
+    """A sentence renders on its FIRST sighting, not its second.
+
+    Counting vendor payments for a line spoken N times: no cache costs N; at a
+    threshold of 2 it costs 3 (two live plus the render) and is free from the
+    third use; at 1 it costs 2 and is free from the SECOND. So 1 wins whenever
+    the line recurs at all and loses one cheap off-call render when it does not.
+
+    Pinned because the value is a silent economic trade — nothing fails if it
+    drifts back to 2, the cache just quietly stops earning on everything with a
+    short tail. Measured on shreya-v3's first day, 54 of 73 sentences sat at one
+    sighting, so a threshold of 2 was holding back the whole backlog.
+    """
+    monkeypatch.delenv("TTS_CACHE_MIN_SEEN", raising=False)
+    from app.config import Settings
+    assert Settings().tts_cache_min_seen == 1


### PR DESCRIPTION
TTS_CACHE_MIN_SEEN defaults to 1.

The threshold hedged against one-off sentences — "Namaste Rohan ji" for a name that never recurs — but the arithmetic does not support the hedge. Counting vendor payments for a line spoken N times: no cache costs N; at 2 it costs 3 (two live utterances plus the render) and is free from the third use; at 1 it costs 2 and is free from the SECOND. So 1 wins whenever the line recurs at all, and loses exactly one render when it never does.

The first day of real data settled it. Of shreya-v3's 73 ledger sentences, 54 sat at a single sighting and none had failed to render — the machinery was fine, the bar was simply holding back the entire backlog. Rendering all 54 speculatively costs 4,237 characters, about Rs 7, and happens off-call where it buys no latency penalty. The hedge was costing more than it saved.

Fixed lines already rendered on the first sighting; this brings LLM sentences to the same footing for a different reason — not "it will certainly recur" but "if it does, we are already ahead".

The knob is unchanged and still honoured, which is the way back if the ledger ever shows a fat never-recurring tail. A test pins the default, because nothing FAILS when this drifts back to 2 — the cache just quietly stops earning on everything with a short tail.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
