### PR TITLE
feat(enroll-invite): notify the team when someone fills an invite form

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/controller/OpenLearnerEnrollInviteController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/controller/OpenLearnerEnrollInviteController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import vacademy.io.admin_core_service.features.enroll_invite.dto.EnrollInviteDTO;
 import vacademy.io.admin_core_service.features.enroll_invite.service.EnrollInviteService;
+import vacademy.io.admin_core_service.features.enroll_invite.service.InviteFormAdminNotificationService;
 import vacademy.io.admin_core_service.features.enroll_invite.service.LearnerEnrollInviteService;
 
 @RestController
@@ -20,6 +21,9 @@ public class OpenLearnerEnrollInviteController {
     @Autowired
     private EnrollInviteService enrollInviteService;
 
+    @Autowired
+    private InviteFormAdminNotificationService inviteFormAdminNotificationService;
+
     @GetMapping
     public ResponseEntity<EnrollInviteDTO> getEnrollInvite(String instituteId, String inviteCode) {
         return ResponseEntity.ok(learnerEnrollInviteService.getEnrollInvite(instituteId, inviteCode));
@@ -28,6 +32,9 @@ public class OpenLearnerEnrollInviteController {
     @GetMapping("/{instituteId}/{enrollInviteId}")
     public ResponseEntity<EnrollInviteDTO> getEnrollInviteById(@PathVariable("instituteId") String instituteId,
             @PathVariable("enrollInviteId") String enrollInviteId) {
-        return ResponseEntity.ok(enrollInviteService.findByEnrollInviteId(enrollInviteId, instituteId));
+        EnrollInviteDTO dto = enrollInviteService.findByEnrollInviteId(enrollInviteId, instituteId);
+        // Open endpoint — strip the team-notification email list before it reaches the browser.
+        dto.setSettingJson(inviteFormAdminNotificationService.redactFromSettingJson(dto.getSettingJson()));
+        return ResponseEntity.ok(dto);
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/dto/EnrollInviteSettingDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/dto/EnrollInviteSettingDTO.java
@@ -28,8 +28,36 @@ public class EnrollInviteSettingDTO {
         @JsonProperty("SUB_ORG_SETTING")
         private SubOrgSetting subOrgSetting;
 
+        /**
+         * Team-notification config for this invite link: who gets mailed when a
+         * learner fills the enrollment form. Mirrors the audience campaign's
+         * to_notify, but kept in setting_json so no new column is needed.
+         */
+        @JsonProperty("NOTIFICATION_SETTING")
+        private NotificationSetting notificationSetting;
+
 
         // You can add other top-level setting blocks here
+    }
+
+    // --- Team Notification Setting Block ---
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class NotificationSetting {
+
+        /**
+         * Comma-separated team email addresses that receive the "form filled"
+         * alert. Same storage shape as audience.to_notify.
+         */
+        @JsonProperty("TO_NOTIFY")
+        private String toNotify;
+
+        /**
+         * Explicit off-switch. Null is treated as enabled so a saved recipient
+         * list keeps working; only {@code false} suppresses the alert.
+         */
+        @JsonProperty("ENABLED")
+        private Boolean enabled;
     }
 
     // --- Sub-Organization Setting Block ---

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/EnrollmentFormService.java
@@ -44,14 +44,17 @@ public class EnrollmentFormService {
     @Autowired
     private CustomFieldValueService customFieldValueService;
 
+    @Autowired
+    private InviteFormAdminNotificationService inviteFormAdminNotificationService;
+
 
     @Transactional
     public EnrollmentFormSubmitResponseDTO submitEnrollmentForm(EnrollmentFormSubmitDTO request) {
-        log.info("Processing enrollment form submission for email: {}", 
+        log.info("Processing enrollment form submission for email: {}",
                 request.getUserDetails() != null ? request.getUserDetails().getEmail() : "null");
 
         // Step 1: Validate EnrollInvite
-        validateEnrollInvite(request.getEnrollInviteId(), request.getInstituteId());
+        EnrollInvite enrollInvite = validateEnrollInvite(request.getEnrollInviteId(), request.getInstituteId());
 
         // Step 2: Create or update user
         UserDTO createdUser = studentRegistrationManager.createUserFromAuthService(
@@ -107,6 +110,15 @@ public class EnrollmentFormService {
                     CustomFieldValueSourceTypeEnum.USER.name(),
                     createdUser.getId());
         }
+
+        // Step 6: Alert the team members configured on this invite
+        // (setting_json → setting.NOTIFICATION_SETTING). FREE invites never reach this
+        // endpoint — the learner FE skips form-submit for them — so that path fires the
+        // same notification from LearnerEnrollRequestService instead.
+        inviteFormAdminNotificationService.notifyAdminsOnFormFill(
+                enrollInvite,
+                createdUser,
+                request.getCustomFieldValues());
 
         log.info("Enrollment form submitted successfully for user: {}, created {} ABANDONED_CART entries",
                 createdUser.getId(), abandonedCartEntryIds.size());

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/InviteFormAdminNotificationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/InviteFormAdminNotificationService.java
@@ -1,0 +1,343 @@
+package vacademy.io.admin_core_service.features.enroll_invite.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.common.entity.CustomFields;
+import vacademy.io.admin_core_service.features.common.repository.CustomFieldRepository;
+import vacademy.io.admin_core_service.features.enroll_invite.dto.EnrollInviteSettingDTO;
+import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
+import vacademy.io.admin_core_service.features.notification_service.service.NotificationService;
+import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.common.dto.CustomFieldValueDTO;
+import vacademy.io.common.notification.dto.GenericEmailRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Sends the "someone filled your invite form" alert to the team members an admin
+ * configured on the invite link.
+ *
+ * <p>
+ * This is the enroll-invite twin of the audience campaign's Team Notifications
+ * (audience.to_notify): the recipient list is authored on the invite-creation
+ * form and stored in enroll_invite.setting_json under
+ * {@code setting.NOTIFICATION_SETTING.TO_NOTIFY} as a comma-separated string, so
+ * no schema change is needed.
+ *
+ * <p>
+ * Every failure here is swallowed — a bad mailbox or a notification-service
+ * outage must never fail the learner's form submission or enrollment.
+ */
+@Slf4j
+@Service
+public class InviteFormAdminNotificationService {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private CustomFieldRepository customFieldRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * Mails every configured team member with the details the learner just submitted.
+     *
+     * @param enrollInvite      the invite whose form was filled (carries the recipient list)
+     * @param user              the learner who filled the form
+     * @param customFieldValues the custom-field answers from the submission (may be null)
+     */
+    public void notifyAdminsOnFormFill(EnrollInvite enrollInvite,
+            UserDTO user,
+            List<CustomFieldValueDTO> customFieldValues) {
+        try {
+            if (enrollInvite == null) {
+                return;
+            }
+
+            List<String> recipients = resolveRecipients(enrollInvite);
+            if (CollectionUtils.isEmpty(recipients)) {
+                return;
+            }
+
+            Map<String, String> customFields = buildCustomFieldMapForEmail(customFieldValues);
+            String inviteName = StringUtils.hasText(enrollInvite.getName())
+                    ? enrollInvite.getName()
+                    : "Invite Link";
+            String body = buildAdminNotificationBody(
+                    inviteName,
+                    user != null ? user.getFullName() : null,
+                    user != null ? user.getEmail() : null,
+                    user != null ? user.getMobileNumber() : null,
+                    customFields);
+
+            log.info("Sending invite-form notification for invite {} to {} recipient(s)",
+                    enrollInvite.getId(), recipients.size());
+
+            for (String recipient : recipients) {
+                GenericEmailRequest emailRequest = new GenericEmailRequest();
+                emailRequest.setTo(recipient);
+                emailRequest.setSubject("New Form Submission - " + inviteName);
+                emailRequest.setBody(body);
+
+                try {
+                    notificationService.sendGenericHtmlMailViaUnified(emailRequest, enrollInvite.getInstituteId());
+                    log.info("Sent invite-form notification to: {}", recipient);
+                } catch (Exception ex) {
+                    log.error("Failed to send invite-form notification to {}: {}", recipient, ex.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to send invite-form admin notifications for invite {}: {}",
+                    enrollInvite != null ? enrollInvite.getId() : null, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Strips {@code setting.NOTIFICATION_SETTING} out of a setting_json blob.
+     *
+     * <p>
+     * The learner-facing invite endpoints are open (no auth) and hand the whole
+     * setting_json to the browser so the FE can read the availability message and
+     * post-form-fill config. The team's email addresses have no business being in
+     * that payload, so every open read runs the JSON through here first.
+     *
+     * @return the setting_json without the notification block, or the input unchanged
+     *         when there is nothing to strip
+     */
+    public String redactFromSettingJson(String settingJson) {
+        if (!StringUtils.hasText(settingJson)) {
+            return settingJson;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(settingJson);
+            JsonNode setting = root.get("setting");
+            if (!(setting instanceof ObjectNode) || !setting.has("NOTIFICATION_SETTING")) {
+                return settingJson;
+            }
+            ((ObjectNode) setting).remove("NOTIFICATION_SETTING");
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception e) {
+            log.warn("Could not redact notification settings from setting_json: {}", e.getMessage());
+            return settingJson;
+        }
+    }
+
+    /**
+     * Reads setting_json → setting.NOTIFICATION_SETTING and returns the de-duplicated,
+     * trimmed recipient list. An explicit {@code ENABLED: false} turns the alert off
+     * without the admin having to clear the addresses.
+     */
+    private List<String> resolveRecipients(EnrollInvite enrollInvite) {
+        if (!StringUtils.hasText(enrollInvite.getSettingJson())) {
+            return Collections.emptyList();
+        }
+
+        EnrollInviteSettingDTO settingDTO;
+        try {
+            settingDTO = objectMapper.readValue(enrollInvite.getSettingJson(), EnrollInviteSettingDTO.class);
+        } catch (Exception e) {
+            log.warn("Could not parse setting_json for invite {}: {}", enrollInvite.getId(), e.getMessage());
+            return Collections.emptyList();
+        }
+
+        if (settingDTO == null || settingDTO.getSetting() == null
+                || settingDTO.getSetting().getNotificationSetting() == null) {
+            return Collections.emptyList();
+        }
+
+        EnrollInviteSettingDTO.NotificationSetting notificationSetting = settingDTO.getSetting()
+                .getNotificationSetting();
+        if (Boolean.FALSE.equals(notificationSetting.getEnabled())) {
+            return Collections.emptyList();
+        }
+        if (!StringUtils.hasText(notificationSetting.getToNotify())) {
+            return Collections.emptyList();
+        }
+
+        Set<String> seen = new LinkedHashSet<>();
+        List<String> recipients = new ArrayList<>();
+        for (String email : notificationSetting.getToNotify().split(",")) {
+            String trimmed = email.trim();
+            if (!StringUtils.hasText(trimmed)) {
+                continue;
+            }
+            if (seen.add(trimmed.toLowerCase(Locale.ROOT))) {
+                recipients.add(trimmed);
+            }
+        }
+        return recipients;
+    }
+
+    /**
+     * Turns the submitted custom-field answers into a readable {label -> value} map by
+     * resolving each custom_field_id against its definition.
+     */
+    private Map<String, String> buildCustomFieldMapForEmail(List<CustomFieldValueDTO> customFieldValues) {
+        if (CollectionUtils.isEmpty(customFieldValues)) {
+            return Collections.emptyMap();
+        }
+
+        Set<String> customFieldIds = customFieldValues.stream()
+                .map(CustomFieldValueDTO::getCustomFieldId)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+
+        if (customFieldIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> fieldIdToName = new HashMap<>();
+        try {
+            for (CustomFields definition : customFieldRepository.findAllById(customFieldIds)) {
+                fieldIdToName.putIfAbsent(definition.getId(), definition.getFieldName());
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve custom field labels for invite-form notification: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+
+        // LinkedHashMap so the email lists the answers in the order the learner filled them.
+        Map<String, String> result = new LinkedHashMap<>();
+        for (CustomFieldValueDTO value : customFieldValues) {
+            String fieldName = fieldIdToName.get(value.getCustomFieldId());
+            if (StringUtils.hasText(fieldName) && StringUtils.hasText(value.getValue())) {
+                result.put(fieldName, value.getValue());
+            }
+        }
+        return result;
+    }
+
+    private String buildAdminNotificationBody(String inviteName, String userName, String userEmail,
+            String userMobile, Map<String, String> customFields) {
+        StringBuilder emailBody = new StringBuilder();
+
+        java.time.ZonedDateTime now = java.time.ZonedDateTime.now();
+        java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter
+                .ofPattern("MMM dd, yyyy hh:mm a z");
+        String submissionTime = now.format(formatter);
+
+        emailBody.append("<!DOCTYPE html>");
+        emailBody.append("<html lang='en'>");
+        emailBody.append("<head>");
+        emailBody.append("<meta charset='UTF-8'>");
+        emailBody.append("<meta name='viewport' content='width=device-width, initial-scale=1.0'>");
+        emailBody.append("<style>");
+        emailBody.append(
+                "body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f5f5f5; margin: 0; padding: 0; }");
+        emailBody.append(
+                ".container { max-width: 600px; margin: 30px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); overflow: hidden; }");
+        emailBody
+                .append(".header { background-color: #2c3e50; color: white; padding: 30px 20px; text-align: center; }");
+        emailBody.append(".header h1 { margin: 0; font-size: 24px; font-weight: 600; }");
+        emailBody.append(
+                ".badge { background-color: rgba(255,255,255,0.2); padding: 5px 15px; border-radius: 20px; display: inline-block; margin-top: 10px; font-size: 14px; }");
+        emailBody.append(".content { padding: 30px 20px; }");
+        emailBody.append(".alert-icon { text-align: center; margin-bottom: 20px; font-size: 48px; }");
+        emailBody.append(
+                ".message { color: #333; font-size: 16px; line-height: 1.6; margin-bottom: 25px; text-align: center; }");
+        emailBody.append(".invite-name { color: #2c3e50; font-weight: 600; font-size: 18px; }");
+        emailBody.append(
+                ".info-section { background-color: #f9f9f9; border-left: 4px solid #2c3e50; padding: 15px 20px; margin: 20px 0; border-radius: 4px; }");
+        emailBody.append(".info-section h3 { color: #2c3e50; margin: 0 0 15px 0; font-size: 16px; font-weight: 600; }");
+        emailBody.append(".info-item { display: flex; padding: 8px 0; border-bottom: 1px solid #e9ecef; }");
+        emailBody.append(".info-item:last-child { border-bottom: none; }");
+        emailBody.append(".info-label { font-weight: 600; color: #495057; min-width: 140px; }");
+        emailBody.append(".info-value { color: #6c757d; flex: 1; word-break: break-word; }");
+        emailBody.append(
+                ".action-section { background-color: #e8e8e8; padding: 20px; margin: 25px 0; border-radius: 8px; text-align: center; border-left: 4px solid #2c3e50; }");
+        emailBody.append(".action-section p { color: #2c3e50; margin: 0; font-size: 14px; font-weight: 600; }");
+        emailBody.append(
+                ".footer { background-color: #f9f9f9; padding: 20px; text-align: center; color: #6c757d; font-size: 14px; }");
+        emailBody.append(".footer p { margin: 5px 0; }");
+        emailBody.append("</style>");
+        emailBody.append("</head>");
+        emailBody.append("<body>");
+        emailBody.append("<div class='container'>");
+
+        emailBody.append("<div class='header'>");
+        emailBody.append("<h1>&#128276; New Form Submission</h1>");
+        emailBody.append("<div class='badge'>Admin Alert</div>");
+        emailBody.append("</div>");
+
+        emailBody.append("<div class='content'>");
+        emailBody.append("<div class='alert-icon'>&#127919;</div>");
+        emailBody.append("<div class='message'>");
+        emailBody.append("Someone just filled the enrollment form for:<br>");
+        emailBody.append("<span class='invite-name'>").append(escapeHtml(inviteName)).append("</span>");
+        emailBody.append("</div>");
+
+        emailBody.append("<div class='info-section'>");
+        emailBody.append("<h3>Submission Details</h3>");
+        appendInfoItem(emailBody, "Name", userName);
+        appendInfoItem(emailBody, "Email", userEmail);
+        appendInfoItem(emailBody, "Mobile", userMobile);
+        appendInfoItem(emailBody, "Submitted", submissionTime);
+        emailBody.append("</div>");
+
+        if (!CollectionUtils.isEmpty(customFields)) {
+            emailBody.append("<div class='info-section'>");
+            emailBody.append("<h3>Additional Information</h3>");
+            for (Map.Entry<String, String> entry : customFields.entrySet()) {
+                appendInfoItem(emailBody, entry.getKey(), entry.getValue());
+            }
+            emailBody.append("</div>");
+        }
+
+        emailBody.append("<div class='action-section'>");
+        emailBody.append(
+                "<p>&#128161; <strong>Action Required:</strong> Follow up with this learner as soon as possible to maximize conversion.</p>");
+        emailBody.append("</div>");
+
+        emailBody.append("</div>");
+
+        emailBody.append("<div class='footer'>");
+        emailBody.append("<p>This is an automated notification from your enrollment system.</p>");
+        emailBody.append("</div>");
+
+        emailBody.append("</div>");
+        emailBody.append("</body>");
+        emailBody.append("</html>");
+
+        return emailBody.toString();
+    }
+
+    private void appendInfoItem(StringBuilder emailBody, String label, String value) {
+        if (!StringUtils.hasText(value)) {
+            return;
+        }
+        emailBody.append("<div class='info-item'>");
+        emailBody.append("<span class='info-label'>").append(escapeHtml(label)).append(":</span>");
+        emailBody.append("<span class='info-value'>").append(escapeHtml(value)).append("</span>");
+        emailBody.append("</div>");
+    }
+
+    /** Learner-supplied answers land in an HTML mail, so keep them from breaking the markup. */
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/LearnerEnrollInviteService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enroll_invite/service/LearnerEnrollInviteService.java
@@ -27,6 +27,9 @@ public class LearnerEnrollInviteService {
     @Autowired
     private WorkflowTriggerService workflowTriggerService;
 
+    @Autowired
+    private InviteFormAdminNotificationService inviteFormAdminNotificationService;
+
     /**
      * Fetches and validates an active enroll invite by instituteId and inviteCode.
      *
@@ -54,6 +57,8 @@ public class LearnerEnrollInviteService {
                 .orElseThrow(() -> new VacademyException("Enroll invite not found."));
 
         EnrollInviteDTO result = enrollInviteService.buildFullEnrollInviteDTO(enrollInvite, instituteId);
+        // This endpoint is open — keep the team-notification email list out of the payload.
+        result.setSettingJson(inviteFormAdminNotificationService.redactFromSettingJson(result.getSettingJson()));
 
         // Only fire the form-fill workflow when the invite is actually open for enrollment.
         if (EnrollInviteAvailabilityUtil.isAvailable(enrollInvite)) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerEnrollRequestService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/LearnerEnrollRequestService.java
@@ -12,6 +12,7 @@ import vacademy.io.admin_core_service.features.enroll_invite.dto.EnrollInviteSet
 import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
 import vacademy.io.admin_core_service.features.enroll_invite.enums.EnrollInviteTag;
 import vacademy.io.admin_core_service.features.enroll_invite.service.EnrollInviteService;
+import vacademy.io.admin_core_service.features.enroll_invite.service.InviteFormAdminNotificationService;
 import vacademy.io.admin_core_service.features.enroll_invite.service.SubOrgService;
 import vacademy.io.admin_core_service.features.faculty.dto.AddUserAccessDTO;
 import vacademy.io.admin_core_service.features.faculty.service.FacultyService;
@@ -108,6 +109,9 @@ public class LearnerEnrollRequestService {
 
     @Autowired
     private SubOrgService subOrgService;
+
+    @Autowired
+    private InviteFormAdminNotificationService inviteFormAdminNotificationService;
 
     @Autowired
     private PackageSessionRepository packageSessionRepository;
@@ -447,6 +451,17 @@ public class LearnerEnrollRequestService {
                 paymentOption,
                 userPlan,
                 extraData);
+
+        // Invite-form team notification for FREE invites only. The learner FE skips the
+        // /open/v1/enrollment/form-submit step when the invite is FREE, so this is the
+        // only place their submission is observed; every other payment type is notified
+        // from EnrollmentFormService, which keeps it exactly-once either way.
+        if (PaymentOptionType.FREE.name().equals(paymentOption.getType())) {
+            inviteFormAdminNotificationService.notifyAdminsOnFormFill(
+                    enrollInvite,
+                    learnerEnrollRequestDTO.getUser(),
+                    enrollDTO.getCustomFieldValues());
+        }
 
         // B2B: Post-processing for SUB_ORG invite enrollment
         // Creates ROOT_ADMIN mappings, StudentSubOrg entry, and faculty mappings

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-components/TeamNotificationsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-components/TeamNotificationsCard.tsx
@@ -1,0 +1,73 @@
+import { forwardRef } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { UseFormReturn } from 'react-hook-form';
+import { BellRinging } from '@phosphor-icons/react';
+import MultiEmailInput, {
+    MultiEmailInputHandle,
+} from '@/routes/audience-manager/list/-components/audience-invite/components/MultiEmailInput';
+import { InviteLinkFormValues } from '../GenerateInviteLinkSchema';
+
+interface TeamNotificationsCardProps {
+    form: UseFormReturn<InviteLinkFormValues>;
+}
+
+/**
+ * Team Notifications for an invite link — the enroll-invite twin of the audience
+ * campaign's Team Notifications box. Every address listed here is mailed when a
+ * learner fills this invite's enrollment form. Persisted to
+ * setting_json.setting.NOTIFICATION_SETTING.TO_NOTIFY (comma-separated).
+ *
+ * Forwards the MultiEmailInput handle so the dialog can flush a half-typed
+ * address into the list at submit time — the input's `blur` doesn't reliably
+ * fire first when the submit button is clicked (Safari/Firefox on macOS).
+ */
+const TeamNotificationsCard = forwardRef<MultiEmailInputHandle, TeamNotificationsCardProps>(
+    ({ form }, ref) => {
+        return (
+            <Card className="mb-4">
+                <CardHeader>
+                    <div className="flex items-center gap-2">
+                        <div>
+                            <div className="flex items-center gap-2">
+                                <BellRinging size={22} />
+                                <CardTitle className="text-2xl font-bold">
+                                    Team Notifications
+                                </CardTitle>
+                            </div>
+                            <span className="text-sm text-gray-600">
+                                Enter email addresses of team members who should be notified
+                                whenever someone fills this invite form. Leave empty to send no
+                                notifications.
+                            </span>
+                        </div>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <FormField
+                        control={form.control}
+                        name="teamNotificationEmails"
+                        render={({ field, fieldState }) => (
+                            <FormItem>
+                                <FormControl>
+                                    <MultiEmailInput
+                                        ref={ref}
+                                        value={field.value ?? []}
+                                        onChange={field.onChange}
+                                        placeholder="Enter email addresses"
+                                        error={fieldState.error?.message}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                </CardContent>
+            </Card>
+        );
+    }
+);
+
+TeamNotificationsCard.displayName = 'TeamNotificationsCard';
+
+export default TeamNotificationsCard;

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
@@ -510,6 +510,24 @@ export function convertInviteData(
                 const { AVAILABILITY_SETTING: _removedAvail, ...restSetting } = next.setting;
                 next.setting = restSetting;
             }
+            // Team notifications → setting.NOTIFICATION_SETTING.TO_NOTIFY (comma-separated,
+            // same shape as audience.to_notify). The backend mails each address when a
+            // learner fills this invite's form. Removed when the admin clears the list.
+            const notifyEmails = (data.teamNotificationEmails || [])
+                .map((email) => email.trim())
+                .filter(Boolean);
+            if (notifyEmails.length > 0) {
+                next.setting = {
+                    ...(next.setting || existing.setting || {}),
+                    NOTIFICATION_SETTING: {
+                        ENABLED: true,
+                        TO_NOTIFY: notifyEmails.join(', '),
+                    },
+                };
+            } else if (next.setting?.NOTIFICATION_SETTING) {
+                const { NOTIFICATION_SETTING: _removedNotify, ...restSetting } = next.setting;
+                next.setting = restSetting;
+            }
             return JSON.stringify(next);
         })(),
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkDialog.tsx
@@ -37,6 +37,8 @@ import CustomHTMLCard from './-components/CustomHTMLCard';
 import InviteAvailabilityCard from './-components/InviteAvailabilityCard';
 import PostFormFillConfigurationCard from './-components/PostFormFillConfigurationCard';
 import SubOrgSettingsCard from './-components/SubOrgSettingsCard';
+import TeamNotificationsCard from './-components/TeamNotificationsCard';
+import { MultiEmailInputHandle } from '@/routes/audience-manager/list/-components/audience-invite/components/MultiEmailInput';
 import { toast } from 'sonner';
 import { AxiosError } from 'axios';
 import { handleEnrollInvite, handleGetEnrollSingleInviteDetails } from './-services/enroll-invite';
@@ -166,6 +168,7 @@ const GenerateInviteLinkDialog = ({
             accessDurationDays: '',
             inviteeEmail: '',
             inviteeEmails: [],
+            teamNotificationEmails: [],
             customHtml: '',
             showRelatedCourses: false,
             selectedOptionValue: 'textfield',
@@ -244,6 +247,9 @@ const GenerateInviteLinkDialog = ({
 
     const { uploadFile, getPublicUrl } = useFileUpload();
 
+    // Lets the submit handler commit a half-typed Team Notifications address before
+    // the payload is built (the input's blur is unreliable on a button click).
+    const teamNotificationsRef = useRef<MultiEmailInputHandle>(null);
     const coursePreviewRef = useRef<HTMLInputElement>(null);
     const courseBannerRef = useRef<HTMLInputElement>(null);
     const courseMediaRef = useRef<HTMLInputElement>(null);
@@ -900,6 +906,13 @@ const GenerateInviteLinkDialog = ({
                         memberCount: subOrg?.MEMBER_COUNT ?? null,
                     };
                 })(),
+                teamNotificationEmails: (
+                    safeJsonParse(inviteLinkDetails?.setting_json, {})?.setting
+                        ?.NOTIFICATION_SETTING?.TO_NOTIFY || ''
+                )
+                    .split(',')
+                    .map((email: string) => email.trim())
+                    .filter(Boolean),
                 autopaySettings: (() => {
                     const autopay = safeJsonParse(inviteLinkDetails?.setting_json, {})?.setting
                         ?.AUTOPAY_SETTING;
@@ -1040,6 +1053,9 @@ const GenerateInviteLinkDialog = ({
 
                             {/* Sub-organization Settings Card */}
                             <SubOrgSettingsCard form={form} />
+
+                            {/* Team members notified on every form fill */}
+                            <TeamNotificationsCard form={form} ref={teamNotificationsRef} />
                         </form>
                     </Form>
                 </div>
@@ -1058,7 +1074,10 @@ const GenerateInviteLinkDialog = ({
                         scale="small"
                         buttonType="primary"
                         className="p-5"
-                        onClick={handleSubmit(onSubmit, onInvalid)}
+                        onClick={() => {
+                            teamNotificationsRef.current?.flush();
+                            handleSubmit(onSubmit, onInvalid)();
+                        }}
                         disable={!form.watch('name') || handleSubmitInviteLinkMutation.isPending}
                     >
                         {handleSubmitInviteLinkMutation.isPending ? (

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
@@ -302,6 +302,11 @@ export const inviteLinkSchema = z.object({
         .transform((val) => val ?? ''),
     inviteeEmail: z.string().default(''),
     inviteeEmails: z.array(z.string()).default([]),
+    // Team members mailed whenever a learner fills this invite's enrollment form.
+    // Mirrors the audience campaign's Team Notifications (audience.to_notify);
+    // serialized to setting_json.setting.NOTIFICATION_SETTING.TO_NOTIFY as a
+    // comma-separated string.
+    teamNotificationEmails: z.array(z.string()).default([]),
     customHtml: z.string().default(''),
     showRelatedCourses: z.boolean().default(false),
     selectedOptionValue: z.string().default('textfield'),


### PR DESCRIPTION
Ports the audience campaign's Team Notifications to the invite link. Admins list team email addresses on the invite-creation form and every one of them gets a "new form submission" mail — learner name, email, mobile and their custom-field answers — the moment a learner submits.

The recipient list lives in enroll_invite.setting_json under setting.NOTIFICATION_SETTING.TO_NOTIFY (comma-separated, same shape as audience.to_notify), so there is no schema change.

Two send sites, mutually exclusive so the mail goes out exactly once: EnrollmentFormService covers every paid/CPO/donation invite, and LearnerEnrollRequestService covers FREE invites, which the learner app deliberately skips /open/v1/enrollment/form-submit for.

The open learner invite endpoints hand the whole setting_json to the browser, so both now strip NOTIFICATION_SETTING before responding — the team's addresses have no business in a public payload. The authenticated /v1/enroll-invite read the admin dialog uses is untouched, so edit-mode hydration still sees the saved list.

Sending is entirely best-effort: a bad mailbox or a notification-service outage can never fail a submission or an enrollment.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
