### PR TITLE
feat(course-settings): flag to update existing LMS users on enrolment

### DIFF
--- a/LMS_EDIT_EXISTING_USER_FLAG.md
+++ b/LMS_EDIT_EXISTING_USER_FLAG.md
@@ -1,0 +1,113 @@
+# Course setting: update existing LMS users on enrolment
+
+A per-course flag deciding whether an enrolment workflow may overwrite the details of a
+learner who **already has an account** on the connected LMS, plus the workflow node that
+does the overwriting.
+
+---
+
+## The gap this closes
+
+The Vet enrolment workflow (`wf_ld_vet_onboarding_01`, fires on `LEARNER_BATCH_ENROLLMENT`)
+looks the learner up by email and skips creation when it finds them:
+
+```
+nt_vet_onb_03_find_user        GET /crm/v1/user?email=#ctx['user']['email']
+nt_vet_onb_04_extract_user_id  -> #ctx['learndashUserId'] = <found id> | null
+nt_vet_onb_05_create_user      condition: #ctx['learndashUserId'] == null
+```
+
+On a hit the existing account is left exactly as it was. A returning learner whose name
+changed in Vacademy keeps the old name on the LMS, forever.
+
+So **existing user ⇔ `#ctx['learndashUserId'] != null`** — the exact inverse of the
+condition `create_user` already carries. That is the hook the new node gates on.
+
+## The flag
+
+Stored as `COURSE_SETTING.data.lms.editExistingUser`, resolved by
+`LmsExistingUserEditPolicyService`:
+
+1. `package.course_setting.setting.COURSE_SETTING.data.lms.editExistingUser` — this course
+2. `INSTITUTE.setting.COURSE_SETTING.data.lms.editExistingUser` — institute-wide default
+3. `false`
+
+Course-then-institute mirrors how `LearnerLmsUserSyncService` already resolves LMS
+connections, because the LMS connection itself is attached per course.
+
+The reader returns `Boolean` (nullable) at each level rather than a primitive, which is what
+makes the fallback correct: a course that has *never seen* the setting falls through to the
+institute, while a course that has explicitly set it to `false` is **not** overridden by an
+institute-wide `true`.
+
+**Defaults false, and every failure path returns false.** This is the opposite of
+`EnrollmentCredentialPolicyService`, which defaults true, and deliberately so: not sending
+an email is recoverable; overwriting a live account on a customer's LMS is not.
+
+## Reaching the workflow
+
+`StudentRegistrationManager.triggerEnrollmentWorkflow` resolves the flag once and puts it on
+the seed context as `lmsEditExistingUser`, next to `packageId` / `packageName`.
+
+Resolved in Java rather than by a QUERY node in each graph because the course → institute
+fallback has no clean SpEL expression. The call is wrapped in its own try/catch: failing to
+read a display flag must never stop an enrolment.
+
+## The node
+
+`VET_ONBOARDING_EDIT_EXISTING_USER_NODE.sql` — an ordinary `HTTP_REQUEST` node, **not** a new
+`NodeType`. `HttpRequestNodeHandler` already supports a SpEL `condition` that skips the call
+and logs the node `SKIPPED`.
+
+```
+"condition": "#ctx['lmsEditExistingUser'] == true && #ctx['learndashUserId'] != null"
+```
+
+That handler evaluates the condition with a **false default on any evaluation error**, so a
+run whose context never carried the key simply skips. Which is why the SQL is safe to apply
+before the backend change ships.
+
+Placement — inserted between 04 and 05, so it runs while `learndashUserId` still means "was
+already there":
+
+```
+04 extract_user_id --> [NEW] 04b edit_existing_user --> 05 create_user --> ...
+```
+
+The only edit to a pre-existing node is node 04's routing target.
+
+### What it sends, and what it deliberately doesn't
+
+```
+POST /crm/v1/edit-user   { email, first_name, last_name }
+```
+
+- **`email` is the lookup key, not an edit.** The learner was found *by* that address, so the
+  account already has it.
+- **No `new_email`.** There is no second address to move them to — and sending one would
+  point the account at an address the find step never matched. Propagating email changes
+  would require node 03 to look users up by something other than email; that is a different
+  change.
+- **No `password`.** Existing users keep the password they already have, consistent with the
+  VetPartners migration.
+
+## Verification
+
+- `admin_core_service` compiles clean.
+- `tsc --noEmit`: no errors in the touched frontend files.
+- `eslint` + `scripts/design-lint.mjs`: clean.
+
+Checked against Vet-Ed prod read-only before writing the SQL: the workflow id, that node 04
+belongs to that one workflow only, that it is the only node routing to node 05, that its
+stored `config_json` contains the exact literal being replaced, that neither new id collides,
+and that `node_template_pkey` is a PK (so `ON CONFLICT (id)` is valid).
+
+**Not run, and not exercised.** The SQL writes to Vet-Ed prod and re-routes a live ACTIVE
+workflow — it is for a human to review and run. No enrolment has been put through the new
+node.
+
+## Not covered
+
+`SUB_ORG_MEMBER_ENROLLMENT` (the add-member flow) does not get the flag on its context. That
+trigger has no single course, so it would always fall through to the institute-level setting;
+worth adding only if that flow needs the same behaviour.

--- a/VET_ONBOARDING_EDIT_EXISTING_USER_NODE.sql
+++ b/VET_ONBOARDING_EDIT_EXISTING_USER_NODE.sql
@@ -1,0 +1,194 @@
+-- =============================================================================
+-- Workflow: "Vet Admin Onboarding (Group Leader)"  (LEARNER_BATCH_ENROLLMENT)
+-- Purpose:  Add an "Update Existing User" HTTP_REQUEST node that pushes the
+--           learner's current name to their EXISTING LearnDash/WordPress
+--           account, gated on the new course setting.
+-- Date:     2026-09-02
+-- Target:   Vet Education prod RDS (database-1...ap-southeast-2), admin_core_service
+--           institute 0bd9421e-2e74-4cfb-bbee-03bc09845bc6
+--
+-- WHY
+-- ---
+-- The workflow finds the learner by email:
+--     nt_vet_onb_03_find_user  GET /crm/v1/user?email=#ctx['user']['email']
+--     nt_vet_onb_04_extract_user_id  -> #ctx['learndashUserId'] = found id | null
+--     nt_vet_onb_05_create_user      condition: #ctx['learndashUserId'] == null
+--
+-- So on a hit, creation is skipped and the existing account is left exactly as
+-- it was -- a returning learner whose name changed in Vacademy keeps the old
+-- name on the LMS. This node closes that gap.
+--
+-- GATING
+-- ------
+-- Two conditions, both required:
+--
+--   #ctx['lmsEditExistingUser'] == true   the course setting
+--                                         (COURSE_SETTING.data.lms.editExistingUser,
+--                                         course-level then institute-level;
+--                                         resolved by LmsExistingUserEditPolicyService
+--                                         and seeded onto the context by
+--                                         StudentRegistrationManager)
+--
+--   #ctx['learndashUserId'] != null       the user actually already existed
+--                                         (exact inverse of node 05's condition)
+--
+-- HttpRequestNodeHandler evaluates `condition` with a false default on any
+-- evaluation error, so a run whose context predates the flag simply skips this
+-- node and logs it SKIPPED. That is why this is safe to install before the
+-- backend change ships.
+--
+-- WHAT IT SENDS
+-- -------------
+--     POST /crm/v1/edit-user   { email, first_name, last_name }
+--
+-- `email` is the LOOKUP KEY, not an edit. The learner was found BY that address,
+-- so `new_email` is deliberately absent -- there is no second email to move them
+-- to, and sending one would risk pointing the account at an address the find
+-- step never matched. `password` is absent too: existing users keep the password
+-- they already have.
+--
+-- PLACEMENT
+-- ---------
+--     04 extract_user_id  --> [NEW] edit_existing_user --> 05 create_user --> ...
+--
+-- Inserted between 04 and 05 so it runs while `learndashUserId` still means
+-- "was already there". The only change to an existing node is node 04's routing
+-- target. When the node skips, routing still carries the run on to node 05.
+--
+-- VERIFIED AGAINST PROD BEFORE WRITING THIS (read-only):
+--   * workflow id            = wf_ld_vet_onboarding_01, name exactly
+--                              'Vet Admin Onboarding (Group Leader)', ACTIVE
+--   * nt_vet_onb_04_extract_user_id is mapped to that ONE workflow only, so
+--     re-routing it cannot affect another graph
+--   * it is also the ONLY node routing to nt_vet_onb_05_create_user
+--   * its stored config_json contains the exact literal being replaced in STEP 3,
+--     including the space after the colon
+--   * neither the new node id nor the new mapping id exists yet
+--   * node_template_pkey is a PRIMARY KEY on id, so ON CONFLICT (id) is valid
+--
+-- node_order 4 duplicates node 04's. That is cosmetic: the engine routes by
+-- targetNodeId and picks its start node via is_start_node (nt_vet_onb_01_init),
+-- so node_order only affects list ordering in the builder.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- STEP 0: BACKUP -- run this FIRST. Authoritative source of truth for revert.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.node_template_backup_20260902_edit_existing_user AS
+SELECT * FROM public.node_template WHERE id = 'nt_vet_onb_04_extract_user_id';
+
+CREATE TABLE IF NOT EXISTS public.wnm_backup_20260902_edit_existing_user AS
+SELECT * FROM public.workflow_node_mapping WHERE workflow_id = 'wf_ld_vet_onboarding_01';
+
+
+-- ---------------------------------------------------------------------------
+-- STEP 1: the new node template.
+-- Mirrors nt_vet_onb_03/05 exactly for url derivation and Basic auth, and reuses
+-- their first/last name split so a one-word full name does not produce a stray
+-- last_name.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.node_template (id, institute_id, node_name, node_type, status, config_json, created_at, updated_at, version)
+VALUES (
+    'nt_vet_onb_04b_edit_existing_user',
+    '0bd9421e-2e74-4cfb-bbee-03bc09845bc6',
+    'Update Existing User',
+    'HTTP_REQUEST',
+    'ACTIVE',
+    $json${
+      "config": {
+        "url": "#ctx['lmsConfig']['apiUrl'].replace('/wp/v2', '') + '/crm/v1/edit-user'",
+        "method": "POST",
+        "requestType": "EXTERNAL",
+        "condition": "#ctx['lmsEditExistingUser'] == true && #ctx['learndashUserId'] != null",
+        "authentication": {
+          "type": "BASIC",
+          "username": "#ctx['lmsConfig']['apiKey']",
+          "password": "#ctx['lmsConfig']['apiSecret']"
+        },
+        "body": {
+          "email": "#ctx['user']['email']",
+          "first_name": "#ctx['user']['fullName'] != null && #ctx['user']['fullName'].contains(' ') ? #ctx['user']['fullName'].substring(0, #ctx['user']['fullName'].indexOf(' ')) : (#ctx['user']['fullName'] != null ? #ctx['user']['fullName'] : '')",
+          "last_name": "#ctx['user']['fullName'] != null && #ctx['user']['fullName'].contains(' ') ? #ctx['user']['fullName'].substring(#ctx['user']['fullName'].indexOf(' ') + 1) : ''"
+        }
+      },
+      "routing": [
+        { "type": "goto", "targetNodeId": "nt_vet_onb_05_create_user" }
+      ],
+      "resultKey": "'editUserHttpResponse'"
+    }$json$,
+    NOW(), NOW(), 1
+)
+ON CONFLICT (id) DO UPDATE
+    SET config_json = EXCLUDED.config_json,
+        node_name   = EXCLUDED.node_name,
+        node_type   = EXCLUDED.node_type,
+        status      = EXCLUDED.status,
+        updated_at  = NOW();
+
+
+-- ---------------------------------------------------------------------------
+-- STEP 2: map the node into the workflow.
+-- node_order 4 keeps it adjacent to 04 in the builder's list view; ordering is
+-- cosmetic here because the engine routes by targetNodeId, not by node_order.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.workflow_node_mapping (id, workflow_id, node_template_id, node_order, is_start_node, is_end_node, created_at)
+SELECT
+    'wnm_vet_onb_04b_edit_existing_user',
+    w.id,
+    'nt_vet_onb_04b_edit_existing_user',
+    4,
+    false,
+    false,
+    NOW()
+FROM public.workflow w
+WHERE w.id = 'wf_ld_vet_onboarding_01'
+  AND NOT EXISTS (
+      SELECT 1 FROM public.workflow_node_mapping m
+      WHERE m.workflow_id = w.id AND m.node_template_id = 'nt_vet_onb_04b_edit_existing_user'
+  );
+
+
+-- ---------------------------------------------------------------------------
+-- STEP 3: re-route node 04 to the new node.
+-- The ONLY edit to a pre-existing node. Guarded so re-running is a no-op.
+-- ---------------------------------------------------------------------------
+
+UPDATE public.node_template
+SET config_json = replace(
+        config_json,
+        '"targetNodeId": "nt_vet_onb_05_create_user"',
+        '"targetNodeId": "nt_vet_onb_04b_edit_existing_user"'
+    ),
+    updated_at = NOW()
+WHERE id = 'nt_vet_onb_04_extract_user_id'
+  AND config_json LIKE '%"targetNodeId": "nt_vet_onb_05_create_user"%'
+RETURNING id, node_name;
+
+
+-- ---------------------------------------------------------------------------
+-- VERIFY
+-- ---------------------------------------------------------------------------
+-- Expect: node 04 routes to 04b, and 04b routes to 05.
+--
+-- SELECT id, node_name, config_json::jsonb -> 'routing' AS routing
+-- FROM public.node_template
+-- WHERE id IN ('nt_vet_onb_04_extract_user_id',
+--              'nt_vet_onb_04b_edit_existing_user',
+--              'nt_vet_onb_05_create_user')
+-- ORDER BY id;
+
+
+-- ---------------------------------------------------------------------------
+-- REVERT
+-- ---------------------------------------------------------------------------
+-- UPDATE public.node_template nt
+-- SET config_json = b.config_json, updated_at = NOW()
+-- FROM public.node_template_backup_20260902_edit_existing_user b
+-- WHERE nt.id = b.id;
+--
+-- DELETE FROM public.workflow_node_mapping WHERE id = 'wnm_vet_onb_04b_edit_existing_user';
+-- DELETE FROM public.node_template        WHERE id = 'nt_vet_onb_04b_edit_existing_user';

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course_settings/service/LmsExistingUserEditPolicyService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/course_settings/service/LmsExistingUserEditPolicyService.java
@@ -1,0 +1,124 @@
+package vacademy.io.admin_core_service.features.course_settings.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import vacademy.io.admin_core_service.features.institute.service.setting.InstituteSettingService;
+
+/**
+ * Single answer to "when an enrolment workflow finds the learner ALREADY exists on the external
+ * LMS, may it overwrite that account's details with ours?".
+ *
+ * <p>Today the Vet enrolment workflow looks the learner up by email
+ * ({@code GET /crm/v1/user}); if it finds them it keeps the returned id and skips creation
+ * ({@code create-user} is gated on {@code learndashUserId == null}). The existing account is
+ * left exactly as it was, so a returning learner whose name changed in Vacademy keeps the old
+ * name on the LMS. This flag is what lets a workflow push the correction instead.</p>
+ *
+ * <p><b>Read as {@code COURSE_SETTING.data.lms.editExistingUser}</b>, per course first and
+ * institute-wide as a fallback:</p>
+ * <ol>
+ *   <li>{@code package.course_setting.setting.COURSE_SETTING.data.lms.editExistingUser}</li>
+ *   <li>{@code INSTITUTE.setting.COURSE_SETTING.data.lms.editExistingUser}</li>
+ *   <li>{@code false}</li>
+ * </ol>
+ *
+ * <p>The two-level resolution mirrors how {@code LearnerLmsUserSyncService} already resolves LMS
+ * connections — course-level config wins, institute config is the default — because the LMS
+ * connection itself is attached per course.</p>
+ *
+ * <p><b>Defaults to false, and every failure path returns false.</b> This is the opposite of
+ * {@code EnrollmentCredentialPolicyService}, which defaults true, and deliberately so: not
+ * sending an email is recoverable, but overwriting a live account on a customer's LMS is not.
+ * An institute that never touched this setting must not start rewriting LMS profiles because of
+ * an unreadable settings blob.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LmsExistingUserEditPolicyService {
+
+    private static final String COURSE_SETTING_KEY = "COURSE_SETTING";
+    /** Group under COURSE_SETTING.data that holds LMS behaviour flags. */
+    private static final String LMS_GROUP = "lms";
+    private static final String EDIT_EXISTING_USER = "editExistingUser";
+
+    /**
+     * Context key the workflow graph reads. An HTTP_REQUEST node gates itself with
+     * {@code "condition": "#ctx['lmsEditExistingUser'] == true && #ctx['learndashUserId'] != null"}
+     * — the handler's SpEL evaluation already defaults to false on error, so a run whose context
+     * never received this key simply skips the edit.
+     */
+    public static final String CONTEXT_KEY = "lmsEditExistingUser";
+
+    private final PackageSettingService packageSettingService;
+    private final InstituteSettingService instituteSettingService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param instituteId institute the learner is being enrolled into
+     * @param packageId   course being enrolled into; null falls straight through to the
+     *                    institute-level setting (e.g. a flow with no single course)
+     * @return whether a workflow may edit an existing LMS account for this enrolment
+     */
+    public boolean mayEditExistingUser(String instituteId, String packageId) {
+        Boolean perCourse = readPackageFlag(packageId);
+        if (perCourse != null) {
+            return perCourse;
+        }
+        Boolean perInstitute = readInstituteFlag(instituteId);
+        return perInstitute != null && perInstitute;
+    }
+
+    /** @return the course-level flag, or null when the course has not set it either way. */
+    private Boolean readPackageFlag(String packageId) {
+        if (!StringUtils.hasText(packageId)) {
+            return null;
+        }
+        try {
+            Object data = packageSettingService.getSettingData(packageId, COURSE_SETTING_KEY);
+            return readFlag(data);
+        } catch (Exception e) {
+            log.warn("Could not read course-level {}.{} for package {}: {}",
+                    LMS_GROUP, EDIT_EXISTING_USER, packageId, e.getMessage());
+            return null;
+        }
+    }
+
+    /** @return the institute-level flag, or null when the institute has not set it either way. */
+    private Boolean readInstituteFlag(String instituteId) {
+        if (!StringUtils.hasText(instituteId)) {
+            return null;
+        }
+        try {
+            Object data = instituteSettingService.getSettingByInstituteIdAndKey(instituteId, COURSE_SETTING_KEY);
+            return readFlag(data);
+        } catch (Exception e) {
+            log.warn("Could not read institute-level {}.{} for institute {}: {}",
+                    LMS_GROUP, EDIT_EXISTING_USER, instituteId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Pull {@code lms.editExistingUser} out of a COURSE_SETTING {@code data} blob.
+     *
+     * <p>Returns null for "not set", which is what makes the course → institute fallback work:
+     * a course that has never seen this setting must fall through, while a course that has
+     * explicitly set it to false must NOT be overridden by an institute-wide true.</p>
+     */
+    private Boolean readFlag(Object data) {
+        if (data == null) {
+            return null;
+        }
+        JsonNode node = objectMapper.valueToTree(data).path(LMS_GROUP).path(EDIT_EXISTING_USER);
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        // Tolerate a string "true"/"false" — settings blobs are hand-edited JSON in places.
+        return node.isBoolean() ? node.asBoolean() : Boolean.parseBoolean(node.asText());
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentRegistrationManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/manager/StudentRegistrationManager.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 import vacademy.io.admin_core_service.features.common.util.JsonUtil;
+import vacademy.io.admin_core_service.features.course_settings.service.LmsExistingUserEditPolicyService;
 import vacademy.io.admin_core_service.features.enroll_invite.entity.EnrollInvite;
 import vacademy.io.admin_core_service.features.enrollment_policy.dto.EnrollmentPolicySettingsDTO;
 import vacademy.io.admin_core_service.features.enrollment_policy.dto.ReenrollmentPolicyDTO;
@@ -68,6 +69,9 @@ public class StudentRegistrationManager {
 
     @Autowired
     private PackageSessionRepository packageSessionRepository;
+
+    @Autowired
+    private LmsExistingUserEditPolicyService lmsExistingUserEditPolicyService;
 
     @Value("${auth.server.baseurl}")
     private String authServerBaseUrl;
@@ -1206,6 +1210,21 @@ public class StudentRegistrationManager {
         // and HTTP_REQUEST webhook bodies can reference the course name directly
         // without needing a separate QUERY node to look it up.
         contextData.put("packageName", pkg.getPackageName());
+        // May a workflow overwrite an LMS account that already exists for this learner?
+        // Resolved here, once, rather than by a QUERY node in each graph: the setting is
+        // course-then-institute (see LmsExistingUserEditPolicyService) and the graph has no
+        // clean way to express that fallback in SpEL. Nodes gate on
+        // #ctx['lmsEditExistingUser'] == true. Best-effort — a failure to read it must not
+        // stop the enrolment, and false is the safe answer (leave the LMS account alone).
+        boolean mayEditExistingLmsUser = false;
+        try {
+            mayEditExistingLmsUser = lmsExistingUserEditPolicyService
+                    .mayEditExistingUser(instituteId, pkg.getId());
+        } catch (Exception e) {
+            log.warn("Could not resolve {} for institute {} / package {} — defaulting to false: {}",
+                    LmsExistingUserEditPolicyService.CONTEXT_KEY, instituteId, pkg.getId(), e.getMessage());
+        }
+        contextData.put(LmsExistingUserEditPolicyService.CONTEXT_KEY, mayEditExistingLmsUser);
 
         final String eventName = WorkflowTriggerEvent.LEARNER_BATCH_ENROLLMENT.name();
         final String finalInstituteId = instituteId;

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/package-settings/LmsExistingUserPolicyCard.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/package-settings/LmsExistingUserPolicyCard.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { CircleNotch, UserGear } from '@phosphor-icons/react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { getPackageSettingData, savePackageSettingKey } from '@/services/package-settings';
+
+interface LmsExistingUserPolicyCardProps {
+    packageId: string;
+    refreshKey?: number;
+}
+
+const COURSE_SETTING_KEY = 'COURSE_SETTING';
+
+type CourseSettingData = Record<string, unknown> & {
+    lms?: Record<string, unknown> & { editExistingUser?: boolean };
+};
+
+/**
+ * "When a learner already exists on the LMS, update their details?"
+ *
+ * Backs `COURSE_SETTING.data.lms.editExistingUser` for this course. The enrolment workflow reads
+ * it (course setting first, institute setting as fallback — see `LmsExistingUserEditPolicyService`)
+ * and puts the answer on the run context as `lmsEditExistingUser`; the edit-user HTTP node is
+ * gated on it.
+ *
+ * Off by default and off when unset: the enrolment workflow looks the learner up by email and, on
+ * a hit, keeps the existing account untouched. Turning this on makes it overwrite that account's
+ * name with ours — a write to a system we don't own, so it's opt-in.
+ */
+export const LmsExistingUserPolicyCard: React.FC<LmsExistingUserPolicyCardProps> = ({
+    packageId,
+    refreshKey,
+}) => {
+    const [enabled, setEnabled] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = (await getPackageSettingData(
+                packageId,
+                COURSE_SETTING_KEY
+            )) as CourseSettingData | null;
+            setEnabled(data?.lms?.editExistingUser === true);
+        } catch {
+            // An unreadable setting means "not configured", which is the same as off. Don't
+            // surface an error toast for a card the admin may not even be looking at.
+            setEnabled(false);
+        } finally {
+            setLoading(false);
+        }
+    }, [packageId]);
+
+    useEffect(() => {
+        void load();
+    }, [load, refreshKey]);
+
+    const handleToggle = async (next: boolean) => {
+        setSaving(true);
+        // Optimistic: the switch should move under the finger, not after a round trip.
+        setEnabled(next);
+        try {
+            // Read-modify-write. save-setting replaces the WHOLE COURSE_SETTING data blob, so
+            // merging is not optional — writing just { lms: {...} } would wipe every other
+            // course setting stored under this key.
+            const current = ((await getPackageSettingData(packageId, COURSE_SETTING_KEY)) ??
+                {}) as CourseSettingData;
+            const merged: CourseSettingData = {
+                ...current,
+                lms: { ...(current.lms ?? {}), editExistingUser: next },
+            };
+            await savePackageSettingKey(packageId, COURSE_SETTING_KEY, merged, 'Course settings');
+            toast.success(
+                next
+                    ? 'Existing LMS users will be updated on enrolment for this course.'
+                    : 'Existing LMS users will be left untouched for this course.'
+            );
+        } catch {
+            setEnabled(!next);
+            toast.error("Couldn't save the setting. Please try again.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Card className="shadow-none">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-body font-semibold">
+                    <UserGear size={18} weight="duotone" className="text-neutral-500" />
+                    Existing LMS users
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                        <Label htmlFor="lms-edit-existing-user" className="text-sm">
+                            Update their details on enrolment
+                        </Label>
+                        <p className="max-w-2xl text-caption text-neutral-500">
+                            When someone enrols and already has an account on the connected LMS,
+                            push their current name from here to that account. Leave this off to
+                            enrol them into the course without touching the account they already
+                            have.
+                        </p>
+                        <p className="max-w-2xl text-caption text-neutral-400">
+                            Their email is how the LMS account is found, so it is never changed —
+                            and their LMS password is never touched.
+                        </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2 pt-1">
+                        {(loading || saving) && (
+                            <CircleNotch className="size-4 animate-spin text-neutral-400" />
+                        )}
+                        <Switch
+                            id="lms-edit-existing-user"
+                            checked={enabled}
+                            disabled={loading || saving}
+                            onCheckedChange={(next) => void handleToggle(next)}
+                        />
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/package-settings/PackageSettingsPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/study-library/courses/course-details/-components/package-settings/PackageSettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { PackageCourseSettingEditor } from './PackageCourseSettingEditor';
 import { LmsSettingsCard } from './LmsSettingsCard';
+import { LmsExistingUserPolicyCard } from './LmsExistingUserPolicyCard';
 import { CourseWorkflowTriggersCard } from './CourseWorkflowTriggersCard';
 import { SubOrgAssociatedCard } from './SubOrgAssociatedCard';
 
@@ -37,9 +38,17 @@ export const PackageSettingsPanel: React.FC<PackageSettingsPanelProps> = ({ pack
                 </TabsList>
                 {/* key={packageId} remounts the cards when you switch courses, so prefilled
                     connection/courseId/triggers never leak from a previously-open course. */}
-                <TabsContent value="lms" className="mt-4">
+                <TabsContent value="lms" className="mt-4 space-y-4">
                     <LmsSettingsCard
                         key={packageId}
+                        packageId={packageId}
+                        refreshKey={refreshKey}
+                    />
+                    {/* Behaviour flag rather than connection config, so it sits in its own card
+                        below the connection form — it stays relevant even once the connection
+                        is set up and the form above is collapsed. */}
+                    <LmsExistingUserPolicyCard
+                        key={`existing-user-${packageId}`}
                         packageId={packageId}
                         refreshKey={refreshKey}
                     />


### PR DESCRIPTION
Adds a per-course setting deciding whether an enrolment workflow may overwrite the details of a learner who **already has an account** on the connected LMS — plus the workflow node that does the overwriting.

## The gap

`wf_ld_vet_onboarding_01` looks the learner up by email and skips creation on a hit:

```
nt_vet_onb_03_find_user        GET /crm/v1/user?email=#ctx['user']['email']
nt_vet_onb_04_extract_user_id  -> #ctx['learndashUserId'] = <found id> | null
nt_vet_onb_05_create_user      condition: #ctx['learndashUserId'] == null
```

The existing account is then left exactly as it was, so a returning learner whose name changed in Vacademy keeps the old name on the LMS forever.

So **existing user ⇔ `learndashUserId != null`** — the exact inverse of the condition `create_user` already carries. That's what the new node gates on.

## The flag

`COURSE_SETTING.data.lms.editExistingUser`, resolved by `LmsExistingUserEditPolicyService`:

1. this course's `package.course_setting`
2. the institute's `COURSE_SETTING`
3. `false`

Course-then-institute mirrors how `LearnerLmsUserSyncService` already resolves LMS connections, since the connection itself is attached per course. Each level returns a **nullable** `Boolean` so "never set" falls through — while an explicit `false` at course level is *not* overridden by an institute-wide `true`.

**Defaults false, and every failure path returns false** — the opposite of `EnrollmentCredentialPolicyService`, deliberately: not sending an email is recoverable, overwriting a live account on a customer's LMS is not.

`StudentRegistrationManager` resolves it once and seeds it onto the enrolment context as `lmsEditExistingUser`. Resolved in Java rather than by a QUERY node per graph because the fallback has no clean SpEL expression, and wrapped in its own try/catch — failing to read a display flag must never stop an enrolment.

## The node

An ordinary **`HTTP_REQUEST`, not a new `NodeType`**. `HttpRequestNodeHandler` already supports a SpEL `condition` that skips the call and logs the node `SKIPPED`:

```
"condition": "#ctx['lmsEditExistingUser'] == true && #ctx['learndashUserId'] != null"
```

That handler evaluates the condition with a **false default on any error**, so a run whose context predates the flag simply skips — which is also why the SQL is safe to apply before this ships.

```
04 extract_user_id --> [NEW] 04b edit_existing_user --> 05 create_user --> ...
```

The only edit to a pre-existing node is node 04's routing target.

### What it sends, and what it deliberately doesn't

```
POST /crm/v1/edit-user   { email, first_name, last_name }
```

- **`email` is the lookup key, not an edit** — the learner was found *by* that address.
- **No `new_email`.** There's no second address to move them to, and sending one would point the account at an address the find step never matched. Propagating email changes needs node 03 to look users up by something other than email — a different change.
- **No `password`.** Existing users keep the one they have.

## Reviewer notes

- **The SQL is not run.** It writes to Vet-Ed prod and re-routes a live ACTIVE workflow, so it's for a human to review and run. Its header records what was verified read-only against that database first: the workflow id, that node 04 belongs to that one workflow only, that it's the only node routing to node 05, that its stored `config_json` contains the exact literal being replaced, that neither new id collides, and that `node_template_pkey` is a PK so `ON CONFLICT (id)` is valid.
- **`StudentRegistrationManager` had moved on `main`** since this work started; my change was 3-way merged onto their version, and the diff against `main` for that file is exactly my added lines.
- **Not wired into `SUB_ORG_MEMBER_ENROLLMENT`** — that trigger has no single course, so it would always fall through to the institute-level setting. Easy to add if the add-member flow needs it.

## Verification

- `admin_core_service` compiles clean.
- `tsc --noEmit`: no errors in the touched frontend files.
- `eslint` + `scripts/design-lint.mjs`: clean.

**Not exercised** — no enrolment has been put through the new node.

Docs: `LMS_EDIT_EXISTING_USER_FLAG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
