### PR TITLE
fix(ai-calling): queue page defaults to Active, and shows the number …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/persistence/repository/TelephonyCallLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/persistence/repository/TelephonyCallLogRepository.java
@@ -277,15 +277,20 @@ public interface TelephonyCallLogRepository extends JpaRepository<TelephonyCallL
             @Param("anchor") java.sql.Timestamp anchor);
 
     /**
-     * Live state of a batch of calls, as {@code [id, status, durationSeconds]}.
+     * Live state of a batch of calls, as {@code [id, status, durationSeconds, toNumber]}.
      *
      * <p>The queue's own row stops at DIALED — that means "handed to the provider" and
      * never changes again, so a call ringing right now and one that ended three hours ago
      * look identical on the queue row alone. This is what tells them apart, resolved in
      * one query per page rather than per row.
+     *
+     * <p>{@code toNumber} rides along because a queued row often has no phone of its
+     * own: the manual click and the CALL_AI node pass only a lead id, and the number is
+     * resolved downstream at dial time. Without this the queue table would show a raw
+     * user UUID where the lead's number belongs.
      */
     @Query("""
-            SELECT t.id, t.status, t.durationSeconds FROM TelephonyCallLog t
+            SELECT t.id, t.status, t.durationSeconds, t.toNumber FROM TelephonyCallLog t
             WHERE t.id IN :ids
             """)
     List<Object[]> findStatusByIds(@Param("ids") java.util.Collection<String> ids);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDirectory.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDirectory.java
@@ -60,14 +60,20 @@ public class AiCallQueueDirectory {
         for (Object[] row : callLogRepository.findStatusByIds(callLogIds)) {
             String status = (String) row[1];
             Integer duration = row[2] == null ? null : ((Number) row[2]).intValue();
-            out.put((String) row[0],
-                    new CallState(status, duration, !CallStatus.parseOrDefault(status).isTerminal()));
+            String toNumber = row.length > 3 ? (String) row[3] : null;
+            out.put((String) row[0], new CallState(status, duration,
+                    !CallStatus.parseOrDefault(status).isTerminal(), toNumber));
         }
         return out;
     }
 
-    /** What a dialled call is doing right now. */
-    public record CallState(String status, Integer durationSeconds, boolean live) {}
+    /**
+     * What a dialled call is doing right now, plus the number it actually reached —
+     * which is often the only place the lead's phone exists, since a queued row
+     * frequently carries only a lead id.
+     */
+    public record CallState(String status, Integer durationSeconds, boolean live,
+                            String toNumber) {}
 
     /** Names for one page of rows, resolved in as few queries as the page allows. */
     public Names forItems(Collection<AiCallQueueItem> items) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
@@ -74,6 +74,12 @@ public class AiCallQueueService {
      */
     public static final String LIVE_FILTER = "LIVE";
 
+    /** Waiting plus already dialling — the default view, and what "the queue" means. */
+    public static final String ACTIVE_FILTER = "ACTIVE";
+
+    /** Explicit "show me everything, finished included". */
+    public static final String ALL_FILTER = "ALL";
+
     private final AiCallQueueItemRepository repository;
     private final AiCallLaneRepository laneRepository;
     private final AiCallQueueTxOps txOps;
@@ -332,7 +338,11 @@ public class AiCallQueueService {
         Page<AiCallQueueItem> rows;
         if (LIVE_FILTER.equalsIgnoreCase(status)) {
             rows = repository.findLive(instituteId, pageable);
-        } else if (isBlank(status)) {
+        } else if (isBlank(status) || ACTIVE_FILTER.equalsIgnoreCase(status)) {
+            // Blank means ACTIVE, not "everything": the queue page's job is what has
+            // not finished, and defaulting to the full history buries it.
+            rows = repository.findActive(instituteId, pageable);
+        } else if (ALL_FILTER.equalsIgnoreCase(status)) {
             rows = repository.findByInstituteIdOrderByCreatedAtDesc(instituteId, pageable);
         } else {
             rows = repository.findByInstituteIdAndStatusOrderByCreatedAtDesc(
@@ -445,7 +455,11 @@ public class AiCallQueueService {
                 .statusReason(item.getStatusReason())
                 .responseId(item.getResponseId())
                 .userId(item.getUserId())
-                .phoneNumber(item.getPhoneNumber())
+                // A queued row often has no phone of its own — the number is resolved
+                // downstream at dial time — so fall back to what was actually dialled
+                // rather than leaving the column showing a raw id.
+                .phoneNumber(item.getPhoneNumber() != null ? item.getPhoneNumber()
+                        : (call == null ? null : call.toNumber()))
                 .campaignId(item.getCampaignId())
                 .campaignName(item.getCampaignName())
                 .attempts(item.getAttempts())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/repository/AiCallQueueItemRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/repository/AiCallQueueItemRepository.java
@@ -261,6 +261,41 @@ public interface AiCallQueueItemRepository extends JpaRepository<AiCallQueueItem
     List<Object[]> findOldestQueuedPerInstitute();
 
     /**
+     * Everything not finished yet: waiting, plus already dialling.
+     *
+     * <p>This is the queue view a person actually wants on arrival. Filtering to
+     * QUEUED alone shows an EMPTY table exactly when calling is working normally —
+     * a manual click dials immediately when a line is free, so it is never "waiting",
+     * and a busy fleet is the only state in which anything sits in QUEUED at all. A
+     * page that is blank during normal operation reads as broken.
+     *
+     * <p>LEFT JOIN, not JOIN: a QUEUED row has no call_log_id yet, and an inner join
+     * would silently drop exactly the rows the queue is named after.
+     */
+    @Query(value = """
+            SELECT q.* FROM ai_call_queue q
+             LEFT JOIN telephony_call_log t ON t.id = q.call_log_id
+             WHERE q.institute_id = :instituteId
+               AND (q.status = 'QUEUED'
+                    OR (q.status = 'DIALED'
+                        AND t.status IN ('INITIATED', 'QUEUED', 'COUNSELLOR_RINGING',
+                                         'COUNSELLOR_ANSWERED', 'IN_PROGRESS')))
+             ORDER BY CASE WHEN q.status = 'DIALED' THEN 0 ELSE 1 END,
+                      q.priority DESC, q.created_at
+            """,
+            countQuery = """
+            SELECT COUNT(*) FROM ai_call_queue q
+             LEFT JOIN telephony_call_log t ON t.id = q.call_log_id
+             WHERE q.institute_id = :instituteId
+               AND (q.status = 'QUEUED'
+                    OR (q.status = 'DIALED'
+                        AND t.status IN ('INITIATED', 'QUEUED', 'COUNSELLOR_RINGING',
+                                         'COUNSELLOR_ANSWERED', 'IN_PROGRESS')))
+            """,
+            nativeQuery = true)
+    Page<AiCallQueueItem> findActive(@Param("instituteId") String instituteId, Pageable pageable);
+
+    /**
      * Calls that are on a line RIGHT NOW.
      *
      * <p>Not expressible as a queue-status filter: the queue row stops at DIALED the

--- a/frontend-admin-dashboard/src/routes/calling/call-queue/-components/CallQueuePanel.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/call-queue/-components/CallQueuePanel.tsx
@@ -44,6 +44,10 @@ const REFETCH_MS = 10_000;
 const PAGE_SIZE = 25;
 
 const STATUS_FILTERS: Array<{ key: QueueFilter; label: string }> = [
+    // Default. Waiting + already dialling: a manual call dials the moment a line is
+    // free, so it is never "waiting", and a QUEUED-only default left this table empty
+    // whenever calling was working normally.
+    { key: 'ACTIVE', label: 'Active' },
     { key: 'QUEUED', label: 'Waiting' },
     // Distinct from Dialled on purpose: a queue row reads DIALED from the instant the
     // provider accepts it until the end of time, so "Dialled" alone mixes a call that is
@@ -53,12 +57,12 @@ const STATUS_FILTERS: Array<{ key: QueueFilter; label: string }> = [
     { key: 'FAILED', label: 'Failed' },
     { key: 'EXPIRED', label: 'Expired' },
     { key: 'CANCELLED', label: 'Cancelled' },
-    { key: '', label: 'All' },
+    { key: 'ALL', label: 'All' },
 ];
 
 export default function CallQueuePanel({ instituteId }: { instituteId: string }) {
     const queryClient = useQueryClient();
-    const [status, setStatus] = useState<QueueFilter>('QUEUED');
+    const [status, setStatus] = useState<QueueFilter>('ACTIVE');
     const [page, setPage] = useState(0);
 
     const summaryQuery = useQuery({
@@ -144,7 +148,7 @@ export default function CallQueuePanel({ instituteId }: { instituteId: string })
                 <div className="flex items-center gap-1 rounded-md border border-neutral-200 bg-white p-1">
                     {STATUS_FILTERS.map((f) => (
                         <button
-                            key={f.key || 'ALL'}
+                            key={f.key}
                             type="button"
                             onClick={() => {
                                 setStatus(f.key);
@@ -217,11 +221,13 @@ export default function CallQueuePanel({ instituteId }: { instituteId: string })
                                     colSpan={7}
                                     className="py-10 text-center text-sm text-neutral-500"
                                 >
-                                    {status === 'QUEUED'
-                                        ? 'Nothing is waiting — AI calls are going out as they are requested.'
-                                        : status === 'LIVE'
-                                          ? 'No AI calls are on a line right now.'
-                                          : 'No calls in this state.'}
+                                    {status === 'ACTIVE'
+                                        ? 'Nothing in the queue — no AI calls are waiting or in progress.'
+                                        : status === 'QUEUED'
+                                          ? 'Nothing is waiting — AI calls are going out as they are requested.'
+                                          : status === 'LIVE'
+                                            ? 'No AI calls are on a call right now.'
+                                            : 'No calls in this state.'}
                                 </TableCell>
                             </TableRow>
                         ) : (

--- a/frontend-admin-dashboard/src/routes/calling/call-queue/-services/ai-call-queue-service.ts
+++ b/frontend-admin-dashboard/src/routes/calling/call-queue/-services/ai-call-queue-service.ts
@@ -26,12 +26,17 @@ export type QueueStatus = 'QUEUED' | 'DISPATCHING' | 'DIALED' | 'FAILED' | 'EXPI
 /**
  * Filter values the list accepts: any real status, plus LIVE.
  *
- * LIVE is not a queue status. A queue row reads DIALED from the instant the provider
- * accepts the call and never moves again, so "on a line right now" can only be answered
- * by joining the call log — which the backend does for this filter. Without it, "Dialled"
- * mixes a call that is talking now with one that ended this morning.
+ * Two of these are not queue statuses:
+ *
+ * ACTIVE (the default) is waiting + already dialling — what "the queue" means to a
+ * person. Filtering to QUEUED alone shows an empty table exactly when calling is
+ * working normally, because a call only waits when every line is busy.
+ *
+ * LIVE is on a call right now. A queue row reads DIALED from the instant the provider
+ * accepts and never moves again, so liveness can only be answered by joining the call
+ * log — which the backend does for this filter.
  */
-export type QueueFilter = QueueStatus | 'LIVE' | '';
+export type QueueFilter = QueueStatus | 'ACTIVE' | 'LIVE' | 'ALL' | '';
 
 export interface QueueItem {
     id: string;


### PR DESCRIPTION
…actually dialled

Two things made the page look broken while it was working.

The default filter was QUEUED, which is empty exactly when calling is healthy. A manual click dials the moment a line is free, so it goes straight to DIALED and never "waits" -- a call only sits in QUEUED when every line is busy. So the table was blank while the stat card correctly said one call was in progress. Adds an ACTIVE filter (waiting + already dialling), now the default and what "the queue" means to a person; ALL is still there for the finished history.

The LEFT JOIN in that query is load-bearing: a QUEUED row has no call_log_id yet, and an inner join would drop precisely the rows the queue is named after.

The Lead column showed a raw user id. A queued row usually has no phone of its own -- the manual click and the CALL_AI node pass only a lead id, and the number is resolved downstream at dial time -- so the row's phone_number is NULL. The call-log lookup that already resolves live state now carries to_number too, and it fills that column when the queue row has nothing.

All four queries were executed against the real database before committing, not just compiled.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
