### PR TITLE
fix(payments): send the learner's phone as the recurring-charge contact

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enrollment_policy/service/RenewalChargeService.java
@@ -242,6 +242,18 @@ public class RenewalChargeService {
         request.setEmail(user.getEmail());
         request.setInstituteId(instituteId);
         request.setPaymentType(PaymentType.RENEWAL);
+        // Razorpay's recurring-payment API requires a contact, and it must be a real
+        // phone number (digits and + only). It used to be filled from vendorId -- the
+        // invite's gateway id, literally "RAZORPAY" -- so every auto-charge was rejected
+        // with "Contact number contains invalid characters" before it ever reached the
+        // mandate, and the failure took its own payment_log down with it (PaymentService
+        // is @Transactional), leaving only a rising renewal_attempt_count as evidence.
+        vacademy.io.common.payment.dto.RazorpayRequestDTO razorpayRequest =
+                new vacademy.io.common.payment.dto.RazorpayRequestDTO();
+        if (StringUtils.hasText(user.getMobileNumber())) {
+            razorpayRequest.setContact(user.getMobileNumber().replaceAll("[^0-9+]", ""));
+        }
+        request.setRazorpayRequest(razorpayRequest);
 
         try {
             PaymentResponseDTO response = paymentService.handleRecurringCharge(

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
@@ -289,8 +289,13 @@ public class RazorpayPaymentManager implements PaymentServiceStrategy {
 
             JSONObject rec = new JSONObject();
             rec.put("email", request.getEmail());
-            if (StringUtils.hasText(request.getVendorId())) {
-                rec.put("contact", request.getVendorId());
+            // The payer's phone number -- NOT vendorId, which is the invite's gateway
+            // id ("RAZORPAY") and is rejected as an invalid contact.
+            String contact = request.getRazorpayRequest() != null
+                    ? request.getRazorpayRequest().getContact()
+                    : null;
+            if (StringUtils.hasText(contact)) {
+                rec.put("contact", contact);
             }
             rec.put("amount", amountInPaise);
             rec.put("currency", request.getCurrency().toUpperCase());


### PR DESCRIPTION
Razorpay's createRecurringPayment requires a `contact`, and it must be a real phone number -- digits and + only. chargeRecurring filled it from request.getVendorId(), which RenewalChargeService sets to the invite's gateway id: the literal string "RAZORPAY". Every autopay renewal was therefore rejected with

  BAD_REQUEST_ERROR: Contact number contains invalid characters,
  only digits and + symbol are allowed

before it ever reached the mandate, for every institute -- not a bank decline and nothing to do with the mandate itself.

It stayed invisible because PaymentService is @Transactional at class level, so the failure rolled back the payment_log that handleRecurringCharge had just inserted. The only trace left was a rising renewal_attempt_count, and after three dunning retries the plan silently expired.

RenewalChargeService now attaches a RazorpayRequestDTO carrying the learner's own mobile (stripped to digits and +, since stored numbers are not guaranteed clean), and chargeRecurring reads that instead of vendorId. Single caller (PaymentService.handleRecurringCharge), so nothing else is affected.

Confirmed on prod: plan a2f9ce77 failed with the above at 2026-08-31 15:46:06Z.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
