### PR TITLE
fix(payments): mark the recurring order with token_id

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
@@ -280,6 +280,13 @@ public class RazorpayPaymentManager implements PaymentServiceStrategy {
             orderRequest.put("currency", request.getCurrency().toUpperCase());
             orderRequest.put("receipt", request.getOrderId());
             orderRequest.put("payment_capture", 1);
+            // token_id is MANDATORY on an order that a subsequent recurring payment will
+            // charge -- it is what marks the order as recurring. Razorpay documents it for
+            // both the card and UPI Autopay flows (they share POST payments/create/recurring).
+            // Without it we created a plain order and then asked Razorpay to charge it as a
+            // recurring one, which it rejects with the misleading
+            // "BAD_REQUEST_ERROR: The requested URL was not found on the server".
+            orderRequest.put("token_id", mandate.getProviderRef());
             JSONObject notes = new JSONObject();
             notes.put("orderId", request.getOrderId());
             notes.put("instituteId", request.getInstituteId());


### PR DESCRIPTION
Razorpay requires token_id on the order that a subsequent recurring payment will charge -- it is what marks the order as recurring. It is documented as mandatory for both the card and the UPI Autopay flows, which share POST payments/create/recurring.

We created a plain order and then asked Razorpay to charge it as a recurring one. Razorpay rejects that with the thoroughly misleading

  BAD_REQUEST_ERROR: The requested URL was not found on the server.

which reads like a wrong endpoint or a disabled feature. Neither was the cause: the SDK path is correct (razorpay-java 1.4.6 Constants.PAYMENT_RECURRING = "payments/create/recurring") and the institute uses a live key.

Observed on prod: plan a2f9ce77 failed with the above at 2026-08-31 17:56:23Z, 3.2s after a real round trip, on the build that already carried the contact-number fix (PR #2726).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
