### PR TITLE
fix(payments): pad single-name learners for eWay so enrolment payment…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_method/service/LearnerPaymentMethodService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner_payment_method/service/LearnerPaymentMethodService.java
@@ -185,6 +185,12 @@ public class LearnerPaymentMethodService {
         LearnerBillingDetailsDTO billing = new LearnerBillingDetailsDTO();
         String firstName = textOrNull(ewayCustomer, "FirstName");
         String lastName = textOrNull(ewayCustomer, "LastName");
+        // eWay refuses an empty LastName, so a learner who gave only a first name is
+        // sent to the gateway as "Jane Jane" (see EwayPaymentManager#ensureLastName).
+        // That padding is for eWay alone — collapse it back to the single name here.
+        if (lastName != null && lastName.equalsIgnoreCase(firstName)) {
+            lastName = null;
+        }
         String fullName = ((firstName != null ? firstName : "") + " " + (lastName != null ? lastName : "")).trim();
         billing.setName(StringUtils.hasText(fullName) ? fullName : null);
         billing.setEmail(textOrNull(ewayCustomer, "Email"));

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/EwayPaymentManager.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/payments/manager/EwayPaymentManager.java
@@ -339,7 +339,23 @@ public class EwayPaymentManager implements PaymentServiceStrategy {
         return transaction;
     }
 
+    /**
+     * eWay rejects a transaction whose Customer.LastName is empty, and learners
+     * enrolling through an invite often supply only a first name. Duplicating the
+     * single token ("Jane" -> "Jane Jane") keeps the checkout going instead of
+     * failing the payment; a name that already has a surname is left untouched.
+     */
+    private String ensureLastName(String fullName) {
+        if (!StringUtils.hasText(fullName)) {
+            return fullName;
+        }
+        String trimmed = fullName.trim();
+        return trimmed.split("\\s+").length == 1 ? trimmed + " " + trimmed : trimmed;
+    }
+
     private EwayApiResponseDTO.Transaction createCardTransactionPayload(String fullName, String email, EwayRequestDTO ewayRequest, int amount, String method, String currencyCode) {
+        fullName = ensureLastName(fullName);
+
         EwayApiResponseDTO.CardDetails cardDetails = new EwayApiResponseDTO.CardDetails();
         cardDetails.Name = fullName;
         cardDetails.Number = ewayRequest.getCardNumber();
@@ -351,7 +367,7 @@ public class EwayPaymentManager implements PaymentServiceStrategy {
         customer.CardDetails = cardDetails;
         customer.Email = email;
         customer.Country = ewayRequest.getCountryCode();
-        String[] nameParts = fullName.trim().split("\\s+", 2);
+        String[] nameParts = StringUtils.hasText(fullName) ? fullName.split("\\s+", 2) : new String[]{""};
         customer.FirstName = nameParts[0];
         customer.LastName = nameParts.length > 1 ? nameParts[1] : "";
 


### PR DESCRIPTION
…s clear

eWay rejects a transaction whose Customer.LastName is empty. Learners enrolling through an invite frequently supply only a first name, which left LastName blank and failed the payment at checkout.

Send such a name to eWay as "Jane Jane" instead. The padding is applied inside createCardTransactionPayload, the single choke point for every eWay card call driven by an eway_request (ProcessPayment and CreateTokenCustomer alike), and only reassigns a local parameter — the caller's UserDTO is untouched, so users.full_name and every downstream notification still store and show the first name alone. No other gateway is affected.

The stored eWay customer snapshot feeds the learner's saved-billing-details card, so collapse a LastName that merely echoes FirstName back to the single name when rendering it.

Also makes the name split null-safe; it could previously NPE on a null full name arriving via createCustomer.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
