### PR TITLE
fix(tts-cache): one audio context per sentence, so a hit can serve mi…

### DIFF
--- a/voice_bot_service/app/ttscache.py
+++ b/voice_bot_service/app/ttscache.py
@@ -97,6 +97,20 @@ _TRAILING = "\"'’”)]》」»"
 _ASYNC_ARRIVAL_ENGINES = frozenset({"sarvam", "smallest", "rumik"})
 
 
+def per_sentence_contexts(tts) -> bool:
+    """True when each sentence gets its OWN pipecat audio context.
+
+    This is what makes cached audio safe to serve mid-turn on an async-arrival
+    engine. With one context per turn (pipecat's default) every sentence shares
+    a single FIFO drained in APPEND order, so a cached sentence — available
+    instantly — lands ahead of vendor audio still in flight for an earlier
+    sentence, and the caller hears them out of order. With one context per
+    sentence they sit in separate slots on the serialization queue, drained in
+    CREATION order, and arrival time stops mattering.
+    """
+    return not getattr(tts, "_reuse_context_id_within_turn", True)
+
+
 def is_async_arrival(engine: str) -> bool:
     """True when the engine delivers audio out-of-band from run_tts (§ ordering)."""
     return (engine or "").strip().lower() in _ASYNC_ARRIVAL_ENGINES
@@ -1078,6 +1092,35 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
                     s.tts_cache_speech_enabled, s.tts_cache_llm_enabled)
         return None
 
+    # ONE CONTEXT PER SENTENCE, for enabled agents on an async-arrival engine.
+    #
+    # This is the fix for the ordering guard starving the cache. pipecat's
+    # create_context_id() reuses one context id for a whole turn by default, so
+    # every sentence of that turn shares a single FIFO drained in APPEND order.
+    # Cached audio is on disk and appends instantly; vendor audio appends when
+    # the websocket delivers it. Serve a cached sentence behind a vendor one and
+    # the caller hears them swapped — so TtsTurnWatcher refused to serve at all
+    # once anything in the turn had gone to the vendor. And because
+    # TTSStoppedFrame brackets the whole TURN on these engines, ONE miss early in
+    # a turn forced every later sentence to the vendor with its audio sitting
+    # ready. Measured on live call a2d883c4: 14 sentences, 955 characters,
+    # already rendered and already paid for, re-synthesised anyway.
+    #
+    # With a context per sentence they occupy separate slots on the
+    # serialization queue, which is drained in CREATION order — so position is
+    # fixed when run_tts is called and arrival time stops mattering.
+    #
+    # Set HERE, after the not-installed return, so it can only ever affect an
+    # agent whose cache is on. Every other agent keeps today's exact turn
+    # bracketing. The cost for the ones that opt in is that TTSStarted/Stopped —
+    # and so BotStartedSpeaking/BotStoppedSpeaking — fire per sentence rather
+    # than per turn; google already behaves that way in production, which is the
+    # evidence the pipeline handles the shape.
+    if async_arrival and getattr(tts, "_reuse_context_id_within_turn", False):
+        tts._reuse_context_id_within_turn = False
+        logger.info("tts-cache: per-sentence audio contexts enabled for {} — "
+                    "cached audio can now be served mid-turn", engine_l)
+
     def _bump(name: str, *args) -> None:
         if diag is None:
             return
@@ -1137,7 +1180,12 @@ def install_tts_cache(tts, *, engine: str, model: str, voice: str, pace,
         # Ordering (§ TtsTurnWatcher): on an async-arrival engine we may only
         # serve when the vendor owes us nothing, or the cached audio would be
         # heard before audio that was requested earlier.
-        may_serve = key and (not async_arrival or not watcher.vendor_inflight)
+        # The ordering guard is only needed while a turn shares one context. With
+        # a context per sentence pipecat fixes the order at creation time, so a
+        # cached sentence can be served even with vendor audio still in flight.
+        may_serve = key and (not async_arrival
+                             or per_sentence_contexts(tts)
+                             or not watcher.vendor_inflight)
 
         if not may_serve and s.tts_cache_debug:
             # The ordering guard, not the cache, refused this one. Worth its own

--- a/voice_bot_service/tests/test_ttscache.py
+++ b/voice_bot_service/tests/test_ttscache.py
@@ -590,6 +590,17 @@ class _FakeTTS:
         pass
 
 
+def _install_on(monkeypatch, tmp_path, tts, *, mode):
+    """install_tts_cache against a caller-supplied service object."""
+    pytest.importorskip("pipecat.frames.frames")
+    monkeypatch.setattr(ttscache, "get_settings",
+                        lambda: _Settings(str(tmp_path)))
+    return ttscache.install_tts_cache(
+        tts, engine="sarvam", model="bulbul:v3", voice="priya", pace=1.1,
+        temperature=0.5, fixed_lines=set(), cache_mode=mode,
+        cache=SpeechCache(root=str(tmp_path / "speech")))
+
+
 def _install(monkeypatch, tmp_path, *, mode, speech=True, llm=True, agents=()):
     pytest.importorskip("pipecat.frames.frames")
     monkeypatch.setattr(
@@ -1078,3 +1089,75 @@ def test_repeated_hits_accumulate_on_the_same_row(cache):
     row = [e for e in cache.export_for_report() if e["agentId"] == "agent-a"][0]
     assert row["hits"] == 3
     assert row["sightings"] == 1, "a hit is not a sighting — ladder owns that"
+
+
+# ── the ordering guard no longer starves the cache ──────────────────────────
+
+def test_enabling_the_cache_switches_the_engine_to_per_sentence_contexts(
+        monkeypatch, tmp_path):
+    """One context per turn is what forced a cached sentence to the vendor."""
+    tts = _FakeTTS()
+    tts._reuse_context_id_within_turn = True
+    _install_on(monkeypatch, tmp_path, tts, mode="FULL")
+    assert tts._reuse_context_id_within_turn is False
+    assert ttscache.per_sentence_contexts(tts) is True
+
+
+def test_a_DISABLED_agent_keeps_pipecat_turn_bracketing(monkeypatch, tmp_path):
+    """The ship-safety guarantee. Turn bracketing drives DuckGate, the watchdog
+    and dead-air measurement, so an agent nobody enabled must not have it
+    changed underneath them."""
+    tts = _FakeTTS()
+    tts._reuse_context_id_within_turn = True
+    _install_on(monkeypatch, tmp_path, tts, mode="OFF")
+    assert tts._reuse_context_id_within_turn is True, "must be left untouched"
+
+
+async def test_a_cached_sentence_serves_even_with_vendor_audio_in_flight(
+        monkeypatch, tmp_path):
+    """THE fix. On live call a2d883c4, 14 sentences worth 955 characters were
+    already rendered and were re-synthesised anyway, because one earlier miss in
+    the turn had set vendor_inflight and TTSStoppedFrame only clears it at the
+    END of a turn on these engines.
+    """
+    monkeypatch.setattr(ttscache, "get_settings",
+                        lambda: _Settings(str(tmp_path)))
+    line = "Theek hai, dhanyavaad."
+    c = SpeechCache(root=str(tmp_path / "speech")); c.open()
+    cand = _cand(line, engine="sarvam", model="bulbul:v3", voice="priya",
+                 pace=1.1, temperature=0.5, fixed=True)
+    c.ladder([cand]); c.store(cand, _pcm(600))
+
+    tts = _FakeTTS()
+    tts._reuse_context_id_within_turn = True
+    watcher = ttscache.install_tts_cache(
+        tts, engine="sarvam", model="bulbul:v3", voice="priya", pace=1.1,
+        temperature=0.5, fixed_lines={line}, cache_mode="FULL", cache=c)
+
+    watcher.note_vendor_dispatch()          # an earlier sentence went to the vendor
+    assert watcher.vendor_inflight is True
+    kinds = [type(f).__name__ async for f in tts.run_tts(line, "ctx-9")
+             if f is not None]
+    assert "TTSAudioRawFrame" in kinds,         "cached audio must serve mid-turn now that ordering is fixed by context"
+
+
+async def test_the_guard_still_applies_if_contexts_are_NOT_per_sentence(
+        monkeypatch, tmp_path):
+    """Belt and braces: on any service we could not switch, serving mid-turn
+    would still reorder audio, so the guard must keep refusing."""
+    monkeypatch.setattr(ttscache, "get_settings",
+                        lambda: _Settings(str(tmp_path)))
+    line = "Theek hai, dhanyavaad."
+    c = SpeechCache(root=str(tmp_path / "speech")); c.open()
+    cand = _cand(line, engine="sarvam", model="bulbul:v3", voice="priya",
+                 pace=1.1, temperature=0.5, fixed=True)
+    c.ladder([cand]); c.store(cand, _pcm(600))
+    tts = _FakeTTS()
+    watcher = ttscache.install_tts_cache(
+        tts, engine="sarvam", model="bulbul:v3", voice="priya", pace=1.1,
+        temperature=0.5, fixed_lines={line}, cache_mode="FULL", cache=c)
+    tts._reuse_context_id_within_turn = True     # pretend the switch did not take
+    watcher.note_vendor_dispatch()
+    kinds = [type(f).__name__ async for f in tts.run_tts(line, "ctx-10")
+             if f is not None]
+    assert "TTSAudioRawFrame" not in kinds, "ordering beats hit rate, always"


### PR DESCRIPTION
…d-turn

Group C from the live-call analysis: 14 sentences worth 955 characters on call a2d883c4 were already rendered, already paid for, and re-synthesised anyway.

pipecat's create_context_id() reuses one context id for a whole turn by default, so every sentence of that turn shares a single FIFO drained in APPEND order. Cached audio is on disk and appends instantly; vendor audio appends when the websocket delivers it, hundreds of milliseconds later. Serving a cached sentence behind a vendor one therefore plays them SWAPPED — so TtsTurnWatcher refused to serve at all once anything in the turn had gone to the vendor. And because TTSStoppedFrame brackets the whole TURN on these engines, not each sentence, ONE miss early in a turn locked the cache out of every sentence after it.

With a context per sentence they occupy separate slots on the serialization queue, which is drained in CREATION order. Position is fixed when run_tts is called and arrival time stops mattering, so the hazard is gone by construction rather than avoided by declining.

Set inside install_tts_cache, AFTER the not-installed return, so it can only reach an agent whose cache is on. Turn bracketing drives DuckGate, the watchdog and dead-air measurement; the 26 agents nobody enabled keep today's behaviour exactly, and a test asserts that. The cost for agents that opt in is that TTSStarted/Stopped — and so BotStartedSpeaking/BotStoppedSpeaking — fire per sentence rather than per turn. google already behaves that way in production, which is the evidence the pipeline handles the shape, but this still wants one live call before it is trusted.

The guard is kept rather than deleted: on any service where the switch does not take, serving mid-turn would still reorder audio. Ordering beats hit rate — paying for a sentence is not a bug, playing it out of order is.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
