### PR TITLE
fix(live-session): import AttendanceEmailBody so admin-core compiles

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
@@ -13,6 +13,7 @@ import vacademy.io.admin_core_service.features.live_session.entity.ScheduleNotif
 import vacademy.io.admin_core_service.features.live_session.enums.LiveClassAction;
 import vacademy.io.admin_core_service.features.live_session.enums.NotificationStatusEnum;
 import vacademy.io.admin_core_service.features.live_session.enums.NotificationTypeEnum;
+import vacademy.io.admin_core_service.features.live_session.constants.AttendanceEmailBody;
 import vacademy.io.admin_core_service.features.live_session.constants.LiveClassEmailBody;
 import vacademy.io.admin_core_service.features.live_session.service.LiveClassTemplateService;
 import vacademy.io.admin_core_service.features.live_session.service.LiveClassTemplateService.ResolvedTemplate;


### PR DESCRIPTION
CI failed with 'cannot find symbol: variable AttendanceEmailBody'. The class lives in live_session.constants while the processor is in live_session.scheduler, so it needs an explicit import — LiveClassEmailBody right beside it has one.

My local verification missed this: I filtered the build log for errors in my own files, and every run was already failing earlier on an unrelated missing package, so I read 'no errors in my files' from a build that never reached this file.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
