### PR TITLE
fix(workflow): make the Retry path survive its own dispatch

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/repository/WorkflowExecutionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/repository/WorkflowExecutionRepository.java
@@ -84,6 +84,21 @@ public interface WorkflowExecutionRepository extends JpaRepository<WorkflowExecu
                         @Param("instituteId") String instituteId,
                         Pageable pageable);
 
+        /**
+         * Load one execution with every association the Retry path copies onto the new run.
+         *
+         * <p>All three are {@code LAZY}, and retry deliberately runs OUTSIDE a transaction (the
+         * new row must be committed before the async worker looks it up), so touching any of
+         * them on a detached entity would throw {@code LazyInitializationException}. Fetching
+         * them up-front is what makes the detached entity safe to read.</p>
+         */
+        @Query("SELECT we FROM WorkflowExecution we " +
+                        "JOIN FETCH we.workflow " +
+                        "LEFT JOIN FETCH we.workflowSchedule " +
+                        "LEFT JOIN FETCH we.workflowTrigger " +
+                        "WHERE we.id = :id")
+        Optional<WorkflowExecution> findByIdForRetry(@Param("id") String id);
+
         List<WorkflowExecution> findByWorkflowIdOrderByStartedAtDesc(String workflowId);
 
         List<WorkflowExecution> findByWorkflowScheduleIdOrderByStartedAtDesc(String workflowScheduleId);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/UserWorkflowRunService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/UserWorkflowRunService.java
@@ -108,10 +108,21 @@ public class UserWorkflowRunService {
      * <p>Dispatch is asynchronous ({@link AsyncWorkflowExecutor}, the same path the trigger
      * queue uses) because a workflow can take far longer than an HTTP request should. The
      * caller gets the new execution id back immediately and polls the run list.</p>
+     *
+     * <p><b>Deliberately NOT {@code @Transactional}.</b> {@code executeAsync} hands the run to
+     * another thread immediately, and that thread finishes by calling
+     * {@code markAsCompleted(idempotencyKey)} in its OWN transaction. If this method held a
+     * transaction, the new execution row would still be uncommitted when the worker looked it
+     * up — the lookup would miss, the completion would be dropped, and the run would sit at
+     * PROCESSING forever (which also permanently blocks retrying it again, since a PROCESSING
+     * run is refused below). Letting {@code createRetryExecution} commit on return, and only
+     * then dispatching, closes that race. Same reasoning as the afterCommit deferral in
+     * {@code StudentRegistrationManager.triggerEnrollmentWorkflow}.</p>
      */
-    @Transactional
     public WorkflowRetryResponseDTO retry(String executionId, String instituteId, String retriedByUserId) {
-        WorkflowExecution original = workflowExecutionRepository.findById(executionId)
+        // findByIdForRetry, not findById: without a transaction the entity comes back detached,
+        // so workflow/schedule/trigger must already be fetched or reading them throws.
+        WorkflowExecution original = workflowExecutionRepository.findByIdForRetry(executionId)
                 .orElseThrow(() -> new VacademyException("Workflow execution not found: " + executionId));
 
         if (original.getWorkflow() == null) {
@@ -141,7 +152,17 @@ public class UserWorkflowRunService {
         ctx.put("retriedManually", true);
         ctx.put("triggerTime", Instant.now().toString());
 
-        asyncWorkflowExecutor.executeAsync(original.getWorkflow().getId(), idempotencyKey, ctx);
+        try {
+            asyncWorkflowExecutor.executeAsync(original.getWorkflow().getId(), idempotencyKey, ctx);
+        } catch (Exception e) {
+            // The row is already committed, so a rejected hand-off (saturated executor, shutting
+            // down) would otherwise leave it stuck at PROCESSING and un-retryable. Mark it FAILED
+            // with the real reason so the tab shows what happened and the button comes back.
+            log.error("Could not queue retry {} of execution {}: {}",
+                    retry.getId(), original.getId(), e.getMessage(), e);
+            idempotencyService.markAsFailed(idempotencyKey, "Could not queue the re-run: " + e.getMessage());
+            throw new VacademyException("Could not start the re-run right now — please try again shortly.");
+        }
 
         log.info("Queued retry {} of execution {} (workflow {}) by user {}",
                 retry.getId(), original.getId(), original.getWorkflow().getId(), retriedByUserId);

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-workflows/student-workflows.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-workflows/student-workflows.tsx
@@ -285,10 +285,14 @@ export const StudentWorkflows = ({ userId, instituteId }: StudentWorkflowsProps)
             setPage(0);
         },
         onError: (err: unknown) => {
-            const message =
-                (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
-                'Could not start the re-run. Please try again.';
-            toast.error(message);
+            // GlobalExceptionHandler returns ErrorInfo — a record of {url, ex, responseCode,
+            // date}. The reason is in `ex`; there is no `message` field, so reading one would
+            // always fall through to the generic text and hide why the retry was refused.
+            const data = (err as { response?: { data?: { ex?: string; message?: string } } })
+                ?.response?.data;
+            toast.error(
+                data?.ex ?? data?.message ?? 'Could not start the re-run. Please try again.'
+            );
         },
     });
 


### PR DESCRIPTION
Follow-up to #2744, which is already merged into `main`. **`main` currently contains a Retry path that cannot complete a run**; this fixes it.

Three defects, all found by auditing the path rather than by compiling — none of them is a compile error, and the feature had never been executed.

## 1. Async dispatch inside a transaction  ⟵ the serious one

`retry()` was `@Transactional` and called `executeAsync` inside it. The worker thread finishes by calling `markAsCompleted(idempotencyKey)` in its **own** transaction, which cannot see a row the caller has not committed yet. Two consequences:

- The completion is dropped, so the run sits at `PROCESSING` **forever** — and because a `PROCESSING` run is refused, that run also becomes permanently un-retryable.
- `workflow_execution_state.execution_id` is `NOT NULL REFERENCES workflow_execution(id)`, so **any retried workflow containing a DELAY node died on a foreign-key violation**. That is most of the drip workflows.

`retry()` is now deliberately non-transactional: `createRetryExecution` commits on return, and only then is the run dispatched — the same afterCommit reasoning already used in `StudentRegistrationManager.triggerEnrollmentWorkflow`.

## 2. `LazyInitializationException`, exposed by fixing (1)

`workflow`, `workflowSchedule` and `workflowTrigger` are all `LAZY`, and `createRetryExecution` reads all three. Off a transaction the entity is detached, so reading them throws. Added `findByIdForRetry`, which `JOIN FETCH`es all three.

## 3. The refusal reason never reached the user

`GlobalExceptionHandler` returns `ErrorInfo` — a record of `{url, ex, responseCode, date}`. There is **no `message` field**, so the UI reading `data.message` always fell through to generic text and hid why a retry was refused ("still in progress", "inputs weren't saved"). Now reads `ex`.

## Hardening

A rejected executor hand-off left the already-committed row stranded at `PROCESSING`. It is now marked `FAILED` with the real reason, so the tab explains itself and the button comes back.

## Honest status

**Still unexercised end to end** — no retry has actually been executed. Verification is compile + typecheck + lint + static analysis (`UserWorkflowRunService` is a leaf bean, so no new startup cycle). Worth a live test before anyone relies on it.

Note that backfilled historical runs carry no `seed_context`, so retry can only be exercised on runs created **after** this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
