### PR TITLE
fix(learner): make a hero button’s "#anchor" target scroll instead of routing

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HeroSectionComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HeroSectionComponent.tsx
@@ -456,7 +456,21 @@ const HeroSectionPlaceholder: React.FC<{
 
   const handleButtonClick = (button: { action?: string; target?: string; audienceId?: string; text?: string }) => {
     if (button.action === "navigate" && button.target) {
-      navigate({ to: button.target });
+      // A bare "#anchor" target is an in-page jump, not a route. navigate()
+      // pushes it as a PATH, so the URL gains the hash and the visitor stays
+      // exactly where they were — which is what made the hero's "Explore our
+      // courses" button appear to do nothing. Scroll it ourselves, the same
+      // way CatalogueLink handles a pure anchor. Fall through to navigate()
+      // when the element is absent, so a real route still routes.
+      const target = button.target.trim();
+      if (target.startsWith("#")) {
+        const el = document.getElementById(target.slice(1));
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+          return;
+        }
+      }
+      navigate({ to: target });
     } else if (button.action === "openForm" && (button.audienceId || '').trim()) {
       // Campaign-bound popup: opens the audience list's form (AudienceFormModal).
       window.dispatchEvent(new CustomEvent('openAudienceForm', {
@@ -834,7 +848,21 @@ const HeroSectionWithState: React.FC<{
 
   const handleButtonClick = (button: { action?: string; target?: string; audienceId?: string; text?: string }) => {
     if (button.action === "navigate" && button.target) {
-      navigate({ to: button.target });
+      // A bare "#anchor" target is an in-page jump, not a route. navigate()
+      // pushes it as a PATH, so the URL gains the hash and the visitor stays
+      // exactly where they were — which is what made the hero's "Explore our
+      // courses" button appear to do nothing. Scroll it ourselves, the same
+      // way CatalogueLink handles a pure anchor. Fall through to navigate()
+      // when the element is absent, so a real route still routes.
+      const target = button.target.trim();
+      if (target.startsWith("#")) {
+        const el = document.getElementById(target.slice(1));
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+          return;
+        }
+      }
+      navigate({ to: target });
     } else if (button.action === "openForm" && (button.audienceId || '').trim()) {
       // Campaign-bound popup: opens the audience list's form (AudienceFormModal).
       window.dispatchEvent(new CustomEvent('openAudienceForm', {


### PR DESCRIPTION
## Problem

The hero's button handler passes every navigate target straight to
`navigate({ to: target })`. For a bare `#anchor` that pushes the hash as a
**path**: the URL becomes `/<tag>/home/#courses` and the visitor stays exactly
where they were.

The 7Cs' "Explore our courses" button has done nothing since it was authored.
Reproduced on prod before the fix — loading `/new-landing-page/home/#courses`
renders the hero at the top, no scroll.

## Change

A target starting with `#` now scrolls to that element, the same way
`CatalogueLink` already handles a pure anchor. When no such element exists it
falls through to `navigate()`, so real routes are unaffected.

Both hero variants (`HeroSectionPlaceholder` and `HeroSectionWithState`) carry
their own copy of the handler; both are patched. +30/−2, two hunks.

## The other half

The page also needs an element with that id. The 7Cs course grid now sets
`anchorId: "courses"` in its catalogue JSON — **already published**, so the
target exists in prod today; this commit is the missing behaviour.

Worth knowing: adding the anchor alone was *not* enough. The SPA renders its
content after the browser has already tried the fragment, so the native jump
finds nothing. That is why this needs a handler change rather than just data.

## Verification

- `tsc -p tsconfig.app.json --noEmit` — **666 errors, identical to baseline**;
  this change contributes none. The 4 pre-existing `HeroSectionComponent`
  errors (`'left' is possibly 'undefined'`) are outside the edited lines.
- `node scripts/design-lint.mjs` — 0 errors.
- The scroll itself is not unit-tested: clicking needs a mounted component, and
  the hero's `useNavigate` requires a router context this repo has no test
  harness for. The logic mirrors `CatalogueLink`'s existing, shipped anchor
  path, and I'll confirm on prod once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)