### PR TITLE
fix(tts-cache): a hit now creates its attribution row instead of vani…

### DIFF
--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -551,22 +551,41 @@ class SpeechCache:
 
     # -- ledger -------------------------------------------------------------
 
-    def note_hit_for_agent(self, key: str, agent_id: str) -> None:
+    def note_hit_for_agent(self, key: str, agent_id: str, agent_name: str = "",
+                           institute_id: str = "") -> None:
         """Attribute a cache hit to an agent. Fire-and-forget: analytics must
         never be a reason a call goes wrong."""
         if not (key and agent_id):
             return
         try:
-            asyncio.get_running_loop().create_task(
-                asyncio.to_thread(self._bump_agent_hit, key, agent_id))
+            asyncio.get_running_loop().create_task(asyncio.to_thread(
+                self._bump_agent_hit, key, agent_id, agent_name, institute_id))
         except RuntimeError:
             pass
 
-    def _bump_agent_hit(self, key: str, agent_id: str) -> None:
+    def _bump_agent_hit(self, key: str, agent_id: str, agent_name: str = "",
+                        institute_id: str = "") -> None:
+        """UPSERT, not UPDATE.
+
+        A cache HIT never ladders — only the miss path adds a candidate — so the
+        provenance row may not exist when the first hit lands. It certainly does
+        not for anything laddered before per-agent tracking existed. A bare
+        UPDATE matched zero rows there and threw the hit away silently, which is
+        why every one of those entries read 0 hits no matter how often it was
+        served. A hit is itself proof this agent spoke the line, so it is enough
+        to create the row.
+        """
         try:
             with self._connect() as db:
-                db.execute("UPDATE seen_agent SET hits = hits + 1, last_hit_at = ?"
-                           " WHERE key = ? AND agent_id = ?", (time.time(), key, agent_id))
+                db.execute(
+                    "INSERT INTO seen_agent(key, agent_id, agent_name,"
+                    " institute_id, sightings, hits, last_hit_at)"
+                    " VALUES(?,?,?,?,0,1,?)"
+                    " ON CONFLICT(key, agent_id) DO UPDATE SET"
+                    " hits = hits + 1, last_hit_at = excluded.last_hit_at,"
+                    " agent_name = COALESCE(NULLIF(excluded.agent_name,''), agent_name),"
+                    " institute_id = COALESCE(NULLIF(excluded.institute_id,''), institute_id)",
+                    (key, agent_id, agent_name or "", institute_id or "", time.time()))
         except Exception:
             logger.debug("tts-cache: agent hit bookkeeping failed", exc_info=True)
 
@@ -1135,7 +1154,8 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
                 if blob:
                     _bump("note_tts_cache_hit", entry.duration_ms, len(norm))
                     cache.note_hit(key)
-                    cache.note_hit_for_agent(key, agent_id)
+                    cache.note_hit_for_agent(key, agent_id, agent_name,
+                                             institute_id)
                     logger.info("tts-cache: HIT {}ms {!r}", entry.duration_ms, norm[:48])
 
                     # Emit the turn brackets ONLY if the base class is not already

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -1046,3 +1046,35 @@ def test_owns_text_frame_defaults_to_not_emitting():
     one corrupts the transcript. Prefer the recoverable failure."""
     class _Unknown: pass
     assert ttscache.owns_text_frame(_Unknown()) is False
+
+
+def test_a_hit_records_itself_even_with_no_prior_provenance(cache):
+    """THE reason every backfilled entry read 0 hits forever.
+
+    A cache HIT never ladders — only the miss path adds a candidate — so the
+    provenance row may not exist when the first hit lands, and it certainly does
+    not for anything laddered before per-agent tracking existed. This used to be
+    a bare UPDATE, which matched zero rows there and dropped the hit silently.
+    """
+    c = _cand("Namaste ji.", fixed=True)          # laddered with NO agent_id
+    cache.ladder([c]); cache.store(c, _pcm(600))
+    assert [e for e in cache.export_for_report()
+            if e["agentId"] == "agent-a"] == [], "no provenance row yet"
+
+    cache._bump_agent_hit(c.key, "agent-a", "AGENT-A", "inst-1")
+
+    rows = [e for e in cache.export_for_report() if e["agentId"] == "agent-a"]
+    assert len(rows) == 1, "the hit must CREATE the attribution row"
+    assert rows[0]["hits"] == 1
+    assert rows[0]["agentName"] == "AGENT-A"
+    assert rows[0]["sentence"] == "Namaste ji."
+
+
+def test_repeated_hits_accumulate_on_the_same_row(cache):
+    c = _acand("Theek hai.", "agent-a", fixed=True)
+    cache.ladder([c])
+    for _ in range(3):
+        cache._bump_agent_hit(c.key, "agent-a", "AGENT-A", "inst-1")
+    row = [e for e in cache.export_for_report() if e["agentId"] == "agent-a"][0]
+    assert row["hits"] == 3
+    assert row["sightings"] == 1, "a hit is not a sighting — ladder owns that"


### PR DESCRIPTION
…shing

Every entry in the live ledger read 0 hits — all 90 of them — while the per-call diagnostics recorded 28 hits on a single call. Both were right; the bookkeeping between them was losing everything.

_bump_agent_hit was a bare UPDATE on seen_agent. A cache HIT never ladders — only the miss path adds a candidate — so the provenance row need not exist when the first hit lands, and for anything laddered before per-agent tracking existed it certainly does not. The UPDATE matched zero rows there and dropped the hit without a word, which is why the 64 backfilled entries were going to read 0 hits however often they were served.

Now an UPSERT. A hit is itself proof this agent spoke the line, so it is enough to create the row; agent_name and institute_id ride along and only overwrite when non-empty, so a later ladder never loses them.

sightings deliberately stays at 0 on the insert: a hit is not a sighting, ladder owns that counter, and conflating them would double-count every miss that later becomes a hit.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
