### PR TITLE
fix(payments): stop sending "halfyearly" as the mandate frequency

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_option_operation/service/SubscriptionPaymentOptionOperation.java
@@ -410,7 +410,18 @@ public class SubscriptionPaymentOptionOperation implements PaymentOptionOperatio
         } else if (days <= 95) {
             return "quarterly";
         } else if (days <= 190) {
-            return "halfyearly";
+            // NOT "halfyearly". Razorpay rejects it with
+            //   BAD_REQUEST_ERROR: Recurring value should be between 1 and 31 for the provided frequency
+            // which kills mandate registration, and with it the whole enrolment:
+            // initiateMandatePayment throws, recordLearnerRequest rolls back, and the learner
+            // is shown "already enrolled" (the FE maps every 510 to that). The committed
+            // REQUIRES_NEW ledger accrual survives, leaving phantom debt behind.
+            //
+            // monthly / quarterly / yearly are all accepted -- verified against live UPI
+            // enrolments on 2026-08-31/09-01 -- so only this bucket is changed.
+            // as_presented is correct for us anyway: RenewalChargeService drives the
+            // schedule, so the mandate advertises "debited as presented by the merchant".
+            return "as_presented";
         } else if (days <= 370) {
             return "yearly";
         }


### PR DESCRIPTION
Razorpay rejects halfyearly on mandate registration:

  BAD_REQUEST_ERROR: Recurring value should be between 1 and 31 for the
  provided frequency

That kills the whole enrolment. initiateMandatePayment throws, the @Transactional recordLearnerRequest rolls back, and the learner is shown "already enrolled" because the frontend maps every 510 to that message. The ledger accrual survives the rollback (recordDebitAccrual is REQUIRES_NEW), leaving phantom debt against a user_plan that no longer exists -- which is why these failures leave almost no trace.

Scope is only this bucket. monthly, quarterly and yearly are all accepted: verified against live UPI enrolments on 2026-08-31 and 2026-09-01 (Tasneem and Ruchi on monthly, Anupama on quarterly, Nitika on yearly -- all PAID). No successful payment in the institute's history carries halfyearly.

as_presented is also the honest value for us: RenewalChargeService drives the charge schedule, so the mandate should advertise "debited as presented by the merchant" rather than a fixed cycle it will not follow.

Observed on prod: soma12312@gmail.com, Half-Yearly (validity 180), four attempts 2026-09-01 01:34-01:39Z, every one rejected at mandate creation.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
