### PR TITLE
feat(catalogue): add a curated "Course showcase" section

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentLibrary.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentLibrary.tsx
@@ -71,6 +71,7 @@ const COMPONENT_GROUPS: { title: string; keys: string[] }[] = [
             'productPageOffer',
             'courseCatalog',
             'productCourseGrid',
+            'courseShowcase',
             'bookCatalogue',
             'pricingTable',
             'cartComponent',

--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentPreviews.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/ComponentPreviews.tsx
@@ -1603,6 +1603,44 @@ const ComponentPreviewSwitch: React.FC<{ component: { type: string; props: any }
                 </div>
             );
         }
+        case 'courseShowcase': {
+            // Curated strip: no filter row, and only `limit` cards — the two
+            // things that distinguish it from productCourseGrid at a glance.
+            const n = Math.min(Math.max(Number(props.limit) || 3, 1), 8);
+            const across = props.layout === 'grid' ? 4 : 3;
+            const sourceLabel: Record<string, string> = {
+                newest: 'Newest', onSale: 'On sale', tag: `Tag: ${props.tag || '—'}`, picked: 'Hand-picked',
+            };
+            return (
+                <div className="bg-catalogue-bg-elevated px-8 py-6">
+                    <div className="mb-1 text-center text-lg font-semibold text-neutral-800">
+                        {props.title || 'Course showcase'}
+                    </div>
+                    {props.subtitle && (
+                        <div className="mb-3 text-center text-xs text-neutral-500">{props.subtitle}</div>
+                    )}
+                    <div className="mb-4 text-center">
+                        <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-caption font-medium text-blue-600">
+                            {sourceLabel[props.source || 'newest']} · {n}
+                        </span>
+                    </div>
+                    <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${across}, 1fr)` }}>
+                        {Array.from({ length: Math.min(n, across) }).map((_, i) => (
+                            <div key={i} className="overflow-hidden rounded-xl border border-neutral-200 bg-catalogue-bg-elevated">
+                                <div className="flex h-24 items-center justify-center bg-neutral-100 text-xs text-neutral-300">
+                                    {t('dispatcher.courseImage')}
+                                </div>
+                                <div className="space-y-2 p-3">
+                                    <div className="h-3 w-3/4 rounded bg-neutral-200" />
+                                    <div className="h-2 w-1/2 rounded bg-neutral-100" />
+                                    <div className="h-6 w-full rounded bg-neutral-200" />
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            );
+        }
         case 'productCourseGrid': {
             const cols = props.columns || 3;
             return (

--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/PropertyPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/PropertyPanel.tsx
@@ -1811,6 +1811,8 @@ const ComponentEditor = ({ component, pageId, updateComponent }: any) => {
             return <LeadFormEditor component={component} pageId={pageId} updateComponent={updateComponent} />;
         case 'productCourseGrid':
             return <ProductCourseGridEditor component={component} pageId={pageId} updateComponent={updateComponent} />;
+        case 'courseShowcase':
+            return <CourseShowcaseEditor component={component} pageId={pageId} updateComponent={updateComponent} />;
         case 'tabsAccordion':
             return <TabsAccordionEditor component={component} pageId={pageId} updateComponent={updateComponent} />;
         case 'logoCloud':
@@ -5253,6 +5255,102 @@ const HtmlBlockEditor = ({ component, pageId, updateComponent }: any) => {
                     placeholder=".my-band { background: var(--primary-50); }"
                 />
             </div>
+        </div>
+    );
+};
+
+/**
+ * Curated course strip. `productCourseGrid` always renders the WHOLE catalogue
+ * with filters; this one shows a chosen few, so the only real decisions are
+ * where the courses come from and how many.
+ */
+const CourseShowcaseEditor = ({ component, pageId, updateComponent }: any) => {
+    const { props } = component;
+    const updateProp = (key: string, value: any) =>
+        updateComponent(pageId, component.id, { props: { ...props, [key]: value } });
+
+    const SOURCES: Array<{ id: string; label: string; hint: string }> = [
+        { id: 'newest', label: 'Newest', hint: 'The most recently created courses.' },
+        { id: 'onSale', label: 'On sale', hint: 'Only courses with a discount (a struck-through price).' },
+        { id: 'tag', label: 'By tag', hint: 'Courses carrying the tag you type below.' },
+        { id: 'picked', label: 'Hand-picked', hint: 'Exactly the course IDs you list, in that order.' },
+    ];
+    const source = props.source || 'newest';
+
+    return (
+        <div className="space-y-4">
+            <div className="space-y-2">
+                <Label className="text-xs">Title</Label>
+                <Input value={props.title || ''} placeholder="Hot right now"
+                    onChange={(e) => updateProp('title', e.target.value)} />
+            </div>
+            <div className="space-y-2">
+                <Label className="text-xs">Subtitle</Label>
+                <Input value={props.subtitle || ''} placeholder="Optional line under the title"
+                    onChange={(e) => updateProp('subtitle', e.target.value)} />
+            </div>
+
+            <div>
+                <Label className="text-xs">Which courses</Label>
+                <div className="mt-1 flex flex-wrap gap-1">
+                    {SOURCES.map((s) => (
+                        <button key={s.id} onClick={() => updateProp('source', s.id)}
+                            className={`rounded px-2.5 py-1 text-caption font-medium ${source === s.id ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                            {s.label}
+                        </button>
+                    ))}
+                </div>
+                <p className="mt-1 text-caption text-gray-400">
+                    {SOURCES.find((s) => s.id === source)?.hint}
+                </p>
+            </div>
+
+            {source === 'tag' && (
+                <div className="space-y-2">
+                    <Label className="text-xs">Tag</Label>
+                    <Input value={props.tag || ''} placeholder="e.g. 2 year old"
+                        onChange={(e) => updateProp('tag', e.target.value)} />
+                    <p className="text-caption text-gray-400">
+                        Must match the course&apos;s tag exactly (capitalisation is ignored).
+                    </p>
+                </div>
+            )}
+
+            {source === 'picked' && (
+                <div className="space-y-2">
+                    <Label className="text-xs">Course IDs</Label>
+                    <Input value={(props.courseIds || []).join(', ')}
+                        placeholder="id-one, id-two, id-three"
+                        onChange={(e) => updateProp('courseIds',
+                            e.target.value.split(',').map((v: string) => v.trim()).filter(Boolean))} />
+                    <p className="text-caption text-gray-400">Comma separated. Shown in the order you list them.</p>
+                </div>
+            )}
+
+            <div>
+                <Label className="text-xs">How many to show</Label>
+                <div className="mt-1 flex flex-wrap gap-1">
+                    {[2, 3, 4, 6, 8].map((n) => (
+                        <button key={n} onClick={() => updateProp('limit', n)}
+                            className={`rounded px-2.5 py-1 text-caption font-medium ${(props.limit || 3) === n ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>{n}</button>
+                    ))}
+                </div>
+            </div>
+
+            <div>
+                <Label className="text-xs">Layout</Label>
+                <div className="mt-1 flex flex-wrap gap-1">
+                    {[{ id: 'row', label: '3 across' }, { id: 'grid', label: '4 across' }].map((l) => (
+                        <button key={l.id} onClick={() => updateProp('layout', l.id)}
+                            className={`rounded px-2.5 py-1 text-caption font-medium ${(props.layout || 'row') === l.id ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>{l.label}</button>
+                    ))}
+                </div>
+            </div>
+
+            <p className="rounded bg-gray-50 px-2 py-1.5 text-caption text-gray-500">
+                Prices, discount badges and images come live from the course catalogue —
+                nothing to keep in sync here. An empty result hides the whole section.
+            </p>
         </div>
     );
 };

--- a/frontend-admin-dashboard/src/routes/manage-pages/-utils/component-labels.ts
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-utils/component-labels.ts
@@ -23,6 +23,7 @@ export const COMPONENT_LABELS: Record<string, string> = {
     productPageOffer: 'Product Page Offer',
     productCourseGrid: 'Course Grid (full catalogue)',
     mediaShowcase: 'Media Showcase',
+    courseShowcase: 'Course showcase',
     statsHighlights: 'Stats',
     testimonialSection: 'Testimonials',
     cartComponent: 'Cart',
@@ -84,6 +85,7 @@ export const COMPONENT_DESCRIPTIONS: Record<string, string> = {
     // ── Persuasion ───────────────────────────────────────────────────────────
     featureGrid: 'Short “why us” points as icon cards',
     detailBlocks: 'One long block per programme — what it covers and who it is for',
+    courseShowcase: 'A few chosen courses — newest, on sale, by tag, or hand-picked',
     statsHighlights: 'A row of big numbers (learners, pass rate, years)',
     testimonialSection: 'Quotes from learners or parents',
     logoCloud: 'A row of partner or school logos',

--- a/frontend-admin-dashboard/src/routes/manage-pages/-utils/component-templates.ts
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-utils/component-templates.ts
@@ -170,6 +170,21 @@ export const buildComponentTemplates = (t: TFunction): Record<string, Omit<Compo
         },
     },
 
+    courseShowcase: {
+        type: 'courseShowcase',
+        enabled: true,
+        props: {
+            title: 'New courses',
+            subtitle: '',
+            // 'newest' | 'onSale' | 'tag' | 'picked' — what fills the strip.
+            source: 'newest',
+            tag: '',
+            courseIds: [],
+            limit: 3,
+            layout: 'row',
+        },
+    },
+
     statsHighlights: {
         type: 'statsHighlights',
         enabled: true,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/JsonRenderer.tsx
@@ -59,6 +59,7 @@ import { FooterComponent } from "./components/FooterComponent";
 import { HeroSectionComponent } from "./components/HeroSectionComponent";
 import { MediaShowcaseComponent } from "./components/MediaShowcaseComponent";
 import { StatsHighlightsComponent } from "./components/StatsHighlightsComponent";
+import { CourseShowcaseComponent } from "./components/CourseShowcaseComponent";
 import { TestimonialSectionComponent } from "./components/TestimonialSectionComponent";
 import { CartComponent } from "./components/CartComponent";
 import { BuyRentSectionComponent } from "./components/BuyRentSectionComponent";
@@ -216,6 +217,17 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
         return <MediaShowcaseComponent key={id} {...props} />;
       case "statsHighlights":
         return <StatsHighlightsComponent key={id} {...props} />;
+      case "courseShowcase":
+        // Curated strip (new / on sale / one tag / hand-picked). Unlike
+        // productCourseGrid this shows a LIMITED, chosen set — no filters.
+        return (
+          <CourseShowcaseComponent
+            key={id}
+            {...props}
+            instituteId={instituteId}
+            tagName={tagName}
+          />
+        );
       case "testimonialSection":
         return <TestimonialSectionComponent key={id} {...props} />;
       case "cartComponent":

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
@@ -1,0 +1,273 @@
+import React, { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { useNavigate } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { urlCourseDetails } from "@/constants/urls";
+import { getPublicUrlWithoutLogin } from "@/services/upload_file";
+import { OfferBadge, PriceWithMrp } from "@/components/common/price-with-mrp";
+import { cn } from "@/lib/utils";
+
+/**
+ * A CURATED strip of courses — "new", "on sale", one tag, or a hand-picked
+ * list — for promoting a few courses on a landing page.
+ *
+ * This is deliberately not `productCourseGrid`: that component renders the
+ * WHOLE catalogue with search, sort and a filter sidebar, and has no way to
+ * limit or curate what it shows. Pricing and the discount ribbon reuse the
+ * shared PriceWithMrp/OfferBadge so a promoted card matches a catalogue card
+ * exactly, including reader-mode hiding and the FREE ribbon.
+ */
+
+/** Where the strip's courses come from. */
+export type CourseShowcaseSource = "newest" | "onSale" | "tag" | "picked";
+
+interface ShowcaseCourse {
+    id: string;
+    title: string;
+    description: string;
+    thumbnailId: string;
+    price: number;
+    elevatedPrice?: number;
+    currency?: string;
+    tags: string[];
+    level?: string;
+    enrollInviteId?: string;
+    packageSessionId?: string;
+}
+
+export interface CourseShowcaseProps {
+    title?: string;
+    subtitle?: string;
+    source?: CourseShowcaseSource;
+    /** Tag to match when source is "tag" (case-insensitive). */
+    tag?: string;
+    /** Course ids to show, in order, when source is "picked". */
+    courseIds?: string[];
+    limit?: number;
+    layout?: "row" | "grid";
+    backgroundColor?: string;
+    instituteId?: string;
+    tagName?: string;
+}
+
+const splitTags = (raw: unknown): string[] =>
+    typeof raw === "string"
+        ? raw.split(",").map((s) => s.trim()).filter(Boolean)
+        : Array.isArray(raw)
+          ? (raw as unknown[]).map((s) => String(s).trim()).filter(Boolean)
+          : [];
+
+/** Resolves a media-service file id to a URL; a direct URL passes through. */
+const ShowcaseImage: React.FC<{ fileId: string; alt: string }> = ({ fileId, alt }) => {
+    const [url, setUrl] = useState("");
+    const [failed, setFailed] = useState(false);
+
+    useEffect(() => {
+        let alive = true;
+        if (!fileId) {
+            setFailed(true);
+            return;
+        }
+        getPublicUrlWithoutLogin(fileId)
+            .then((u) => alive && (u ? setUrl(u) : setFailed(true)))
+            .catch(() => alive && setFailed(true));
+        return () => {
+            alive = false;
+        };
+    }, [fileId]);
+
+    if (failed) {
+        return (
+            <div className="flex h-full w-full items-center justify-center bg-catalogue-bg-muted px-4 text-center text-sm font-medium text-catalogue-text-muted">
+                {alt}
+            </div>
+        );
+    }
+    if (!url) return <div className="h-full w-full animate-pulse bg-catalogue-bg-muted" />;
+    return <img src={url} alt={alt} loading="lazy" className="h-full w-full object-cover" />;
+};
+
+export const CourseShowcaseComponent: React.FC<CourseShowcaseProps> = ({
+    title,
+    subtitle,
+    source = "newest",
+    tag,
+    courseIds,
+    limit = 3,
+    layout = "row",
+    backgroundColor,
+    instituteId,
+    tagName,
+}) => {
+    const { t } = useTranslation("coursePlayerB");
+    const navigate = useNavigate();
+    const [courses, setCourses] = useState<ShowcaseCourse[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let alive = true;
+        if (!instituteId) {
+            setLoading(false);
+            return;
+        }
+        // Same open search endpoint the catalogue grid uses. `createdAt,desc`
+        // is what makes "newest" simply the first N — no client-side date sort.
+        axios
+            .post(
+                urlCourseDetails,
+                {
+                    status: [],
+                    level_ids: [],
+                    faculty_ids: [],
+                    search_by_name: "",
+                    tag: [],
+                    min_percentage_completed: 0,
+                    max_percentage_completed: 0,
+                },
+                {
+                    params: { instituteId, page: 0, size: 200, sort: "createdAt,desc" },
+                    headers: { "Content-Type": "application/json" },
+                },
+            )
+            .then((res) => {
+                if (!alive) return;
+                const raw = res.data?.content || res.data || [];
+                setCourses(
+                    (raw as Array<Record<string, any>>).map((c) => ({
+                        id: c.id || c.packageId,
+                        title: c.package_name || "",
+                        description: String(c.course_html_description_html || "")
+                            .replace(/<[^>]*>/g, "")
+                            .replace(/&nbsp;/g, " ")
+                            .trim(),
+                        thumbnailId:
+                            c.course_preview_image_media_id ||
+                            c.course_banner_media_id ||
+                            c.thumbnail_file_id ||
+                            "",
+                        price: c.min_plan_actual_price || 0,
+                        elevatedPrice:
+                            typeof c.min_plan_elevated_price === "number"
+                                ? c.min_plan_elevated_price
+                                : undefined,
+                        currency: c.currency,
+                        tags: splitTags(c.comma_separeted_tags),
+                        level: c.level_name,
+                        enrollInviteId: c.enroll_invite_id,
+                        packageSessionId: c.package_session_id,
+                    })),
+                );
+            })
+            .catch((e) => console.error("[CourseShowcase] fetch failed:", e))
+            .finally(() => alive && setLoading(false));
+        return () => {
+            alive = false;
+        };
+    }, [instituteId]);
+
+    const shown = useMemo(() => {
+        let list = courses;
+        if (source === "onSale") {
+            list = list.filter(
+                (c) => typeof c.elevatedPrice === "number" && c.elevatedPrice > c.price,
+            );
+        } else if (source === "tag") {
+            const want = (tag || "").trim().toLowerCase();
+            list = want
+                ? list.filter((c) => c.tags.some((x) => x.toLowerCase() === want))
+                : [];
+        } else if (source === "picked") {
+            const order = (courseIds || []).filter(Boolean);
+            const byId = new Map(list.map((c) => [c.id, c]));
+            list = order.map((id) => byId.get(id)).filter(Boolean) as ShowcaseCourse[];
+        }
+        return list.slice(0, Math.max(1, limit));
+    }, [courses, source, tag, courseIds, limit]);
+
+    const openCourse = (c: ShowcaseCourse) =>
+        navigate({
+            to: `/${tagName}/${c.id}`,
+            search: {
+                enrollInviteId: c.enrollInviteId,
+                packageSessionId: c.packageSessionId,
+                level: c.level,
+            },
+        });
+
+    // An empty curated strip is a configuration mistake (a tag that matches
+    // nothing, say) — render nothing rather than an empty titled band.
+    if (!loading && shown.length === 0) return null;
+
+    return (
+        <section
+            className="catalogue-section bg-catalogue-bg"
+            style={backgroundColor ? { backgroundColor } : undefined} // design-lint-ignore: author-picked page-builder color
+        >
+            <div className="catalogue-shell">
+                {title && (
+                    <h2 className="catalogue-h2 mb-2 text-center text-catalogue-text-primary">{title}</h2>
+                )}
+                {subtitle && (
+                    <p className="catalogue-lead catalogue-measure mx-auto mb-10 text-center text-catalogue-text-muted">
+                        {subtitle}
+                    </p>
+                )}
+
+                <div
+                    className={cn(
+                        "grid gap-6",
+                        layout === "row"
+                            ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+                            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+                    )}
+                >
+                    {loading
+                        ? Array.from({ length: Math.min(limit, 4) }).map((_, i) => (
+                              <div
+                                  key={i}
+                                  className="h-80 animate-pulse rounded-catalogue-lg bg-catalogue-bg-muted"
+                              />
+                          ))
+                        : shown.map((c) => (
+                              <button
+                                  key={c.id}
+                                  type="button"
+                                  onClick={() => openCourse(c)}
+                                  className="group flex flex-col overflow-hidden rounded-catalogue-lg border border-catalogue-border-subtle bg-catalogue-bg-elevated text-start shadow-sm transition-transform duration-300 ease-out hover:-translate-y-1"
+                              >
+                                  <div className="relative aspect-video w-full overflow-hidden bg-catalogue-bg-muted">
+                                      <ShowcaseImage fileId={c.thumbnailId} alt={c.title} />
+                                      <div className="absolute start-3 top-3">
+                                          <OfferBadge actual={c.price} elevated={c.elevatedPrice} />
+                                      </div>
+                                  </div>
+                                  <div className="flex flex-1 flex-col gap-2 p-5">
+                                      <h3 className="text-base font-semibold text-catalogue-text-primary">
+                                          {c.title}
+                                      </h3>
+                                      {c.description && (
+                                          <p className="line-clamp-2 text-sm text-catalogue-text-muted">
+                                              {c.description}
+                                          </p>
+                                      )}
+                                      <div className="mt-auto pt-3">
+                                          <PriceWithMrp
+                                              actual={c.price}
+                                              elevated={c.elevatedPrice}
+                                              currency={c.currency}
+                                              layout="inline"
+                                          />
+                                          <span className="catalogue-btn catalogue-btn-primary mt-3 w-full justify-center">
+                                              {t("courseCatalog.viewCourse", { course: "Course" })}
+                                          </span>
+                                      </div>
+                                  </div>
+                              </button>
+                          ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CourseShowcaseComponent;

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/course-showcase.test.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/course-showcase.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+// The component navigates on card click, and TanStack's useNavigate throws
+// without a router context. The tests below assert rendering, not routing.
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => () => {},
+  useParams: () => ({ tagName: "tag" }),
+  useRouter: () => ({ navigate: () => {} }),
+  Link: () => null,
+}));
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { JsonRenderer } from "./JsonRenderer";
+
+/**
+ * `courseShowcase` is the curated alternative to `productCourseGrid`, which
+ * always renders the whole catalogue and cannot be limited. These assert the
+ * component is wired into the renderer and paints its own chrome — the course
+ * data itself arrives from an effect, so SSR shows the loading skeletons.
+ */
+const page = (props: Record<string, unknown>) => ({
+  id: "p", route: "p", title: "p",
+  components: [{ id: "s", type: "courseShowcase", enabled: true, props }],
+});
+
+const render = (props: Record<string, unknown>) =>
+  renderToString(
+    React.createElement(JsonRenderer, {
+      page: page(props), globalSettings: {} as never,
+      instituteId: "inst", tagName: "tag",
+    } as never),
+  );
+
+describe("courseShowcase", () => {
+  it("is a known component type (not the unknown-type fallback)", () => {
+    const html = render({ title: "Hot right now", limit: 3 });
+    expect(html).toContain("Hot right now");
+  });
+
+  it("renders its subtitle when given one", () => {
+    expect(render({ title: "New", subtitle: "Fresh from the studio" }))
+      .toContain("Fresh from the studio");
+  });
+
+  it("shows a skeleton per course while loading, capped at 4", () => {
+    const html = render({ title: "X", limit: 8 });
+    expect((html.match(/animate-pulse/g) || []).length).toBe(4);
+  });
+
+  it("honours the limit for small counts", () => {
+    const html = render({ title: "X", limit: 2 });
+    expect((html.match(/animate-pulse/g) || []).length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Why

`productCourseGrid` is the only way to put courses on a landing page, and it
always renders the **whole catalogue** with search, sort and a filter sidebar.
Its props — `title`, `showFilters`, `defaultSort`, `filtersConfig`,
`cartButtonConfig`, `render` — have no way to limit or curate what it shows, so
there is no way to promote "new", "on sale" or a hand-picked few.
(`courseRecommendations` exists as a case in the renderer but is hardcoded
`return null`.)

## What

`courseShowcase` — a limited strip fed by one of four sources:

| Source | How it resolves |
|---|---|
| `newest` | the first N — the search API already sorts `createdAt,desc` |
| `onSale` | `elevatedPrice > price`, i.e. the courses showing a discount |
| `tag` | one tag from `comma_separeted_tags`, matched case-insensitively |
| `picked` | explicit course ids, rendered in the order given |

Plus `title`, `subtitle`, `limit` and a 3-across / 4-across `layout`.

**Admin**: template, label, palette entry (Courses & selling), canvas preview,
and a property editor for all of the above. Nothing is hardcoded per institute.

## Decisions worth reviewing

- **Reuses the shared `PriceWithMrp` / `OfferBadge`** rather than reimplementing
  currency and discount rules, so a promoted card matches a catalogue card
  exactly — including reader-mode hiding and the FREE ribbon — and cannot drift.
- **Self-contained rather than extracting from `CourseCatalogComponent`.** That
  file is 1820 lines and renders the institute's main catalogue; pulling the card
  out of it would have put a regression there for no user-visible gain.
- **An empty result renders nothing**, not an empty titled band — a tag matching
  no course is a config mistake, not a section worth showing.
- **No Add-to-cart.** The grid's cart handler is entangled with its quantity and
  toast state; the showcase links through to the course instead. Easy follow-up.

## Verification

- **learner** `tsc -p tsconfig.app.json` — contributes **0** errors. The single
  delta vs the 666 baseline is a duplicate property in `use-domain-routing.ts`,
  which is someone else's uncommitted WIP in the tree, not this branch.
- **admin** `tsc` — exits **0**, 0 errors.
- `design-lint` — **0 errors** in both apps.
- **607 learner tests pass** (51 files), including 4 new render tests asserting
  the type is wired in, the subtitle renders, and the loading skeletons honour
  `limit` (capped at 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)