### PR TITLE
fix(subscriptions): disable autopay when a plan is cancelled

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserPlanService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/UserPlanService.java
@@ -126,6 +126,9 @@ public class UserPlanService {
     @Autowired
     private vacademy.io.admin_core_service.features.user_account.service.UserAccountLedgerService userAccountLedgerService;
 
+    @Autowired
+    private UserInstitutePaymentGatewayMappingService mandateService;
+
     public UserPlan createUserPlan(String userId,
             PaymentPlan paymentPlan,
             AppliedCouponDiscount appliedCouponDiscount,
@@ -1290,7 +1293,29 @@ public class UserPlanService {
                 .orElseThrow(() -> new RuntimeException("UserPlan not found with ID: " + userPlanId));
 
         userPlan.setStatus(force ? UserPlanStatusEnum.TERMINATED.name() : UserPlanStatusEnum.CANCELED.name());
+        // Cancelling has to stop autopay too. Leaving auto_renewal_enabled = true meant a
+        // cancelled plan was excluded from the renewal sweep only by its status, so any later
+        // reactivation (the manual "pay to continue" flow reuses the SAME UserPlan and flips it
+        // back to ACTIVE) silently resumed charging someone who had cancelled. Mirrors
+        // SubscriptionService.cancelSubscription, which the learner self-service path already did.
+        userPlan.setAutoRenewalEnabled(false);
         userPlanRepository.save(userPlan);
+
+        // Revoke the stored mandate for the same reason. Wrapped so a mandate failure
+        // can never undo the cancel itself.
+        try {
+            String mandateInstituteId = userPlan.getEnrollInvite() != null
+                    ? userPlan.getEnrollInvite().getInstituteId() : null;
+            String mandateVendor = userPlan.getEnrollInvite() != null
+                    ? userPlan.getEnrollInvite().getVendor() : null;
+            if (mandateInstituteId != null && !mandateInstituteId.isBlank()
+                    && mandateVendor != null && !mandateVendor.isBlank()) {
+                mandateService.revokeMandate(userPlan.getUserId(), mandateInstituteId,
+                        mandateVendor, userPlan.getId());
+            }
+        } catch (Exception me) {
+            logger.warn("Failed to revoke mandate on cancel for plan {}: {}", userPlanId, me.getMessage());
+        }
 
         // Fire the matching workflow trigger so admin/learner workflows can react
         // (welcome-back nudge on CANCEL, access-revoked email on TERMINATED, etc.).


### PR DESCRIPTION
cancelUserPlan() set only the status, leaving auto_renewal_enabled = true and the stored mandate live. A cancelled plan was therefore excluded from the renewal sweep by its status alone, so any later reactivation -- the manual "pay to continue" flow reuses the SAME UserPlan and flips it back to ACTIVE -- silently resumed charging a learner who had cancelled.

Both the soft cancel (CANCELED) and the hard cancel (TERMINATED) now clear the flag and revoke the stored mandate, matching SubscriptionService.cancelSubscription which the learner self-service path already did. The mandate revoke is wrapped so a failure there can never undo the cancel itself.

Found on SuchBliss, where 2 cancelled plans still carried auto_renewal_enabled = true (Anushka, Rachna); both corrected in the database separately.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
