### PR TITLE
Assessment: default the learner preview to off

### DIFF
--- a/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step1BasicInfo.tsx
+++ b/frontend-admin-dashboard/src/routes/assessment/create-assessment/$assessmentId/$examtype/-components/StepComponents/Step1BasicInfo.tsx
@@ -595,7 +595,12 @@ const Step1BasicInfo: React.FC<StepContentProps> = ({
                 },
             },
             assessmentPreview: {
-                checked: storeDataStep1.assessmentPreview?.checked || true, // Default to true
+                // Off by default, and `??` not `||`: with `||` a stored `false` was
+                // coerced straight back to `true`, so once this had ever been on the
+                // toggle could not be turned off again — every remount re-enabled it.
+                // (The three flags below still have that coercion bug; two of them are
+                // stuck on the opposite of what their own comment says they default to.)
+                checked: storeDataStep1.assessmentPreview?.checked ?? false,
                 previewTimeLimit:
                     storeDataStep1.assessmentPreview?.previewTimeLimit || timeLimit[0], // Default preview time
             },


### PR DESCRIPTION
Two bugs on one line.

The default was `true`, and the preview screen (read-only countdown before Start Test) is not something most assessments want.

More importantly the expression was `|| true`, not `?? true`. A stored `false` was therefore coerced straight back to `true`, so once preview had ever been enabled the toggle could not be turned off again -- every remount silently re-enabled it. The trailing "// Default to true" comment described an intent the operator could not actually express.

Only new-assessment defaults were affected. Editing an existing assessment reads `checked` from `assessment_preview > 0` and was always correct.

Note the three flags immediately below still carry the same `|| true` coercion, and two of them are pinned to the opposite of what their own comments say:

    switchSections:           ... || true   // "Default to false"
    raiseReattemptRequest:    ... || true   // "Default to true"
    raiseTimeIncreaseRequest: ... || true   // "Default to false"

Left alone deliberately: changing those defaults is a behaviour change nobody has asked for yet.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
