### PR TITLE
feat(live-session): time attendance to the second, and explain every …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportDTO.java
@@ -19,5 +19,8 @@ public interface AttendanceReportDTO {
     String getStatusType();
     String getEngagementData();
     Integer getProviderTotalDurationMinutes();
+
+    /** Exact seconds when the provider reports them (BBB); NULL for Zoom. */
+    Integer getProviderTotalDurationSeconds();
     String getFeedbackDetails();
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportDTOImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportDTOImpl.java
@@ -30,5 +30,7 @@ public class AttendanceReportDTOImpl implements AttendanceReportDTO {
     private String statusType;
     private String engagementData;
     private Integer providerTotalDurationMinutes;
+    /** Exact seconds when the provider reports them (BBB); NULL for Zoom. */
+    private Integer providerTotalDurationSeconds;
     private String feedbackDetails;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportProjection.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/AttendanceReportProjection.java
@@ -27,5 +27,8 @@ public interface AttendanceReportProjection {
     String getFeedbackDetails();
     String getPackageSessionId();
     Integer getProviderTotalDurationMinutes();
+
+    /** Exact seconds when the provider reports them (BBB); NULL for Zoom. */
+    Integer getProviderTotalDurationSeconds();
     String getEngagementData();
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GuestAttendanceDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/dto/GuestAttendanceDTO.java
@@ -16,5 +16,8 @@ public interface GuestAttendanceDTO {
     String getStatusType();
     String getEngagementData();
     Integer getProviderTotalDurationMinutes();
+
+    /** Exact seconds when the provider reports them (BBB); NULL for Zoom. */
+    Integer getProviderTotalDurationSeconds();
 }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSessionLogs.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/entity/LiveSessionLogs.java
@@ -79,6 +79,14 @@ public class LiveSessionLogs {
     private Integer providerTotalDurationMinutes;
 
     /**
+     * Exact seconds in the meeting, when the provider reports that precisely
+     * (BBB does; Zoom gives whole minutes, leaving this NULL). The minutes
+     * column above is a floor of this and is kept for existing consumers.
+     */
+    @Column(name = "provider_total_duration_seconds")
+    private Integer providerTotalDurationSeconds;
+
+    /**
      * Audit of the attendance-criteria evaluation for this row: verdict, reason,
      * attendedMinutes, scheduledMinutes, requiredMinutes, thresholdPercent,
      * previousStatus, evaluatedAt. Attendance is disputed data, so an absence

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/provider/controller/LiveSessionProviderController.java
@@ -586,8 +586,17 @@ public class LiveSessionProviderController {
         Optional<LiveSessionLogs> existing = liveSessionLogsRepository
                 .findExistingAttendanceRecord(scheduleId, attendee.getExtUserId());
 
+        // Round, don't floor. The minutes column is what reports, CSV exports and
+        // the workflow query layer read; flooring discarded up to 59 seconds and
+        // always against the learner. Rounding halves the worst case and removes
+        // the bias. The attendance rule itself compares the exact seconds below,
+        // so this value is presentational.
         int durationMinutes = attendee.getDuration() != null
-                ? (int) (attendee.getDuration() / 60) : 0;
+                ? (int) Math.round(attendee.getDuration() / 60.0) : 0;
+        // Keep the exact seconds too — the minutes value above floors away up to
+        // 59 seconds, which decides borderline minimum-attendance verdicts.
+        int durationSeconds = attendee.getDuration() != null
+                ? attendee.getDuration().intValue() : 0;
 
         String engagementJson = buildEngagementJson(attendee.getEngagement());
 
@@ -597,7 +606,19 @@ public class LiveSessionProviderController {
             // Sum duration with existing (for retry/recreate scenario)
             int existingDuration = log.getProviderTotalDurationMinutes() != null
                     ? log.getProviderTotalDurationMinutes() : 0;
-            log.setProviderTotalDurationMinutes(existingDuration + durationMinutes);
+            int existingSeconds = log.getProviderTotalDurationSeconds() != null
+                    ? log.getProviderTotalDurationSeconds() : 0;
+            int totalSeconds = existingSeconds + durationSeconds;
+            log.setProviderTotalDurationSeconds(totalSeconds);
+            // Derive minutes from the seconds total rather than summing a second,
+            // independent series. Two columns holding one fact will drift the
+            // moment a future edit touches only one of them — and summing
+            // per-callback floors compounded the loss: floor(90s)+floor(90s) = 2
+            // minutes for 3 minutes of attendance. floor(total) is both correct
+            // and impossible to disagree with the seconds column.
+            log.setProviderTotalDurationMinutes(
+                    totalSeconds > 0 ? (int) Math.round(totalSeconds / 60.0)
+                                     : existingDuration + durationMinutes);
 
             // Merge engagement data (sum counts)
             log.setEngagementData(mergeEngagementJson(log.getEngagementData(), engagementJson));
@@ -626,6 +647,7 @@ public class LiveSessionProviderController {
                     .details(attendee.getName() + " | role=" + (Boolean.TRUE.equals(attendee.getModerator()) ? "MODERATOR" : "VIEWER"))
                     .providerMeetingId(providerMeetingId)
                     .providerTotalDurationMinutes(durationMinutes)
+                    .providerTotalDurationSeconds(durationSeconds)
                     .engagementData(engagementJson)
                     .createdAt(new Timestamp(System.currentTimeMillis()))
                     .updatedAt(new Timestamp(System.currentTimeMillis()))

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionParticipantRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/LiveSessionParticipantRepository.java
@@ -93,6 +93,7 @@ public interface LiveSessionParticipantRepository extends JpaRepository<LiveSess
                 lsl.status_type AS statusType,
                 lsl.engagement_data AS engagementData,
                 lsl.provider_total_duration_minutes AS providerTotalDurationMinutes,
+                lsl.provider_total_duration_seconds AS providerTotalDurationSeconds,
                 fbl.details AS feedbackDetails,
                 1 AS priority
             FROM live_session_participants lsp
@@ -134,6 +135,7 @@ public interface LiveSessionParticipantRepository extends JpaRepository<LiveSess
                 lsl.status_type AS statusType,
                 lsl.engagement_data AS engagementData,
                 lsl.provider_total_duration_minutes AS providerTotalDurationMinutes,
+                lsl.provider_total_duration_seconds AS providerTotalDurationSeconds,
                 fbl.details AS feedbackDetails,
                 2 AS priority
             FROM live_session_participants lsp
@@ -204,6 +206,7 @@ public interface LiveSessionParticipantRepository extends JpaRepository<LiveSess
         fbl.details AS feedbackDetails,
         lsp.source_id AS packageSessionId,
         lsl.provider_total_duration_minutes AS providerTotalDurationMinutes,
+                lsl.provider_total_duration_seconds AS providerTotalDurationSeconds,
         lsl.engagement_data AS engagementData
     FROM live_session_participants lsp
     JOIN student_session_institute_group_mapping m
@@ -314,6 +317,7 @@ public interface LiveSessionParticipantRepository extends JpaRepository<LiveSess
         fbl.details AS feedbackDetails,
         lsp.source_id AS packageSessionId,
         lsl.provider_total_duration_minutes AS providerTotalDurationMinutes,
+                lsl.provider_total_duration_seconds AS providerTotalDurationSeconds,
         lsl.engagement_data AS engagementData
     FROM live_session_participants lsp
     JOIN student_session_institute_group_mapping m

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/SessionGuestRegistrationRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/repository/SessionGuestRegistrationRepository.java
@@ -59,7 +59,8 @@ public interface SessionGuestRegistrationRepository extends JpaRepository<Sessio
                 'EXTERNAL_USER' AS sourceType,
                 lsl.status_type AS statusType,
                 lsl.engagement_data AS engagementData,
-                lsl.provider_total_duration_minutes AS providerTotalDurationMinutes
+                lsl.provider_total_duration_minutes AS providerTotalDurationMinutes,
+                lsl.provider_total_duration_seconds AS providerTotalDurationSeconds
             FROM session_guest_registrations sgr
             LEFT JOIN live_session_logs lsl
                 ON lsl.session_id = sgr.session_id

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
@@ -984,6 +984,16 @@ public class LiveSessionNotificationProcessor {
      * Checks LiveSessionNotificationConfig for ATTENDANCE type.
      */
     public void sendAttendanceNotification(String sessionId, String userId, String status) {
+        sendAttendanceNotification(sessionId, userId, status, null);
+    }
+
+    /**
+     * @param reasonDetail plain-language explanation appended to the message, e.g.
+     *                     why a learner fell short of the minimum-attendance rule.
+     *                     Null/blank keeps the original wording.
+     */
+    public void sendAttendanceNotification(String sessionId, String userId, String status,
+                                           String reasonDetail) {
         try {
             Optional<LiveSessionNotificationConfig> configOpt = notificationConfigRepository
                     .findBySessionIdAndNotificationType(sessionId, NotificationTypeEnum.ATTENDANCE.name());
@@ -1001,6 +1011,11 @@ public class LiveSessionNotificationProcessor {
             String sessionTitle = session.getTitle() != null ? session.getTitle() : "Live Class";
             String title = "Attendance Marked: " + status;
             String body = "You have been marked as " + status + " for " + sessionTitle;
+            if (reasonDetail != null && !reasonDetail.isBlank()) {
+                // A learner told they are absent for a class they attended part of
+                // deserves the arithmetic, not just the verdict.
+                body = body + ". " + reasonDetail;
+            }
 
             if (channels.contains("PUSH_NOTIFICATION")) {
                 notificationService.sendPushViaUnified(
@@ -1026,7 +1041,9 @@ public class LiveSessionNotificationProcessor {
                     Map<String, String> placeholders = new HashMap<>();
                     placeholders.put("NAME", student.getFullName() != null ? student.getFullName() : "Student");
                     placeholders.put("SESSION_TITLE", sessionTitle);
-                    placeholders.put("ACTION", "Attendance: " + status);
+                    placeholders.put("ACTION", reasonDetail != null && !reasonDetail.isBlank()
+                            ? "Attendance: " + status + " — " + reasonDetail
+                            : "Attendance: " + status);
                     placeholders.put("THEME_COLOR", getThemeColor(session.getInstituteId()));
                     placeholders.put("INSTITUTE_NAME", getInstituteName(session.getInstituteId()));
                     placeholders.put("YEAR", getCurrentYear());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaEvaluator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceCriteriaEvaluator.java
@@ -134,7 +134,12 @@ public class AttendanceCriteriaEvaluator {
                 log.warn("attendance_criteria.no_scheduled_duration scheduleId={} - skipping", scheduleId);
                 return;
             }
-            double requiredMinutes = scheduledMinutes * (config.getMinDurationPercent() / 100.0);
+            // Compare in seconds. Minutes are a floor of the real figure, so a
+            // learner present for 4m50s of a 7-minute class (69%) was truncated to
+            // 4 and failed a 4.2-minute bar — an absence for a class they attended.
+            int scheduledSeconds = scheduledMinutes * 60;
+            double requiredSeconds = scheduledSeconds * (config.getMinDurationPercent() / 100.0);
+            double requiredMinutes = requiredSeconds / 60.0;
 
             List<LiveSessionLogs> rows =
                     liveSessionLogsRepository.findAllAttendanceByScheduleId(scheduleId);
@@ -165,13 +170,18 @@ public class AttendanceCriteriaEvaluator {
                     // The provider says they were here but gave no minutes; we
                     // cannot judge how long, and they demonstrably attended.
                     writeAudit(row, config, STATUS_PRESENT, "NO_DURATION_DATA",
-                            null, scheduledMinutes, requiredMinutes);
+                            null, scheduledMinutes, requiredMinutes, null, requiredSeconds, false);
                     liveSessionLogsRepository.save(row);
                     continue;
                 }
 
                 int attendedMinutes = inRoster ? reported : 0;
-                boolean meets = attendedMinutes >= requiredMinutes;
+                // Exact seconds when the provider gave them (BBB); otherwise fall
+                // back to the floored minutes (Zoom reports whole minutes only).
+                Integer exactSeconds = row.getProviderTotalDurationSeconds();
+                int attendedSeconds = !inRoster ? 0
+                        : (exactSeconds != null ? exactSeconds : attendedMinutes * 60);
+                boolean meets = attendedSeconds >= requiredSeconds;
                 String verdict = meets ? STATUS_PRESENT : STATUS_ABSENT;
                 String reason = meets ? "MET_THRESHOLD" : (inRoster ? "BELOW_THRESHOLD" : "NO_SHOW");
 
@@ -185,10 +195,20 @@ public class AttendanceCriteriaEvaluator {
                 // when the underlying numbers do.
                 String previousVerdict = previousVerdict(row);
                 String previousStatus = row.getStatus();
-                boolean verdictMoved = !verdict.equalsIgnoreCase(
-                        previousVerdict != null ? previousVerdict : previousStatus);
+                // The first evaluation always notifies: while a rule is in force the
+                // join-time mail is suppressed, so this is the learner's only word on
+                // the class — including a PRESENT confirmation.
+                //
+                // After that, only a real change of verdict notifies. Keying off the
+                // stored verdict rather than the row's status matters because both
+                // provider paths reset status to PRESENT on every sync, and Zoom
+                // re-syncs an ended schedule every 15 minutes for two days — status
+                // would look "changed" every time and mail ~190 times.
+                boolean verdictMoved = previousVerdict == null
+                        || !verdict.equalsIgnoreCase(previousVerdict);
 
-                writeAudit(row, config, verdict, reason, attendedMinutes, scheduledMinutes, requiredMinutes);
+                writeAudit(row, config, verdict, reason, attendedMinutes, scheduledMinutes,
+                        requiredMinutes, attendedSeconds, requiredSeconds, exactSeconds != null);
 
                 if (!verdict.equalsIgnoreCase(previousStatus)) {
                     row.setStatus(verdict);
@@ -198,7 +218,9 @@ public class AttendanceCriteriaEvaluator {
                 liveSessionLogsRepository.save(row);
 
                 if (verdictMoved) {
-                    notify(session, row, verdict);
+                    notify(session, row, verdict,
+                            explain(verdict, reason, attendedSeconds, scheduledSeconds,
+                                    requiredSeconds, config.getMinDurationPercent()));
                 }
             }
 
@@ -230,7 +252,8 @@ public class AttendanceCriteriaEvaluator {
 
     private void writeAudit(LiveSessionLogs row, AttendanceCriteriaConfigDTO config, String verdict,
                             String reason, Integer attendedMinutes, Integer scheduledMinutes,
-                            double requiredMinutes) {
+                            double requiredMinutes, Integer attendedSeconds, Double requiredSeconds,
+                            boolean exact) {
         Map<String, Object> audit = new LinkedHashMap<>();
         audit.put("verdict", verdict);
         audit.put("reason", reason);
@@ -238,9 +261,15 @@ public class AttendanceCriteriaEvaluator {
         audit.put("scheduledMinutes", scheduledMinutes);
         audit.put("thresholdPercent", config.getMinDurationPercent());
         audit.put("requiredMinutes", Math.round(requiredMinutes));
-        if (attendedMinutes != null && scheduledMinutes != null && scheduledMinutes > 0) {
-            audit.put("attendedPercent", Math.round(attendedMinutes * 1000.0 / scheduledMinutes) / 10.0);
+        if (attendedSeconds != null && scheduledMinutes != null && scheduledMinutes > 0) {
+            audit.put("attendedPercent",
+                    Math.round(attendedSeconds * 1000.0 / (scheduledMinutes * 60)) / 10.0);
         }
+        audit.put("attendedSeconds", attendedSeconds);
+        audit.put("requiredSeconds", requiredSeconds == null ? null : Math.round(requiredSeconds));
+        audit.put("attendedDisplay", attendedSeconds == null ? null : hms(attendedSeconds));
+        // false = provider gave only whole minutes, so the figures are floored.
+        audit.put("exactSeconds", exact);
         audit.put("previousStatus", row.getStatus());
         audit.put("evaluatedAt", Instant.now().toString());
         try {
@@ -292,10 +321,38 @@ public class AttendanceCriteriaEvaluator {
         }
     }
 
-    private void notify(LiveSession session, LiveSessionLogs row, String newStatus) {
+    /**
+     * Plain-language arithmetic for the learner. Being told you are absent for a
+     * class you sat through most of is only defensible if the message says how
+     * many minutes were counted and how many were needed.
+     */
+    private String explain(String verdict, String reason, int attendedSeconds,
+                           int scheduledSeconds, double requiredSeconds, Integer pct) {
+        if (STATUS_PRESENT.equals(verdict)) {
+            return null;
+        }
+        String required = hms((int) Math.round(requiredSeconds));
+        if ("NO_SHOW".equals(reason)) {
+            return "Our records show you did not join the class. At least " + required
+                    + " of the " + hms(scheduledSeconds) + " class (" + pct + "%) was required"
+                    + " to be marked present.";
+        }
+        return "You were in the class for " + hms(attendedSeconds) + " of its "
+                + hms(scheduledSeconds) + ". At least " + required + " (" + pct + "%) was"
+                + " required to be marked present.";
+    }
+
+    /** "4m 50s", or "50s" under a minute — the learner-facing form of a duration. */
+    private static String hms(int totalSeconds) {
+        int m = totalSeconds / 60, sec = totalSeconds % 60;
+        if (m == 0) return sec + "s";
+        return sec == 0 ? m + "m" : m + "m " + sec + "s";
+    }
+
+    private void notify(LiveSession session, LiveSessionLogs row, String newStatus, String reasonDetail) {
         try {
             notificationProcessor.sendAttendanceNotification(
-                    session.getId(), row.getUserSourceId(), newStatus);
+                    session.getId(), row.getUserSourceId(), newStatus, reasonDetail);
         } catch (Exception e) {
             log.warn("attendance_criteria.notify_failed userId={}: {}",
                     row.getUserSourceId(), e.getMessage());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceReportService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/AttendanceReportService.java
@@ -298,6 +298,7 @@ public class AttendanceReportService {
                     .statusType(guestDto.getStatusType())
                     .engagementData(guestDto.getEngagementData())
                     .providerTotalDurationMinutes(guestDto.getProviderTotalDurationMinutes())
+                    .providerTotalDurationSeconds(guestDto.getProviderTotalDurationSeconds())
                     .feedbackDetails(null)
                     .build();
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/service/LIveSessionAttendanceService.java
@@ -7,7 +7,9 @@ import vacademy.io.admin_core_service.features.live_session.dto.AdminMarkAttenda
 import vacademy.io.admin_core_service.features.live_session.dto.MarkAttendanceRequestDTO;
 import vacademy.io.admin_core_service.features.live_session.entity.LiveSessionLogs;
 import vacademy.io.admin_core_service.features.live_session.enums.SessionLog;
+import vacademy.io.admin_core_service.features.live_session.dto.AttendanceCriteriaConfigDTO;
 import vacademy.io.admin_core_service.features.live_session.repository.LiveSessionLogsRepository;
+import vacademy.io.admin_core_service.features.live_session.repository.LiveSessionRepository;
 import vacademy.io.admin_core_service.features.live_session.scheduler.LiveSessionNotificationProcessor;
 import vacademy.io.common.auth.model.CustomUserDetails;
 
@@ -25,6 +27,12 @@ public class LIveSessionAttendanceService {
     @Autowired
     private LiveSessionNotificationProcessor notificationProcessor;
 
+    @Autowired
+    private AttendanceCriteriaService attendanceCriteriaService;
+
+    @Autowired
+    private LiveSessionRepository liveSessionRepository;
+
     public void markAttendance(MarkAttendanceRequestDTO request , CustomUserDetails user) {
         String userId = request.getUserSourceId().isEmpty() ? user.getUserId() : request.getUserSourceId();
 
@@ -34,7 +42,13 @@ public class LIveSessionAttendanceService {
         // waiting room re-marks on a 30s poll (and again on every rejoin or
         // refresh), so an unconditional call here mailed the learner dozens of
         // times for one class. The row was always idempotent; the mail was not.
-        if (isStatusChange(previousStatus, "PRESENT")) {
+        //
+        // And stay silent entirely while a minimum-attendance rule is in force:
+        // this row only records that the learner opened the join link, so
+        // "you were marked present" is not yet true. The provider callback
+        // decides, and notifies once with the real verdict — otherwise a learner
+        // who leaves early is told PRESENT and then ABSENT for the same class.
+        if (isStatusChange(previousStatus, "PRESENT") && !criteriaDecidesLater(request.getSessionId())) {
             notificationProcessor.sendAttendanceNotification(request.getSessionId(), userId, "PRESENT");
         }
     }
@@ -63,6 +77,22 @@ public class LIveSessionAttendanceService {
                 "PRESENT",
                 "ONLINE",
                 request.getDetails());
+    }
+
+    /**
+     * Whether this session defers the attendance verdict to the provider callback.
+     * Any failure resolves to false, so a lookup problem can only cost the old
+     * behaviour (a join-time mail), never silence a learner who gets no other one.
+     */
+    private boolean criteriaDecidesLater(String sessionId) {
+        try {
+            return liveSessionRepository.findById(sessionId)
+                    .map(attendanceCriteriaService::resolve)
+                    .map(AttendanceCriteriaConfigDTO::isActive)
+                    .orElse(false);
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/admin_core_service/src/main/resources/db/migration/V469__attendance_duration_seconds.sql
+++ b/admin_core_service/src/main/resources/db/migration/V469__attendance_duration_seconds.sql
@@ -1,0 +1,18 @@
+-- BBB reports each attendee's time in the room in SECONDS, but we stored only
+-- (seconds / 60) as an integer — a floor, so every learner silently lost up to
+-- 59 seconds and the loss always counted against them.
+--
+-- That is invisible on a long class but decides borderline cases: on a 7-minute
+-- class at 60% the bar is 4.2 minutes, so a learner present for 4m50s (69%) was
+-- truncated to 4 and marked ABSENT for a class they clearly attended.
+--
+-- Keep provider_total_duration_minutes exactly as it is — reports, exports and
+-- the workflow query layer all read it. This adds the precise value alongside,
+-- so the attendance rule can compare in seconds and the UI can show m:ss.
+-- NULL means the provider gave us no better than minutes (Zoom reports whole
+-- minutes only), and callers fall back to the minutes column.
+ALTER TABLE live_session_logs
+    ADD COLUMN IF NOT EXISTS provider_total_duration_seconds INTEGER;
+
+COMMENT ON COLUMN live_session_logs.provider_total_duration_seconds IS
+    'Exact seconds the attendee was in the meeting, as reported by the provider (BBB). NULL when only whole minutes are available (Zoom). provider_total_duration_minutes remains the floored minute value for existing consumers.';

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/-components/AttendanceMarkingTable.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/-components/AttendanceMarkingTable.tsx
@@ -48,6 +48,21 @@ interface AttendanceMarkingTableProps {
 type SortField = 'status' | 'duration' | 'activePoints';
 type SortDir = 'asc' | 'desc';
 
+/**
+ * Vacademy Meet reports exact seconds; Zoom only whole minutes. Show "4m 50s"
+ * when we have the real figure, and plain minutes when that is all the provider
+ * gave — the minutes column is a floor, so "4 min" can be anything up to 4m59s.
+ */
+const formatAttendedDuration = (mins: number | null, secs?: number | null): string => {
+    if (secs != null) {
+        const m = Math.floor(secs / 60);
+        const s = secs % 60;
+        if (m === 0) return `${s}s`;
+        return s === 0 ? `${m}m` : `${m}m ${s}s`;
+    }
+    return mins != null ? `${mins} min` : '--';
+};
+
 function parseEngagement(json: string | null): EngagementData | null {
     if (!json) return null;
     try {
@@ -552,7 +567,10 @@ export function AttendanceMarkingTable({
                                             {student.providerTotalDurationMinutes != null ? (
                                                 <span className="flex items-center gap-1">
                                                     <Clock size={14} className="text-gray-400" />
-                                                    {student.providerTotalDurationMinutes} min
+                                                    {formatAttendedDuration(
+                                                        student.providerTotalDurationMinutes,
+                                                        student.providerTotalDurationSeconds
+                                                    )}
                                                 </span>
                                             ) : (
                                                 <span className="text-gray-300">--</span>
@@ -610,7 +628,11 @@ export function AttendanceMarkingTable({
                                                     {student.providerTotalDurationMinutes != null && (
                                                         <span className="flex items-center gap-1">
                                                             <Clock size={14} className="text-gray-400" />
-                                                            Duration: {student.providerTotalDurationMinutes} min
+                                                            Duration:{' '}
+                                                            {formatAttendedDuration(
+                                                                student.providerTotalDurationMinutes,
+                                                                student.providerTotalDurationSeconds
+                                                            )}
                                                         </span>
                                                     )}
                                                     {engagement && (

--- a/frontend-admin-dashboard/src/routes/study-library/live-session/-services/utils.ts
+++ b/frontend-admin-dashboard/src/routes/study-library/live-session/-services/utils.ts
@@ -266,6 +266,8 @@ export interface LiveSessionReport {
     statusType: string | null;
     engagementData: string | null;
     providerTotalDurationMinutes: number | null;
+    /** Exact seconds when the provider reports them (Vacademy Meet); null for Zoom. */
+    providerTotalDurationSeconds?: number | null;
     feedbackDetails: string | null;
 }
 


### PR DESCRIPTION
…absence

Three follow-ups to the minimum-attendance rule, all inert unless a class opted in.

1. Second-level precision.

BBB reports each attendee's time in the room in seconds; we stored only (seconds / 60) as an integer. That floor always counted against the learner and decided borderline cases: on a 7-minute class at 60% the bar is 4.2 minutes, so a learner present for 4m50s (69%) was truncated to 4 and marked ABSENT for a class they clearly attended.

V469 adds provider_total_duration_seconds alongside the existing minutes column, which reports, CSV export, the workflow query layer, Institute Pulse and the learner past-sessions endpoint all read - changing that column's unit would have broken every one of them silently, by a factor of 60.

The rule now compares exact seconds. Minutes is DERIVED from the seconds total rather than summed as a second independent series: two columns holding one fact drift the moment an edit touches only one, and per-callback flooring compounded the loss - floor(90s) + floor(90s) reported 2 minutes for 3 minutes of attendance. Minutes is also now rounded rather than floored, so its error is +/-30s and unbiased instead of 0..59s always against the learner.

Zoom reports whole minutes only, so the seconds column stays NULL there and the evaluator falls back to minutes * 60. The audit records an exactSeconds flag so a floored figure is visible rather than silent.

2. One notification per class, after the verdict.

While a rule is in force the join-time PRESENT mail is suppressed: that row only records that the learner opened the join link, so "you were marked present" is not yet true. Without this a learner who leaves early is told PRESENT at 15:38 and ABSENT at 15:52 for the same class. The evaluator's first evaluation now always notifies - including the PRESENT confirmation - so suppressing the early mail cannot leave an attending learner with no message at all. Later syncs still notify only on a real change of verdict.

3. Absences say why.

sendAttendanceNotification takes an optional reason; the existing 3-arg signature delegates with null so nothing else changes wording. An absent learner now reads "You were in the class for 4m 50s of its 7m. At least 4m 12s (60%) was required to be marked present." The admin table shows m:ss where seconds exist and falls back to whole minutes for Zoom. CSV export stays numeric minutes - a spreadsheet needs a value it can sort and sum.

Note for deploy: BBB attendance minutes will read up to a minute higher than before. Existing rows are not rewritten, so the step change is at the boundary.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
