### PR TITLE
fix(invoice): revert default template to the single-figure total

### DIFF
--- a/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
+++ b/admin_core_service/src/main/resources/templates/invoice/default_invoice.html
@@ -268,13 +268,22 @@
             text-align: center;
         }
         
-        /* Totals block. A plain container: {{totals_rows}} brings its own two-column
-           table, which aligns label and value in the PDF renderer without relying
-           on flexbox, and carries its own emphasis on the paid line — so this must
-           not force bold onto every row. */
+        /* Total Purchases */
         .total-purchases {
+            display: flex;
+            justify-content: space-between;
             padding: 10px 15px;
+            font-size: 15px;
+            font-weight: bold;
             border-bottom: 1px solid #e0e0e0;
+        }
+        
+        .total-purchases-label {
+            color: #333;
+        }
+        
+        .total-purchases-amount {
+            color: #333;
         }
         
         /* Payment Details Section */
@@ -532,12 +541,10 @@
             </tbody>
         </table>
         
-        <!-- Totals: what the courses cost, what was taken off, what was paid.
-             {{totals_rows}} is rendered by InvoiceService and omits the rows that
-             do not apply, because a template has no conditionals and a hard-coded
-             "Discount" line prints blank on every full-price invoice. -->
+        <!-- Total Purchases -->
         <div class="total-purchases">
-            {{totals_rows}}
+            <span class="total-purchases-label">Total Purchases</span>
+            <span class="total-purchases-amount">{{total_amount}}</span>
         </div>
         
         <!-- Payment Details Section -->

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceTotalsRowsTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/invoice/service/InvoiceTotalsRowsTest.java
@@ -80,13 +80,19 @@ class InvoiceTotalsRowsTest {
     }
 
     @Test
-    @DisplayName("the shipped default invoice template has somewhere to put it")
-    void defaultTemplateUsesTheBlock() throws IOException {
+    @DisplayName("the shipped default invoice template keeps the block out")
+    void defaultTemplateDoesNotUseTheBlock() throws IOException {
         String template = Files.readString(
                 Path.of("src/main/resources/templates/invoice/default_invoice.html"));
-        assertTrue(template.contains("{{totals_rows}}"),
-                "default_invoice.html must render the totals block");
-        assertFalse(template.contains("Total Purchases</span>"),
-                "the bare single-figure total it replaced should be gone");
+        // The block is built with raw &nbsp;. default_invoice.html names its
+        // placeholder inside a CSS comment and an HTML comment as well as at the
+        // real insertion point, and jsoup emits <style> data and comments verbatim
+        // -- so substituting it put an undeclared XML entity into the document and
+        // every invoice PDF died on it. Until the block stops emitting named
+        // entities, the shipped template stays on the single-figure total.
+        assertFalse(template.contains("{{totals_rows}}"),
+                "default_invoice.html must not embed the totals block");
+        assertTrue(template.contains("Total Purchases</span>"),
+                "the single-figure total is what it renders instead");
     }
 }


### PR DESCRIPTION
Every invoice PDF has failed since 84afeb3882 shipped:

  Failed to generate PDF: Can't load the XML resource (using TRaX
  transformer). lineNumber: 271; columnNumber: 260; The entity "nbsp"
  was referenced, but not declared.

buildTotalsRowsHtml emits raw &nbsp;, and default_invoice.html named {{totals_rows}} in a CSS comment and an HTML comment as well as at the real insertion point. jsoup escapes text nodes but emits <style> data and comments verbatim, so those two copies carried an undeclared entity into the document openhtmltopdf parses as XML, and the render aborted.

The cost is not a missing PDF. generateInvoiceWithResult is @Transactional, so the throw marks the enrolling transaction rollback-only: on 2026-09-03 a learner was charged at eWay, the invoice died, and user_plan / payment_log / the enrollment all rolled back -- leaving the money taken, no enrollment, and only the REQUIRES_NEW ledger rows behind. She paid twice trying again.

Restore the pre-84afeb3882 template. The invoice goes back to a single "Total Purchases" line and loses the Amount / Discount / Tax breakdown, which is the trade for rendering at all. buildTotalsRowsHtml is left alone -- nothing references it now, and the real fix belongs there (numeric &#160;) rather than in a revert.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
