### PR TITLE
fix(catalogue): centre a course showcase that has fewer courses than tracks

### DIFF
--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
@@ -184,6 +184,23 @@ export const CourseShowcaseComponent: React.FC<CourseShowcaseProps> = ({
         return list.slice(0, Math.max(1, limit));
     }, [courses, source, tag, courseIds, limit]);
 
+    // A curated strip is often ONE or TWO courses. Left-aligning those in a
+    // 3- or 4-up grid leaves the row visibly half-empty, so narrow the track
+    // count to what is actually shown and centre it. Skeletons use `limit`
+    // because `shown` is still empty while loading.
+    const maxCols = layout === "grid" ? 4 : 3;
+    const visibleCount = Math.min(
+        Math.max(loading ? limit : shown.length, 1),
+        maxCols,
+    );
+    const gridClass = cn(
+        "grid gap-6 mx-auto",
+        visibleCount === 1 && "max-w-sm grid-cols-1",
+        visibleCount === 2 && "max-w-3xl grid-cols-1 sm:grid-cols-2",
+        visibleCount === 3 && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+        visibleCount >= 4 && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+    );
+
     const openCourse = (c: ShowcaseCourse) =>
         navigate({
             to: `/${tagName}/${c.id}`,
@@ -213,16 +230,9 @@ export const CourseShowcaseComponent: React.FC<CourseShowcaseProps> = ({
                     </p>
                 )}
 
-                <div
-                    className={cn(
-                        "grid gap-6",
-                        layout === "row"
-                            ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-                            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
-                    )}
-                >
+                <div className={gridClass}>
                     {loading
-                        ? Array.from({ length: Math.min(limit, 4) }).map((_, i) => (
+                        ? Array.from({ length: visibleCount }).map((_, i) => (
                               <div
                                   key={i}
                                   className="h-80 animate-pulse rounded-catalogue-lg bg-catalogue-bg-muted"

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/course-showcase.test.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/course-showcase.test.ts
@@ -43,13 +43,32 @@ describe("courseShowcase", () => {
       .toContain("Fresh from the studio");
   });
 
-  it("shows a skeleton per course while loading, capped at 4", () => {
+  it("shows a skeleton per course while loading, capped at the track count", () => {
     const html = render({ title: "X", limit: 8 });
-    expect((html.match(/animate-pulse/g) || []).length).toBe(4);
+    expect((html.match(/animate-pulse/g) || []).length).toBe(3);
   });
 
   it("honours the limit for small counts", () => {
     const html = render({ title: "X", limit: 2 });
     expect((html.match(/animate-pulse/g) || []).length).toBe(2);
+  });
+
+  // A one- or two-course strip must not sit left-aligned in a 3-up grid.
+  it("narrows and centres the grid for a single course", () => {
+    const html = render({ title: "X", limit: 1 });
+    expect(html).toContain("max-w-sm");
+    expect(html).toContain("mx-auto");
+    expect(html).not.toContain("lg:grid-cols-3");
+  });
+
+  it("narrows to two tracks for two courses", () => {
+    const html = render({ title: "X", limit: 2 });
+    expect(html).toContain("max-w-3xl");
+    expect(html).toContain("sm:grid-cols-2");
+  });
+
+  it("uses four tracks only in grid layout", () => {
+    expect(render({ title: "X", limit: 8, layout: "grid" })).toContain("lg:grid-cols-4");
+    expect(render({ title: "X", limit: 8, layout: "row" })).toContain("lg:grid-cols-3");
   });
 });


### PR DESCRIPTION
Follow-up to #2796, found the first time the component was used for real.

## Problem

A curated strip is often **one** course — that is the point of "hand-picked".
The grid was a fixed 3-up (`lg:grid-cols-3`), so a single card sat left-aligned
with two thirds of the row visibly empty:

```
Featured right now
A gentle 2-day live workshop for parents of toddlers.

[ The Heartful Beginning ]                        <- empty
```

## Fix

The track count follows what is actually shown, capped at the layout maximum,
and the grid is centred:

| Courses | Grid |
|---|---|
| 1 | `max-w-sm`, single column, centred |
| 2 | `max-w-3xl`, two columns, centred |
| 3+ | full 3-up (or 4-up in `grid` layout) |

Skeletons key off `limit` rather than `shown`, which is empty while loading.

## Verification

- `design-lint` clean, `tsc` contributes 0 errors.
- **610 learner tests pass**, including 3 new ones asserting a single course
  narrows and centres, two courses get two tracks, and 4-up happens only in
  `grid` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)