### PR TITLE
fix(learner): stop the phone flag button painting out the input's border

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
@@ -796,7 +796,11 @@ const ContactFormRenderer: React.FC<any> = ({ heading, subheading, fields = [], 
                     placeholder={t("leadCollectionModal.phonePlaceholder")}
                     containerClass="!w-full"
                     inputClass="!w-full !h-11 !rounded-lg !border-catalogue-border !bg-catalogue-bg !text-catalogue-text-primary !text-sm"
-                    buttonClass="!rounded-s-lg !border-catalogue-border !bg-catalogue-bg"
+                    // No buttonClass: the flag button is absolutely positioned OVER the
+                    // input's left edge, so giving it an opaque background paints out the
+                    // input's border and rounded corner — the control then reads as two
+                    // detached boxes. The app's own .react-tel-input theming already gives
+                    // it the divider and radius.
                   />
                 ) : (
                   <input type={field.type} required={field.required} value={formData[field.name] || ''} onChange={(e) => setFormData({ ...formData, [field.name]: e.target.value })} className="w-full rounded-lg border border-catalogue-border bg-catalogue-bg text-catalogue-text-primary px-4 py-2.5 text-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500/20 focus:outline-none" />


### PR DESCRIPTION
Follow-up to #2791. The country picker is live on The 7Cs' "Ask Mira" form and
renders as **two detached boxes** — a flag sitting outside, then the input
starting to its right, misaligned with every other field in the form.

## Root cause

The geometry was never wrong. Measured against the **deployed** CSS bundle:

| | left | width | notes |
|---|---|---|---|
| input | 40 | 640 | `padding-left: 60px` |
| flag dropdown | 40 | 53 | `position: absolute` |

react-phone-input-2 positions `.flag-dropdown` *over* the input's left edge, and
the input reserves 60px of padding for it. The bug is **paint, not layout**:
`buttonClass` gave that overlay an opaque `!bg-catalogue-bg`, which covered the
input's own left border and rounded corner — so a single control read as two.

## Fix

Drop `buttonClass`. The app already ships `.react-tel-input .flag-dropdown`
theming (divider + radius, catalogue tokens), which is what the other phone
fields in the app rely on.

## Verification

Rendered the component's **real SSR output** against the deployed CSS bundle
(`/assets/index-822506dd-bf7cdb8c.css`) rather than hand-written markup, and
compared three variants. Result: one integrated control, left edge and width
flush with the sibling email field.

- `node scripts/design-lint.mjs` — 0 errors
- 4 phone tests + full suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)