### PR TITLE
feat(admin): show the real WhatsApp message when picking a template

### DIFF
--- a/frontend-admin-dashboard/public/locales/ar/manageStudentsIndividualSendDialog.json
+++ b/frontend-admin-dashboard/public/locales/ar/manageStudentsIndividualSendDialog.json
@@ -74,7 +74,9 @@
         "selectPlaceholder": "اختر قالبًا معتمدًا",
         "emptyText": "لا يوجد قالب معتمد يطابق بحثك.",
         "languageCodeLabel": "رمز اللغة",
-        "templatePreviewLabel": "معاينة القالب"
+        "templatePreviewLabel": "معاينة القالب",
+        "previewHint": "الأجزاء المميّزة هي متغيّرات — ستُملأ ببيانات هذا المتعلّم في الخطوة التالية.",
+        "headerBadge": "ترويسة {{kind}}"
     },
     "mediaKind": {
         "image": "صورة",
@@ -95,7 +97,8 @@
         "sourcePlaceholder": "اختر المصدر...",
         "literalOption": "قيمة ثابتة...",
         "literalPlaceholder": "اكتب قيمة",
-        "unresolved": "(غير محدد)"
+        "unresolved": "(غير محدد)",
+        "livePreviewLabel": "معاينة الرسالة"
     },
     "reviewStep": {
         "messageSent": "تم إرسال الرسالة",
@@ -124,10 +127,21 @@
             "DELIVERED": "تم التسليم",
             "READ": "تمت القراءة",
             "FAILED": "فشل"
-        }
+        },
+        "messagePreviewLabel": "الرسالة التي سيتم إرسالها"
     },
     "footer": {
         "back": "رجوع",
         "next": "التالي"
+    },
+    "templatePicker": {
+        "showFullMessage": "عرض الرسالة كاملة",
+        "showLess": "عرض أقل"
+    },
+    "waPreview": {
+        "image": "صورة",
+        "video": "فيديو",
+        "document": "مستند",
+        "emptyBody": "لا يحتوي هذا القالب على نص رسالة."
     }
 }

--- a/frontend-admin-dashboard/public/locales/en/manageStudentsIndividualSendDialog.json
+++ b/frontend-admin-dashboard/public/locales/en/manageStudentsIndividualSendDialog.json
@@ -74,7 +74,9 @@
         "selectPlaceholder": "Select an approved template",
         "emptyText": "No approved template matches your search.",
         "languageCodeLabel": "Language Code",
-        "templatePreviewLabel": "Template Preview"
+        "templatePreviewLabel": "Template Preview",
+        "previewHint": "Highlighted parts are placeholders — the next step fills them with this learner's details.",
+        "headerBadge": "{{kind}} header"
     },
     "mediaKind": {
         "image": "image",
@@ -95,7 +97,8 @@
         "sourcePlaceholder": "Select source...",
         "literalOption": "Literal value...",
         "literalPlaceholder": "Type a value",
-        "unresolved": "(unresolved)"
+        "unresolved": "(unresolved)",
+        "livePreviewLabel": "Message preview"
     },
     "reviewStep": {
         "messageSent": "Message Sent",
@@ -124,10 +127,21 @@
             "DELIVERED": "Delivered",
             "READ": "Read",
             "FAILED": "Failed"
-        }
+        },
+        "messagePreviewLabel": "Message that will be sent"
     },
     "footer": {
         "back": "Back",
         "next": "Next"
+    },
+    "templatePicker": {
+        "showFullMessage": "Show full message",
+        "showLess": "Show less"
+    },
+    "waPreview": {
+        "image": "Image",
+        "video": "Video",
+        "document": "Document",
+        "emptyBody": "This template has no message body."
     }
 }

--- a/frontend-admin-dashboard/public/locales/fr/manageStudentsIndividualSendDialog.json
+++ b/frontend-admin-dashboard/public/locales/fr/manageStudentsIndividualSendDialog.json
@@ -74,7 +74,9 @@
         "selectPlaceholder": "Sélectionner un modèle approuvé",
         "emptyText": "Aucun modèle approuvé ne correspond à votre recherche.",
         "languageCodeLabel": "Code de langue",
-        "templatePreviewLabel": "Aperçu du modèle"
+        "templatePreviewLabel": "Aperçu du modèle",
+        "previewHint": "Les parties surlignées sont des variables — l'étape suivante les remplit avec les données de cet apprenant.",
+        "headerBadge": "En-tête {{kind}}"
     },
     "mediaKind": {
         "image": "image",
@@ -95,7 +97,8 @@
         "sourcePlaceholder": "Sélectionner une source...",
         "literalOption": "Valeur fixe...",
         "literalPlaceholder": "Saisissez une valeur",
-        "unresolved": "(non résolu)"
+        "unresolved": "(non résolu)",
+        "livePreviewLabel": "Aperçu du message"
     },
     "reviewStep": {
         "messageSent": "Message envoyé",
@@ -124,10 +127,21 @@
             "DELIVERED": "Remis",
             "READ": "Lu",
             "FAILED": "Échec"
-        }
+        },
+        "messagePreviewLabel": "Message qui sera envoyé"
     },
     "footer": {
         "back": "Retour",
         "next": "Suivant"
+    },
+    "templatePicker": {
+        "showFullMessage": "Afficher le message complet",
+        "showLess": "Afficher moins"
+    },
+    "waPreview": {
+        "image": "Image",
+        "video": "Vidéo",
+        "document": "Document",
+        "emptyBody": "Ce modèle n'a pas de corps de message."
     }
 }

--- a/frontend-admin-dashboard/public/locales/hi/manageStudentsIndividualSendDialog.json
+++ b/frontend-admin-dashboard/public/locales/hi/manageStudentsIndividualSendDialog.json
@@ -74,7 +74,9 @@
         "selectPlaceholder": "एक स्वीकृत टेम्पलेट चुनें",
         "emptyText": "आपकी खोज से मेल खाने वाला कोई स्वीकृत टेम्पलेट नहीं है।",
         "languageCodeLabel": "भाषा कोड",
-        "templatePreviewLabel": "टेम्पलेट पूर्वावलोकन"
+        "templatePreviewLabel": "टेम्पलेट पूर्वावलोकन",
+        "previewHint": "हाइलाइट किए गए हिस्से प्लेसहोल्डर हैं — अगले चरण में इन्हें इस शिक्षार्थी की जानकारी से भरा जाएगा।",
+        "headerBadge": "{{kind}} हेडर"
     },
     "mediaKind": {
         "image": "छवि",
@@ -95,7 +97,8 @@
         "sourcePlaceholder": "स्रोत चुनें...",
         "literalOption": "निश्चित मान...",
         "literalPlaceholder": "एक मान लिखें",
-        "unresolved": "(अनसुलझा)"
+        "unresolved": "(अनसुलझा)",
+        "livePreviewLabel": "संदेश पूर्वावलोकन"
     },
     "reviewStep": {
         "messageSent": "संदेश भेजा गया",
@@ -124,10 +127,21 @@
             "DELIVERED": "डिलीवर हो गया",
             "READ": "पढ़ा गया",
             "FAILED": "विफल"
-        }
+        },
+        "messagePreviewLabel": "जो संदेश भेजा जाएगा"
     },
     "footer": {
         "back": "पीछे",
         "next": "आगे"
+    },
+    "templatePicker": {
+        "showFullMessage": "पूरा संदेश देखें",
+        "showLess": "कम दिखाएं"
+    },
+    "waPreview": {
+        "image": "छवि",
+        "video": "वीडियो",
+        "document": "दस्तावेज़",
+        "emptyBody": "इस टेम्पलेट में कोई संदेश सामग्री नहीं है।"
     }
 }

--- a/frontend-admin-dashboard/src/components/templates/TemplateSearchableSelect.test.tsx
+++ b/frontend-admin-dashboard/src/components/templates/TemplateSearchableSelect.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TemplateSearchableSelect, toTemplateOptions } from './TemplateSearchableSelect';
+
+/**
+ * The picker's row is where an admin decides which message to send, and the body is the only thing
+ * that distinguishes `reminder_v2` from `reminder_v3`. Two clamped lines cut that off mid-sentence,
+ * so each row can be opened out — and opening one must NOT also pick the template and close the
+ * list, which is the whole trap of putting a button inside a cmdk item.
+ */
+const longBody =
+    'Dear {{1}}, To access your scheduled classes, attempt assigned tests, and track your daily ' +
+    'course updates, please log in to the official Shiksha Nation mobile application. You can ' +
+    'download it from the Play Store.';
+
+const options = [
+    {
+        value: 'shiksha_nation_batch_portal_update_app',
+        name: 'shiksha_nation_batch_portal_update_app',
+        status: 'APPROVED',
+        category: 'MARKETING',
+        language: 'en',
+        preview: longBody.replace('{{1}}', '[name]'),
+    },
+];
+
+describe('TemplateSearchableSelect', () => {
+    it('opens a row out without selecting it', async () => {
+        const onChange = vi.fn();
+        render(
+            <TemplateSearchableSelect options={options} value={undefined} onChange={onChange} />
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+        fireEvent.click(screen.getByRole('button', { name: /show full message/i }));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
+    });
+
+    it('still selects the template when the row itself is clicked', async () => {
+        const onChange = vi.fn();
+        render(
+            <TemplateSearchableSelect options={options} value={undefined} onChange={onChange} />
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+        fireEvent.click(screen.getByText('shiksha_nation_batch_portal_update_app'));
+
+        expect(onChange).toHaveBeenCalledWith('shiksha_nation_batch_portal_update_app');
+    });
+
+    it('spends both clamped lines on words, not on the body’s blank lines', async () => {
+        const onChange = vi.fn();
+        render(
+            <TemplateSearchableSelect
+                options={[
+                    {
+                        value: 'greeting',
+                        name: 'greeting_template',
+                        preview: 'Dear [name],\n\nYour batch starts tomorrow.',
+                    },
+                ]}
+                value={undefined}
+                onChange={onChange}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+        // Collapsed: one flowing paragraph, so the clamp shows message text on both lines.
+        expect(screen.getByText('Dear [name], Your batch starts tomorrow.')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /show full message/i }));
+        expect(
+            screen.getByText('Dear [name],\n\nYour batch starts tomorrow.', {
+                collapseWhitespace: false,
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('offers no expander for a body that already fits', async () => {
+        render(
+            <TemplateSearchableSelect
+                options={[
+                    { value: 'short', name: 'short_template', preview: 'Your OTP is [otp].' },
+                ]}
+                value={undefined}
+                onChange={vi.fn()}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+
+        expect(
+            screen.queryByRole('button', { name: /show full message/i })
+        ).not.toBeInTheDocument();
+    });
+});
+
+describe('toTemplateOptions', () => {
+    it('shows what the message says instead of its positional placeholders', () => {
+        const [option] = toTemplateOptions([
+            {
+                id: 'tpl-1',
+                name: 'batch_portal_update',
+                bodyText: 'Dear {{1}}, your {{2}} starts tomorrow.',
+                bodyVariableNames: ['name', 'course_name'],
+            },
+        ]);
+
+        expect(option?.preview).toBe('Dear [name], your [course_name] starts tomorrow.');
+    });
+
+    it('strips email HTML down to readable text', () => {
+        const [option] = toTemplateOptions([
+            { id: 'tpl-2', name: 'welcome_email', content: '<p>Hi&nbsp;{{name}}</p>' },
+        ]);
+
+        expect(option?.preview).toBe('Hi [name]');
+    });
+});

--- a/frontend-admin-dashboard/src/components/templates/TemplateSearchableSelect.tsx
+++ b/frontend-admin-dashboard/src/components/templates/TemplateSearchableSelect.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Check, CaretUpDown, MagnifyingGlass } from '@phosphor-icons/react';
+import { Check, CaretDown, CaretUpDown, MagnifyingGlass } from '@phosphor-icons/react';
 
 import { cn } from '@/lib/utils';
+import { flattenTemplateBody, humanizeTemplateText } from './template-text';
 import { Button } from '@/components/ui/button';
 import {
     Command,
@@ -43,6 +44,9 @@ interface TemplateSearchableSelectProps {
     disabled?: boolean;
     loading?: boolean;
     className?: string;
+    /** Row expander copy, for translated callers. */
+    expandLabel?: string;
+    collapseLabel?: string;
     /** Rendered as the first entry, e.g. "No template" or "Custom — write from scratch". */
     noneOption?: { value: string; label: string };
     /**
@@ -71,12 +75,17 @@ export function TemplateSearchableSelect({
     disabled = false,
     loading = false,
     className,
+    expandLabel = 'Show full message',
+    collapseLabel = 'Show less',
     noneOption,
     portal = true,
     id,
 }: TemplateSearchableSelectProps) {
     const [open, setOpen] = React.useState(false);
     const [query, setQuery] = React.useState('');
+    // Which rows have their message opened out. Two lines is enough to tell templates apart but not
+    // enough to read one, and the body is the only thing that says what the message actually says.
+    const [expandedRows, setExpandedRows] = React.useState<Record<string, boolean>>({});
 
     const selected = React.useMemo(
         () => options.find((option) => option.value === value),
@@ -111,7 +120,8 @@ export function TemplateSearchableSelect({
     }, [options, query]);
 
     const showNoneOption =
-        !!noneOption && (!query.trim() || noneOption.label.toLowerCase().includes(query.trim().toLowerCase()));
+        !!noneOption &&
+        (!query.trim() || noneOption.label.toLowerCase().includes(query.trim().toLowerCase()));
 
     const handleSelect = (selectedValue: string) => {
         onChange(selectedValue);
@@ -122,8 +132,14 @@ export function TemplateSearchableSelect({
     const handleOpenChange = (next: boolean) => {
         setOpen(next);
         // Start each visit with the full list rather than the last search.
-        if (!next) setQuery('');
+        if (!next) {
+            setQuery('');
+            setExpandedRows({});
+        }
     };
+
+    const toggleRow = (rowValue: string) =>
+        setExpandedRows((prev) => ({ ...prev, [rowValue]: !prev[rowValue] }));
 
     const triggerLabel = loading
         ? 'Loading templates…'
@@ -180,7 +196,16 @@ export function TemplateSearchableSelect({
                                 message text contains it.
                             </p>
                         )}
-                        <CommandGroup className="max-h-72 overflow-auto">
+                        {/* Rows carry a name, badges and two lines of body, so the old 18rem showed
+                            barely two of them — an institute with a dozen templates could not see
+                            past the first. 24rem shows four, but only when there is room for it:
+                            whichever is smaller, 24rem or the space Radix measured between the
+                            trigger and the viewport edge, so a list opening low on a short screen
+                            still scrolls inside itself instead of running off the page. The
+                            fallback keeps a sane cap on the frame before Radix has measured. */}
+                        <CommandGroup
+                            className="max-h-[min(24rem,var(--radix-popover-content-available-height,24rem))] overflow-auto" // design-lint-ignore: dynamic Radix-computed CSS var (available viewport space), not a fixed magic number a token could represent
+                        >
                             {showNoneOption && noneOption && (
                                 <CommandItem
                                     key={noneOption.value}
@@ -196,56 +221,101 @@ export function TemplateSearchableSelect({
                                     {noneOption.label}
                                 </CommandItem>
                             )}
-                            {visible.map((option) => (
-                                <CommandItem
-                                    key={option.value}
-                                    // Unique per row — cmdk keys highlight/selection off this. It is
-                                    // no longer what search matches against (see `visible` above).
-                                    value={option.value}
-                                    onSelect={() => handleSelect(option.value)}
-                                    className="items-start"
-                                >
-                                    <Check
-                                        className={cn(
-                                            'mr-2 mt-1 size-4 shrink-0',
-                                            value === option.value ? 'opacity-100' : 'opacity-0'
-                                        )}
-                                    />
-                                    <div className="min-w-0 flex-1">
-                                        <div className="flex flex-wrap items-center gap-1.5">
-                                            <span className="truncate font-medium">
-                                                {option.name}
-                                            </span>
-                                            {option.status && (
-                                                <span
+                            {visible.map((option) => {
+                                const isExpanded = !!expandedRows[option.value];
+                                // Anything past two lines is cut off mid-sentence by the clamp, and
+                                // a multi-paragraph body loses every line but the first two.
+                                const isTruncatable =
+                                    !!option.preview &&
+                                    (option.preview.length > 110 || option.preview.includes('\n'));
+                                // Collapsed, the body flows as one paragraph. Keeping its line
+                                // breaks spent the two clamped lines on "Dear [name]," and a blank
+                                // — the reader learned nothing about the message. Expanded, the
+                                // paragraphs come back.
+                                const collapsedPreview = option.preview?.replace(/\s*\n+\s*/g, ' ');
+                                return (
+                                    <CommandItem
+                                        key={option.value}
+                                        // Unique per row — cmdk keys highlight/selection off this. It is
+                                        // no longer what search matches against (see `visible` above).
+                                        value={option.value}
+                                        onSelect={() => handleSelect(option.value)}
+                                        className="items-start"
+                                    >
+                                        <Check
+                                            className={cn(
+                                                'mr-2 mt-1 size-4 shrink-0',
+                                                value === option.value ? 'opacity-100' : 'opacity-0'
+                                            )}
+                                        />
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex flex-wrap items-center gap-1.5">
+                                                <span className="truncate font-medium">
+                                                    {option.name}
+                                                </span>
+                                                {option.status && (
+                                                    <span
+                                                        className={cn(
+                                                            'rounded px-1.5 py-0.5 text-2xs font-medium',
+                                                            statusTone[option.status] ??
+                                                                'bg-neutral-100 text-neutral-500'
+                                                        )}
+                                                    >
+                                                        {option.status}
+                                                    </span>
+                                                )}
+                                                {option.category && (
+                                                    <span className="rounded bg-primary-50 px-1.5 py-0.5 text-2xs text-primary-500">
+                                                        {option.category}
+                                                    </span>
+                                                )}
+                                                {option.language && (
+                                                    <span className="text-2xs text-neutral-400">
+                                                        {option.language}
+                                                    </span>
+                                                )}
+                                            </div>
+                                            {option.preview && (
+                                                <p
                                                     className={cn(
-                                                        'rounded px-1.5 py-0.5 text-2xs font-medium',
-                                                        statusTone[option.status] ??
-                                                            'bg-neutral-100 text-neutral-500'
+                                                        'mt-1 break-words text-xs leading-relaxed text-neutral-600',
+                                                        isExpanded
+                                                            ? 'whitespace-pre-wrap'
+                                                            : 'line-clamp-2'
                                                     )}
                                                 >
-                                                    {option.status}
-                                                </span>
+                                                    {isExpanded ? option.preview : collapsedPreview}
+                                                </p>
                                             )}
-                                            {option.category && (
-                                                <span className="rounded bg-primary-50 px-1.5 py-0.5 text-2xs text-primary-500">
-                                                    {option.category}
-                                                </span>
-                                            )}
-                                            {option.language && (
-                                                <span className="text-2xs text-neutral-400">
-                                                    {option.language}
-                                                </span>
+                                            {isTruncatable && (
+                                                // Inside a cmdk item, whose own onClick selects the row:
+                                                // stop the click here so opening the message does not
+                                                // also pick the template and close the list.
+                                                <button
+                                                    type="button"
+                                                    tabIndex={-1}
+                                                    onClick={(event) => {
+                                                        event.stopPropagation();
+                                                        toggleRow(option.value);
+                                                    }}
+                                                    onPointerDown={(event) =>
+                                                        event.stopPropagation()
+                                                    }
+                                                    className="mt-1 inline-flex items-center gap-1 text-2xs font-medium text-primary-500 hover:underline"
+                                                >
+                                                    {isExpanded ? collapseLabel : expandLabel}
+                                                    <CaretDown
+                                                        className={cn(
+                                                            'size-3 transition-transform',
+                                                            isExpanded && 'rotate-180'
+                                                        )}
+                                                    />
+                                                </button>
                                             )}
                                         </div>
-                                        {option.preview && (
-                                            <p className="mt-0.5 line-clamp-2 text-xs text-neutral-500">
-                                                {option.preview}
-                                            </p>
-                                        )}
-                                    </div>
-                                </CommandItem>
-                            ))}
+                                    </CommandItem>
+                                );
+                            })}
                         </CommandGroup>
                     </CommandList>
                 </Command>
@@ -265,6 +335,8 @@ interface TemplateLike {
     bodyText?: string;
     subject?: string;
     content?: string;
+    /** Names behind a WhatsApp template's positional `{{1}}` placeholders, when it has them. */
+    bodyVariableNames?: string[];
 }
 
 /**
@@ -282,10 +354,13 @@ export const toTemplateOptions = (
             category: t.category || t.templateCategory,
             language: t.language,
             status: t.status,
-            preview: (t.bodyText || t.subject || t.content || '')
-                .replace(/<[^>]*>/g, ' ')
-                .replace(/\s+/g, ' ')
-                .trim(),
+            // Placeholders are resolved to their names first: a Meta template's body reads
+            // "Dear {{1}}, your {{2}} starts…", which tells the reader nothing about the message.
+            preview: flattenTemplateBody(
+                humanizeTemplateText(t.bodyText || t.subject || t.content || '', {
+                    variableNames: t.bodyVariableNames,
+                })
+            ),
         }))
         .filter((option) => !!option.value);
 

--- a/frontend-admin-dashboard/src/components/templates/WhatsAppTemplatePreview.test.tsx
+++ b/frontend-admin-dashboard/src/components/templates/WhatsAppTemplatePreview.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WhatsAppTemplatePreview } from './WhatsAppTemplatePreview';
+
+/**
+ * The send dialogs used to preview a template as its `bodyText` in a grey box, so an admin approved
+ * a send having never seen the header, the footer or the buttons that go out with it — and read
+ * `Dear {{1}}` where the message says a name. This asserts the whole approved template renders.
+ */
+const template = {
+    name: 'batch_portal_update',
+    headerType: 'TEXT',
+    headerText: 'Shiksha Nation',
+    bodyText: 'Dear {{1}},\nYour {{2}} batch starts tomorrow.',
+    footerText: 'Reply STOP to opt out',
+    bodyVariableNames: ['name', 'course_name'],
+    buttons: [{ type: 'URL', text: 'Open the app', url: 'https://example.com' }],
+};
+
+describe('WhatsAppTemplatePreview', () => {
+    it('renders header, body, footer and buttons', () => {
+        render(<WhatsAppTemplatePreview template={template} />);
+
+        expect(screen.getByText('Shiksha Nation')).toBeInTheDocument();
+        expect(screen.getByText(/Your/)).toBeInTheDocument();
+        expect(screen.getByText('Reply STOP to opt out')).toBeInTheDocument();
+        expect(screen.getByText('Open the app')).toBeInTheDocument();
+    });
+
+    it('labels each placeholder with its field until a value is known', () => {
+        render(<WhatsAppTemplatePreview template={template} />);
+
+        expect(screen.getByText('name')).toBeInTheDocument();
+        expect(screen.getByText('course_name')).toBeInTheDocument();
+        expect(screen.queryByText(/\{\{1\}\}/)).not.toBeInTheDocument();
+    });
+
+    it('substitutes resolved values', () => {
+        render(
+            <WhatsAppTemplatePreview
+                template={template}
+                values={{ name: 'Priya', course_name: 'NEET 2027' }}
+            />
+        );
+
+        expect(screen.getByText('Priya')).toBeInTheDocument();
+        expect(screen.getByText('NEET 2027')).toBeInTheDocument();
+        expect(screen.queryByText('name')).not.toBeInTheDocument();
+    });
+
+    it('shows the media actually being sent, not the approved sample', () => {
+        render(
+            <WhatsAppTemplatePreview
+                template={{ ...template, headerType: 'IMAGE', headerSampleUrl: 'https://a/s.png' }}
+                mediaUrl="https://b/live.png"
+                labels={{ image: 'Image' }}
+            />
+        );
+
+        expect(screen.getByRole('img', { name: 'Image' })).toHaveAttribute(
+            'src',
+            'https://b/live.png'
+        );
+    });
+
+    it('does not leak body values into a positional header', () => {
+        // Header placeholders are numbered in their own namespace: `{{1}}` in the header is not the
+        // body's `{{1}}`, and filling it from the body's values would preview a lie.
+        render(
+            <WhatsAppTemplatePreview
+                template={{
+                    headerType: 'TEXT',
+                    headerText: 'Update for {{1}}',
+                    headerSampleValues: ['Class 10'],
+                    bodyText: 'Dear {{1}}',
+                }}
+                values={{ '1': 'Priya' }}
+            />
+        );
+
+        expect(screen.getByText('Class 10')).toBeInTheDocument();
+        expect(screen.getByText('Priya')).toBeInTheDocument();
+    });
+
+    it('says so when a template has no body', () => {
+        render(
+            <WhatsAppTemplatePreview
+                template={{ bodyText: '' }}
+                labels={{ emptyBody: 'No message body.' }}
+            />
+        );
+
+        expect(screen.getByText('No message body.')).toBeInTheDocument();
+    });
+});

--- a/frontend-admin-dashboard/src/components/templates/WhatsAppTemplatePreview.tsx
+++ b/frontend-admin-dashboard/src/components/templates/WhatsAppTemplatePreview.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react';
+import {
+    ArrowBendUpLeft,
+    ArrowSquareOut,
+    Checks,
+    FileText,
+    ImageSquare,
+    Phone,
+    VideoCamera,
+} from '@phosphor-icons/react';
+
+import { cn } from '@/lib/utils';
+import { splitTemplateText } from './template-text';
+
+/**
+ * The message as WhatsApp will render it — header, body, footer and buttons in a chat bubble.
+ *
+ * Every send dialog used to preview a template as `bodyText` dumped into a grey box, which showed
+ * an admin the raw `Dear {{1}}` and dropped the header, the footer and the buttons entirely. What
+ * arrives on the learner's phone is none of those things, so this renders the whole approved
+ * template and picks the placeholders out: filled with the recipient's data once it is known,
+ * labelled with the variable's name until then.
+ */
+
+export interface WhatsAppPreviewButton {
+    type?: string;
+    text?: string;
+    url?: string;
+    phoneNumber?: string;
+}
+
+/** The fields of a WhatsApp template that show up on the phone. Structurally satisfied by the DTO. */
+export interface WhatsAppPreviewTemplate {
+    name?: string;
+    headerType?: string;
+    headerText?: string;
+    headerSampleUrl?: string;
+    headerSampleValues?: string[];
+    bodyText?: string;
+    footerText?: string;
+    buttons?: WhatsAppPreviewButton[];
+    bodyVariableNames?: string[];
+}
+
+export interface WhatsAppTemplatePreviewProps {
+    template: WhatsAppPreviewTemplate;
+    /** Resolved values keyed by variable name. Placeholders without one show their name instead. */
+    values?: Record<string, string>;
+    /** The media going out with THIS send — falls back to the sample approved with the template. */
+    mediaUrl?: string;
+    /** Media-header words, so a translated dialog can pass its own. */
+    labels?: { image?: string; video?: string; document?: string; emptyBody?: string };
+    className?: string;
+}
+
+const DEFAULT_LABELS = {
+    image: 'Image',
+    video: 'Video',
+    document: 'Document',
+    emptyBody: 'This template has no message body.',
+};
+
+/**
+ * The approved media, or a labelled tile when there is none to show.
+ *
+ * Remounted per URL by its `key` so a broken image from a previous template cannot leave the tile
+ * stuck in its error state.
+ */
+function MediaHeader({ kind, url, label }: { kind: string; url?: string; label: string }) {
+    const [broken, setBroken] = React.useState(false);
+    const Icon = kind === 'IMAGE' ? ImageSquare : kind === 'VIDEO' ? VideoCamera : FileText;
+    const showImage = kind === 'IMAGE' && !!url && !broken;
+
+    return (
+        <div className="p-1.5">
+            {showImage ? (
+                <img
+                    src={url}
+                    alt={label}
+                    onError={() => setBroken(true)}
+                    className="h-36 w-full rounded-md object-cover"
+                />
+            ) : (
+                <div
+                    className={cn(
+                        'flex flex-col items-center justify-center gap-1 rounded-md bg-neutral-100 text-neutral-500',
+                        kind === 'DOCUMENT' ? 'h-16' : 'h-24'
+                    )}
+                >
+                    <Icon className="size-6" />
+                    <span className="text-2xs font-medium uppercase tracking-wide">{label}</span>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ButtonIcon({ type }: { type?: string }) {
+    if (type === 'URL') return <ArrowSquareOut className="size-3.5" />;
+    if (type === 'PHONE_NUMBER') return <Phone className="size-3.5" />;
+    return <ArrowBendUpLeft className="size-3.5" />;
+}
+
+/** Body/header text with each `{{…}}` picked out as a chip. */
+function TemplateText({
+    text,
+    variableNames,
+    values,
+    className,
+}: {
+    text: string;
+    variableNames?: string[];
+    values?: Record<string, string>;
+    className?: string;
+}) {
+    const parts = React.useMemo(
+        () => splitTemplateText(text, { variableNames, values }),
+        [text, variableNames, values]
+    );
+
+    return (
+        <p className={cn('whitespace-pre-wrap break-words', className)}>
+            {parts.map((part, index) => {
+                if (part.kind === 'text') return <span key={index}>{part.text}</span>;
+                const filled = part.value?.trim();
+                return (
+                    <span
+                        key={index}
+                        title={`{{${part.token}}}`}
+                        className={cn(
+                            'rounded-sm px-0.5 font-medium',
+                            filled
+                                ? 'bg-success-50 text-success-700'
+                                : 'bg-primary-100 text-primary-600'
+                        )}
+                    >
+                        {filled || part.name}
+                    </span>
+                );
+            })}
+        </p>
+    );
+}
+
+export function WhatsAppTemplatePreview({
+    template,
+    values,
+    mediaUrl,
+    labels,
+    className,
+}: WhatsAppTemplatePreviewProps) {
+    const copy = { ...DEFAULT_LABELS, ...labels };
+    const headerKind = template.headerType?.toUpperCase() ?? 'NONE';
+    const isMediaHeader =
+        headerKind === 'IMAGE' || headerKind === 'VIDEO' || headerKind === 'DOCUMENT';
+    const mediaLabel =
+        headerKind === 'IMAGE' ? copy.image : headerKind === 'VIDEO' ? copy.video : copy.document;
+    const media = mediaUrl?.trim() || template.headerSampleUrl?.trim();
+    const buttons = template.buttons ?? [];
+
+    const headerValues = React.useMemo(() => {
+        const out: Record<string, string> = {};
+        (template.headerSampleValues ?? []).forEach((sample, index) => {
+            if (sample) out[String(index + 1)] = sample;
+        });
+        return out;
+    }, [template.headerSampleValues]);
+
+    // Fixed at mount: a clock that ticks with every re-render of a form is a distraction, and the
+    // exact minute is set dressing — it is there so the bubble reads as a chat message.
+    const sentAt = React.useMemo(
+        () => new Date().toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }),
+        []
+    );
+
+    return (
+        <div className={cn('rounded-lg bg-neutral-100 p-3', className)}>
+            <div className="mx-auto w-full max-w-sm overflow-hidden rounded-lg rounded-tl-sm border border-neutral-200 bg-white shadow-sm">
+                {headerKind === 'TEXT' && template.headerText && (
+                    <div className="px-3 pt-2">
+                        {/* Header placeholders are numbered in their OWN namespace and the send
+                            path never sets them, so they are filled from the samples approved with
+                            the template — never from the body's values, which would collide on a
+                            positional template where both sides are `{{1}}`. */}
+                        <TemplateText
+                            text={template.headerText}
+                            values={headerValues}
+                            className="text-sm font-semibold text-neutral-900"
+                        />
+                    </div>
+                )}
+                {isMediaHeader && (
+                    <MediaHeader
+                        key={media ?? headerKind}
+                        kind={headerKind}
+                        url={media}
+                        label={mediaLabel}
+                    />
+                )}
+
+                <div className="px-3 pt-2">
+                    {template.bodyText?.trim() ? (
+                        <TemplateText
+                            text={template.bodyText}
+                            variableNames={template.bodyVariableNames}
+                            values={values}
+                            className="text-sm leading-relaxed text-neutral-800"
+                        />
+                    ) : (
+                        <p className="text-sm italic text-neutral-400">{copy.emptyBody}</p>
+                    )}
+                </div>
+
+                {template.footerText && (
+                    <p className="px-3 pt-1.5 text-2xs text-neutral-400">{template.footerText}</p>
+                )}
+
+                <div className="flex items-center justify-end gap-1 px-3 pb-2 pt-1.5 text-2xs text-neutral-400">
+                    <span>{sentAt}</span>
+                    <Checks className="size-3.5 text-info-500" weight="bold" />
+                </div>
+
+                {buttons.length > 0 && (
+                    <div className="border-t border-neutral-200">
+                        {buttons.map((button, index) => (
+                            <div
+                                key={`${button.text ?? 'button'}-${index}`}
+                                className="flex items-center justify-center gap-1.5 border-b border-neutral-100 py-2 text-sm font-medium text-info-600 last:border-b-0"
+                            >
+                                <ButtonIcon type={button.type} />
+                                <span className="truncate">{button.text}</span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default WhatsAppTemplatePreview;

--- a/frontend-admin-dashboard/src/components/templates/template-text.test.ts
+++ b/frontend-admin-dashboard/src/components/templates/template-text.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { flattenTemplateBody, humanizeTemplateText, splitTemplateText } from './template-text';
+
+/**
+ * Every WhatsApp preview in the admin reads a template through here, and the shape it has to cope
+ * with is Meta's: a body that says `Dear {{1}}` with the names living in a parallel array. Getting
+ * the index off by one would silently label a message with the wrong field, which an admin has no
+ * way to notice before the message is on someone's phone.
+ */
+describe('splitTemplateText', () => {
+    it('names positional placeholders from bodyVariableNames', () => {
+        const parts = splitTemplateText('Dear {{1}}, your {{2}} starts today.', {
+            variableNames: ['name', 'course_name'],
+        });
+
+        expect(parts).toEqual([
+            { kind: 'text', text: 'Dear ' },
+            { kind: 'variable', token: '1', name: 'name', value: undefined },
+            { kind: 'text', text: ', your ' },
+            { kind: 'variable', token: '2', name: 'course_name', value: undefined },
+            { kind: 'text', text: ' starts today.' },
+        ]);
+    });
+
+    it('fills placeholders from values keyed by name or by raw token', () => {
+        const byName = splitTemplateText('Hi {{1}}', {
+            variableNames: ['name'],
+            values: { name: 'Priya' },
+        });
+        const byToken = splitTemplateText('Hi {{1}}', { values: { '1': 'Priya' } });
+
+        expect(byName[1]).toMatchObject({ name: 'name', value: 'Priya' });
+        expect(byToken[1]).toMatchObject({ name: '1', value: 'Priya' });
+    });
+
+    it('keeps the token when no name exists for that position', () => {
+        const parts = splitTemplateText('Hi {{2}}', { variableNames: ['name'] });
+
+        expect(parts[1]).toMatchObject({ token: '2', name: '2' });
+    });
+
+    it('finds the first placeholder on every call', () => {
+        // A module-level /g regex would keep `lastIndex` and drop this on the second call.
+        const first = splitTemplateText('{{1}} hello', { variableNames: ['name'] });
+        const second = splitTemplateText('{{1}} hello', { variableNames: ['name'] });
+
+        expect(second).toEqual(first);
+        expect(second[0]).toMatchObject({ kind: 'variable', name: 'name' });
+    });
+
+    it('returns nothing for an absent body', () => {
+        expect(splitTemplateText(undefined)).toEqual([]);
+        expect(splitTemplateText('')).toEqual([]);
+    });
+});
+
+describe('humanizeTemplateText', () => {
+    it('reads as the message, not as its placeholders', () => {
+        expect(
+            humanizeTemplateText('Dear {{1}}, welcome to {{2}}.', {
+                variableNames: ['name', 'institute'],
+            })
+        ).toBe('Dear [name], welcome to [institute].');
+    });
+
+    it('prefers a resolved value over the field name', () => {
+        expect(
+            humanizeTemplateText('Dear {{1}}', {
+                variableNames: ['name'],
+                values: { name: 'Priya' },
+            })
+        ).toBe('Dear Priya');
+    });
+
+    it('falls back to the name when the resolved value is blank', () => {
+        expect(
+            humanizeTemplateText('Dear {{1}}', { variableNames: ['name'], values: { name: '  ' } })
+        ).toBe('Dear [name]');
+    });
+});
+
+describe('flattenTemplateBody', () => {
+    it('turns email HTML into readable lines', () => {
+        expect(flattenTemplateBody('<p>Hi&nbsp;Priya</p><p>Your seat is <b>booked</b>.</p>')).toBe(
+            'Hi Priya\nYour seat is booked .'
+        );
+    });
+
+    it('keeps a WhatsApp body’s paragraphs but caps the blank runs', () => {
+        expect(flattenTemplateBody('Line one\n\n\n\nLine two')).toBe('Line one\n\nLine two');
+    });
+
+    it('is empty for empty content', () => {
+        expect(flattenTemplateBody(undefined)).toBe('');
+    });
+});

--- a/frontend-admin-dashboard/src/components/templates/template-text.ts
+++ b/frontend-admin-dashboard/src/components/templates/template-text.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared reading of a message template's `{{…}}` placeholders.
+ *
+ * Meta approves WhatsApp templates with POSITIONAL placeholders — the approved body literally says
+ * `Dear {{1}}` — and the human name for each one lives in `bodyVariableNames` at that index. An
+ * admin picking a template out of a list learns nothing from `{{1}}`, so every preview surface
+ * reads the body through here instead of printing `bodyText` raw.
+ *
+ * The placeholder pattern is deliberately identical to the one the send path interpolates
+ * (`{{word}}`, no inner spaces). A looser pattern here would preview substitutions that the send
+ * would not actually make.
+ */
+
+const PLACEHOLDER_SOURCE = '\\{\\{(\\w+)\\}\\}';
+
+export interface TemplateTextContext {
+    /** `bodyVariableNames` from the template — index 0 names `{{1}}`. */
+    variableNames?: string[];
+    /** Resolved values, keyed by variable name and/or by the raw token. */
+    values?: Record<string, string>;
+}
+
+export type TemplatePart =
+    | { kind: 'text'; text: string }
+    | { kind: 'variable'; token: string; name: string; value?: string };
+
+/** `"1"` → `"name"` when the template carries semantic names; otherwise the token itself. */
+export function variableNameFor(token: string, variableNames?: string[]): string {
+    const position = Number(token);
+    if (Number.isInteger(position) && position > 0) {
+        const name = variableNames?.[position - 1];
+        if (name) return name;
+    }
+    return token;
+}
+
+/** Split a template body into literal runs and placeholders, each resolved where possible. */
+export function splitTemplateText(
+    text: string | undefined | null,
+    context: TemplateTextContext = {}
+): TemplatePart[] {
+    if (!text) return [];
+    const { variableNames, values } = context;
+    const parts: TemplatePart[] = [];
+    // A fresh regex per call — a shared /g regex carries `lastIndex` between calls and would skip
+    // the first placeholder on every other body.
+    const pattern = new RegExp(PLACEHOLDER_SOURCE, 'g');
+    let cursor = 0;
+    let match: RegExpExecArray | null = pattern.exec(text);
+    while (match !== null) {
+        if (match.index > cursor) {
+            parts.push({ kind: 'text', text: text.slice(cursor, match.index) });
+        }
+        const token = match[1] ?? '';
+        const name = variableNameFor(token, variableNames);
+        parts.push({ kind: 'variable', token, name, value: values?.[name] ?? values?.[token] });
+        cursor = match.index + match[0].length;
+        match = pattern.exec(text);
+    }
+    if (cursor < text.length) parts.push({ kind: 'text', text: text.slice(cursor) });
+    return parts;
+}
+
+/**
+ * The body as one readable string: resolved values where they exist, `[name]` where they don't.
+ * For one-line contexts (list rows, summaries) that cannot render chips.
+ */
+export function humanizeTemplateText(
+    text: string | undefined | null,
+    context: TemplateTextContext = {}
+): string {
+    return splitTemplateText(text, context)
+        .map((part) => {
+            if (part.kind === 'text') return part.text;
+            return part.value?.trim() ? part.value : `[${part.name}]`;
+        })
+        .join('');
+}
+
+const ENTITIES: Record<string, string> = {
+    '&nbsp;': ' ',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&apos;': "'",
+};
+
+/**
+ * Flatten template content down to plain text for a list row.
+ *
+ * Email templates carry HTML, so the tags come out and their entities are decoded — an admin
+ * scanning the list should read “Dear Priya”, not `Dear&nbsp;Priya`. Line breaks survive (collapsed
+ * to at most one blank line) because a WhatsApp body's paragraphs are most of its shape.
+ */
+export function flattenTemplateBody(raw: string | undefined | null): string {
+    if (!raw) return '';
+    return raw
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<\/(p|div|li|h[1-6]|tr)>/gi, '\n')
+        .replace(/<[^>]*>/g, ' ')
+        .replace(
+            /&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;|&apos;/g,
+            (entity) => ENTITIES[entity] ?? entity
+        )
+        .replace(/[ \t]+/g, ' ')
+        .split('\n')
+        .map((line) => line.trim())
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/individual-send-dialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/individual-send-dialog.tsx
@@ -38,6 +38,7 @@ import {
     TemplateSearchableSelect,
     toTemplateOptions,
 } from '@/components/templates/TemplateSearchableSelect';
+import { WhatsAppTemplatePreview } from '@/components/templates/WhatsAppTemplatePreview';
 import { sendNotification, getDeliveryStatus } from '@/services/unified-send-service';
 import type { DeliveryStatus, UnifiedSendResponse } from '@/services/unified-send-service';
 import {
@@ -654,6 +655,37 @@ export function IndividualSendDialog({
 
     // ------- render helpers -------
 
+    const waPreviewLabels = useMemo(
+        () => ({
+            image: t('waPreview.image'),
+            video: t('waPreview.video'),
+            document: t('waPreview.document'),
+            emptyBody: t('waPreview.emptyBody'),
+        }),
+        [t]
+    );
+
+    /**
+     * The message as it will land on the phone, with whatever the mapping has resolved so far.
+     * Shown on every WhatsApp step after the template is picked: the admin is sending a message
+     * they cannot edit, so the only protection against sending the wrong one is seeing it.
+     */
+    const renderWaMessagePreview = (label: string) =>
+        // The mapping and review steps are shared by both channels. Today's callers mount a fresh
+        // dialog per channel so a WhatsApp template cannot survive into an email flow, but the
+        // channel check keeps that true no matter how the dialog is mounted later.
+        channel === 'WHATSAPP' && selectedWaTemplate ? (
+            <div className="space-y-2">
+                <Label>{label}</Label>
+                <WhatsAppTemplatePreview
+                    template={selectedWaTemplate}
+                    values={resolvedVariables}
+                    mediaUrl={headerMediaUrl}
+                    labels={waPreviewLabels}
+                />
+            </div>
+        ) : null;
+
     const renderStepIndicator = () => (
         <div className="mb-6 flex w-full min-w-0 items-center gap-1 overflow-hidden">
             {STEP_TITLES.map((title, i) => {
@@ -709,6 +741,8 @@ export function IndividualSendDialog({
                         placeholder={t('emailTemplateStep.selectPlaceholder')}
                         emptyText={t('emailTemplateStep.emptyText')}
                         noneOption={{ value: 'custom', label: t('emailTemplateStep.customOption') }}
+                        expandLabel={t('templatePicker.showFullMessage')}
+                        collapseLabel={t('templatePicker.showLess')}
                         disabled={loadingTemplateContent}
                         portal={false}
                     />
@@ -814,6 +848,8 @@ export function IndividualSendDialog({
                         onChange={handleWaTemplateSelect}
                         placeholder={t('waTemplateStep.selectPlaceholder')}
                         emptyText={t('waTemplateStep.emptyText')}
+                        expandLabel={t('templatePicker.showFullMessage')}
+                        collapseLabel={t('templatePicker.showLess')}
                         portal={false}
                     />
                 )}
@@ -829,10 +865,36 @@ export function IndividualSendDialog({
             </div>
             {selectedWaTemplate && (
                 <div className="space-y-2">
-                    <Label>{t('waTemplateStep.templatePreviewLabel')}</Label>
-                    <div className="whitespace-pre-wrap rounded-md border bg-muted/30 p-4 text-sm">
-                        {selectedWaTemplate.bodyText}
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <Label>{t('waTemplateStep.templatePreviewLabel')}</Label>
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            {selectedWaTemplate.category && (
+                                <span className="rounded bg-primary-50 px-1.5 py-0.5 text-2xs text-primary-500">
+                                    {selectedWaTemplate.category}
+                                </span>
+                            )}
+                            {selectedWaTemplate.language && (
+                                <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-2xs text-neutral-500">
+                                    {selectedWaTemplate.language}
+                                </span>
+                            )}
+                            {waHeaderKind && (
+                                <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-2xs text-neutral-500">
+                                    {t('waTemplateStep.headerBadge', {
+                                        kind: t(`mediaKind.${waHeaderKind}`),
+                                    })}
+                                </span>
+                            )}
+                        </div>
                     </div>
+                    {/* No values yet — every placeholder shows the field it will be filled from. */}
+                    <WhatsAppTemplatePreview
+                        template={selectedWaTemplate}
+                        labels={waPreviewLabels}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        {t('waTemplateStep.previewHint')}
+                    </p>
                 </div>
             )}
         </div>
@@ -872,12 +934,13 @@ export function IndividualSendDialog({
     const renderVariableMappingStep = () => {
         if (variableKeys.length === 0) {
             return (
-                <div>
+                <div className="space-y-4">
                     {renderHeaderMediaField()}
-                    <div className="flex flex-col items-center justify-center gap-2 py-12 text-muted-foreground">
+                    <div className="flex flex-col items-center justify-center gap-2 py-8 text-muted-foreground">
                         <CheckCircle className="size-8" />
                         <p className="text-sm">{t('variableMappingStep.noVariables')}</p>
                     </div>
+                    {renderWaMessagePreview(t('variableMappingStep.livePreviewLabel'))}
                 </div>
             );
         }
@@ -966,6 +1029,9 @@ export function IndividualSendDialog({
                             </div>
                         );
                     })}
+                </div>
+                <div className="pt-4">
+                    {renderWaMessagePreview(t('variableMappingStep.livePreviewLabel'))}
                 </div>
             </div>
         );
@@ -1121,6 +1187,7 @@ export function IndividualSendDialog({
                         </div>
                     )}
                 </div>
+                {renderWaMessagePreview(t('reviewStep.messagePreviewLabel'))}
                 <Button className="w-full" onClick={handleSend} disabled={isSending}>
                     {isSending ? (
                         <>
@@ -1154,8 +1221,13 @@ export function IndividualSendDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-h-dialog-tall w-dialog-md overflow-y-auto overflow-x-hidden">
-                <DialogHeader>
+            {/* A column, not the base grid: the header, the step rail and the Back/Next bar hold
+                still while only the step's own content scrolls. Before this the whole dialog
+                scrolled, so opening the template list pushed Next out of sight and the list itself
+                was read through a letterbox. `min-h-dialog-md` stops the panel collapsing to the
+                height of a closed picker and jumping on every step. */}
+            <DialogContent className="flex max-h-dialog-tall min-h-dialog-md w-dialog-lg flex-col overflow-hidden">
+                <DialogHeader className="shrink-0">
                     <DialogTitle>
                         {t('dialogTitle', {
                             channelLabel:
@@ -1178,10 +1250,13 @@ export function IndividualSendDialog({
                 </DialogHeader>
 
                 {renderStepIndicator()}
-                {renderStep()}
+
+                {/* min-h-0: without it a flex child refuses to shrink below its content and the
+                    scroll lands on the dialog again. */}
+                <div className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1">{renderStep()}</div>
 
                 {!sendResult && (
-                    <div className="mt-6 flex items-center justify-between">
+                    <div className="mt-4 flex shrink-0 items-center justify-between border-t pt-4">
                         <div>
                             {step > 1 && (
                                 <Button variant="ghost" size="sm" onClick={handleBack}>

--- a/frontend-admin-dashboard/tailwind.config.mjs
+++ b/frontend-admin-dashboard/tailwind.config.mjs
@@ -71,6 +71,14 @@ module.exports = {
                 'slide-dialog-md': '31.25rem',
                 'slide-dialog-lg': '32.5rem',
             },
+            minHeight: {
+                // Floor for the multi-step send/compose dialogs, whose steps
+                // differ wildly in height. Without it the panel is only as tall
+                // as a closed template picker, so opening the list or moving to
+                // the message preview makes the whole dialog jump. Always below
+                // maxHeight.dialog-tall, at every viewport.
+                'dialog-md': 'min(80vh, 40rem)',
+            },
             fontFamily: {
                 sans: ['Open Sans', 'sans-serif'],
                 // Institute-configured font: index.tsx sets `--app-font-family` on

--- a/frontend-admin-dashboard/vite.config.ts
+++ b/frontend-admin-dashboard/vite.config.ts
@@ -489,6 +489,7 @@ export default defineConfig(({ mode }) => {
                 'src/routes/**/*.test.{ts,tsx}',
                 'src/services/**/*.test.{ts,tsx}',
                 'src/constants/**/*.test.{ts,tsx}',
+                'src/components/templates/**/*.test.{ts,tsx}',
             ],
         },
         server: {


### PR DESCRIPTION
The send dialog previewed a template as raw bodyText in a grey box, so an admin read "Dear {{1}}" and never saw the header, footer or buttons that actually go out. Picker rows now resolve placeholders to their field names and open out on demand; a shared WhatsAppTemplatePreview renders the whole approved template on the select, mapping and review steps, filling in with the learner's data as it is mapped. The review step previously showed no message at all before Send.

The dialog also gets room to show this: wider, with a height floor, and a fixed header/footer around a scrolling body so Next no longer disappears when the template list opens.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
