### PR TITLE
fix(payments): send as_presented as the mandate frequency

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
@@ -401,20 +401,23 @@ public class SubscriptionPaymentOptionOperation implements PaymentOptionOperatio
      * back to "as_presented", which imposes no fixed cadence and always registers.
      */
     private String resolveMandateFrequency(PaymentPlan paymentPlan) {
-        if (paymentPlan == null || paymentPlan.getValidityInDays() == null) {
-            return "as_presented";
-        }
-        int days = paymentPlan.getValidityInDays();
-        if (days <= 31) {
-            return "monthly";
-        } else if (days <= 95) {
-            return "quarterly";
-        } else if (days <= 190) {
-            return "halfyearly";
-        } else if (days <= 370) {
-            return "yearly";
-        }
+        // Always "as_presented".
+        //
+        // Razorpay only accepts a named cadence (monthly / quarterly / halfyearly /
+        // yearly) when the token also carries a numeric recurring_value (day 1-31).
+        // We never sent one, so every mandate registration on a plan whose validity
+        // mapped to a named cadence was rejected at source with
+        //   BAD_REQUEST_ERROR: Recurring value should be between 1 and 31 for the provided frequency
+        // -- taking the whole enrolment down with it (the learner sees "already
+        // enrolled", because the FE maps every 510 to that) and leaving orphan
+        // ledger accruals behind, since recordDebitAccrual is REQUIRES_NEW.
+        //
+        // "as_presented" is also the semantically correct value for us: we drive the
+        // charge schedule ourselves from RenewalChargeService, so the mandate should
+        // advertise "debited as presented by the merchant" rather than a fixed cycle.
+        // Every mandate in the database that actually works carries this value.
         return "as_presented";
     }
+
 
 }


### PR DESCRIPTION
Razorpay only accepts a named cadence (monthly / quarterly / halfyearly / yearly) when the token also carries a numeric recurring_value (day 1-31). We never sent one, so mandate registration was rejected at source:

  BAD_REQUEST_ERROR: Recurring value should be between 1 and 31 for the
  provided frequency

That kills the whole enrolment: initiateMandatePayment throws, recordLearnerRequest rolls back, and the learner is shown "already enrolled" because the frontend maps every 510 to that message. The committed REQUIRES_NEW ledger accrual survives the rollback, leaving phantom debt against a user_plan that no longer exists.

Introduced by 0bdecd4da3 "send real mandate frequency from plan validity" (3 Aug). The orphan-accrual burst that day began nine minutes after it deployed, and every mandate in the database that actually works still carries "as_presented".

as_presented is also the correct value for us: RenewalChargeService drives the charge schedule, so the mandate should advertise "debited as presented by the merchant", not a fixed cycle. The method's own comment already noted the value is cosmetic.

Observed on prod: soma12312@gmail.com, Half-Yearly (validity 180 -> "halfyearly"), four attempts 2026-09-01 01:34-01:39Z, all rejected.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
