### PR TITLE
fix(live-class): drop the "REC" label beside the recording dot

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/study-library/live-class/embed/index.tsx
@@ -643,17 +643,19 @@ function EmbedComponent() {
           </h1>
           {/* A recording dot rather than the word "Live". These classes are a
               scheduled playback, not a broadcast, and "LIVE" alongside YouTube's
-              own chrome read as a claim the class could not keep. The dot is
-              shrink-0 so the title truncates against it instead of squashing it. */}
+              own chrome read as a claim the class could not keep. The dot carries
+              the meaning on its own — the "REC" label beside it was redundant next
+              to YouTube's own chrome. The accessible name is kept on the wrapper so
+              screen readers still announce it. The dot is shrink-0 so the title
+              truncates against it instead of squashing it. */}
           {sessionId ? (
             <span
-              className="flex shrink-0 items-center gap-2 rounded px-3 py-1 text-sm font-semibold uppercase text-neutral-600 shadow"
+              className="flex shrink-0 items-center rounded px-2 py-1"
               role="status"
               aria-label={t("liveClass.embed.recording")}
               title={t("liveClass.embed.recording")}
             >
               <span className="size-2 shrink-0 rounded-full bg-red-600" aria-hidden="true" />
-              {t("liveClass.embed.rec")}
             </span>
           ) : (
             <span className="shrink-0 rounded bg-primary-300 px-3 py-1 text-sm font-semibold uppercase text-white shadow">


### PR DESCRIPTION
The embedded class header showed a red dot followed by the word REC. The player below it is YouTube, which renders its own chrome, so the label restated what the surface already conveys and competed with the session title for width on narrow screens.

Keeps the dot, which carries the meaning on its own, and keeps aria-label and title on the wrapper so screen readers still announce "recording" -- removing the visible text without that would leave the indicator meaningless to anyone not perceiving colour.

Also drops gap-2, the uppercase/semibold text styling and the shadow, which existed to frame the label. A lone 8px dot inside that pill read as stranded.

liveClass.embed.rec now has no usages. The locale key is left in place rather than removed across every language file.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
