### PR TITLE
fix(ai-calling): queue primary keys are VARCHAR, not UUID

### DIFF
--- a/admin_core_service/src/main/resources/db/migration/V473__ai_call_queue_id_varchar.sql
+++ b/admin_core_service/src/main/resources/db/migration/V473__ai_call_queue_id_varchar.sql
@@ -1,0 +1,31 @@
+-- V473: the AI call queue's primary keys are VARCHAR, not UUID.
+--
+-- V472 declared ai_call_queue.id and ai_voice_box.id as UUID with a
+-- gen_random_uuid() default. Both entities map that id as a Java String annotated
+-- @UuidGenerator, exactly like every other telephony entity, so Hibernate binds a
+-- varchar parameter -- and Postgres will not implicitly cast varchar to uuid in an
+-- INSERT or in a WHERE. Every enqueue failed on staging with:
+--
+--   column "id" is of type uuid but expression is of type character varying
+--
+-- and the drain job's claimForDispatch (WHERE id = :id) would have failed the same
+-- way. The rest of the schema was already right; only these two columns deviated
+-- from the convention every sibling table follows -- telephony_call_log (V319),
+-- ai_calling_config (V344) and the rest all use VARCHAR(36) PRIMARY KEY.
+--
+-- Fixed forward in a new migration rather than by editing V472: that migration has
+-- already run, and rewriting an applied script breaks Flyway's checksum validation
+-- for every environment that has it.
+--
+-- The DEFAULT goes with the type. It was only ever used by V472's own seed row --
+-- the application always supplies its own id through @UuidGenerator -- and
+-- gen_random_uuid() cannot be a default for a varchar column anyway.
+--
+-- Safe on data: both tables hold at most the seeded voice-box row and queue rows
+-- that never dialled, and uuid::text is lossless in any case.
+
+ALTER TABLE ai_call_queue ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE ai_call_queue ALTER COLUMN id TYPE VARCHAR(36) USING id::text;
+
+ALTER TABLE ai_voice_box ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE ai_voice_box ALTER COLUMN id TYPE VARCHAR(36) USING id::text;


### PR DESCRIPTION
Every enqueue failed on staging:

  column "id" is of type uuid but expression is of type character varying

V472 declared ai_call_queue.id and ai_voice_box.id as UUID, but both entities map that id as a Java String annotated @UuidGenerator -- the same shape every other telephony entity uses -- so Hibernate binds varchar, and Postgres will not implicitly cast varchar to uuid in an INSERT. The drain job's claimForDispatch (WHERE id = :id) would have failed identically once anything reached the queue.

Only these two columns deviated from the convention; telephony_call_log (V319), ai_calling_config (V344) and the rest all use VARCHAR(36) PRIMARY KEY. The rest of the V472 schema binds correctly -- the timestamps and varchars in the failing statement all went through fine.

Fixed forward rather than by editing V472, which has already run: rewriting an applied script breaks Flyway checksum validation everywhere it landed. The DEFAULT is dropped with the type -- it only ever served V472's own seed row, the application always supplies its own id, and gen_random_uuid() cannot default a varchar column.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
