### PR TITLE
Require auth on POST /notification-service/v1/send-email

### DIFF
--- a/notification_service/src/main/java/vacademy/io/notification_service/config/WebSecurityConfig.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/config/WebSecurityConfig.java
@@ -32,7 +32,6 @@ public class WebSecurityConfig {
             "/notification-service/whatsapp/v1/send-template-whatsapp",
             "/notification-service/whatsapp/v1/send-template-whatsapp/multiple",
             "/auth/**",
-            "/notification-service/v1/send-email",
             "/notification-service/actuator/**",
             "/actuator/**",
             "/notification-service/internal/**",
@@ -68,6 +67,14 @@ public class WebSecurityConfig {
             "/notification-service/webhook/v1/meta/**"
     };
 
+    /**
+     * Paths that must carry a valid JWT. These are matched BEFORE ALLOWED_PATHS,
+     * so they win over the broad "/notification-service/v1/**" permitAll entry.
+     */
+    private static final String[] SECURED_PATHS = {
+            "/notification-service/v1/send-email"
+    };
+
     @Autowired
     private JwtAuthFilter jwtAuthFilter; // Inject JwtAuthFilter dependency
     @Autowired
@@ -86,6 +93,15 @@ public class WebSecurityConfig {
                     // before the broad "/notification-service/v1/**" permitAll below, which would
                     // otherwise swallow them. Scoped to /v1/chat/** only — no other endpoint is affected.
                     authz.requestMatchers(AntPathRequestMatcher.antMatcher("/notification-service/v1/chat/**")).authenticated();
+
+                    // Generic mailer. Left open it is an unauthenticated relay that will send an
+                    // arbitrary subject/body to any address. Registered here, ahead of the broad
+                    // "/notification-service/v1/**" permitAll below, so it actually takes effect.
+                    // Service-to-service callers should use /notification-service/internal/** ;
+                    // the OTP endpoints stay public because they are pre-login flows.
+                    for (String path : SECURED_PATHS) {
+                        authz.requestMatchers(AntPathRequestMatcher.antMatcher(path)).authenticated();
+                    }
 
                     // Use AntPathRequestMatcher for Ant-style pattern matching (compatible with
                     // Spring 6)


### PR DESCRIPTION
The generic mailer was in ALLOWED_PATHS, so anyone could POST {to, subject, text} and have the service send an arbitrary email from the institute's verified sender to any address.

Removing the entry alone would not have helped: ALLOWED_PATHS also carries the catch-all "/notification-service/v1/**". So the path is now registered with .authenticated() ahead of the permitAll loop, the same ordering the existing /v1/chat/** rule relies on.

No caller in the repo hits this endpoint. The OTP siblings (/v1/send-email-otp, /v1/verify-email-otp) stay public because they are pre-login flows, and service-to-service email keeps using /notification-service/internal/**.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
