### PR TITLE
fix(ai-calling): never rotate a lead away from the counsellor who own…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallOutcomeProcessor.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallOutcomeProcessor.java
@@ -12,8 +12,10 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
 import vacademy.io.admin_core_service.features.audience.entity.LeadStatus;
+import vacademy.io.admin_core_service.features.audience.entity.UserLeadProfile;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
 import vacademy.io.admin_core_service.features.audience.repository.LeadStatusRepository;
+import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
 import vacademy.io.admin_core_service.features.audience.service.LeadStatusService;
 import vacademy.io.admin_core_service.features.audience.service.UserLeadProfileService;
 import vacademy.io.admin_core_service.features.counselor_pool.service.CounselorAssignmentService;
@@ -72,6 +74,7 @@ public class AiCallOutcomeProcessor {
     private final LeadStatusService leadStatusService;
     private final CounselorAssignmentService counselorAssignmentService;
     private final UserLeadProfileService userLeadProfileService;
+    private final UserLeadProfileRepository userLeadProfileRepository;
     private final AiCallingSettingsService settingsService;
     private final AiCallOutcomeClassifier classifier;
     private final CallLogService callLogService;
@@ -728,6 +731,27 @@ public class AiCallOutcomeProcessor {
     private void assignCounsellor(Lead lead) {
         if (lead.audienceId() == null || lead.userId() == null) {
             log.info("ai-call assign: skipped (no audience/user) for lead {}", lead.userId());
+            return;
+        }
+        // A lead that ALREADY has a counsellor keeps them. The rotation exists to give an
+        // UNOWNED lead an owner, not to move one between people.
+        //
+        // Before CALL_AI could opt out of the already-assigned guard, this could not happen:
+        // automation never dialled an owned lead, so every lead reaching this method was
+        // unowned and the rotation was always the right answer. With ignoreAssignedGuard the
+        // canonical flow is "counsellor rings the lead, marks it DNP, the bot re-calls" — and
+        // without this check that flow ENDS by handing their lead to whoever is next in the
+        // rotation and ringing that person's bell, silently taking it off the counsellor who
+        // is actively working it. assignCounselor() overwrites assigned_counselor_id with no
+        // guard of its own (it is also the manual-reassignment path, so it must not grow one).
+        String currentOwner = userLeadProfileRepository
+                .findByUserIdAndInstituteId(lead.userId(), lead.instituteId())
+                .map(UserLeadProfile::getAssignedCounselorId)
+                .filter(id -> id != null && !id.isBlank())
+                .orElse(null);
+        if (currentOwner != null) {
+            log.info("ai-call assign: lead {} already owned by counsellor {} — keeping them (no rotation)",
+                    lead.userId(), currentOwner);
             return;
         }
         Optional<String> counselorId = counselorAssignmentService.assignCounselorForLead(lead.audienceId());


### PR DESCRIPTION
…s it

The AI-call handoff ended with counselorAssignmentService picking the NEXT counsellor in the round-robin and userLeadProfileService.assignCounselor overwriting assigned_counselor_id unconditionally. For an UNOWNED lead that is correct and is the whole point of the rotation.

For an owned lead it silently transfers the lead. Two paths reach it:

- the new ignoreAssignedGuard flow, whose canonical use case is "counsellor rings the lead, marks it DNP, the bot re-calls it" — that flow would have ENDED by moving their lead to whoever is next in the rotation and ringing that person's bell instead;
- a manual click-to-AI-call (CallTrigger.MANUAL) on a lead the counsellor already owns, which has always been able to reach this and reassign it away from the person who clicked.

So keep an existing owner and skip the rotation entirely — which also leaves the pool pointer untouched, correct since nobody received a new lead, and skips the pool-admin "could not auto-assign" alert, correct since the lead is not unassigned.

The guard belongs here and not in UserLeadProfileService.assignCounselor: that method is also the manual-reassignment / bulk-import / backup path, which must keep overwriting.

Unowned leads are unaffected, so the existing exhausted-retry handoff behaves exactly as before.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
