### PR TITLE
fix(ai-calling): show the lead's name in the queue, and leave a gap b…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -23,6 +23,16 @@ import java.util.Optional;
 @Repository
 public interface AudienceResponseRepository extends JpaRepository<AudienceResponse, String> {
 
+    /**
+     * Bulk lead id -> display name and number, for screens that list leads they do not
+     * otherwise load. The AI call queue resolves a whole page at once; a per-row lookup
+     * would turn one page into fifty queries.
+     */
+    @Query(value = "SELECT ar.id, ar.parent_name, ar.parent_mobile FROM audience_response ar "
+            + "WHERE ar.id IN (:ids)", nativeQuery = true)
+    List<Object[]> findIdNameAndMobileByIds(@Param("ids") java.util.Collection<String> ids);
+
+
         /**
          * Find all leads for a specific campaign, INCLUDING soft-deleted ones.
          *

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallService.java
@@ -85,6 +85,14 @@ public class AiCallService {
     private int globalMaxCallsPerDay;
 
     /**
+     * Minimum minutes between two AI calls to the same lead, for automation and bulk.
+     * 0 disables it. Deliberately far larger than the 30-second duplicate window, which
+     * exists to collapse an accidental double dispatch rather than to pace a lead's day.
+     */
+    @org.springframework.beans.factory.annotation.Value("${telephony.ai.min-recall-gap-minutes:60}")
+    private int minRecallGapMinutes;
+
+    /**
      * Striped per-lead locks so the dedup check + INITIATED insert are atomic for a
      * given lead WITHIN this replica (the duplicate dispatch originates on one replica
      * — same workflow run / scheduler tick / bulk pool). Bounded (no per-lead growth);
@@ -276,6 +284,36 @@ public class AiCallService {
                             .providerMessage("Daily AI-call limit reached for this institute.")
                             .build();
                 }
+            }
+        }
+
+        // MINIMUM GAP between two AI calls to the SAME lead.
+        //
+        // The only thing standing between a lead and two calls in a row was a 30-second
+        // duplicate window, whose job is collapsing an accidental double dispatch — not
+        // pacing a person's day. So a campaign call at 10:00 and a workflow retry at
+        // 10:02 both went out, and the lead answered twice in two minutes.
+        //
+        // Distinct from the daily cap below: that bounds how MANY calls a lead gets,
+        // this bounds how CLOSE together they are. Three calls are reasonable across a
+        // day and unreasonable inside five minutes.
+        //
+        // Manual keeps its exemption, as with every other throttle here: a person who
+        // clicks Call has just decided this lead should be rung now, and silently
+        // refusing them is the failure mode this guard set keeps producing.
+        if (!mock && trigger.enforcesPerLeadDailyCap() && minRecallGapMinutes > 0) {
+            java.sql.Timestamp since = java.sql.Timestamp.from(
+                    Instant.now().minus(Duration.ofMinutes(minRecallGapMinutes)));
+            if (callLogRepo.countOutboundToLeadSince(
+                    req.getInstituteId(), userId, provider, since) > 0) {
+                log.info("AI call skipped: lead {} was called within the last {} min",
+                        userId, minRecallGapMinutes);
+                return AiCallResponseDTO.builder()
+                        .status("SKIPPED_RECALL_GAP")
+                        .dispatched(false)
+                        .providerMessage("This lead was called very recently — leaving a gap "
+                                + "before calling again.")
+                        .build();
             }
         }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDirectory.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDirectory.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceRepository;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
 import vacademy.io.admin_core_service.features.institute.repository.InstituteRepository;
 import vacademy.io.admin_core_service.features.telephony.core.AiCallingSettingsService;
 import vacademy.io.admin_core_service.features.telephony.core.dto.AiCallingSettingsPojo;
@@ -44,6 +45,7 @@ public class AiCallQueueDirectory {
 
     private final InstituteRepository instituteRepository;
     private final AudienceRepository audienceRepository;
+    private final AudienceResponseRepository audienceResponseRepository;
     private final AiAgentRepository aiAgentRepository;
     private final TelephonyCallLogRepository callLogRepository;
     private final AiCallingSettingsService settingsService;
@@ -94,9 +96,17 @@ public class AiCallQueueDirectory {
                 runRefs.add(item.getSourceRef());
             }
         }
+        // The lead's own name. A queue row stores only ids and, often, not even a phone
+        // — the number is resolved downstream at dial time — so without this the Lead
+        // column showed a bare number, or a raw uuid, for every row.
+        Set<String> responseIds = new HashSet<>();
+        for (AiCallQueueItem item : items) {
+            if (notBlank(item.getResponseId())) responseIds.add(item.getResponseId());
+        }
         Map<String, String> institutes = instituteNames(instituteIds);
         Map<String, String> agents = agentNames(campaignIds);
         Map<String, String> runs = campaignNamesFor(runRefs);
+        Map<String, LeadRef> leads = leadNames(responseIds);
 
         // Only reach for an institute's settings when a campaign id is STILL unnamed
         // after ai_agent — i.e. an Aavtaar campaign. Most deployments never pay for this.
@@ -124,7 +134,27 @@ public class AiCallQueueDirectory {
                         + "naming agents: {}", instituteId, e.getMessage());
             }
         }
-        return new Names(institutes, agents, runs);
+        return new Names(institutes, agents, runs, leads);
+    }
+
+    /** A lead's display name and the number on its CRM record. */
+    public record LeadRef(String name, String mobile) {}
+
+    /** Lead ids (audience_response ids) → name + number. */
+    public Map<String, LeadRef> leadNames(Collection<String> responseIds) {
+        Map<String, LeadRef> out = new HashMap<>();
+        if (responseIds == null || responseIds.isEmpty()) return out;
+        try {
+            for (Object[] row : audienceResponseRepository.findIdNameAndMobileByIds(responseIds)) {
+                if (row[0] != null) {
+                    out.put((String) row[0], new LeadRef((String) row[1], (String) row[2]));
+                }
+            }
+        } catch (Exception e) {
+            // A deleted lead must not blank out the names on the rest of the page.
+            log.debug("ai-call queue: could not resolve lead names: {}", e.getMessage());
+        }
+        return out;
     }
 
     /** Bulk-run ids (audience ids) → campaign name. */
@@ -166,12 +196,26 @@ public class AiCallQueueDirectory {
         private final Map<String, String> institutes;
         private final Map<String, String> agents;
         private final Map<String, String> runs;
+        private final Map<String, LeadRef> leads;
 
         Names(Map<String, String> institutes, Map<String, String> agents,
-              Map<String, String> runs) {
+              Map<String, String> runs, Map<String, LeadRef> leads) {
             this.institutes = institutes;
             this.agents = agents;
             this.runs = runs;
+            this.leads = leads;
+        }
+
+        /** The lead's name, or null when the CRM record has none. */
+        public String leadName(String responseId) {
+            LeadRef ref = responseId == null ? null : leads.get(responseId);
+            return ref == null || ref.name() == null || ref.name().isBlank() ? null : ref.name();
+        }
+
+        /** The number on the lead's CRM record — a fallback when the queue row has none. */
+        public String leadMobile(String responseId) {
+            LeadRef ref = responseId == null ? null : leads.get(responseId);
+            return ref == null ? null : ref.mobile();
         }
 
         /** The campaign a bulk row came from, or null when it is not a bulk row. */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDrainJob.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueDrainJob.java
@@ -82,6 +82,7 @@ public class AiCallQueueDrainJob {
     private static final String SKIPPED_DAILY_CAP = "SKIPPED_DAILY_CAP";
     private static final String SKIPPED_DUPLICATE = "SKIPPED_DUPLICATE";
     private static final String SKIPPED_LEAD_DAILY_CAP = "SKIPPED_LEAD_DAILY_CAP";
+    private static final String SKIPPED_RECALL_GAP = "SKIPPED_RECALL_GAP";
 
     /** Give up on an item after this many dial attempts. */
     private static final int MAX_ATTEMPTS = 3;
@@ -96,6 +97,9 @@ public class AiCallQueueDrainJob {
 
     /** How long an institute that just hit its daily cap is left alone. */
     private static final Duration DAILY_CAP_BACKOFF = Duration.ofHours(1);
+
+    /** How long an item waits after being refused for being too close to the last call. */
+    private static final Duration RECALL_GAP_BACKOFF = Duration.ofMinutes(20);
 
     /** How long an institute with no credits is left alone. */
     private static final Duration NO_CREDITS_BACKOFF = Duration.ofMinutes(15);
@@ -347,6 +351,15 @@ public class AiCallQueueDrainJob {
                 case SKIPPED_DUPLICATE -> {
                     finish(item, AiCallQueueStatus.CANCELLED,
                             "This lead was called by another path moments ago.");
+                    return DispatchOutcome.ITEM_HANDLED;
+                }
+                case SKIPPED_RECALL_GAP -> {
+                    // Unlike the daily cap this clears on its own, so the item WAITS
+                    // rather than being dropped: the lead is still due a call, just not
+                    // this minute. Only this item is held — the rest of the lane is
+                    // about different leads and keeps dialling.
+                    deferItem(item, Instant.now().plus(RECALL_GAP_BACKOFF),
+                            "Called very recently — waiting before calling again.");
                     return DispatchOutcome.ITEM_HANDLED;
                 }
                 case SKIPPED_LEAD_DAILY_CAP -> {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/AiCallQueueService.java
@@ -505,11 +505,14 @@ public class AiCallQueueService {
                 .statusReason(item.getStatusReason())
                 .responseId(item.getResponseId())
                 .userId(item.getUserId())
+                .leadName(names.leadName(item.getResponseId()))
                 // A queued row often has no phone of its own — the number is resolved
-                // downstream at dial time — so fall back to what was actually dialled
-                // rather than leaving the column showing a raw id.
-                .phoneNumber(item.getPhoneNumber() != null ? item.getPhoneNumber()
-                        : (call == null ? null : call.toNumber()))
+                // downstream at dial time — so fall back to what was actually dialled,
+                // then to the number on the lead's CRM record, rather than leaving the
+                // column showing a raw id.
+                .phoneNumber(firstNonBlank(item.getPhoneNumber(),
+                        call == null ? null : call.toNumber(),
+                        names.leadMobile(item.getResponseId())))
                 .campaignId(item.getCampaignId())
                 .campaignName(item.getCampaignName())
                 .attempts(item.getAttempts())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/dto/AiCallQueueDTOs.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/queue/dto/AiCallQueueDTOs.java
@@ -56,6 +56,8 @@ public final class AiCallQueueDTOs {
         private String statusReason;
         private String responseId;
         private String userId;
+        /** The lead's name from their CRM record. Null when the record has none. */
+        private String leadName;
         private String phoneNumber;
         private String campaignId;
         private String campaignName;

--- a/frontend-admin-dashboard/src/routes/calling/call-queue/-components/CallQueuePanel.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/call-queue/-components/CallQueuePanel.tsx
@@ -340,8 +340,15 @@ function QueueRow({
             <TableCell className="text-sm text-neutral-500">
                 {waiting && item.aheadInLane != null ? item.aheadInLane + 1 : '—'}
             </TableCell>
+            {/* Name first; the number is the subtitle. Showing only a number made the
+                column read as empty to anyone scanning for a person. */}
             <TableCell className="text-sm text-neutral-900">
-                {item.phoneNumber || item.userId || '—'}
+                <div className="flex flex-col">
+                    <span>{item.leadName || item.phoneNumber || item.userId || '—'}</span>
+                    {item.leadName && item.phoneNumber && (
+                        <span className="text-xs text-neutral-500">{item.phoneNumber}</span>
+                    )}
+                </div>
             </TableCell>
             <TableCell className="text-sm text-neutral-700">{item.agentName || '—'}</TableCell>
             <TableCell className="text-sm text-neutral-600">{sourceLabel(item)}</TableCell>

--- a/frontend-admin-dashboard/src/routes/calling/call-queue/-services/ai-call-queue-service.ts
+++ b/frontend-admin-dashboard/src/routes/calling/call-queue/-services/ai-call-queue-service.ts
@@ -57,6 +57,8 @@ export interface QueueItem {
     statusReason?: string | null;
     responseId?: string | null;
     userId?: string | null;
+    /** The lead's name from their CRM record. */
+    leadName?: string | null;
     phoneNumber?: string | null;
     campaignId?: string | null;
     campaignName?: string | null;


### PR DESCRIPTION
…efore re-calling

LEAD NAME WAS MISSING. A queue row stores ids, and often not even a phone — the number is resolved downstream at dial time — so the Lead column fell back to a bare number, or a raw uuid. It now resolves audience_response.parent_name for the whole page in one query and shows the name with the number beneath it. The number also gains a last-resort fallback to the lead's CRM record.

NOTHING PACED CALLS TO THE SAME LEAD. The only guard was a 30-second duplicate window, whose job is collapsing an accidental double dispatch rather than pacing a person's day — so a campaign call at 10:00 and a workflow retry at 10:02 both went out and the lead answered twice in two minutes. Adds a minimum re-call gap (telephony.ai.min-recall-gap-minutes, default 60).

It is distinct from the per-lead daily cap: that bounds how MANY calls a lead gets, this bounds how CLOSE together they are. Three calls across a day are reasonable; three inside five minutes are not.

A gap refusal does not drop the call the way the daily cap does — the condition clears on its own, so the item waits 20 minutes and tries again. Only that item is held; the rest of the lane is about other leads and keeps dialling.

Manual keeps its exemption, as with every throttle here: someone who clicks Call has just decided this lead should be rung now.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
