### PR TITLE
revert(payments): stop sending token_id on the recurring order

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/RazorpayPaymentManager.java
@@ -280,13 +280,10 @@ public class RazorpayPaymentManager implements PaymentServiceStrategy {
             orderRequest.put("currency", request.getCurrency().toUpperCase());
             orderRequest.put("receipt", request.getOrderId());
             orderRequest.put("payment_capture", 1);
-            // token_id is MANDATORY on an order that a subsequent recurring payment will
-            // charge -- it is what marks the order as recurring. Razorpay documents it for
-            // both the card and UPI Autopay flows (they share POST payments/create/recurring).
-            // Without it we created a plain order and then asked Razorpay to charge it as a
-            // recurring one, which it rejects with the misleading
-            // "BAD_REQUEST_ERROR: The requested URL was not found on the server".
-            orderRequest.put("token_id", mandate.getProviderRef());
+            // NOTE: do NOT send token_id on this order. The public docs list it as
+            // mandatory for subsequent recurring payments, but this account rejects it
+            // outright: "BAD_REQUEST_ERROR: token_id is/are not required and should not
+            // be sent" -- and it fails at orders.create, so the charge never even starts.
             JSONObject notes = new JSONObject();
             notes.put("orderId", request.getOrderId());
             notes.put("instituteId", request.getInstituteId());


### PR DESCRIPTION
Razorpay rejects it for this account:

  BAD_REQUEST_ERROR: token_id is/are not required and should not be sent

and it fails at orders.create (439ms) rather than at the charge, so it is strictly worse than before: previously the order was created and only payments/create/recurring failed.

The public docs do list token_id as mandatory on the order for subsequent recurring payments, for both cards and UPI Autopay. This account disagrees, so the docs' flow is not the one available to us here.

Keeps a comment so nobody re-adds it.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
