### PR TITLE
feat(dashboard): put LMS health first, full width, hidden by default

### DIFF
--- a/LMS_CONNECTION_HEALTH_WIDGET.md
+++ b/LMS_CONNECTION_HEALTH_WIDGET.md
@@ -114,12 +114,31 @@ New widget id `lmsConnectionHealth`, threaded through the four places
 
 1. the `DashboardWidgetId` union (`types/display-settings.ts`)
 2. `DASHBOARD_WIDGET_LABELS` → "LMS connection health"
-3. admin defaults — bucket 6 (LMS operations), **visible**
-4. teacher defaults — same position, **hidden** (integration health is an admin concern; an
-   admin can still switch it on per role)
+3. admin defaults — **first** in the order, **hidden**
+4. teacher defaults — same position, **hidden**
 
-Rendered behind `isWidgetVisible('lmsConnectionHealth')` and wrapped in `TrackedWidget` for
-view telemetry, exactly like the other widgets.
+### Position and width
+
+Rendered as the **first child of the dashboard's full-width main-content column**, so it spans
+the screen instead of sharing a row. First because a broken LMS connection silently breaks
+enrolment for every course wired to it — that outranks anything else on the page.
+
+Note the main dashboard layout is fixed JSX order; the `order` field only sorts one analytics
+sub-group and drives the Settings list. So "first" had to be a JSX move, not an order change —
+the order value is set to match so the two don't disagree.
+
+### Hidden by default, strictly
+
+Ships `visible: false` for **every** role. A connection-health card is only meaningful to an
+institute that has actually connected an external LMS, and enabling it starts polling that
+customer's site every minute — so it is opt-in.
+
+Gated on `isWidgetExplicitlyVisible`, not the shared `isWidgetVisible`. The shared helper fails
+**open** (`vis !== false`), which is right for widgets that have always shipped on — a
+settings-load failure shouldn't blank the dashboard. But an opt-in widget must not switch
+itself on that way, and this one starts hitting the customer's LMS the moment it renders.
+
+Wrapped in `TrackedWidget` for view telemetry, like the other widgets.
 
 **Existing institutes pick it up automatically.** `mergeDisplayWithDefaults` starts from the
 defaults, so a widget missing from a saved blob is auto-added with the default visibility and

--- a/frontend-admin-dashboard/src/constants/display-settings/admin-defaults.ts
+++ b/frontend-admin-dashboard/src/constants/display-settings/admin-defaults.ts
@@ -77,7 +77,15 @@ function defaultDashboardWidgetsAdmin(): DashboardWidgetConfig[] {
     //   6. LMS operations                — classes, courses, assessments
     //   7. Reference data                — team makeup, institute summary
     //   8. Promotional                   — discovery cards, last slot
+    // Ships OFF for everyone. A connection-health card is only meaningful to an institute
+    // that has actually connected an external LMS, and enabling it starts polling that
+    // customer's site every minute — so an admin opts in rather than opting out.
+    const defaultOff = new Set<DashboardWidgetConfig['id']>(['lmsConnectionHealth']);
+
     const ids: DashboardWidgetConfig['id'][] = [
+        // 0. Integration health — first on the page: a broken LMS connection silently
+        //    breaks enrolment for every course wired to it.
+        'lmsConnectionHealth',
         // 1. Navigation shortcuts
         'quickActions',
         // 2. KPIs
@@ -117,7 +125,7 @@ function defaultDashboardWidgetsAdmin(): DashboardWidgetConfig[] {
         // 8. Promotional
         'aiFeaturesCard',
     ];
-    return ids.map((id, idx) => ({ id, order: idx + 1, visible: true }));
+    return ids.map((id, idx) => ({ id, order: idx + 1, visible: !defaultOff.has(id) }));
 }
 
 export const DEFAULT_ADMIN_DISPLAY_SETTINGS: DisplaySettingsData = {

--- a/frontend-admin-dashboard/src/constants/display-settings/teacher-defaults.ts
+++ b/frontend-admin-dashboard/src/constants/display-settings/teacher-defaults.ts
@@ -80,6 +80,9 @@ function defaultDashboardWidgetsTeacher(): DashboardWidgetConfig[] {
     ]);
 
     const orderedIds: DashboardWidgetConfig['id'][] = [
+        // 0. Integration health — first on the page. Hidden for teachers (absent from
+        //    teacherOn): integration health is an admin concern.
+        'lmsConnectionHealth',
         // 1. Navigation shortcuts
         'quickActions',
         // 2. KPIs

--- a/frontend-admin-dashboard/src/routes/dashboard/-components/LmsConnectionHealthWidget.tsx
+++ b/frontend-admin-dashboard/src/routes/dashboard/-components/LmsConnectionHealthWidget.tsx
@@ -144,6 +144,8 @@ interface LmsConnectionHealthWidgetProps {
     instituteId: string;
 }
 
+const POLL_INTERVAL_MS = 60_000;
+
 /**
  * Dashboard widget: are the institute's LMS connections actually reachable right now?
  *
@@ -154,9 +156,12 @@ interface LmsConnectionHealthWidgetProps {
  * Renders nothing when the institute has no external LMS connected: an institute on the built-in
  * Vacademy LMS has no integration to be unhealthy, and an empty card would be noise on every
  * dashboard. Same self-hiding convention the sub-org widgets use.
+ *
+ * Renders first on the dashboard and full-bleed: a broken LMS connection silently breaks
+ * enrolment for every course wired to it. It nonetheless ships hidden for every role — only an
+ * institute that has actually connected an LMS wants it, and turning it on starts polling that
+ * customer's site every minute.
  */
-const POLL_INTERVAL_MS = 60_000;
-
 export const LmsConnectionHealthWidget = ({ instituteId }: LmsConnectionHealthWidgetProps) => {
     const router = useRouter();
 
@@ -211,7 +216,7 @@ export const LmsConnectionHealthWidget = ({ instituteId }: LmsConnectionHealthWi
 
     if (isLoading) {
         return (
-            <Card className="grow shadow-none">
+            <Card className="w-full shadow-none">
                 <CardHeader className="p-4">
                     <CardTitle className="flex items-center gap-2 text-body font-semibold text-neutral-700">
                         <CircleNotch className="size-4 animate-spin text-neutral-400" />
@@ -226,7 +231,7 @@ export const LmsConnectionHealthWidget = ({ instituteId }: LmsConnectionHealthWi
     // LMS is down because our own endpoint errored. Offer a retry and say what actually happened.
     if (error) {
         return (
-            <Card className="grow border-neutral-200 shadow-none">
+            <Card className="w-full border-neutral-200 shadow-none">
                 <CardHeader className="p-4">
                     <CardTitle className="flex items-center gap-2 text-body font-semibold text-neutral-700">
                         <WarningCircle weight="duotone" className="size-4 text-warning-500" />
@@ -260,7 +265,7 @@ export const LmsConnectionHealthWidget = ({ instituteId }: LmsConnectionHealthWi
     return (
         <Card
             className={cn(
-                'grow shadow-none transition-all',
+                'w-full shadow-none transition-all',
                 allHealthy ? 'border-neutral-200' : 'border-danger-200 bg-danger-50/40'
             )}
         >

--- a/frontend-admin-dashboard/src/routes/dashboard/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/dashboard/index.lazy.tsx
@@ -494,6 +494,17 @@ export function DashboardComponent({ onOpenAllAlerts }: { onOpenAllAlerts?: () =
         return vis !== false; // default to true
     };
 
+    /**
+     * Strict variant of isWidgetVisible: hidden unless settings EXPLICITLY say visible.
+     *
+     * isWidgetVisible fails open (`vis !== false`), which is right for widgets that have always
+     * shipped on — a settings-load failure shouldn't blank the dashboard. But an opt-in widget
+     * must not switch itself on that way, and this one starts polling the customer's LMS the
+     * moment it renders.
+     */
+    const isWidgetExplicitlyVisible = (id: DashboardWidgetId): boolean =>
+        roleDisplay?.dashboard.widgets.find((w) => w.id === id)?.visible === true;
+
     const orderOf = (id: DashboardWidgetId): number => {
         return roleDisplay?.dashboard.widgets.find((w) => w.id === id)?.order ?? 0;
     };
@@ -628,6 +639,16 @@ export function DashboardComponent({ onOpenAllAlerts }: { onOpenAllAlerts?: () =
             )}
             {/* Main content */}
             <div className="mt-5 flex w-full flex-col gap-4">
+                {/* LMS connection health — first, and full-bleed. A broken LMS connection
+                    silently breaks enrolment for every course wired to it, so it outranks
+                    anything else on the page. Direct child of this w-full flex column, so it
+                    spans the screen rather than sharing a row. Self-hides when nothing was
+                    actually probed, and ships hidden by default. */}
+                {isWidgetExplicitlyVisible('lmsConnectionHealth') && (
+                    <TrackedWidget widgetId="lmsConnectionHealth">
+                        <LmsConnectionHealthWidget instituteId={instituteDetails?.id || ''} />
+                    </TrackedWidget>
+                )}
                 {/* Super-admin-managed widgets (onboarding tracker / info cards) — additive, renders
                     nothing when none are configured. Role filtering is enforced server-side. */}
                 <TrackedWidget widgetId="superAdminWidgets">
@@ -1024,18 +1045,6 @@ export function DashboardComponent({ onOpenAllAlerts }: { onOpenAllAlerts?: () =
                             </Card>
                         )}
                     </div>
-                    {/* LMS operations: is the external LMS integration actually up?
-                        Self-hides when the institute has no external LMS connected, so an
-                        institute on the built-in Vacademy LMS never sees an empty card. */}
-                    {isWidgetVisible('lmsConnectionHealth') && (
-                        <TrackedWidget widgetId="lmsConnectionHealth">
-                            <div className="flex flex-1 flex-col gap-4 md:flex-row">
-                                <LmsConnectionHealthWidget
-                                    instituteId={instituteDetails?.id || ''}
-                                />
-                            </div>
-                        </TrackedWidget>
-                    )}
                     <div className="flex flex-1 flex-col gap-4 md:flex-row">
                         {isWidgetVisible('liveClasses') && (
                             <LiveClassesWidget instituteId={instituteDetails?.id || ''} />


### PR DESCRIPTION
Follow-up to #2748 (already merged). Three presentation changes to the LMS connection-health widget.

## First on the page

A broken LMS connection silently breaks enrolment for every course wired to it, so it outranks everything else on the dashboard.

Worth knowing for future widget work: **the main dashboard layout is fixed JSX order.** `orderOf()` only sorts one analytics sub-group and drives the Settings list — it does not position widgets on the page. So "first" had to be a JSX move. The default `order` value is set to match so the two don't disagree.

## Full width

Now a direct child of the main-content `w-full` flex column instead of nested in a `md:flex-row` group, and the Card's `grow` becomes `w-full` — `grow` acts on the flex **main** axis, which is vertical in that column, so it was never doing what the name suggests here.

## Hidden by default, for every role

A connection-health card is only meaningful to an institute that has actually connected an external LMS, and enabling it starts polling that customer's site every minute — so it's opt-in rather than opt-out.

Gated on a new `isWidgetExplicitlyVisible()` rather than the shared `isWidgetVisible()`. The shared helper fails **open** (`vis !== false`), which is right for widgets that have always shipped on — a settings-load failure shouldn't blank the dashboard. But an opt-in widget must not switch itself on that way, and this one starts hitting the customer's LMS the moment it renders.

## Reviewer note

`index.lazy.tsx` is **33 changed lines, all mine.** An earlier `eslint --fix` on that file had auto-formatted a batch of pre-existing violations elsewhere in it (ScrollArea comments, `ROLE_DISPLAY_LABEL` parens, `financeSummary` indentation); I rebuilt the file from the branch head with only the three logical edits re-applied, so none of that unrelated churn is in this diff.

## Verification

`eslint` and `scripts/design-lint.mjs` clean on the touched files. Typecheck was skipped at the author's request for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
