### PR TITLE
fix(ai-calling): interactive calls jump the queue, per-lead daily cap…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
@@ -279,6 +279,37 @@ public class AiCallService {
             }
         }
 
+        // PER-LEAD ceiling, rolling 24h. Distinct from the institute cap above: that
+        // one bounds total spend, this one stops a single lead being dialled over and
+        // over. It exists because the queue stretched a bulk run from minutes to hours
+        // — the campaign's own cooldown only looks back five minutes, so re-firing a
+        // run mid-flight re-enqueued every lead already called and rang them again.
+        // The setting was already there (maxCallsPerDayPerLead, default 3); only the
+        // CALL_AI workflow node ever honoured it, so bulk and automation had no
+        // per-lead ceiling at all.
+        //
+        // Skipped for a single manual click, exactly like the institute cap: a person
+        // asking for one call cannot fan out, and silently refusing them is the failure
+        // mode this whole guard set keeps producing.
+        if (!mock && trigger.enforcesPerLeadDailyCap()) {
+            int perLead = settings.getMaxCallsPerDayPerLead() > 0
+                    ? settings.getMaxCallsPerDayPerLead() : 3;
+            java.sql.Timestamp since = java.sql.Timestamp.from(
+                    Instant.now().minus(Duration.ofHours(24)));
+            long already = callLogRepo.countOutboundToLeadSince(
+                    req.getInstituteId(), userId, provider, since);
+            if (already >= perLead) {
+                log.info("AI call skipped: lead {} already had {} {} call(s) in the last 24h "
+                        + "(cap {})", userId, already, provider, perLead);
+                return AiCallResponseDTO.builder()
+                        .status("SKIPPED_LEAD_DAILY_CAP")
+                        .dispatched(false)
+                        .providerMessage("This lead has already been called the maximum number "
+                                + "of times today.")
+                        .build();
+            }
+        }
+
         // De-duplicate a near-simultaneous double dispatch for the SAME lead. Aavtaar
         // doesn't echo our correlation id, so two dials placed within milliseconds (the
         // CALL_AI node entered twice / a bulk run + the node) become two real calls — one

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/enums/CallTrigger.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/enums/CallTrigger.java
@@ -53,6 +53,18 @@ public enum CallTrigger {
         return this != MANUAL;
     }
 
+    /**
+     * True when the PER-LEAD rolling 24h cap should block the dial.
+     *
+     * <p>Same profile as the institute cap, and for the same reason: it bounds
+     * fan-out, and a person clicking Call on one lead cannot fan anything out. This
+     * is the guard that stops a lead being called twice by a re-fired campaign — the
+     * bulk cooldown only spans minutes, while a queued run now spans hours.
+     */
+    public boolean enforcesPerLeadDailyCap() {
+        return this != MANUAL;
+    }
+
     /** True when a near-simultaneous duplicate for the same lead should be collapsed. */
     public boolean enforcesDuplicateWindow() {
         return this != MANUAL;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/persistence/repository/TelephonyCallLogRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/persistence/repository/TelephonyCallLogRepository.java
@@ -99,6 +99,27 @@ public interface TelephonyCallLogRepository extends JpaRepository<TelephonyCallL
                                      @Param("excludeId") String excludeId);
 
     /**
+     * Outbound dials to ONE lead in a rolling window.
+     *
+     * <p>Backs the per-lead daily cap. The bulk campaign's own cooldown only looks back
+     * a few minutes, which was enough when a run finished in minutes; a queued run
+     * spans hours, so re-firing it mid-flight re-enqueued every lead that had already
+     * been called and dialled them a second time. Unlike
+     * {@link #countRecentOutboundAttempts} this excludes nothing — it is a ceiling, not
+     * an attempt counter.
+     */
+    @Query("""
+            SELECT COUNT(t) FROM TelephonyCallLog t
+            WHERE t.instituteId = :instituteId AND t.userId = :userId
+              AND t.providerType = :providerType AND t.direction = 'OUTBOUND'
+              AND t.createdAt >= :since
+            """)
+    long countOutboundToLeadSince(@Param("instituteId") String instituteId,
+                                  @Param("userId") String userId,
+                                  @Param("providerType") String providerType,
+                                  @Param("since") java.sql.Timestamp since);
+
+    /**
      * All outbound dials this institute placed on a provider since {@code since}
      * (rolling-window daily-cap guardrail — see {@code AiCallingSettingsPojo.maxCallsPerDay}).
      * Provider-scoped so an institute's Exotel/Airtel human calls never count

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDrainJob.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDrainJob.java
@@ -81,6 +81,7 @@ public class AiCallQueueDrainJob {
     private static final String SKIPPED_ASSIGNED = "SKIPPED_ASSIGNED";
     private static final String SKIPPED_DAILY_CAP = "SKIPPED_DAILY_CAP";
     private static final String SKIPPED_DUPLICATE = "SKIPPED_DUPLICATE";
+    private static final String SKIPPED_LEAD_DAILY_CAP = "SKIPPED_LEAD_DAILY_CAP";
 
     /** Give up on an item after this many dial attempts. */
     private static final int MAX_ATTEMPTS = 3;
@@ -346,6 +347,13 @@ public class AiCallQueueDrainJob {
                 case SKIPPED_DUPLICATE -> {
                     finish(item, AiCallQueueStatus.CANCELLED,
                             "This lead was called by another path moments ago.");
+                    return DispatchOutcome.ITEM_HANDLED;
+                }
+                case SKIPPED_LEAD_DAILY_CAP -> {
+                    // Per LEAD, not per institute, so only this item is dropped — the
+                    // rest of the lane is unaffected and keeps dialling.
+                    finish(item, AiCallQueueStatus.CANCELLED,
+                            "Already called the maximum number of times today.");
                     return DispatchOutcome.ITEM_HANDLED;
                 }
                 case SKIPPED_DAILY_CAP -> {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
@@ -68,6 +68,25 @@ public class AiCallQueueService {
     /** Rows per insert transaction for a bulk enqueue. */
     private static final int CHUNK = 100;
 
+    /** Ordinary work: bulk campaigns and automation. */
+    public static final int PRIORITY_DEFAULT = 100;
+
+    /**
+     * A person clicked Call and is waiting.
+     *
+     * <p>Everything used to enqueue at the same priority, which meant a counsellor's
+     * click during a 100-lead campaign landed at position 101 and waited out the whole
+     * run — roughly an hour and a half. It could not even be rescued by reserving a
+     * slot: the drain query takes each lane's OLDEST rows, so the click was never in
+     * the candidate set to begin with.
+     *
+     * <p>Ranking it above bulk fixes both ends at once. The drainer orders by priority
+     * first, so it surfaces immediately; and {@code countAheadInLane} counts only rows
+     * that outrank it, so the inline fast path sees an empty lane ahead and dials on the
+     * request thread exactly as it does on an idle fleet.
+     */
+    public static final int PRIORITY_INTERACTIVE = 200;
+
     /**
      * Pseudo-status for "on a line right now". Not a real {@link AiCallQueueStatus} —
      * the queue row stops at DIALED, so liveness is a join against the call log.
@@ -188,7 +207,7 @@ public class AiCallQueueService {
         return AiCallQueueItem.builder()
                 .instituteId(req.getInstituteId())
                 .provider(provider)
-                .priority(100)
+                .priority(trigger == CallTrigger.MANUAL ? PRIORITY_INTERACTIVE : PRIORITY_DEFAULT)
                 .source(source)
                 .sourceRef(sourceRef)
                 .callTrigger((trigger == null ? CallTrigger.AUTOMATION : trigger).name())
@@ -304,7 +323,18 @@ public class AiCallQueueService {
         if (ahead <= 0) return 0;
         int laneSlots = Math.max(1, snap.laneCapacityFor(instituteId, provider));
         double batches = Math.ceil((double) ahead / laneSlots);
-        return Math.max(1, Math.round(batches * capacityService.avgCallSeconds() / 60.0));
+        long dialing = Math.max(1, Math.round(batches * capacityService.avgCallSeconds() / 60.0));
+
+        // Nothing dials while the lane is held, so the wait is the hold PLUS the work.
+        // Reporting only the work told an admin at 20:55, with the window closing at
+        // 21:00, that a hundred-lead run had "about 1 h 40 min left" when in truth
+        // nothing would happen until 09:00 the next morning.
+        Instant earliest = repository.findEarliestNotBefore(instituteId);
+        if (earliest != null && earliest.isAfter(Instant.now())) {
+            long held = Duration.between(Instant.now(), earliest).toMinutes();
+            return Math.max(1, held + dialing);
+        }
+        return dialing;
     }
 
     public QueueSummary summary(String instituteId) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/repository/AiCallQueueItemRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/repository/AiCallQueueItemRepository.java
@@ -159,6 +159,20 @@ public interface AiCallQueueItemRepository extends JpaRepository<AiCallQueueItem
     @Query("SELECT COUNT(q) FROM AiCallQueueItem q WHERE q.instituteId = :instituteId AND q.status = 'QUEUED'")
     long countQueuedForInstitute(@Param("instituteId") String instituteId);
 
+    /**
+     * When this institute's queue can next dial anything.
+     *
+     * <p>Null means "now". A value in the future means the whole lane is held — outside
+     * calling hours, out of credits, or behind its daily cap. Without this the ETA is
+     * computed purely from depth and slot count, so a run parked until 09:00 still
+     * reported "about 1 h 40 min left" at five to nine in the evening.
+     */
+    @Query("""
+            SELECT MIN(q.notBefore) FROM AiCallQueueItem q
+            WHERE q.instituteId = :instituteId AND q.status = 'QUEUED'
+            """)
+    Instant findEarliestNotBefore(@Param("instituteId") String instituteId);
+
     @Query("SELECT COUNT(q) FROM AiCallQueueItem q WHERE q.status = 'QUEUED'")
     long countQueuedTotal();
 


### PR DESCRIPTION
…, honest ETA when held

Three defects that only surface once a bulk run is long enough to overlap with everything else.

MANUAL CALLS STARVED BEHIND A BULK RUN. Every path enqueued at the same priority, so a counsellor clicking Call during a 100-lead campaign landed at position 101 and waited out the whole run — about an hour and a half. Reserving a slot could not have helped: the drain query takes each lane's OLDEST rows, so the click was never in the candidate set. MANUAL now enqueues above bulk, which fixes both ends — the drainer orders by priority first, and countAheadInLane counts only rows that outrank it, so the inline fast path sees an empty lane and dials on the request thread exactly as it does on an idle fleet.

A RE-FIRED CAMPAIGN CALLED PEOPLE TWICE. The bulk cooldown looks back five minutes, which was enough when a run finished in minutes; a queued run spans hours, so re-firing it re-enqueued every lead already called. maxCallsPerDayPerLead existed and defaulted to 3, but ONLY the CALL_AI workflow node honoured it — bulk and automation had no per-lead ceiling at all. placeCall now enforces it, with the same exemption the institute cap uses: a single manual click is never refused, because one person asking for one call cannot fan out.

THE ETA LIED WHILE THE LANE WAS HELD. It was computed purely from depth and slot count, ignoring not_before — so at 20:55, with the calling window closing at 21:00, a run reported "about 1 h 40 min left" when nothing would dial until 09:00. It now adds the hold to the work.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
