### PR TITLE
feat(audience): audit CRM actions and make the activity log filterabl…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/controller/AdminActivityLogController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/controller/AdminActivityLogController.java
@@ -22,6 +22,10 @@ import vacademy.io.common.exceptions.VacademyException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin-core-service/audit/v1")
@@ -30,28 +34,34 @@ public class AdminActivityLogController {
     @Autowired
     private AdminActivityLogReadService readService;
 
+    /**
+     * Page of audit rows for the calling institute.
+     *
+     * <p>{@code actorId}, {@code entityType} and {@code action} each accept a
+     * comma-separated list ({@code actorId=a,b,c}) and have plural aliases, so
+     * the UI's multi-selects need no new params and every existing single-value
+     * link keeps working. Commas, not repeated {@code param[]=} keys — bracketed
+     * array params are rejected by the ingress before they reach this service.
+     */
     @GetMapping("/logs")
     public ResponseEntity<Page<AdminActivityLogResponseDTO>> list(
             HttpServletRequest request,
             @RequestParam(required = false) Long startDate,
             @RequestParam(required = false) Long endDate,
             @RequestParam(required = false) String actorId,
+            @RequestParam(required = false) String actorIds,
             @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) String entityTypes,
             @RequestParam(required = false) String entityId,
             @RequestParam(required = false) String action,
+            @RequestParam(required = false) String actions,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
         String instituteId = requireInstituteId(request);
 
-        AdminActivityLogFilterDTO filter = AdminActivityLogFilterDTO.builder()
-                .startDate(startDate != null ? new Timestamp(startDate) : null)
-                .endDate(endDate != null ? new Timestamp(endDate) : null)
-                .actorId(actorId)
-                .entityType(entityType)
-                .entityId(entityId)
-                .action(action)
-                .build();
+        AdminActivityLogFilterDTO filter = buildFilter(
+                startDate, endDate, actorId, actorIds, entityType, entityTypes, entityId, action, actions);
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return ResponseEntity.ok(readService.list(instituteId, filter, pageable));
@@ -76,20 +86,17 @@ public class AdminActivityLogController {
             @RequestParam(required = false) Long startDate,
             @RequestParam(required = false) Long endDate,
             @RequestParam(required = false) String actorId,
+            @RequestParam(required = false) String actorIds,
             @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) String entityTypes,
             @RequestParam(required = false) String entityId,
-            @RequestParam(required = false) String action) {
+            @RequestParam(required = false) String action,
+            @RequestParam(required = false) String actions) {
 
         String instituteId = requireInstituteId(request);
 
-        AdminActivityLogFilterDTO filter = AdminActivityLogFilterDTO.builder()
-                .startDate(startDate != null ? new Timestamp(startDate) : null)
-                .endDate(endDate != null ? new Timestamp(endDate) : null)
-                .actorId(actorId)
-                .entityType(entityType)
-                .entityId(entityId)
-                .action(action)
-                .build();
+        AdminActivityLogFilterDTO filter = buildFilter(
+                startDate, endDate, actorId, actorIds, entityType, entityTypes, entityId, action, actions);
 
         byte[] csv = readService.exportCsv(instituteId, filter);
 
@@ -101,6 +108,45 @@ public class AdminActivityLogController {
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=\"" + filename + "\"")
                 .body(csv);
+    }
+
+    /** Shared by the list and the CSV export so both honour the same filters. */
+    private AdminActivityLogFilterDTO buildFilter(Long startDate,
+            Long endDate,
+            String actorId,
+            String actorIds,
+            String entityType,
+            String entityTypes,
+            String entityId,
+            String action,
+            String actions) {
+        return AdminActivityLogFilterDTO.builder()
+                .startDate(startDate != null ? new Timestamp(startDate) : null)
+                .endDate(endDate != null ? new Timestamp(endDate) : null)
+                .actorIds(csvValues(actorId, actorIds))
+                .entityTypes(csvValues(entityType, entityTypes))
+                .entityId(entityId)
+                .actions(csvValues(action, actions))
+                .build();
+    }
+
+    /**
+     * Splits one or more comma-separated params into a de-duplicated list.
+     * Null when nothing usable was passed, so the spec skips the predicate
+     * entirely rather than emitting an {@code IN ()} that matches no rows.
+     */
+    private List<String> csvValues(String... params) {
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        for (String param : params) {
+            if (param == null || param.isBlank()) {
+                continue;
+            }
+            Arrays.stream(param.split(","))
+                    .map(String::trim)
+                    .filter(value -> !value.isEmpty())
+                    .forEach(values::add);
+        }
+        return values.isEmpty() ? null : new ArrayList<>(values);
     }
 
     private String requireInstituteId(HttpServletRequest request) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/dto/AdminActivityLogFilterDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/dto/AdminActivityLogFilterDTO.java
@@ -8,7 +8,21 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
+import java.util.List;
 
+/**
+ * Filter set for a log read.
+ *
+ * <p>Actor, resource and activity are <em>lists</em>: the audit UI lets an admin
+ * tick several people ("what did the three counsellors do today?") or several
+ * resources at once, which one equality predicate cannot express. A single
+ * value is just a one-element list, so the old single-value query params keep
+ * working unchanged.
+ *
+ * <p>{@code entityId} stays singular on purpose — bulk actions store a
+ * comma-joined list of ids in that column, so splitting it on commas would
+ * silently break the "history of this entity" lookup.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,8 +31,8 @@ import java.sql.Timestamp;
 public class AdminActivityLogFilterDTO {
     private Timestamp startDate;
     private Timestamp endDate;
-    private String actorId;
-    private String entityType;
+    private List<String> actorIds;
+    private List<String> entityTypes;
     private String entityId;
-    private String action;
+    private List<String> actions;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/AdminActivityLogReadService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/AdminActivityLogReadService.java
@@ -2,6 +2,8 @@ package vacademy.io.admin_core_service.features.admin_activity_logs.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -165,21 +167,44 @@ public class AdminActivityLogReadService {
                 if (filter.getEndDate() != null) {
                     predicates.add(cb.lessThanOrEqualTo(root.get("createdAt"), filter.getEndDate()));
                 }
-                if (filter.getActorId() != null && !filter.getActorId().isBlank()) {
-                    predicates.add(cb.equal(root.get("actorId"), filter.getActorId()));
-                }
-                if (filter.getEntityType() != null && !filter.getEntityType().isBlank()) {
-                    predicates.add(cb.equal(root.get("entityType"), filter.getEntityType()));
-                }
+                // One value emits `= ?` (the composite indexes' fast path);
+                // several emit `IN (...)`, which those same indexes still serve.
+                addInPredicate(predicates, cb, root.get("actorId"), filter.getActorIds());
+                addInPredicate(predicates, cb, root.get("entityType"), filter.getEntityTypes());
                 if (filter.getEntityId() != null && !filter.getEntityId().isBlank()) {
                     predicates.add(cb.equal(root.get("entityId"), filter.getEntityId()));
                 }
-                if (filter.getAction() != null && !filter.getAction().isBlank()) {
-                    predicates.add(cb.equal(root.get("action"), filter.getAction()));
-                }
+                addInPredicate(predicates, cb, root.get("action"), filter.getActions());
             }
             return cb.and(predicates.toArray(new Predicate[0]));
         };
+    }
+
+    /**
+     * Adds an equality (one value) or {@code IN} (several) predicate, skipping
+     * blank entries. An empty list adds nothing: a filter the caller left empty
+     * must widen the result set, never empty it.
+     */
+    private void addInPredicate(List<Predicate> predicates,
+            CriteriaBuilder cb,
+            Path<String> column,
+            List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        List<String> cleaned = values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+        if (cleaned.isEmpty()) {
+            return;
+        }
+        if (cleaned.size() == 1) {
+            predicates.add(cb.equal(column, cleaned.get(0)));
+            return;
+        }
+        predicates.add(column.in(cleaned));
     }
 
     private AdminActivityLogResponseDTO toDto(AdminActivityLog log) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/CrmAuditNarrator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/CrmAuditNarrator.java
@@ -1,0 +1,324 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import vacademy.io.admin_core_service.features.audience.entity.Audience;
+import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
+import vacademy.io.admin_core_service.features.audience.entity.LeadFollowup;
+import vacademy.io.admin_core_service.features.audience.entity.LeadStatus;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceRepository;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
+import vacademy.io.admin_core_service.features.audience.repository.LeadFollowupRepository;
+import vacademy.io.admin_core_service.features.audience.repository.LeadStatusRepository;
+import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
+import vacademy.io.common.auth.entity.User;
+import vacademy.io.common.auth.repository.UserRepository;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * CRM-side twin of {@link AuditNarrator}: turns the ids a CRM request carries
+ * into the phrases stored in {@code admin_activity_log.description}.
+ *
+ * <p>Kept separate from {@link AuditNarrator} so the learner/course lookups and
+ * the audience/lead lookups don't drag each other's repositories into one bean.
+ * Annotations reach it as {@code @crmAuditNarrator.<method>(...)}.
+ *
+ * <p>Conventions carried over from {@link AuditNarrator}, and they matter:
+ * <ul>
+ *   <li><b>Never throw.</b> Every method degrades to an id, a count, or null —
+ *       an audit lookup must not be able to fail a customer mutation.</li>
+ *   <li><b>No actor in the phrase</b> — the read UI prepends {@code actor_name}.</li>
+ *   <li><b>One name, many counted.</b> Listing 200 leads makes a row unreadable;
+ *       the count is what an admin scanning the log needs.</li>
+ *   <li><b>Distinct method names, no overloads</b> — SpEL resolves overloads
+ *       poorly when an argument is null.</li>
+ * </ul>
+ */
+@Component
+public class CrmAuditNarrator {
+
+    private static final Logger logger = LoggerFactory.getLogger(CrmAuditNarrator.class);
+
+    @Autowired
+    private AudienceRepository audienceRepository;
+
+    @Autowired
+    private AudienceResponseRepository audienceResponseRepository;
+
+    @Autowired
+    private LeadStatusRepository leadStatusRepository;
+
+    @Autowired
+    private LeadFollowupRepository leadFollowupRepository;
+
+    @Autowired
+    private UserLeadProfileRepository userLeadProfileRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // ── Audiences (campaigns) ─────────────────────────────────────────────
+
+    /** Campaign name for an audience id, falling back to the raw id. */
+    public String audienceFor(String audienceId) {
+        if (isBlank(audienceId)) {
+            return null;
+        }
+        try {
+            return audienceRepository.findById(audienceId)
+                    .map(Audience::getCampaignName)
+                    .filter(name -> !isBlank(name))
+                    .map(String::trim)
+                    .orElse(audienceId);
+        } catch (Exception e) {
+            logger.warn("Could not resolve audience name for {}: {}", audienceId, e.getMessage());
+            return audienceId;
+        }
+    }
+
+    /**
+     * Snapshot of an audience for {@code captureBefore}. Returned as a map
+     * rather than the entity so the JSON in {@code before_payload} stays small
+     * and stable, and so {@code descriptionExpr} can read the name back as
+     * {@code #before['name']} <em>after</em> the row is gone (a DELETE cannot
+     * look the name up again).
+     */
+    public Map<String, Object> audienceSnapshot(String audienceId) {
+        if (isBlank(audienceId)) {
+            return null;
+        }
+        try {
+            return audienceRepository.findById(audienceId)
+                    .map(audience -> {
+                        Map<String, Object> snapshot = new LinkedHashMap<>();
+                        snapshot.put("id", audience.getId());
+                        snapshot.put("name", audience.getCampaignName());
+                        snapshot.put("type", audience.getCampaignType());
+                        snapshot.put("objective", audience.getCampaignObjective());
+                        snapshot.put("status", audience.getStatus());
+                        snapshot.put("description", audience.getDescription());
+                        snapshot.put("to_notify", audience.getToNotify());
+                        snapshot.put("start_date", String.valueOf(audience.getStartDate()));
+                        snapshot.put("end_date", String.valueOf(audience.getEndDate()));
+                        return snapshot;
+                    })
+                    .orElse(null);
+        } catch (Exception e) {
+            logger.warn("Could not snapshot audience {}: {}", audienceId, e.getMessage());
+            return null;
+        }
+    }
+
+    /** Reads a name out of an {@code audienceSnapshot}, for post-delete phrasing. */
+    public String nameFromSnapshot(Object snapshot, String fallback) {
+        if (snapshot instanceof Map<?, ?> map) {
+            Object name = map.get("name");
+            if (name != null && !isBlank(name.toString())) {
+                return name.toString().trim();
+            }
+        }
+        return fallback;
+    }
+
+    // ── Leads ─────────────────────────────────────────────────────────────
+
+    /**
+     * Display name for one lead (an {@code audience_response} row): the lead's
+     * own user record first, then the parent/guardian name captured on the
+     * form, then the raw id.
+     */
+    public String leadFor(String audienceResponseId) {
+        if (isBlank(audienceResponseId)) {
+            return null;
+        }
+        try {
+            AudienceResponse response = audienceResponseRepository.findById(audienceResponseId).orElse(null);
+            if (response == null) {
+                return audienceResponseId;
+            }
+            String name = personFor(response.getUserId());
+            if (!isBlank(name) && !name.equals(response.getUserId())) {
+                return name;
+            }
+            if (!isBlank(response.getParentName())) {
+                return response.getParentName().trim();
+            }
+            if (!isBlank(response.getParentEmail())) {
+                return response.getParentEmail().trim();
+            }
+            if (!isBlank(response.getParentMobile())) {
+                return response.getParentMobile().trim();
+            }
+            return audienceResponseId;
+        } catch (Exception e) {
+            logger.warn("Could not resolve lead name for {}: {}", audienceResponseId, e.getMessage());
+            return audienceResponseId;
+        }
+    }
+
+    /** Names one lead, or counts several — "Amit Kumar" vs "5 lead(s)". */
+    public String leadsFor(List<String> audienceResponseIds) {
+        List<String> ids = distinctNonBlank(audienceResponseIds);
+        if (ids.isEmpty()) {
+            return null;
+        }
+        if (ids.size() > 1) {
+            return ids.size() + " lead(s)";
+        }
+        return leadFor(ids.get(0));
+    }
+
+    /** Human label of a lead status id ("Interested"), falling back to the id. */
+    public String leadStatusFor(String leadStatusId) {
+        if (isBlank(leadStatusId)) {
+            return null;
+        }
+        try {
+            return leadStatusRepository.findById(leadStatusId)
+                    .map(LeadStatus::getLabel)
+                    .filter(label -> !isBlank(label))
+                    .map(String::trim)
+                    .orElse(leadStatusId);
+        } catch (Exception e) {
+            logger.warn("Could not resolve lead status label for {}: {}", leadStatusId, e.getMessage());
+            return leadStatusId;
+        }
+    }
+
+    /** Snapshot of a lead status row, for UPDATE/DELETE before-payloads. */
+    public Map<String, Object> leadStatusSnapshot(String leadStatusId) {
+        if (isBlank(leadStatusId)) {
+            return null;
+        }
+        try {
+            return leadStatusRepository.findById(leadStatusId)
+                    .map(status -> {
+                        Map<String, Object> snapshot = new LinkedHashMap<>();
+                        snapshot.put("id", status.getId());
+                        snapshot.put("name", status.getLabel());
+                        snapshot.put("status_key", status.getStatusKey());
+                        snapshot.put("color", status.getColor());
+                        snapshot.put("display_order", status.getDisplayOrder());
+                        snapshot.put("is_default", status.getIsDefault());
+                        snapshot.put("is_active", status.getIsActive());
+                        return snapshot;
+                    })
+                    .orElse(null);
+        } catch (Exception e) {
+            logger.warn("Could not snapshot lead status {}: {}", leadStatusId, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── Follow-ups ────────────────────────────────────────────────────────
+
+    /** "Amit Kumar" — the lead a follow-up belongs to, for update/close rows. */
+    public String followupLeadFor(String followupId) {
+        if (isBlank(followupId)) {
+            return null;
+        }
+        try {
+            return leadFollowupRepository.findById(followupId)
+                    .map(LeadFollowup::getAudienceResponseId)
+                    .map(this::leadFor)
+                    .orElse(null);
+        } catch (Exception e) {
+            logger.warn("Could not resolve follow-up {}: {}", followupId, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── People (counsellors, staff) ───────────────────────────────────────
+
+    /** Full name of any platform user (counsellor, staff), falling back to the id. */
+    public String personFor(String userId) {
+        if (isBlank(userId)) {
+            return null;
+        }
+        try {
+            return userRepository.findById(userId)
+                    .map(User::getFullName)
+                    .filter(name -> !isBlank(name))
+                    .map(String::trim)
+                    .orElse(userId);
+        } catch (Exception e) {
+            logger.warn("Could not resolve user name for {}: {}", userId, e.getMessage());
+            return userId;
+        }
+    }
+
+    /** Names one person, or counts several — for bulk assign/target actions. */
+    public String peopleFor(List<String> userIds) {
+        List<String> ids = distinctNonBlank(userIds);
+        if (ids.isEmpty()) {
+            return null;
+        }
+        if (ids.size() > 1) {
+            return ids.size() + " user(s)";
+        }
+        return personFor(ids.get(0));
+    }
+
+    // ── Phrase helpers used directly from annotations ─────────────────────
+
+    /**
+     * The counsellor currently on a lead, read <em>before</em> a reassignment.
+     * Exists so the audit can tell a real removal from a no-op: the assign
+     * endpoint returns early, and 200, when asked to unassign a lead that has
+     * no counsellor, and logging that would claim an action nobody performed.
+     */
+    public String assignedCounsellorFor(String leadUserId, String instituteId) {
+        if (isBlank(leadUserId) || isBlank(instituteId)) {
+            return null;
+        }
+        try {
+            return userLeadProfileRepository.findByUserIdAndInstituteId(leadUserId, instituteId)
+                    .map(profile -> profile.getAssignedCounselorId())
+                    .filter(id -> !isBlank(id))
+                    .orElse(null);
+        } catch (Exception e) {
+            logger.warn("Could not read the assigned counsellor for {}: {}", leadUserId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * "assigned Amit Kumar to Rahul" / "unassigned Amit Kumar from Rahul".
+     * The counsellor name is optional — assignment dialogs send it, other
+     * callers only send the id, which we then resolve.
+     */
+    public String counsellorAssignment(String leadUserId, String counsellorId, String counsellorName) {
+        String who = personFor(leadUserId);
+        if (isBlank(counsellorId)) {
+            return who == null ? null : "unassigned counsellor from lead " + who;
+        }
+        String counsellor = !isBlank(counsellorName) ? counsellorName.trim() : personFor(counsellorId);
+        if (who == null) {
+            return counsellor == null ? null : "assigned a lead to " + counsellor;
+        }
+        return "assigned lead " + who + " to " + (counsellor != null ? counsellor : counsellorId);
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private List<String> distinctNonBlank(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isBlank())
+                .distinct()
+                .toList();
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.audience.dto.*;
 import vacademy.io.admin_core_service.features.audience.service.AudienceService;
 import vacademy.io.admin_core_service.features.audience.service.LeadAssignmentNotifier;
@@ -77,6 +78,11 @@ public class AudienceController {
     }
 
     @PostMapping("/campaign")
+    @Auditable(
+            entityType = "AUDIENCE",
+            action = "CREATE",
+            entityIdExpr = "#result?.body",
+            descriptionExpr = "'created audience ' + (#audienceDTO?.campaignName ?: 'list')")
     public ResponseEntity<String> createCampaign(
             @RequestBody AudienceDTO audienceDTO,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -91,6 +97,13 @@ public class AudienceController {
     }
 
     @PutMapping("/campaign/{audienceId}")
+    @Auditable(
+            entityType = "AUDIENCE",
+            action = "UPDATE",
+            entityIdExpr = "#audienceId",
+            captureBefore = "@crmAuditNarrator.audienceSnapshot(#audienceId)",
+            descriptionExpr = "'updated audience ' + (#audienceDTO?.campaignName "
+                    + "?: @crmAuditNarrator.nameFromSnapshot(#before, #audienceId))")
     public ResponseEntity<String> updateCampaign(
             @PathVariable String audienceId,
             @RequestBody AudienceDTO audienceDTO,
@@ -120,6 +133,14 @@ public class AudienceController {
     }
 
     @DeleteMapping("/campaign/{instituteId}/{audienceId}")
+    @Auditable(
+            entityType = "AUDIENCE",
+            action = "DELETE",
+            entityIdExpr = "#audienceId",
+            // The name has to be read before the delete — after it, there is
+            // nothing left to look up.
+            captureBefore = "@crmAuditNarrator.audienceSnapshot(#audienceId)",
+            descriptionExpr = "'deleted audience ' + @crmAuditNarrator.nameFromSnapshot(#before, #audienceId)")
     public ResponseEntity<String> deleteCampaign(
             @PathVariable String instituteId,
             @PathVariable String audienceId) {
@@ -142,6 +163,12 @@ public class AudienceController {
      * unaffected.
      */
     @PostMapping("/lead/submit")
+    @Auditable(
+            entityType = "LEAD",
+            action = "CREATE",
+            entityIdExpr = "#result?.body",
+            descriptionExpr = "'added lead ' + (#requestDTO?.userDTO?.fullName "
+                    + "?: #requestDTO?.userDTO?.mobileNumber ?: #requestDTO?.userDTO?.email ?: 'contact')")
     public ResponseEntity<String> submitLead(
             @RequestBody SubmitLeadRequestDTO requestDTO,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -157,6 +184,16 @@ public class AudienceController {
      * running the import when the audience-access setting asks for it.
      */
     @PostMapping("/lead/bulk-submit")
+    @Auditable(
+            entityType = "LEAD",
+            action = "IMPORT",
+            entityIdExpr = "#request?.audienceId",
+            // A CSV import body is unbounded — thousands of rows of PII. The
+            // summary in the description is what an audit reader needs.
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'imported ' + (#result?.body?.summary?.successful ?: (#request?.rows?.size() ?: 0)) "
+                    + "+ ' lead(s)' + (#request?.audienceId != null ? ' into ' "
+                    + "+ @crmAuditNarrator.audienceFor(#request.audienceId) : '')")
     public ResponseEntity<BulkSubmitLeadResponseDTO> bulkSubmitLead(
             @RequestBody BulkSubmitLeadRequestDTO request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -218,6 +255,16 @@ public class AudienceController {
      * {@code institute_id} the ADMIN check is made against.</p>
      */
     @PostMapping("/leads/delete")
+    @Auditable(
+            entityType = "LEAD",
+            action = "DELETE",
+            entityIdExpr = "#request?.responseIds != null and #request.responseIds.size() == 1 "
+                    + "? #request.responseIds[0] : null",
+            // A delete that matched nothing still returns 200; logging it would
+            // claim leads were removed that never were.
+            conditionExpr = "#result?.body != null and #result.body['deleted'] != null "
+                    + "and #result.body['deleted'] > 0",
+            descriptionExpr = "'deleted lead ' + @crmAuditNarrator.leadsFor(#request?.responseIds)")
     public ResponseEntity<Map<String, Object>> deleteLeads(
             @RequestBody LeadDeleteRequestDTO request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -227,6 +274,14 @@ public class AudienceController {
 
     /** Restore soft-deleted leads — the inverse of {@link #deleteLeads}. ADMIN only. */
     @PostMapping("/leads/restore")
+    @Auditable(
+            entityType = "LEAD",
+            action = "RESTORE",
+            entityIdExpr = "#request?.responseIds != null and #request.responseIds.size() == 1 "
+                    + "? #request.responseIds[0] : null",
+            conditionExpr = "#result?.body != null and #result.body['restored'] != null "
+                    + "and #result.body['restored'] > 0",
+            descriptionExpr = "'restored lead ' + @crmAuditNarrator.leadsFor(#request?.responseIds)")
     public ResponseEntity<Map<String, Object>> restoreLeads(
             @RequestBody LeadDeleteRequestDTO request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -242,6 +297,11 @@ public class AudienceController {
      * and the lead's custom field values. It never touches {@code student}.
      */
     @PutMapping("/lead/{responseId}/profile")
+    @Auditable(
+            entityType = "LEAD",
+            action = "UPDATE",
+            entityIdExpr = "#responseId",
+            descriptionExpr = "'updated lead ' + @crmAuditNarrator.leadFor(#responseId)")
     public ResponseEntity<String> updateLeadProfile(@PathVariable String responseId,
                                                     @RequestBody LeadProfileEditRequestDTO request) {
         audienceService.updateLeadProfile(responseId, request);
@@ -252,6 +312,11 @@ public class AudienceController {
      * Send a message to audience campaign leads.
      */
     @PostMapping("/campaign/{audienceId}/send")
+    @Auditable(
+            entityType = "AUDIENCE",
+            action = "SEND_MESSAGE",
+            entityIdExpr = "#audienceId",
+            descriptionExpr = "'sent a message to audience ' + @crmAuditNarrator.audienceFor(#audienceId)")
     public ResponseEntity<SendAudienceMessageResponseDTO> sendMessage(
             @PathVariable String audienceId,
             @RequestBody SendAudienceMessageRequestDTO request) {
@@ -298,6 +363,12 @@ public class AudienceController {
      * POST /admin-core-service/v1/audience/walk-in/submit
      */
     @PostMapping("/walk-in/submit")
+    @Auditable(
+            entityType = "LEAD",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.audienceResponseId",
+            descriptionExpr = "'registered walk-in lead ' + (#walkInDTO?.parentName "
+                    + "?: #walkInDTO?.childName ?: #walkInDTO?.parentMobile ?: 'contact')")
     public ResponseEntity<SubmitLeadWithEnquiryResponseDTO> submitWalkIn(
             @RequestBody WalkInRegistrationDTO walkInDTO,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -324,6 +395,12 @@ public class AudienceController {
      * Body: { "score": 75 }  — pass null to clear the override.
      */
     @PutMapping("/lead/{responseId}/score/manual")
+    @Auditable(
+            entityType = "LEAD",
+            action = "SCORE_CHANGE",
+            entityIdExpr = "#responseId",
+            descriptionExpr = "'changed lead score of ' + @crmAuditNarrator.leadFor(#responseId) "
+                    + "+ ' to ' + (#body != null and #body['score'] != null ? #body['score'] : 'auto')")
     public ResponseEntity<LeadScoreDTO> setManualScore(
             @PathVariable String responseId,
             @RequestBody java.util.Map<String, Integer> body,
@@ -338,6 +415,11 @@ public class AudienceController {
      * POST /admin-core-service/v1/audience/campaign/{audienceId}/recalculate-scores
      */
     @PostMapping("/campaign/{audienceId}/recalculate-scores")
+    @Auditable(
+            entityType = "AUDIENCE",
+            action = "RECALCULATE_SCORES",
+            entityIdExpr = "#audienceId",
+            descriptionExpr = "'recalculated lead scores for audience ' + @crmAuditNarrator.audienceFor(#audienceId)")
     public ResponseEntity<String> recalculateScores(@PathVariable String audienceId) {
         audienceService.recalculateScoresForAudience(audienceId);
         return ResponseEntity.ok("Scores recalculated for campaign: " + audienceId);
@@ -373,6 +455,11 @@ public class AudienceController {
      * POST /admin-core-service/v1/audience/user-lead-profile/mark-converted
      */
     @PostMapping("/user-lead-profile/mark-converted")
+    @Auditable(
+            entityType = "LEAD",
+            action = "CONVERT",
+            entityIdExpr = "#userId",
+            descriptionExpr = "'marked lead ' + @crmAuditNarrator.personFor(#userId) + ' as converted'")
     public ResponseEntity<UserLeadProfileDTO> markLeadConverted(
             @RequestParam String userId,
             @RequestParam String instituteId) {
@@ -385,6 +472,11 @@ public class AudienceController {
      * POST /admin-core-service/v1/audience/user-lead-profile/update-status?userId=...&instituteId=...&status=...
      */
     @PostMapping("/user-lead-profile/update-status")
+    @Auditable(
+            entityType = "LEAD",
+            action = "STATUS_CHANGE",
+            entityIdExpr = "#userId",
+            descriptionExpr = "'changed lead status of ' + @crmAuditNarrator.personFor(#userId) + ' to ' + #status")
     public ResponseEntity<UserLeadProfileDTO> updateLeadStatus(
             @RequestParam String userId,
             @RequestParam String instituteId,
@@ -424,6 +516,11 @@ public class AudienceController {
      * POST /admin-core-service/v1/audience/user-lead-profile/update-tier?userId=...&instituteId=...&tier=HOT
      */
     @PostMapping("/user-lead-profile/update-tier")
+    @Auditable(
+            entityType = "LEAD",
+            action = "TIER_CHANGE",
+            entityIdExpr = "#userId",
+            descriptionExpr = "'changed lead tier of ' + @crmAuditNarrator.personFor(#userId) + ' to ' + #tier")
     public ResponseEntity<UserLeadProfileDTO> updateLeadTier(
             @RequestParam String userId,
             @RequestParam String instituteId,
@@ -479,6 +576,17 @@ public class AudienceController {
      * assigned is a silent no-op (no event noise).
      */
     @PostMapping("/user-lead-profile/assign-counselor")
+    @Auditable(
+            entityType = "LEAD",
+            // One mapping, two logical operations: a blank counselorId removes
+            // the assignment. Stamping both ASSIGN would make removals invisible.
+            actionExpr = "(#counselorId == null or #counselorId.isBlank()) ? 'UNASSIGN' : 'ASSIGN'",
+            entityIdExpr = "#userId",
+            // Unassigning a lead that has no counsellor returns early with a 200
+            // and changes nothing; only a lead that HAD one is a real removal.
+            captureBefore = "@crmAuditNarrator.assignedCounsellorFor(#userId, #instituteId)",
+            conditionExpr = "(#counselorId != null and !#counselorId.isBlank()) or #before != null",
+            descriptionExpr = "@crmAuditNarrator.counsellorAssignment(#userId, #counselorId, #counselorName)")
     public ResponseEntity<UserLeadProfileDTO> assignCounselor(
             @RequestParam String userId,
             @RequestParam String instituteId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadFollowupController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadFollowupController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.audience.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.audience.dto.CloseLeadFollowupRequest;
 import vacademy.io.admin_core_service.features.audience.dto.CreateLeadFollowupRequest;
 import vacademy.io.admin_core_service.features.audience.dto.LeadFollowupDto;
@@ -20,6 +21,12 @@ public class LeadFollowupController {
     private final LeadFollowupService leadFollowupService;
 
     @PostMapping
+    @Auditable(
+            entityType = "LEAD_FOLLOWUP",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'scheduled a follow-up for lead ' "
+                    + "+ @crmAuditNarrator.leadFor(#request?.audienceResponseId)")
     public ResponseEntity<LeadFollowupDto> create(@RequestBody CreateLeadFollowupRequest request,
                                                    @RequestAttribute("user") CustomUserDetails user) {
         return ResponseEntity.ok(leadFollowupService.create(request, user));
@@ -46,6 +53,11 @@ public class LeadFollowupController {
     }
 
     @PutMapping("/{id}")
+    @Auditable(
+            entityType = "LEAD_FOLLOWUP",
+            action = "UPDATE",
+            entityIdExpr = "#id",
+            descriptionExpr = "'rescheduled a follow-up for lead ' + @crmAuditNarrator.followupLeadFor(#id)")
     public ResponseEntity<LeadFollowupDto> update(@PathVariable String id,
                                                    @RequestBody UpdateLeadFollowupRequest request,
                                                    @RequestAttribute("user") CustomUserDetails user) {
@@ -53,6 +65,11 @@ public class LeadFollowupController {
     }
 
     @PutMapping("/{id}/close")
+    @Auditable(
+            entityType = "LEAD_FOLLOWUP",
+            action = "CLOSE",
+            entityIdExpr = "#id",
+            descriptionExpr = "'closed a follow-up for lead ' + @crmAuditNarrator.followupLeadFor(#id)")
     public ResponseEntity<LeadFollowupDto> close(@PathVariable String id,
                                                   @RequestBody CloseLeadFollowupRequest request,
                                                   @RequestAttribute("user") CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadSlaConfigController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadSlaConfigController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.audience.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.audience.dto.LeadSlaSettingsDTO;
 import vacademy.io.admin_core_service.features.audience.service.LeadSlaConfigService;
 import vacademy.io.common.auth.model.CustomUserDetails;
@@ -23,6 +24,14 @@ public class LeadSlaConfigController {
     }
 
     @PutMapping
+    @Auditable(
+            entityType = "LEAD_SLA_CONFIG",
+            action = "UPDATE",
+            entityIdExpr = "#instituteId",
+            captureBefore = "@leadSlaConfigService.getSettings(#instituteId)",
+            // Not "updated lead ..." — the audit table's name matcher would read
+            // the rest of that sentence as a lead's name and bold it.
+            descriptionExpr = "'updated TAT and follow-up SLA settings'")
     public ResponseEntity<String> save(@RequestParam String instituteId,
                                        @RequestBody LeadSlaSettingsDTO dto,
                                        @RequestAttribute("user") CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadStatusController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/LeadStatusController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.audience.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.audience.dto.LeadStatusDTO;
 import vacademy.io.admin_core_service.features.audience.service.LeadStatusService;
 import vacademy.io.common.auth.model.CustomUserDetails;
@@ -31,6 +32,11 @@ public class LeadStatusController {
     }
 
     @PostMapping
+    @Auditable(
+            entityType = "LEAD_STATUS",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'created lead status ' + (#dto?.label ?: #dto?.statusKey)")
     public ResponseEntity<LeadStatusDTO> create(@RequestParam String instituteId,
                                                 @RequestBody LeadStatusDTO dto,
                                                 @RequestAttribute("user") CustomUserDetails user) {
@@ -38,6 +44,13 @@ public class LeadStatusController {
     }
 
     @PutMapping("/{id}")
+    @Auditable(
+            entityType = "LEAD_STATUS",
+            action = "UPDATE",
+            entityIdExpr = "#id",
+            captureBefore = "@crmAuditNarrator.leadStatusSnapshot(#id)",
+            descriptionExpr = "'updated lead status ' + (#dto?.label "
+                    + "?: @crmAuditNarrator.nameFromSnapshot(#before, #id))")
     public ResponseEntity<LeadStatusDTO> update(@PathVariable String id,
                                                 @RequestBody LeadStatusDTO dto,
                                                 @RequestAttribute("user") CustomUserDetails user) {
@@ -45,6 +58,12 @@ public class LeadStatusController {
     }
 
     @DeleteMapping("/{id}")
+    @Auditable(
+            entityType = "LEAD_STATUS",
+            action = "DELETE",
+            entityIdExpr = "#id",
+            captureBefore = "@crmAuditNarrator.leadStatusSnapshot(#id)",
+            descriptionExpr = "'deleted lead status ' + @crmAuditNarrator.nameFromSnapshot(#before, #id)")
     public ResponseEntity<Void> delete(@PathVariable String id,
                                        @RequestAttribute("user") CustomUserDetails user) {
         leadStatusService.deactivate(id);
@@ -53,6 +72,12 @@ public class LeadStatusController {
 
     /** Set a lead's current status (manual change from the leads UI). */
     @PostMapping("/lead/{audienceResponseId}")
+    @Auditable(
+            entityType = "LEAD",
+            action = "STATUS_CHANGE",
+            entityIdExpr = "#audienceResponseId",
+            descriptionExpr = "'changed lead status of ' + @crmAuditNarrator.leadFor(#audienceResponseId) "
+                    + "+ ' to ' + @crmAuditNarrator.leadStatusFor(#statusId)")
     public ResponseEntity<String> setLeadStatus(@PathVariable String audienceResponseId,
                                                 @RequestParam String statusId,
                                                 @RequestParam(required = false, defaultValue = "MANUAL") String source,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/MetaOAuthController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/MetaOAuthController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.audience.dto.AdConnectorSetupRequest;
 import vacademy.io.admin_core_service.features.audience.dto.ConnectorHealthDTO;
 import vacademy.io.admin_core_service.features.audience.dto.ConnectorListItemDTO;
@@ -396,6 +397,20 @@ public class MetaOAuthController {
      */
     @PostMapping("/connector")
     @Transactional
+    @Auditable(
+            entityType = "LEAD_CONNECTOR",
+            action = "CREATE",
+            entityIdExpr = "#result?.body != null ? #result.body['connector_id'] : null",
+            // This mapping answers a missing sessionKey/formId with a 400-carrying
+            // ResponseEntity instead of throwing, and the aspect only ever sees a
+            // successful return — without this guard a rejected request would be
+            // logged as a connector that was created.
+            conditionExpr = "#result?.body != null and #result.body['connector_id'] != null",
+            // The body carries OAuth session keys — never persist it.
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'connected Meta lead form ' + (#request?.platformFormName "
+                    + "?: #request?.platformFormId) + (#request?.audienceId != null ? ' to audience ' "
+                    + "+ @crmAuditNarrator.audienceFor(#request.audienceId) : '')")
     public ResponseEntity<Map<String, String>> saveConnector(
             @RequestBody AdConnectorSetupRequest request) {
 
@@ -506,6 +521,16 @@ public class MetaOAuthController {
     // ── Google connector (no OAuth) ───────────────────────────────────────────
 
     @PostMapping("/google/connector")
+    @Auditable(
+            entityType = "LEAD_CONNECTOR",
+            action = "CREATE",
+            entityIdExpr = "#result?.body != null ? #result.body['connector_id'] : null",
+            // Same 400-without-throwing shape as the Meta connector above.
+            conditionExpr = "#result?.body != null and #result.body['connector_id'] != null",
+            // googleKey is a credential — keep it out of the audit table.
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'connected a Google lead form' + (#request?.audienceId != null "
+                    + "? ' to audience ' + @crmAuditNarrator.audienceFor(#request.audienceId) : '')")
     public ResponseEntity<Map<String, String>> saveGoogleConnector(
             @RequestBody AdConnectorSetupRequest request) {
 
@@ -571,6 +596,11 @@ public class MetaOAuthController {
      */
     @DeleteMapping("/connectors/{connectorId}")
     @Transactional
+    @Auditable(
+            entityType = "LEAD_CONNECTOR",
+            action = "DELETE",
+            entityIdExpr = "#connectorId",
+            descriptionExpr = "'disconnected a lead connector'")
     public ResponseEntity<Map<String, String>> deactivateConnector(
             @PathVariable String connectorId) {
         FormWebhookConnector connector = connectorRepository.findById(connectorId)
@@ -600,6 +630,11 @@ public class MetaOAuthController {
      */
     @PutMapping("/connectors/{connectorId}")
     @Transactional
+    @Auditable(
+            entityType = "LEAD_CONNECTOR",
+            action = "UPDATE",
+            entityIdExpr = "#connectorId",
+            descriptionExpr = "'updated lead connector ' + (#result?.body?.platformFormName ?: #connectorId)")
     public ResponseEntity<ConnectorListItemDTO> updateConnector(
             @PathVariable String connectorId,
             @RequestBody ConnectorUpdateRequest request) {
@@ -654,6 +689,11 @@ public class MetaOAuthController {
      */
     @PostMapping("/connectors/{connectorId}/resubscribe")
     @Transactional
+    @Auditable(
+            entityType = "LEAD_CONNECTOR",
+            action = "RESUBSCRIBE",
+            entityIdExpr = "#connectorId",
+            descriptionExpr = "'re-subscribed a lead connector to its page webhook'")
     public ResponseEntity<Map<String, String>> resubscribeConnector(
             @PathVariable String connectorId) {
         FormWebhookConnector connector = connectorRepository.findById(connectorId)

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_target/controller/CounsellorTargetController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_target/controller/CounsellorTargetController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.counsellor_target.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.counsellor_target.dto.BulkCounsellorTargetRequest;
 import vacademy.io.admin_core_service.features.counsellor_target.dto.CounsellorTargetDTO;
 import vacademy.io.admin_core_service.features.counsellor_target.dto.CounsellorTargetProgressDTO;
@@ -45,12 +46,21 @@ public class CounsellorTargetController {
 
     /** Set/replace one counsellor's target for a (metric, period) slot. */
     @PutMapping
+    @Auditable(
+            entityType = "COUNSELLOR_TARGET",
+            action = "UPDATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'set a target for ' + @crmAuditNarrator.personFor(#request?.counsellorUserId)")
     public ResponseEntity<CounsellorTargetDTO> upsert(@RequestBody UpsertCounsellorTargetRequest request) {
         return ResponseEntity.ok(settingService.upsertTarget(request));
     }
 
     /** Apply the same target to many counsellors (bulk-apply to a team). */
     @PostMapping("/bulk")
+    @Auditable(
+            entityType = "COUNSELLOR_TARGET",
+            action = "BULK_UPDATE",
+            descriptionExpr = "'set targets for ' + @crmAuditNarrator.peopleFor(#request?.counsellorUserIds)")
     public ResponseEntity<Void> bulk(@RequestBody BulkCounsellorTargetRequest request) {
         settingService.bulkUpsertTargets(request);
         return ResponseEntity.ok().build();
@@ -58,6 +68,11 @@ public class CounsellorTargetController {
 
     /** Remove one target by id. */
     @DeleteMapping("/{targetId}")
+    @Auditable(
+            entityType = "COUNSELLOR_TARGET",
+            action = "DELETE",
+            entityIdExpr = "#targetId",
+            descriptionExpr = "'removed a target for ' + @crmAuditNarrator.personFor(#counsellorUserId)")
     public ResponseEntity<Void> delete(
             @PathVariable String targetId,
             @RequestParam("instituteId") String instituteId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/controller/CounsellorWorkbenchController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counsellor_workbench/controller/CounsellorWorkbenchController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.counsellor_workbench.dto.*;
 import vacademy.io.admin_core_service.features.counsellor_workbench.service.CounsellorReassignService;
 import vacademy.io.admin_core_service.features.counsellor_workbench.service.CounsellorWorkbenchService;
@@ -47,6 +48,10 @@ public class CounsellorWorkbenchController {
      * exists on {@link WorkbenchConfig} and Jackson skips unknown properties).
      */
     @PutMapping("/config")
+    @Auditable(
+            entityType = "COUNSELLOR_WORKBENCH_CONFIG",
+            action = "UPDATE",
+            descriptionExpr = "'updated counsellor workbench settings'")
     public ResponseEntity<WorkbenchConfig> updateConfig(@RequestBody WorkbenchConfig request) {
         boolean hasRatingFields = request.getStrategyType() != null
                 || request.getStartingRating() != null
@@ -149,6 +154,12 @@ public class CounsellorWorkbenchController {
     // ────────────────────────────────────────────────────────────────
 
     @PatchMapping("/counsellors/{userId}/status")
+    @Auditable(
+            entityType = "COUNSELLOR",
+            action = "STATUS_CHANGE",
+            entityIdExpr = "#userId",
+            descriptionExpr = "'changed status of counsellor ' + @crmAuditNarrator.personFor(#userId) "
+                    + "+ (#request?.status != null ? ' to ' + #request.status : '')")
     public ResponseEntity<StatusChangeResponseDTO> setStatus(
             @PathVariable String userId,
             @RequestBody SetStatusRequest request,
@@ -169,6 +180,16 @@ public class CounsellorWorkbenchController {
     }
 
     @PostMapping("/reassign")
+    @Auditable(
+            entityType = "LEAD",
+            action = "REASSIGN",
+            // The same service also serves /reassign/preview; a dry run moved
+            // nothing and must not be recorded as if it had.
+            conditionExpr = "#result?.body?.dryRun != true",
+            descriptionExpr = "'reassigned ' + (#result?.body?.totalLeads ?: 0) + ' lead(s) from ' "
+                    + "+ @crmAuditNarrator.personFor(#request?.fromUserId) "
+                    + "+ (#request?.targetUserId != null ? ' to ' "
+                    + "+ @crmAuditNarrator.personFor(#request.targetUserId) : '')")
     public ResponseEntity<ReassignResultDTO> reassign(
             @RequestBody ReassignRequest request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -187,6 +208,13 @@ public class CounsellorWorkbenchController {
     }
 
     @PostMapping("/assign")
+    @Auditable(
+            entityType = "LEAD",
+            action = "ASSIGN",
+            conditionExpr = "#result?.body?.dryRun != true",
+            descriptionExpr = "'assigned ' + (#result?.body?.totalLeads ?: 0) + ' lead(s)' "
+                    + "+ (#request?.targetUserId != null ? ' to ' "
+                    + "+ @crmAuditNarrator.personFor(#request.targetUserId) : '')")
     public ResponseEntity<AssignLeadsResultDTO> assign(
             @RequestBody AssignLeadsRequest request,
             @RequestAttribute("user") CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/counselor_pool/controller/CounselorPoolController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.counselor_pool.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.counselor_pool.dto.*;
 import vacademy.io.admin_core_service.features.counselor_pool.service.CounselorPoolService;
 import vacademy.io.admin_core_service.features.counselor_pool.service.CounselorPoolShiftService;
@@ -29,6 +30,11 @@ public class CounselorPoolController {
     // ────────────────────────────────────────────────────────────────
 
     @PostMapping
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'created counsellor pool ' + (#result?.body?.name ?: '')")
     public ResponseEntity<CounselorPoolDTO> createPool(
             @RequestBody CreatePoolRequest request,
             @RequestAttribute("user") CustomUserDetails user) {
@@ -46,6 +52,11 @@ public class CounselorPoolController {
     }
 
     @PatchMapping("/{poolId}")
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "UPDATE",
+            entityIdExpr = "#poolId",
+            descriptionExpr = "'updated counsellor pool ' + (#result?.body?.name ?: #poolId)")
     public ResponseEntity<CounselorPoolDTO> updatePool(
             @PathVariable String poolId,
             @RequestBody UpdatePoolRequest request) {
@@ -53,6 +64,11 @@ public class CounselorPoolController {
     }
 
     @DeleteMapping("/{poolId}")
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "DELETE",
+            entityIdExpr = "#poolId",
+            descriptionExpr = "'deleted a counsellor pool'")
     public ResponseEntity<String> deletePool(@PathVariable String poolId) {
         poolService.deletePool(poolId);
         return ResponseEntity.ok("Pool deleted");
@@ -106,6 +122,11 @@ public class CounselorPoolController {
      * Body: { counselor_user_ids: [...] }. If any id fails, nothing is added.
      */
     @PostMapping("/{poolId}/counselors")
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "ADD_MEMBER",
+            entityIdExpr = "#poolId",
+            descriptionExpr = "'added ' + @crmAuditNarrator.peopleFor(#request?.counselorUserIds) + ' to a counsellor pool'")
     public ResponseEntity<String> addCounselorsToPool(
             @PathVariable String poolId,
             @RequestBody AddCounselorsRequest request,
@@ -115,6 +136,11 @@ public class CounselorPoolController {
     }
 
     @DeleteMapping("/{poolId}/counselors/{counselorUserId}")
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "REMOVE_MEMBER",
+            entityIdExpr = "#poolId",
+            descriptionExpr = "'removed ' + @crmAuditNarrator.personFor(#counselorUserId) + ' from a counsellor pool'")
     public ResponseEntity<String> removeCounselorFromPool(
             @PathVariable String poolId,
             @PathVariable String counselorUserId) {
@@ -130,6 +156,12 @@ public class CounselorPoolController {
      * right actor.
      */
     @PatchMapping("/{poolId}/counselors/{counselorUserId}/status")
+    @Auditable(
+            entityType = "COUNSELLOR_POOL",
+            action = "MEMBER_STATUS_CHANGE",
+            entityIdExpr = "#poolId",
+            descriptionExpr = "'changed pool status of ' + @crmAuditNarrator.personFor(#counselorUserId) "
+                    + "+ (#request?.status != null ? ' to ' + #request.status : '')")
     public ResponseEntity<String> updateMemberStatus(
             @PathVariable String poolId,
             @PathVariable String counselorUserId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/engagement/controller/EngagementEngineController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/engagement/controller/EngagementEngineController.java
@@ -23,6 +23,7 @@ import vacademy.io.admin_core_service.features.engagement.service.EngagementEngi
 import vacademy.io.admin_core_service.features.engagement.spi.DataPointRegistry;
 import vacademy.io.admin_core_service.features.engagement.spi.DataPointSpec;
 import vacademy.io.admin_core_service.features.engagement.service.EngagementAccessGuard;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.common.auth.model.CustomUserDetails;
 
 import java.util.List;
@@ -51,6 +52,11 @@ public class EngagementEngineController {
     private int defaultFirstN;
 
     @PostMapping
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'created engagement engine ' + (#request?.name ?: '')")
     public ResponseEntity<EngagementEngine> create(@RequestParam String instituteId,
                                                    @RequestBody CreateEngineRequest request,
                                                    @RequestAttribute("user") CustomUserDetails user) {
@@ -85,6 +91,11 @@ public class EngagementEngineController {
 
     /** Resolve audience selectors → enroll (idempotent, jittered) + exit leavers. */
     @PostMapping("/{engineId}/enroll")
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "ENROLL",
+            entityIdExpr = "#engineId",
+            descriptionExpr = "'refreshed the audience of an engagement engine'")
     public ResponseEntity<EngagementEngineService.EnrollmentResult> enroll(
             @PathVariable String engineId,
             @RequestParam String instituteId,
@@ -95,6 +106,12 @@ public class EngagementEngineController {
 
     /** DRAFT → DRY_RUN/ACTIVE → PAUSED → ARCHIVED. Activation requires an enrolled audience. */
     @PutMapping("/{engineId}/status")
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "STATUS_CHANGE",
+            entityIdExpr = "#engineId",
+            descriptionExpr = "'changed status of engagement engine ' + (#result?.body?.name ?: #engineId) "
+                    + "+ ' to ' + #toStatus")
     public ResponseEntity<EngagementEngine> transition(@PathVariable String engineId,
                                                        @RequestParam String instituteId,
                                                        @RequestParam String toStatus,
@@ -105,6 +122,11 @@ public class EngagementEngineController {
 
     /** The prompt that grows: append an amendment; base_text is immutable. */
     @PostMapping("/{engineId}/prompt")
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "UPDATE",
+            entityIdExpr = "#engineId",
+            descriptionExpr = "'edited the prompt of an engagement engine'")
     public ResponseEntity<EngagementPromptVersion> editPrompt(@PathVariable String engineId,
                                                               @RequestParam String instituteId,
                                                               @RequestBody PromptEditRequest request,
@@ -115,6 +137,12 @@ public class EngagementEngineController {
 
     /** Kill switch: stop/resume autonomous sending (the engine keeps drafting copilot tasks). */
     @PutMapping("/{engineId}/autonomy")
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "AUTONOMY_CHANGE",
+            entityIdExpr = "#engineId",
+            descriptionExpr = "(#killed ? 'paused' : 'resumed') + ' autonomous sending for engagement engine ' "
+                    + "+ (#result?.body?.name ?: #engineId)")
     public ResponseEntity<EngagementEngine> setAutonomy(@PathVariable String engineId,
                                                         @RequestParam String instituteId,
                                                         @RequestParam boolean killed,
@@ -146,6 +174,11 @@ public class EngagementEngineController {
     }
 
     @DeleteMapping("/{engineId}")
+    @Auditable(
+            entityType = "ENGAGEMENT_ENGINE",
+            action = "DELETE",
+            entityIdExpr = "#engineId",
+            descriptionExpr = "'archived an engagement engine'")
     public ResponseEntity<Void> archive(@PathVariable String engineId,
                                         @RequestParam String instituteId,
                                         @RequestAttribute("user") CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enquiry/controller/EnquiryInternalController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/enquiry/controller/EnquiryInternalController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.enquiry.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.enquiry.dto.AdminEnquiryDetailResponseDTO;
 import vacademy.io.admin_core_service.features.enquiry.dto.BulkEnquiryStatusUpdateRequestDTO;
 import vacademy.io.admin_core_service.features.enquiry.dto.BulkEnquiryStatusUpdateResponseDTO;
@@ -17,6 +18,10 @@ public class EnquiryInternalController {
     private EnquiryService enquiryService;
 
     @PostMapping("/link-counselor")
+    @Auditable(
+            entityType = "ENQUIRY",
+            action = "ASSIGN",
+            descriptionExpr = "'linked a counsellor to an enquiry'")
     public ResponseEntity<String> linkCounselor(@RequestBody LinkCounselorDTO request,
             @RequestAttribute("user") vacademy.io.common.auth.model.CustomUserDetails user) {
         String response = enquiryService.linkCounselorToSource(request, user);
@@ -31,6 +36,11 @@ public class EnquiryInternalController {
     }
 
     @PostMapping("/v1/admin/update-status")
+    @Auditable(
+            entityType = "ENQUIRY",
+            action = "STATUS_CHANGE",
+            descriptionExpr = "'changed the status of ' + (#request?.enquiryIds?.size() ?: 0) + ' enquiry(s)'"
+                    + " + (#request?.enquiryStatus != null ? ' to ' + #request.enquiryStatus : '')")
     public ResponseEntity<BulkEnquiryStatusUpdateResponseDTO> bulkUpdateEnquiryStatus(
             @RequestBody BulkEnquiryStatusUpdateRequestDTO request,
             @RequestAttribute("user") vacademy.io.common.auth.model.CustomUserDetails user) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/tag_management/controller/TagController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/tag_management/controller/TagController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.tag_management.dto.*;
 import vacademy.io.admin_core_service.features.tag_management.service.CsvTagService;
 import vacademy.io.admin_core_service.features.tag_management.service.TagService;
@@ -31,6 +32,11 @@ public class TagController {
      * Create a new tag for institute
      */
     @PostMapping("/institutes/{instituteId}/tags")
+    @Auditable(
+            entityType = "TAG",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'created tag ' + (#createTagDTO?.tagName ?: '')")
     public ResponseEntity<TagDTO> createTag(
             @PathVariable String instituteId,
             @Valid @RequestBody CreateTagDTO createTagDTO,
@@ -85,6 +91,11 @@ public class TagController {
      * Delete a tag (mark as inactive) - only non-default tags
      */
     @DeleteMapping("/institutes/{instituteId}/tags/{tagId}")
+    @Auditable(
+            entityType = "TAG",
+            action = "DELETE",
+            entityIdExpr = "#tagId",
+            descriptionExpr = "'deleted a tag'")
     public ResponseEntity<String> deleteTag(
             @PathVariable String instituteId,
             @PathVariable String tagId,
@@ -158,6 +169,10 @@ public class TagController {
      * Add tags to users
      */
     @PostMapping("/institutes/{instituteId}/users/tags/add")
+    @Auditable(
+            entityType = "TAG",
+            action = "TAG_USERS",
+            descriptionExpr = "'tagged ' + (#result?.body?.successCount ?: 0) + ' contact(s)'")
     public ResponseEntity<BulkUserTagOperationResultDTO> addTagsToUsers(
             @PathVariable String instituteId,
             @Valid @RequestBody AddTagsToUsersDTO request,
@@ -175,6 +190,11 @@ public class TagController {
      * Add single tag to multiple users
      */
     @PostMapping("/institutes/{instituteId}/tags/{tagId}/users/add")
+    @Auditable(
+            entityType = "TAG",
+            action = "TAG_USERS",
+            entityIdExpr = "#tagId",
+            descriptionExpr = "'tagged ' + (#result?.body?.successCount ?: 0) + ' contact(s)'")
     public ResponseEntity<BulkUserTagOperationResultDTO> addTagToUsers(
             @PathVariable String instituteId,
             @PathVariable String tagId,
@@ -193,6 +213,10 @@ public class TagController {
      * Add tag by name to multiple users (auto-creates tag if it doesn't exist)
      */
     @PostMapping("/institutes/{instituteId}/tags/by-name/{tagName}/users/add")
+    @Auditable(
+            entityType = "TAG",
+            action = "TAG_USERS",
+            descriptionExpr = "'tagged ' + (#result?.body?.successCount ?: 0) + ' contact(s) with ' + #tagName")
     public ResponseEntity<BulkUserTagOperationResultDTO> addTagByNameToUsers(
             @PathVariable String instituteId,
             @PathVariable String tagName,
@@ -211,6 +235,10 @@ public class TagController {
      * Deactivate user tags for specific users
      */
     @PostMapping("/institutes/{instituteId}/users/tags/deactivate")
+    @Auditable(
+            entityType = "TAG",
+            action = "UNTAG_USERS",
+            descriptionExpr = "'removed tags from ' + (#result?.body?.successCount ?: 0) + ' contact(s)'")
     public ResponseEntity<BulkUserTagOperationResultDTO> deactivateUserTags(
             @PathVariable String instituteId,
             @RequestParam List<String> userIds,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyConfigController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyConfigController.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.bind.annotation.*;
 import vacademy.io.admin_core_service.features.audience.service.TokenEncryptionService;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.telephony.controller.dto.TelephonyConfigDTO;
 import vacademy.io.admin_core_service.features.telephony.controller.dto.TelephonyConfigViewDTO;
 import vacademy.io.admin_core_service.features.telephony.core.TelephonyConfigCache;
@@ -59,6 +60,15 @@ public class TelephonyConfigController {
 
     @PutMapping("/{instituteId}")
     @Transactional
+    @Auditable(
+            entityType = "TELEPHONY_CONFIG",
+            action = "UPDATE",
+            entityIdExpr = "#instituteId",
+            // The body carries provider API tokens; REDACTED masks the usual
+            // key names but not every provider's, so capture nothing.
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'updated calling settings' + (#body?.providerType != null "
+                    + "? ' (provider ' + #body.providerType + ')' : '')")
     public ResponseEntity<TelephonyConfigViewDTO> upsert(
             @PathVariable String instituteId,
             @RequestBody TelephonyConfigDTO body,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyNumberController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyNumberController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.telephony.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.telephony.controller.dto.TelephonyProviderNumberDTO;
 import vacademy.io.admin_core_service.features.telephony.core.InboundFlowAttacher;
 import vacademy.io.admin_core_service.features.telephony.core.TelephonyNumberTxOps;
@@ -30,6 +31,11 @@ public class TelephonyNumberController {
     }
 
     @PostMapping
+    @Auditable(
+            entityType = "TELEPHONY_NUMBER",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'added calling number ' + (#body?.phoneNumber ?: '')")
     public ResponseEntity<TelephonyProviderNumberDTO> create(
             @RequestBody TelephonyProviderNumberDTO body) {
         if (body.getInstituteId() == null || body.getInstituteId().isBlank()) {
@@ -51,6 +57,11 @@ public class TelephonyNumberController {
     }
 
     @PutMapping("/{id}")
+    @Auditable(
+            entityType = "TELEPHONY_NUMBER",
+            action = "UPDATE",
+            entityIdExpr = "#id",
+            descriptionExpr = "'updated calling number ' + (#body?.phoneNumber ?: #id)")
     public ResponseEntity<TelephonyProviderNumberDTO> update(
             @PathVariable String id,
             @RequestBody TelephonyProviderNumberDTO body) {
@@ -67,6 +78,11 @@ public class TelephonyNumberController {
 
     /** Re-run the attach for a number whose last attempt was PENDING / FAILED. */
     @PostMapping("/{id}/attach")
+    @Auditable(
+            entityType = "TELEPHONY_NUMBER",
+            action = "ATTACH",
+            entityIdExpr = "#id",
+            descriptionExpr = "'re-attached calling number ' + (#result?.body?.phoneNumber ?: #id) + ' to its flow'")
     public ResponseEntity<TelephonyProviderNumberDTO> retryAttach(@PathVariable String id) {
         flowAttacher.retry(id);
         return numberRepo.findById(id)
@@ -75,6 +91,11 @@ public class TelephonyNumberController {
     }
 
     @DeleteMapping("/{id}")
+    @Auditable(
+            entityType = "TELEPHONY_NUMBER",
+            action = "DELETE",
+            entityIdExpr = "#id",
+            descriptionExpr = "'removed a calling number'")
     public ResponseEntity<Void> delete(@PathVariable String id) {
         TelephonyProviderNumber existing = numberRepo.findById(id).orElse(null);
         if (existing != null) flowAttacher.detachQuietly(existing);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.workflow.dto.*;
 import vacademy.io.admin_core_service.features.workflow.entity.WorkflowTemplate;
 import vacademy.io.admin_core_service.features.workflow.entity.WorkflowTrigger;
@@ -79,6 +80,14 @@ public class WorkflowController {
     }
 
     @PostMapping
+    @Auditable(
+            entityType = "AUTOMATION",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            // A builder payload is the whole node graph — big, and re-readable
+            // from the workflow itself. The name is what an audit row needs.
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'created automation ' + (#dto?.name ?: '')")
     public ResponseEntity<WorkflowBuilderDTO> createWorkflow(
             @RequestBody WorkflowBuilderDTO dto,
             @RequestParam(value = "userId") String userId) {
@@ -95,6 +104,12 @@ public class WorkflowController {
      * the original behind. Use this when saving edits from the visual builder.
      */
     @PutMapping("/{workflowId}")
+    @Auditable(
+            entityType = "AUTOMATION",
+            action = "UPDATE",
+            entityIdExpr = "#workflowId",
+            payload = Auditable.PayloadMode.NONE,
+            descriptionExpr = "'updated automation ' + (#dto?.name ?: #workflowId)")
     public ResponseEntity<WorkflowBuilderDTO> updateWorkflow(
             @PathVariable String workflowId,
             @RequestBody WorkflowBuilderDTO dto,
@@ -115,6 +130,11 @@ public class WorkflowController {
     }
 
     @DeleteMapping("/{workflowId}")
+    @Auditable(
+            entityType = "AUTOMATION",
+            action = "DELETE",
+            entityIdExpr = "#workflowId",
+            descriptionExpr = "'deleted an automation'")
     public ResponseEntity<Void> deleteWorkflow(
             @PathVariable String workflowId) {
 
@@ -200,6 +220,11 @@ public class WorkflowController {
      * {@code initialContext}.
      */
     @PostMapping("/{workflowId}/trigger-now")
+    @Auditable(
+            entityType = "AUTOMATION",
+            action = "TRIGGER",
+            entityIdExpr = "#workflowId",
+            descriptionExpr = "'manually ran an automation'")
     public ResponseEntity<Map<String, Object>> triggerWorkflowNow(
             @PathVariable String workflowId,
             @RequestBody(required = false) Map<String, Object> sampleContext) {

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AdminActivityLogFilterParsingTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AdminActivityLogFilterParsingTest.java
@@ -1,0 +1,143 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import vacademy.io.admin_core_service.features.admin_activity_logs.controller.AdminActivityLogController;
+import vacademy.io.admin_core_service.features.admin_activity_logs.dto.AdminActivityLogFilterDTO;
+import vacademy.io.admin_core_service.features.admin_activity_logs.service.AdminActivityLogReadService;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * How the log endpoint turns query params into a filter.
+ *
+ * <p>Worth pinning because the audit UI's multi-selects send several values in
+ * one param ({@code actorId=a,b,c}) — repeated {@code actorId[]=} keys are
+ * rejected by the ingress before they reach the service — while every existing
+ * bookmark and CSV-export link still sends a single value. Both have to keep
+ * working, and an empty filter must widen the result set rather than empty it.
+ */
+class AdminActivityLogFilterParsingTest {
+
+    private static final String INSTITUTE = "inst-1";
+
+    private AdminActivityLogReadService readService;
+    private AdminActivityLogController controller;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        readService = mock(AdminActivityLogReadService.class);
+        when(readService.list(any(), any(), any())).thenReturn(Page.empty());
+        when(readService.exportCsv(any(), any())).thenReturn(new byte[0]);
+
+        controller = new AdminActivityLogController();
+        ReflectionTestUtils.setField(controller, "readService", readService);
+
+        request = new MockHttpServletRequest();
+        request.addHeader("clientId", INSTITUTE);
+    }
+
+    @Test
+    @DisplayName("a comma-separated actor param becomes a multi-value filter")
+    void splitsCommaSeparatedActors() {
+        controller.list(request, null, null, "user-a,user-b , user-c", null,
+                null, null, null, null, null, 0, 20);
+
+        assertEquals(List.of("user-a", "user-b", "user-c"), captureFilter().getActorIds());
+    }
+
+    @Test
+    @DisplayName("a single value still filters, so old links keep working")
+    void keepsSingleValueParamsWorking() {
+        controller.list(request, null, null, "user-a", null,
+                "LEAD", null, null, "CREATE", null, 0, 20);
+
+        AdminActivityLogFilterDTO filter = captureFilter();
+        assertEquals(List.of("user-a"), filter.getActorIds());
+        assertEquals(List.of("LEAD"), filter.getEntityTypes());
+        assertEquals(List.of("CREATE"), filter.getActions());
+    }
+
+    @Test
+    @DisplayName("plural aliases merge with the singular params and de-duplicate")
+    void mergesPluralAliases() {
+        controller.list(request, null, null, "user-a", "user-b,user-a", null,
+                "LEAD,AUDIENCE", null, null, "CREATE,CREATE", 0, 20);
+
+        AdminActivityLogFilterDTO filter = captureFilter();
+        assertEquals(List.of("user-a", "user-b"), filter.getActorIds());
+        assertEquals(List.of("LEAD", "AUDIENCE"), filter.getEntityTypes());
+        assertEquals(List.of("CREATE"), filter.getActions());
+    }
+
+    @Test
+    @DisplayName("blank and empty params leave the filter unset, never IN ()")
+    void treatsBlankParamsAsNoFilter() {
+        controller.list(request, null, null, "  ", ",,", "", null, null, null, null, 0, 20);
+
+        AdminActivityLogFilterDTO filter = captureFilter();
+        assertNull(filter.getActorIds());
+        assertNull(filter.getEntityTypes());
+        assertNull(filter.getActions());
+    }
+
+    @Test
+    @DisplayName("entityId is never split — bulk rows store a comma-joined id list")
+    void keepsEntityIdIntact() {
+        controller.list(request, null, null, null, null, null, null,
+                "course-1,course-2", null, null, 0, 20);
+
+        assertEquals("course-1,course-2", captureFilter().getEntityId());
+    }
+
+    @Test
+    @DisplayName("the CSV export honours exactly the same filters as the list")
+    void exportUsesTheSameFilters() {
+        controller.exportCsv(request, 1000L, 2000L, "user-a,user-b", null,
+                "LEAD", null, null, "DELETE", null);
+
+        ArgumentCaptor<AdminActivityLogFilterDTO> captor =
+                ArgumentCaptor.forClass(AdminActivityLogFilterDTO.class);
+        verify(readService).exportCsv(eq(INSTITUTE), captor.capture());
+
+        AdminActivityLogFilterDTO filter = captor.getValue();
+        assertEquals(List.of("user-a", "user-b"), filter.getActorIds());
+        assertEquals(List.of("LEAD"), filter.getEntityTypes());
+        assertEquals(List.of("DELETE"), filter.getActions());
+        assertEquals(1000L, filter.getStartDate().getTime());
+        assertEquals(2000L, filter.getEndDate().getTime());
+    }
+
+    @Test
+    @DisplayName("a request without clientId is refused — tenant scope is not optional")
+    void refusesRequestWithoutInstituteHeader() {
+        MockHttpServletRequest anonymous = new MockHttpServletRequest();
+
+        assertThrows(VacademyException.class, () -> controller.list(
+                anonymous, null, null, null, null, null, null, null, null, null, 0, 20));
+    }
+
+    private AdminActivityLogFilterDTO captureFilter() {
+        ArgumentCaptor<AdminActivityLogFilterDTO> captor =
+                ArgumentCaptor.forClass(AdminActivityLogFilterDTO.class);
+        verify(readService).list(eq(INSTITUTE), captor.capture(), any(Pageable.class));
+        return captor.getValue();
+    }
+}

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AuditableAnnotationContractTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AuditableAnnotationContractTest.java
@@ -1,0 +1,285 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.expression.spel.SpelParseException;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Compile-time-ish guard for every {@code @Auditable} annotation in the service.
+ *
+ * <p>The SpEL on these annotations is a string: nothing checks it until an admin
+ * performs the action in production, and when it is wrong the aspect swallows
+ * the failure (by design — audit must never break a mutation) and writes a row
+ * with a null description. A typo therefore ships silently and is only noticed
+ * when someone reads the audit log and finds blank sentences.
+ *
+ * <p>So this test walks every annotated controller method and checks the three
+ * things that are statically knowable:
+ * <ol>
+ *   <li>the expressions <b>parse</b>;</li>
+ *   <li>every {@code #variable} they reference is a real parameter of that
+ *       method (or one of the aspect-supplied {@code #user} / {@code #result} /
+ *       {@code #before});</li>
+ *   <li>every {@code @beanName} they call resolves to a class that exists.</li>
+ * </ol>
+ *
+ * <p>What it cannot check is property names inside the expressions
+ * ({@code #dto?.campaignName}) — SpEL resolves those reflectively at runtime.
+ */
+class AuditableAnnotationContractTest {
+
+    private static final String BASE_PACKAGE = "vacademy.io";
+
+    /** Variables the aspect puts into the evaluation context itself. */
+    private static final Set<String> ASPECT_PROVIDED = Set.of("user", "result", "before");
+
+    private static final Pattern VARIABLE_REF = Pattern.compile("#([A-Za-z_][A-Za-z0-9_]*)");
+    private static final Pattern BEAN_REF = Pattern.compile("@([A-Za-z_][A-Za-z0-9_]*)");
+    private static final Pattern ENTITY_TYPE = Pattern.compile("[A-Z][A-Z0-9_]*");
+
+    /**
+     * Every class file, interfaces included — a type filter and not
+     * {@code AssignableTypeFilter(Object.class)}, which silently skips
+     * interfaces and would then miss the Spring Data repositories that
+     * {@code captureBefore} expressions call into.
+     */
+    private static final TypeFilter MATCH_EVERYTHING = (metadataReader, metadataReaderFactory) -> true;
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+    private final ParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
+
+    @Test
+    @DisplayName("every @Auditable expression parses, and its #variables and @beans exist")
+    void auditableAnnotationsAreWellFormed() {
+        List<Method> annotated = findAuditableMethods();
+        assertTrue(annotated.size() >= 20,
+                "Expected the audit coverage to still be in place, found only " + annotated.size()
+                        + " @Auditable methods — did a scan path change?");
+
+        Set<String> beanNames = scanBeanNames();
+        List<String> problems = new ArrayList<>();
+
+        for (Method method : annotated) {
+            Auditable auditable = method.getAnnotation(Auditable.class);
+            String where = method.getDeclaringClass().getSimpleName() + "#" + method.getName();
+
+            if (auditable.entityType().isBlank()) {
+                problems.add(where + ": entityType is blank");
+            } else if (!ENTITY_TYPE.matcher(auditable.entityType()).matches()) {
+                problems.add(where + ": entityType '" + auditable.entityType()
+                        + "' must be UPPER_SNAKE_CASE — the UI filters on the exact string");
+            }
+            if (auditable.action().isBlank() && auditable.actionExpr().isBlank()) {
+                problems.add(where + ": neither action nor actionExpr is set — "
+                        + "the aspect skips the row because action is NOT NULL");
+            }
+
+            Set<String> parameterNames = parameterNamesOf(method);
+            checkExpression(auditable.entityIdExpr(), where, "entityIdExpr", parameterNames, beanNames, problems);
+            checkExpression(auditable.descriptionExpr(), where, "descriptionExpr", parameterNames, beanNames, problems);
+            checkExpression(auditable.captureBefore(), where, "captureBefore", parameterNames, beanNames, problems);
+            checkExpression(auditable.actionExpr(), where, "actionExpr", parameterNames, beanNames, problems);
+            checkExpression(auditable.conditionExpr(), where, "conditionExpr", parameterNames, beanNames, problems);
+
+            // captureBefore runs before the wrapped call, so #result is not there yet.
+            if (auditable.captureBefore().contains("#result")) {
+                problems.add(where + ": captureBefore references #result, which is always null "
+                        + "before the method runs");
+            }
+        }
+
+        assertTrue(problems.isEmpty(), "Malformed @Auditable annotations:\n  " + String.join("\n  ", problems));
+    }
+
+    /**
+     * The read UI filters on the exact {@code entity_type} / {@code action}
+     * strings written here, from two hand-maintained lists in
+     * {@code ActivityLogFilters.tsx}. Nothing links the two, so for a long time
+     * new resources simply could not be filtered — the rows were in the table
+     * and invisible from the dropdown. This fails the build instead.
+     *
+     * <p>Skipped when the frontend is not checked out alongside the service.
+     */
+    @Test
+    @DisplayName("every audited entityType and action is offered by the log UI's filters")
+    void filterDropdownsCoverEveryAuditedValue() throws IOException {
+        Path filters = Path.of("..", "frontend-admin-dashboard", "src", "routes",
+                "admin-activity-logs", "-components", "ActivityLogFilters.tsx");
+        assumeTrue(Files.exists(filters), "frontend-admin-dashboard not checked out — skipping");
+
+        String source = Files.readString(filters);
+        List<String> missing = new ArrayList<>();
+
+        for (Method method : findAuditableMethods()) {
+            Auditable auditable = method.getAnnotation(Auditable.class);
+            String where = method.getDeclaringClass().getSimpleName() + "#" + method.getName();
+
+            if (!source.contains("'" + auditable.entityType() + "'")) {
+                missing.add(where + ": entityType " + auditable.entityType()
+                        + " has no entry in RESOURCE_GROUPS");
+            }
+            // Only a literal action can be checked — an actionExpr resolves at
+            // runtime, and its possible values are not knowable from here.
+            if (!auditable.action().isBlank()
+                    && !SYNTHETIC_ACTIONS.contains(auditable.action())
+                    && !source.contains("'" + auditable.action() + "'")) {
+                missing.add(where + ": action " + auditable.action()
+                        + " has no entry in ACTIVITY_OPTIONS");
+            }
+        }
+
+        assertTrue(missing.isEmpty(),
+                "The audit log's filter dropdowns are missing values the backend emits.\n"
+                        + "Add them to ActivityLogFilters.tsx:\n  "
+                        + String.join("\n  ", missing));
+    }
+
+    /**
+     * Placeholder actions that only exist as the fallback behind an
+     * {@code actionExpr} and never describe a real operation, so they would be
+     * noise in a filter dropdown.
+     */
+    private static final Set<String> SYNTHETIC_ACTIONS = Set.of("ACTION");
+
+    private void checkExpression(String expression,
+            String where,
+            String field,
+            Set<String> parameterNames,
+            Set<String> beanNames,
+            List<String> problems) {
+        if (expression == null || expression.isBlank()) {
+            return;
+        }
+        try {
+            parser.parseExpression(expression);
+        } catch (SpelParseException e) {
+            problems.add(where + "." + field + ": does not parse — " + e.getMessage());
+            return;
+        }
+
+        Matcher variables = VARIABLE_REF.matcher(expression);
+        while (variables.find()) {
+            String name = variables.group(1);
+            if (ASPECT_PROVIDED.contains(name) || parameterNames.contains(name)) {
+                continue;
+            }
+            problems.add(where + "." + field + ": references #" + name
+                    + ", which is neither a parameter of the method " + parameterNames
+                    + " nor supplied by the aspect " + ASPECT_PROVIDED);
+        }
+
+        Matcher beans = BEAN_REF.matcher(expression);
+        while (beans.find()) {
+            String name = beans.group(1);
+            if (!beanNames.contains(name)) {
+                problems.add(where + "." + field + ": references bean @" + name + ", "
+                        + "and no class named " + Character.toUpperCase(name.charAt(0)) + name.substring(1)
+                        + " was found");
+            }
+        }
+    }
+
+    private Set<String> parameterNamesOf(Method method) {
+        String[] names = parameterNameDiscoverer.getParameterNames(method);
+        return names == null ? Set.of() : new HashSet<>(List.of(names));
+    }
+
+    /** Every {@code @Auditable} method reachable from the service's own classes. */
+    private List<Method> findAuditableMethods() {
+        ClassPathScanningCandidateComponentProvider scanner = new PermissiveScanner();
+        scanner.addIncludeFilter(MATCH_EVERYTHING);
+
+        List<Method> methods = new ArrayList<>();
+        for (BeanDefinition definition : scanner.findCandidateComponents(BASE_PACKAGE)) {
+            Class<?> type = loadOrNull(definition.getBeanClassName());
+            if (type == null) {
+                continue;
+            }
+            for (Method method : safeMethods(type)) {
+                if (method.isAnnotationPresent(Auditable.class)) {
+                    methods.add(method);
+                }
+            }
+        }
+        return methods;
+    }
+
+    /**
+     * Bean names SpEL could resolve, derived from class names the way Spring's
+     * default naming strategy does. Interfaces count: Spring Data repositories
+     * are referenced from {@code captureBefore} expressions and only exist as
+     * interfaces on the classpath.
+     */
+    private Set<String> scanBeanNames() {
+        ClassPathScanningCandidateComponentProvider scanner = new PermissiveScanner();
+        scanner.addIncludeFilter(MATCH_EVERYTHING);
+
+        Set<String> names = new HashSet<>();
+        for (BeanDefinition definition : scanner.findCandidateComponents(BASE_PACKAGE)) {
+            String className = definition.getBeanClassName();
+            if (className == null) {
+                continue;
+            }
+            String simpleName = className.substring(className.lastIndexOf('.') + 1);
+            if (simpleName.isEmpty()) {
+                continue;
+            }
+            names.add(Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1));
+        }
+        return names;
+    }
+
+    private static Method[] safeMethods(Class<?> type) {
+        try {
+            return type.getDeclaredMethods();
+        } catch (Throwable ignored) {
+            // A class whose signature references a type missing at test scope.
+            return new Method[0];
+        }
+    }
+
+    private static Class<?> loadOrNull(String className) {
+        if (className == null) {
+            return null;
+        }
+        try {
+            return Class.forName(className, false, AuditableAnnotationContractTest.class.getClassLoader());
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /** Scanner that also yields interfaces and abstract classes. */
+    private static final class PermissiveScanner extends ClassPathScanningCandidateComponentProvider {
+        private PermissiveScanner() {
+            super(false);
+        }
+
+        @Override
+        protected boolean isCandidateComponent(
+                org.springframework.beans.factory.annotation.AnnotatedBeanDefinition beanDefinition) {
+            return true;
+        }
+    }
+}

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AuditableExpressionSemanticsTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/AuditableExpressionSemanticsTest.java
@@ -1,0 +1,110 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two `@Auditable` expressions whose *meaning* decides whether a row is
+ * written at all, evaluated for real.
+ *
+ * <p>{@link AuditableAnnotationContractTest} proves every expression parses and
+ * references real variables. It cannot prove they behave — and both of these
+ * fail silently if they don't: a throwing expression makes the aspect skip the
+ * row (audit lost, business call untouched), and a wrong branch stamps an
+ * action that never happened.
+ */
+class AuditableExpressionSemanticsTest {
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    /** Copied verbatim from AudienceController#assignCounselor. */
+    private static final String ASSIGN_ACTION_EXPR =
+            "(#counselorId == null or #counselorId.isBlank()) ? 'UNASSIGN' : 'ASSIGN'";
+
+    /** Copied verbatim from CounsellorWorkbenchController#assign / #reassign. */
+    private static final String NOT_A_DRY_RUN = "#result?.body?.dryRun != true";
+
+    /** Copied verbatim from AudienceController#assignCounselor. */
+    private static final String ASSIGN_CONDITION =
+            "(#counselorId != null and !#counselorId.isBlank()) or #before != null";
+
+    @Test
+    @DisplayName("a blank or missing counsellor id resolves to UNASSIGN, without dereferencing null")
+    void assignActionExprHandlesBothBranches() {
+        assertEquals("UNASSIGN", evaluate(ASSIGN_ACTION_EXPR, ctx -> ctx.setVariable("counselorId", null)));
+        assertEquals("UNASSIGN", evaluate(ASSIGN_ACTION_EXPR, ctx -> ctx.setVariable("counselorId", "  ")));
+        assertEquals("ASSIGN", evaluate(ASSIGN_ACTION_EXPR, ctx -> ctx.setVariable("counselorId", "user-1")));
+    }
+
+    @Test
+    @DisplayName("the dry-run guard skips previews and passes real runs, including a null flag")
+    void dryRunGuardOnlySkipsPreviews() {
+        assertFalse(condition(NOT_A_DRY_RUN, resultWithDryRun(Boolean.TRUE)),
+                "a preview must not be recorded as a completed assignment");
+        assertTrue(condition(NOT_A_DRY_RUN, resultWithDryRun(Boolean.FALSE)));
+        // A DTO that never set the flag must still be logged — the guard exists
+        // to exclude previews, not to drop everything it is unsure about.
+        assertTrue(condition(NOT_A_DRY_RUN, resultWithDryRun(null)));
+        assertTrue(condition(NOT_A_DRY_RUN, null), "a null response must not silently drop the row");
+    }
+
+    @Test
+    @DisplayName("removing a counsellor from a lead that has none is not recorded")
+    void assignConditionSkipsTheUnassignNoOp() {
+        // Assigning always counts, whatever was there before.
+        assertTrue(assignCondition("user-1", null));
+        assertTrue(assignCondition("user-1", "previous-counsellor"));
+        // Removing a counsellor that exists is a real change …
+        assertTrue(assignCondition(null, "previous-counsellor"));
+        assertTrue(assignCondition("   ", "previous-counsellor"));
+        // … removing one that was never there is the endpoint's early return.
+        assertFalse(assignCondition(null, null));
+        assertFalse(assignCondition("  ", null));
+    }
+
+    private boolean assignCondition(String counselorId, String before) {
+        StandardEvaluationContext ctx = new StandardEvaluationContext();
+        ctx.setVariable("counselorId", counselorId);
+        ctx.setVariable("before", before);
+        return Boolean.TRUE.equals(parser.parseExpression(ASSIGN_CONDITION).getValue(ctx));
+    }
+
+    private static Object resultWithDryRun(Boolean dryRun) {
+        return new Response(new Body(dryRun));
+    }
+
+    /** Stand-ins shaped like ResponseEntity + the assign result DTO. */
+    public record Response(Body body) {
+        public Body getBody() {
+            return body;
+        }
+    }
+
+    public record Body(Boolean dryRun) {
+        public Boolean getDryRun() {
+            return dryRun;
+        }
+    }
+
+    private Object evaluate(String expression, java.util.function.Consumer<StandardEvaluationContext> setup) {
+        StandardEvaluationContext ctx = new StandardEvaluationContext();
+        setup.accept(ctx);
+        return parser.parseExpression(expression).getValue(ctx);
+    }
+
+    /**
+     * Mirrors {@code AuditableAspect#passesCondition}: only an explicit
+     * {@code true} writes the row.
+     */
+    private boolean condition(String expression, Object result) {
+        StandardEvaluationContext ctx = new StandardEvaluationContext();
+        ctx.setVariable("result", result);
+        return Boolean.TRUE.equals(parser.parseExpression(expression).getValue(ctx));
+    }
+}

--- a/docs/ADMIN_ACTIVITY_LOGS.md
+++ b/docs/ADMIN_ACTIVITY_LOGS.md
@@ -265,7 +265,63 @@ The audit table renders each row as `**{actor_name}** {description}`. Names insi
 | `updated WhatsApp credentials for X` | updated WhatsApp credentials for **X** |
 | `removed WhatsApp credentials for X` | removed WhatsApp credentials for **X** |
 
+CRM sentences (added 2026-09-08):
+
+| Backend `descriptionExpr` outputs | Renders as |
+|---|---|
+| `created / updated / deleted audience X` | created audience **X** |
+| `sent a message to audience X` | sent a message to audience **X** |
+| `imported 340 lead(s) into X` | imported **340 lead(s)** into **X** |
+| `added / updated / deleted / restored lead X` | added lead **X** |
+| `registered walk-in lead X` | registered walk-in lead **X** |
+| `assigned lead X to Y` | assigned lead **X** to **Y** |
+| `assigned / reassigned 12 lead(s) to Y` | assigned **12 lead(s)** to **Y** |
+| `changed lead status / tier / score of X to Y` | changed lead status of **X** to **Y** |
+| `marked lead X as converted` | marked lead **X** as converted |
+| `scheduled / rescheduled / closed a follow-up for lead X` | … for lead **X** |
+| `created / updated / deleted lead status X` | created lead status **X** |
+| `connected Meta lead form X to audience Y` | connected Meta lead form **X** to audience **Y** |
+| `created / updated counsellor pool X` | created counsellor pool **X** |
+| `tagged 48 contact(s) with X` | tagged **48 contact(s)** with **X** |
+| `created / updated / deleted automation X` | created automation **X** |
+| `created engagement engine X` | created engagement engine **X** |
+| `changed the status of 6 enquiry(s) to X` | changed the status of **6 enquiry(s)** to **X** |
+
 If your new endpoint emits a verb-noun phrase the frontend doesn't recognize, the description renders as plain text (no bolding). That's fine — adding a new pattern is a one-line regex addition in `NAMED_DESCRIPTION_PATTERNS`. Keep the alternating-group convention or the renderer will bold the wrong half.
+
+**Mind the prefixes you share with an existing pattern.** `updated lead <X>` bolds
+`<X>` as a lead's name, so a settings endpoint phrased "updated lead TAT and
+follow-up SLA settings" rendered "updated lead **TAT and follow-up SLA
+settings**". It now says "updated TAT and follow-up SLA settings". The split is
+pinned by [activity-log-sentence.test.ts](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/activity-log-sentence.test.ts)
+— add a case there with every new phrase, since a mis-bolded row is invisible to
+types and to a passing render.
+
+---
+
+## Filtering (read side)
+
+`GET /logs` and `GET /logs/export.csv` accept `actorId`, `entityType` and
+`action` as **comma-separated lists** (`actorId=a,b,c`), with `actorIds` /
+`entityTypes` / `actions` as plural aliases. One value emits `= ?`, several emit
+`IN (...)`; both are served by the existing composite indexes. A single value
+behaves exactly as before, so old links and bookmarks keep working.
+
+Commas rather than repeated `actorId[]=` keys is not a style choice — the
+ingress rejects raw brackets in a query string with a 400 before the request
+reaches the service.
+
+`entityId` is deliberately **not** split: bulk actions store a comma-joined list
+of ids in that column, so splitting it would break the "history of this entity"
+lookup.
+
+On the UI side the three filters are multi-selects. "Performed by" lists the
+institute's own team (the Teams-page roster, via `fetchEligibleOrgUsers`) by full
+name and email rather than asking for a pasted user id — deliberately not a
+`DISTINCT actor_id` over the log table, which would be an aggregate over every
+row an institute has ever written. An actor who has since left the institute is
+therefore not offered in the dropdown; a URL that names their id still filters
+correctly and shows the id in the chip.
 
 ---
 
@@ -377,12 +433,23 @@ Backend — `admin_core_service/src/main/java/vacademy/io/admin_core_service/fea
 | `entity/AdminActivityLog.java` | JPA entity. JSONB columns for `request_payload` and `before_payload`. |
 | `repository/AdminActivityLogRepository.java` | `JpaRepository + JpaSpecificationExecutor`; chunked retention DELETE native query. |
 | `retention/AdminActivityLogRetentionJob.java` | Nightly chunked DELETE. |
-| `service/AdminActivityLogReadService.java` | Filter spec + CSV builder. |
+| `service/AdminActivityLogReadService.java` | Filter spec (equality for one value, `IN` for several) + CSV builder. |
+| `service/AuditNarrator.java` | Learner / course id → name phrasing for descriptions. |
+| `service/CrmAuditNarrator.java` | Audience, lead, follow-up, counsellor id → name phrasing. |
 | `service/PayloadRedactor.java` | Sensitive-key masking before JSON serialization. |
 | `util/AuditSpelEvaluator.java` | Cached SpEL parser + `BeanFactoryResolver` wiring. |
 | `util/RequestContextSnapshot.java` | Immutable POJO for the request-thread context. |
 
-Migration: `src/main/resources/db/migration/V259__Admin_activity_log.sql`.
+Migration: `src/main/resources/db/migration/V259__Admin_activity_log.sql`. No migration was
+needed for the CRM coverage or the multi-select filters — the table and its three composite
+indexes already carry both.
+
+Tests — `admin_core_service/src/test/java/.../admin_activity_logs/`:
+
+| Path | Purpose |
+|---|---|
+| `AuditableAnnotationContractTest.java` | Every `@Auditable` expression parses, its `#vars` are real parameters of that method, its `@beans` exist, and its entityType/action appear in the UI's filter dropdowns. |
+| `AdminActivityLogFilterParsingTest.java` | Comma-separated / plural / single-value query params → filter, and `entityId` is never split. |
 
 POM: `spring-boot-starter-aop` added in `admin_core_service/pom.xml`.
 
@@ -392,11 +459,14 @@ Frontend — `frontend-admin-dashboard/src/routes/admin-activity-logs/`:
 |---|---|
 | `index.tsx` | Route registration + `beforeLoad` toggle gate. |
 | `index.lazy.tsx` | Page shell + state plumbing. |
-| `-components/ActivityLogFilters.tsx` | Resource / Activity dropdowns, date range, refresh, **Export CSV** button. |
-| `-components/ActivityLogTable.tsx` | The table — relative timestamps, status dots, sentence rendering with entity-name bolding. |
-| `-components/PayloadDrawer.tsx` | Side drawer with Before → After JSON view and copy buttons. |
+| `-components/ActivityLogFilters.tsx` | Resource / Activity / Performed-by multi-selects, date presets + range, applied-filter chips, refresh, **Export CSV**. |
+| `-components/ActivityLogTable.tsx` | The table — relative timestamps, actor initials, status dots, resource column, sentence rendering with entity-name bolding, `MyPagination`. |
+| `-components/PayloadDrawer.tsx` | Side drawer: fixed header + one scrolling body, request/actor detail that wraps rather than truncates, payload rendered as labelled fields with a Raw JSON toggle, Before → After for `captureBefore` rows. |
+| `-components/activity-log-sentence.test.ts` | Pins which fragment of each description gets bolded. |
 
-Service hook: `frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogs.ts`.
+Service hooks: `frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogs.ts`
+(list, by-id, CSV export) and `getActivityLogActors.ts` (the institute team roster behind the
+"Performed by" filter).
 
 Display-settings integration: `sidebar/constant.ts` (`controlledTabs`), `sidebar/helper.ts` (`adminOnlyIds`), `constants/display-settings/admin-defaults.ts` + `teacher-defaults.ts` (default-off).
 
@@ -414,7 +484,7 @@ Display-settings integration: `sidebar/constant.ts` (`controlledTabs`), `sidebar
 
 5. **PayloadMode.NONE on file-upload endpoints.** If your endpoint takes a `MultipartFile`, set `payload = PayloadMode.NONE` — Jackson will try to serialize the multipart and either explode or produce useless binary. The action + actor are still captured.
 
-6. **Adding to the frontend dropdowns.** New `entityType` / `action` values will work in the backend immediately but won't appear in the filter dropdowns until they're added to `RESOURCE_OPTIONS` / `ACTIVITY_OPTIONS` in [ActivityLogFilters.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx). Filters still accept any string typed/pasted, just no autocomplete.
+6. **Adding to the frontend dropdowns is enforced.** New `entityType` / `action` values work in the backend immediately but are unfilterable until they are added to `RESOURCE_GROUPS` / `ACTIVITY_OPTIONS` in [ActivityLogFilters.tsx](../frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx). That gap went unnoticed for months — the HR, ERP, mentorship and booking resources were all being written and none of them could be picked. `AuditableAnnotationContractTest#filterDropdownsCoverEveryAuditedValue` now fails the build when a value is missing (it skips itself when the frontend is not checked out beside the service). Values from an `actionExpr` cannot be checked statically — add those by hand.
 
 7. **Partial-success endpoints need `conditionExpr`, not avoidance.** Endpoints
    that loop over items, catch per-item exceptions, and return a
@@ -430,9 +500,51 @@ Display-settings integration: `sidebar/constant.ts` (`controlledTabs`), `sidebar
    users by inline `new_users` or a filter, so the request does not say how many
    learners were actually enrolled.
 
-8. **The `clientId` header is required.** The axios interceptor in [axiosInstance.ts](../frontend-admin-dashboard/src/lib/auth/axiosInstance.ts) attaches it automatically from `getInstituteId()`. If you ever build a non-axios request path (e.g., a worker-side fetch), make sure that header is included or audit silently drops the row.
+8. **A description that starts like an existing pattern gets bolded like it.** Prefixes are shared across resources — `updated lead …` claims everything after it as a lead's name — so read the "Frontend description rendering" table before choosing a phrase, and add the phrase to `activity-log-sentence.test.ts`.
+
+9. **The `clientId` header is required.** The axios interceptor in [axiosInstance.ts](../frontend-admin-dashboard/src/lib/auth/axiosInstance.ts) attaches it automatically from `getInstituteId()`. If you ever build a non-axios request path (e.g., a worker-side fetch), make sure that header is included or audit silently drops the row.
 
 ---
+
+## CRM coverage (added 2026-09-08)
+
+The CRM was the largest unaudited surface — audience lists, leads and every
+counsellor action were invisible in the log. Now instrumented:
+
+| Resource | Actions | Where |
+|---|---|---|
+| `AUDIENCE` | CREATE, UPDATE, DELETE, SEND_MESSAGE, RECALCULATE_SCORES | `AudienceController` |
+| `LEAD` | CREATE (manual, walk-in), IMPORT, UPDATE, DELETE, RESTORE, ASSIGN, UNASSIGN, REASSIGN, STATUS_CHANGE, TIER_CHANGE, SCORE_CHANGE, CONVERT | `AudienceController`, `LeadStatusController`, `CounsellorWorkbenchController` |
+| `LEAD_STATUS` | CREATE, UPDATE, DELETE | `LeadStatusController` |
+| `LEAD_FOLLOWUP` | CREATE, UPDATE, CLOSE | `LeadFollowupController` |
+| `LEAD_SLA_CONFIG` | UPDATE (with before/after) | `LeadSlaConfigController` |
+| `LEAD_CONNECTOR` | CREATE, UPDATE, DELETE, RESUBSCRIBE | `MetaOAuthController` |
+| `ENQUIRY` | ASSIGN, STATUS_CHANGE | `EnquiryInternalController` |
+| `COUNSELLOR` | STATUS_CHANGE | `CounsellorWorkbenchController` |
+| `COUNSELLOR_POOL` | CREATE, UPDATE, DELETE, ADD_MEMBER, REMOVE_MEMBER, MEMBER_STATUS_CHANGE | `CounselorPoolController` |
+| `COUNSELLOR_TARGET` | UPDATE, BULK_UPDATE, DELETE | `CounsellorTargetController` |
+| `COUNSELLOR_WORKBENCH_CONFIG` | UPDATE | `CounsellorWorkbenchController` |
+| `TAG` | CREATE, DELETE, TAG_USERS, UNTAG_USERS | `TagController` |
+| `TELEPHONY_CONFIG` / `TELEPHONY_NUMBER` | UPDATE / CREATE, UPDATE, ATTACH, DELETE | `TelephonyConfigController`, `TelephonyNumberController` |
+| `ENGAGEMENT_ENGINE` | CREATE, UPDATE, DELETE, ENROLL, STATUS_CHANGE, AUTONOMY_CHANGE | `EngagementEngineController` |
+| `AUTOMATION` | CREATE, UPDATE, DELETE, TRIGGER | `WorkflowController` |
+
+Three decisions worth keeping if you extend this:
+
+- **`payload = NONE` wherever the body carries a credential or is unbounded** —
+  the Meta/Google connector saves (OAuth session keys, `googleKey`), the
+  telephony config (provider API tokens; `REDACTED` only masks the key names it
+  knows), the CSV lead import (thousands of rows of PII) and the workflow
+  builder (the whole node graph). The actor, the action and a counted
+  description are what an audit reader needs from those.
+- **Previews must not be logged.** `/counsellor-workbench/assign` and
+  `/reassign` back both the dry run and the real thing;
+  `conditionExpr = "#result?.body?.dryRun != true"` keeps a preview out of the
+  log. Written as `!= true` rather than `!…dryRun`, since a SpEL `!null` throws
+  and the aspect fails closed — silently dropping real rows.
+- **Names come from `CrmAuditNarrator`, not from SpEL.** Lead and audience ids
+  mean nothing in a log line; the narrator resolves them, degrades to a count or
+  an id, and never throws.
 
 ## Coverage reality check
 
@@ -453,5 +565,7 @@ carry `@Auditable`. An absent row usually means *not instrumented*, not *broken*
 - **Bolding patterns auto-derived from `entityType`/`action`** instead of regex matching the description text.
 - **Per-institute retention override** via institute settings, falling back to the global `audit.retention.days`.
 - **S3 / cold-storage archival before delete** — required for SOC 2 / ISO 27001 evidence trails.
-- **Read-side filter on actor by name/email** instead of raw user-id paste. Backend would need a join to `users` table or a denormalized `actor_name` LIKE index.
+- ~~**Read-side filter on actor by name/email** instead of raw user-id paste.~~
+  Done 2026-09-08 without touching the backend: the UI lists the institute's own
+  team roster and sends the ids it already knows.
 - **Compaction** — if volume ever crosses 50M rows, switch to monthly partitioning by `created_at` so retention deletes become `DROP PARTITION` (instant) instead of chunked DELETEs.

--- a/frontend-admin-dashboard/src/components/shared/leads/multi-select-filter.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/multi-select-filter.tsx
@@ -15,6 +15,12 @@ import { cn } from '@/lib/utils';
 export interface MultiSelectOption {
     value: string;
     label: string;
+    /**
+     * Secondary line under the label — an email, a role. Also folded into the
+     * text the search box matches, so two people with the same name stay
+     * tellable apart.
+     */
+    sublabel?: string;
     /** When true, selecting this clears all other selections (acts like "All"). */
     clearAll?: boolean;
 }
@@ -80,7 +86,7 @@ export function MultiSelectFilter({
     const triggerLabel = showSelectedLabel
         ? count === 0
             ? label
-            : (soleSelectedLabel ?? `${count} selected`)
+            : soleSelectedLabel ?? `${count} selected`
         : count > 0
           ? `${label} · ${count}`
           : label;
@@ -108,7 +114,12 @@ export function MultiSelectFilter({
                     <CaretDown className="size-4 shrink-0 text-neutral-400" />
                 </Button>
             </PopoverTrigger>
-            <PopoverContent align="start" className="w-56 p-0">
+            {/* Only the two-line (sublabel) variant needs the extra width; every
+                existing call site keeps the width it had. */}
+            <PopoverContent
+                align="start"
+                className={cn('p-0', options.some((opt) => opt.sublabel) ? 'w-64' : 'w-56')}
+            >
                 <Command>
                     <CommandInput placeholder={placeholder} className="h-9" />
                     <CommandList className="max-h-64 overflow-y-auto">
@@ -126,7 +137,9 @@ export function MultiSelectFilter({
                             {options.map((opt) => (
                                 <CommandItem
                                     key={opt.value}
-                                    value={opt.label}
+                                    value={
+                                        opt.sublabel ? `${opt.label} ${opt.sublabel}` : opt.label
+                                    }
                                     onSelect={() => toggle(opt.value, opt.clearAll)}
                                     className="cursor-pointer"
                                 >
@@ -142,7 +155,14 @@ export function MultiSelectFilter({
                                                   : 'opacity-0'
                                         )}
                                     />
-                                    <span className="truncate">{opt.label}</span>
+                                    <span className="flex min-w-0 flex-col">
+                                        <span className="truncate">{opt.label}</span>
+                                        {opt.sublabel && (
+                                            <span className="truncate text-xs text-neutral-500">
+                                                {opt.sublabel}
+                                            </span>
+                                        )}
+                                    </span>
                                 </CommandItem>
                             ))}
                         </CommandGroup>

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
@@ -1,21 +1,29 @@
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { useMemo } from 'react';
+import { MyButton } from '@/components/design-system/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
-import { ArrowsClockwise, X, FunnelSimple, DownloadSimple } from '@phosphor-icons/react';
+    ArrowsClockwise,
+    X,
+    FunnelSimple,
+    DownloadSimple,
+    Stack,
+    Lightning,
+    UserCircle,
+} from '@phosphor-icons/react';
+import {
+    MultiSelectFilter,
+    type MultiSelectOption,
+} from '@/components/shared/leads/multi-select-filter';
+import { ChipsWrapper } from '@/components/design-system/chips';
 import {
     exportActivityLogsCsv,
     type AdminActivityLogFilters,
 } from '@/services/admin-activity-logs/getActivityLogs';
+import { useActivityLogActors } from '@/services/admin-activity-logs/getActivityLogActors';
 import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 
 interface Props {
     value: AdminActivityLogFilters;
@@ -24,74 +32,290 @@ interface Props {
     isFetching: boolean;
 }
 
-// Curated dropdown choices. Keep `value` aligned with the entity_type / action
-// strings the backend emits in @Auditable annotations; `label` is what an
-// institute owner reads. Add new entries here as the audit coverage grows.
-const RESOURCE_OPTIONS: { value: string; label: string }[] = [
-    { value: 'COURSE', label: 'Course' },
-    { value: 'LIVE_SESSION', label: 'Live session' },
-    { value: 'LEARNER', label: 'Learner' },
-    { value: 'GUARDIAN_LINK', label: 'Guardian link' },
-    { value: 'INSTITUTE_SETTING', label: 'Settings' },
+// Dropdown choices. Each `value` is an entity_type the backend emits from an
+// @Auditable annotation; `label` is what an institute owner reads. The list has
+// to stay complete: a resource missing here is a resource nobody can filter by,
+// and it was for a long time — AuditableAnnotationContractTest (admin_core_service)
+// now fails the build when a new entityType or action lands without an entry.
+const RESOURCE_GROUPS: { group: string; options: MultiSelectOption[] }[] = [
+    {
+        group: 'CRM',
+        options: [
+            { value: 'AUDIENCE', label: 'Audience list' },
+            { value: 'LEAD', label: 'Lead' },
+            { value: 'LEAD_STATUS', label: 'Lead status' },
+            { value: 'LEAD_FOLLOWUP', label: 'Follow-up' },
+            { value: 'LEAD_SLA_CONFIG', label: 'Lead SLA settings' },
+            { value: 'LEAD_CONNECTOR', label: 'Lead connector' },
+            { value: 'ENQUIRY', label: 'Enquiry' },
+            { value: 'COUNSELLOR', label: 'Counsellor' },
+            { value: 'COUNSELLOR_POOL', label: 'Counsellor pool' },
+            { value: 'COUNSELLOR_TARGET', label: 'Counsellor target' },
+            { value: 'COUNSELLOR_WORKBENCH_CONFIG', label: 'Workbench settings' },
+            { value: 'TAG', label: 'Tag' },
+            { value: 'TELEPHONY_CONFIG', label: 'Calling settings' },
+            { value: 'TELEPHONY_NUMBER', label: 'Calling number' },
+            { value: 'ENGAGEMENT_ENGINE', label: 'Engagement engine' },
+            { value: 'AUTOMATION', label: 'Automation' },
+        ],
+    },
+    {
+        group: 'Learning',
+        options: [
+            { value: 'COURSE', label: 'Course' },
+            { value: 'LIVE_SESSION', label: 'Live session' },
+            { value: 'LEARNER', label: 'Learner' },
+            { value: 'GUARDIAN_LINK', label: 'Guardian link' },
+            { value: 'INSTITUTE_SETTING', label: 'Settings' },
+        ],
+    },
+    {
+        group: 'Mentorship & meetings',
+        options: [
+            { value: 'MENTOR', label: 'Mentor' },
+            { value: 'MENTOR_ASSIGNMENT', label: 'Mentor assignment' },
+            { value: 'MENTOR_REQUEST', label: 'Mentor request' },
+            { value: 'MENTOR_SESSION', label: 'Mentor session' },
+            { value: 'BOOKING_PAGE', label: 'Booking page' },
+            { value: 'BOOKING_INSTANCE', label: 'Booking' },
+        ],
+    },
+    {
+        group: 'People & payroll',
+        options: [
+            { value: 'HR_EMPLOYEE', label: 'Employee' },
+            { value: 'HR_EMPLOYEE_BANK', label: 'Employee bank details' },
+            { value: 'HR_EMPLOYEE_DOCUMENT', label: 'Employee document' },
+            { value: 'HR_DEPARTMENT', label: 'Department' },
+            { value: 'HR_DESIGNATION', label: 'Designation' },
+            { value: 'HR_TEACHING', label: 'Teaching activity' },
+            { value: 'HR_ATTENDANCE', label: 'Attendance' },
+            { value: 'HR_ATTENDANCE_CONFIG', label: 'Attendance settings' },
+            { value: 'HR_ATTENDANCE_REGULARIZATION', label: 'Attendance regularization' },
+            { value: 'HR_SHIFT', label: 'Shift' },
+            { value: 'HR_HOLIDAY', label: 'Holiday' },
+            { value: 'HR_LEAVE', label: 'Leave' },
+            { value: 'HR_LEAVE_BALANCE', label: 'Leave balance' },
+            { value: 'HR_PAYROLL_RUN', label: 'Payroll run' },
+            { value: 'HR_PAYROLL_ENTRY', label: 'Payroll entry' },
+            { value: 'HR_PAYROLL_ADJUSTMENT', label: 'Payroll adjustment' },
+            { value: 'HR_PAYROLL_FNF', label: 'Full and final settlement' },
+            { value: 'HR_PAYSLIP', label: 'Payslip' },
+            { value: 'HR_SALARY_COMPONENT', label: 'Salary component' },
+            { value: 'HR_SALARY_STRUCTURE', label: 'Salary structure' },
+            { value: 'HR_SALARY_TEMPLATE', label: 'Salary template' },
+            { value: 'HR_LOAN', label: 'Loan' },
+            { value: 'HR_REIMBURSEMENT', label: 'Reimbursement' },
+            { value: 'HR_INCENTIVE', label: 'Incentive' },
+            { value: 'HR_BONUS', label: 'Bonus' },
+            { value: 'HR_BANK_EXPORT', label: 'Bank export' },
+            { value: 'HR_TAX_CONFIG', label: 'Tax settings' },
+            { value: 'HR_TAX_DECLARATION', label: 'Tax declaration' },
+            { value: 'HR_TDS_CHALLAN', label: 'TDS challan' },
+            { value: 'HR_FORM16', label: 'Form 16' },
+            { value: 'HR_FORM24Q', label: 'Form 24Q' },
+            { value: 'HR_PF_ECR', label: 'PF ECR' },
+            { value: 'HR_ESI_RETURN', label: 'ESI return' },
+            { value: 'HR_PT_RETURN', label: 'PT return' },
+            { value: 'HR_WPS', label: 'WPS file' },
+            { value: 'HR_EOSB_PROVISION', label: 'End-of-service provision' },
+        ],
+    },
+    {
+        group: 'Finance',
+        options: [
+            { value: 'ERP_JOURNAL', label: 'Journal entry' },
+            { value: 'ERP_FINANCE_PNL', label: 'Profit and loss' },
+        ],
+    },
 ];
 
-const ACTIVITY_OPTIONS: { value: string; label: string }[] = [
+const RESOURCE_OPTIONS: MultiSelectOption[] = RESOURCE_GROUPS.flatMap((section) =>
+    section.options.map((option) => ({ ...option, sublabel: section.group }))
+);
+
+const RESOURCE_LABELS: Record<string, string> = Object.fromEntries(
+    RESOURCE_OPTIONS.map((option) => [option.value, option.label])
+);
+
+const ACTIVITY_OPTIONS: MultiSelectOption[] = [
     { value: 'CREATE', label: 'Created' },
     { value: 'UPDATE', label: 'Updated' },
     { value: 'DELETE', label: 'Deleted' },
-    { value: 'CANCEL', label: 'Cancelled' },
+    { value: 'RESTORE', label: 'Restored' },
+    { value: 'BULK_CREATE', label: 'Bulk created' },
+    { value: 'BULK_UPDATE', label: 'Bulk updated' },
+    { value: 'IMPORT', label: 'Imported' },
+    { value: 'EXPORT', label: 'Exported' },
+    { value: 'DOWNLOAD', label: 'Downloaded' },
+    { value: 'PURGE', label: 'Purged' },
+    { value: 'ASSIGN', label: 'Assigned' },
+    { value: 'UNASSIGN', label: 'Unassigned' },
+    { value: 'REASSIGN', label: 'Reassigned' },
+    { value: 'BULK_ROUND_ROBIN', label: 'Round-robin assigned' },
+    { value: 'STATUS_CHANGE', label: 'Status changed' },
+    { value: 'TIER_CHANGE', label: 'Tier changed' },
+    { value: 'SCORE_CHANGE', label: 'Score changed' },
+    { value: 'CONVERT', label: 'Marked converted' },
+    { value: 'SEND_MESSAGE', label: 'Message sent' },
+    { value: 'EMAIL', label: 'Emailed' },
+    { value: 'CLOSE', label: 'Closed' },
+    { value: 'RESCHEDULE', label: 'Rescheduled' },
+    { value: 'ESCALATE', label: 'Escalated' },
+    { value: 'TAG_USERS', label: 'Tagged contacts' },
+    { value: 'UNTAG_USERS', label: 'Untagged contacts' },
+    { value: 'TRIGGER', label: 'Triggered' },
+    { value: 'ADD_MEMBER', label: 'Member added' },
+    { value: 'REMOVE_MEMBER', label: 'Member removed' },
+    { value: 'MEMBER_STATUS_CHANGE', label: 'Member status changed' },
+    { value: 'AUTONOMY_CHANGE', label: 'Autonomy changed' },
+    { value: 'RESUBSCRIBE', label: 'Re-subscribed' },
+    { value: 'RECALCULATE_SCORES', label: 'Scores recalculated' },
+    { value: 'ATTACH', label: 'Attached' },
     { value: 'ENROLL', label: 'Enrolled' },
-    // Emitted by the learner status endpoint, which derives its action from the
-    // operation it was asked to perform.
+    { value: 'CANCEL', label: 'Cancelled' },
     { value: 'TERMINATE', label: 'Terminated' },
     { value: 'MAKE_INACTIVE', label: 'Deactivated' },
     { value: 'MAKE_ACTIVE', label: 'Reactivated' },
     { value: 'UPDATE_BATCH', label: 'Moved to another batch' },
     { value: 'ADD_EXPIRY', label: 'Expiry changed' },
-    { value: 'UPDATE_STATUS', label: 'Status changed' },
+    { value: 'UPDATE_STATUS', label: 'Learner status changed' },
+    { value: 'ACCESS_CHANGE', label: 'Access changed' },
+    { value: 'SHARE_CREDENTIALS', label: 'Credentials shared' },
+    { value: 'EXPORT_CREDENTIALS', label: 'Credentials exported' },
+    { value: 'DEACTIVATE', label: 'Deactivated (record)' },
+    { value: 'PROVISION_BOOKING_PAGE', label: 'Booking page provisioned' },
+    { value: 'APPROVE', label: 'Approved' },
+    { value: 'REJECT', label: 'Rejected' },
+    { value: 'DECLINE', label: 'Declined' },
+    { value: 'VERIFY', label: 'Verified' },
+    { value: 'HOLD', label: 'Put on hold' },
+    { value: 'RELEASE', label: 'Released' },
+    { value: 'PROCESS', label: 'Processed' },
+    { value: 'PREPARE', label: 'Prepared' },
+    { value: 'GENERATE', label: 'Generated' },
+    { value: 'MATERIALIZE', label: 'Materialized' },
+    { value: 'PAY_MATERIALIZE', label: 'Paid and materialized' },
+    { value: 'MARK_PAID', label: 'Marked paid' },
+    { value: 'ADJUST', label: 'Adjusted' },
+    { value: 'ACCRUE', label: 'Accrued' },
+    { value: 'BULK_MARK', label: 'Bulk marked' },
+    { value: 'ATTENDANCE_SYNC', label: 'Attendance synced' },
+    { value: 'CREATE_FROM_STAFF', label: 'Created from staff' },
+    { value: 'YEAR_END', label: 'Year-end run' },
 ];
 
-// Sentinel value used in the Select for "any" (Radix Select doesn't allow
-// empty-string SelectItem values).
-const ANY = '__any__';
+const ACTIVITY_LABELS: Record<string, string> = Object.fromEntries(
+    ACTIVITY_OPTIONS.map((option) => [option.value, option.label])
+);
 
-const toDateInput = (epochMs: number | undefined) =>
-    epochMs ? new Date(epochMs).toISOString().slice(0, 10) : '';
-
-const fromDateInput = (value: string): number | undefined =>
-    value ? new Date(`${value}T00:00:00.000Z`).getTime() : undefined;
-
-const countActiveFilters = (value: AdminActivityLogFilters): number => {
-    let n = 0;
-    if (value.entityType) n++;
-    if (value.action) n++;
-    if (value.actorId) n++;
-    if (value.startDate) n++;
-    if (value.endDate) n++;
-    return n;
+/**
+ * Local, not UTC. The table prints timestamps in the reader's own timezone, so
+ * a range picked here has to mean the same days they can see — and the "To"
+ * day is inclusive, which is what "logs up to today" plainly means. Sending
+ * midnight would silently drop everything that happened on the last day.
+ */
+const startOfDay = (value: string): number | undefined => {
+    if (!value) return undefined;
+    const parsed = new Date(`${value}T00:00:00`);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.getTime();
 };
+
+const endOfDay = (value: string): number | undefined => {
+    if (!value) return undefined;
+    const parsed = new Date(`${value}T23:59:59.999`);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.getTime();
+};
+
+const toDateInput = (epochMs: number | undefined): string => {
+    if (!epochMs) return '';
+    const date = new Date(epochMs);
+    if (Number.isNaN(date.getTime())) return '';
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+};
+
+const daysAgoRange = (days: number): { startDate: number; endDate: number } => {
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+    const start = new Date();
+    start.setDate(start.getDate() - (days - 1));
+    start.setHours(0, 0, 0, 0);
+    return { startDate: start.getTime(), endDate: end.getTime() };
+};
+
+const DATE_PRESETS: { label: string; range: () => { startDate: number; endDate: number } }[] = [
+    { label: 'Today', range: () => daysAgoRange(1) },
+    { label: 'Last 7 days', range: () => daysAgoRange(7) },
+    { label: 'Last 30 days', range: () => daysAgoRange(30) },
+];
+
+/** Drops one value from a multi-select, collapsing an emptied list to undefined
+ *  so the query param disappears instead of being sent empty. */
+const without = (values: string[] | undefined, value: string): string[] | undefined => {
+    const next = (values ?? []).filter((candidate) => candidate !== value);
+    return next.length > 0 ? next : undefined;
+};
+
+const countActiveFilters = (value: AdminActivityLogFilters): number =>
+    (value.entityTypes?.length ?? 0) +
+    (value.actions?.length ?? 0) +
+    (value.actorIds?.length ?? 0) +
+    (value.startDate ? 1 : 0) +
+    (value.endDate ? 1 : 0);
 
 export function ActivityLogFilters({ value, onChange, onRefresh, isFetching }: Props) {
     const activeCount = countActiveFilters(value);
-    const [isExporting, setIsExporting] = useState(false);
+    const actorsQuery = useActivityLogActors();
+
+    const actorOptions: MultiSelectOption[] = useMemo(() => {
+        const known = (actorsQuery.data ?? []).map((actor) => ({
+            value: actor.id,
+            label: actor.fullName,
+            sublabel: actor.email ?? undefined,
+        }));
+        // An id that came in on the URL but is not on the current roster (a
+        // teammate who has since left) still has to render as a removable chip,
+        // otherwise the filter looks broken.
+        const knownIds = new Set(known.map((option) => option.value));
+        const orphans = (value.actorIds ?? [])
+            .filter((id) => !knownIds.has(id))
+            .map((id) => ({ value: id, label: id, sublabel: 'No longer on the team' }));
+        return [...known, ...orphans];
+    }, [actorsQuery.data, value.actorIds]);
+
+    const actorLabels = useMemo(
+        () => Object.fromEntries(actorOptions.map((option) => [option.value, option.label])),
+        [actorOptions]
+    );
+
+    // Presets compare against the exact range they would produce, so the pill
+    // lights up only while the filter still matches it.
+    const activePreset = DATE_PRESETS.find((preset) => {
+        if (!value.startDate || !value.endDate) return false;
+        const range = preset.range();
+        return range.startDate === value.startDate && range.endDate === value.endDate;
+    });
 
     const clearAll = () =>
         onChange({
-            entityType: undefined,
-            action: undefined,
-            actorId: undefined,
+            entityTypes: undefined,
+            actions: undefined,
+            actorIds: undefined,
             startDate: undefined,
             endDate: undefined,
             page: 0,
         });
 
+    // MyButton's onAsyncClick owns the spinner and the double-submit guard, so
+    // this only has to do the work and report the outcome.
     const handleExport = async () => {
-        setIsExporting(true);
         try {
             await exportActivityLogsCsv({
-                entityType: value.entityType,
-                action: value.action,
-                actorId: value.actorId,
+                entityTypes: value.entityTypes,
+                actions: value.actions,
+                actorIds: value.actorIds,
                 entityId: value.entityId,
                 startDate: value.startDate,
                 endDate: value.endDate,
@@ -101,15 +325,13 @@ export function ActivityLogFilters({ value, onChange, onRefresh, isFetching }: P
             toast.error('Failed to export activity logs');
             // eslint-disable-next-line no-console
             console.error('Activity logs CSV export failed', e);
-        } finally {
-            setIsExporting(false);
         }
     };
 
     return (
         <Card className="border-gray-200 shadow-sm">
-            <CardContent className="flex flex-col gap-3 p-4">
-                <div className="flex items-center justify-between">
+            <CardContent className="flex flex-col gap-3 p-3 sm:p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                     <div className="flex items-center gap-2 text-sm font-medium text-gray-700">
                         <FunnelSimple className="size-4" />
                         Filters
@@ -121,109 +343,197 @@ export function ActivityLogFilters({ value, onChange, onRefresh, isFetching }: P
                     </div>
                     <div className="flex items-center gap-2">
                         {activeCount > 0 && (
-                            <Button variant="ghost" size="sm" onClick={clearAll}>
+                            <MyButton
+                                buttonType="text"
+                                scale="medium"
+                                className="sm:!min-w-0"
+                                onClick={clearAll}
+                            >
                                 <X className="mr-1 size-4" /> Clear
-                            </Button>
+                            </MyButton>
                         )}
-                        <Button
-                            variant="outline"
-                            size="sm"
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            className="sm:!min-w-0"
                             onClick={onRefresh}
-                            disabled={isFetching}
+                            disable={isFetching}
                         >
                             <ArrowsClockwise
-                                className={`mr-1 size-4 ${isFetching ? 'animate-spin' : ''}`}
+                                className={cn('mr-1 size-4', isFetching && 'animate-spin')}
                             />
                             Refresh
-                        </Button>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={handleExport}
-                            disabled={isExporting}
+                        </MyButton>
+                        <MyButton
+                            buttonType="secondary"
+                            scale="medium"
+                            className="sm:!min-w-0"
+                            onAsyncClick={handleExport}
+                            loadingText="Exporting…"
                             title="Download a CSV of all rows matching the current filters (max 50,000)"
                         >
-                            <DownloadSimple
-                                className={`mr-1 size-4 ${isExporting ? 'animate-pulse' : ''}`}
-                            />
-                            {isExporting ? 'Exporting…' : 'Export CSV'}
-                        </Button>
+                            <DownloadSimple className="mr-1 size-4" />
+                            Export CSV
+                        </MyButton>
                     </div>
                 </div>
 
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
-                    <Field label="Resource">
-                        <Select
-                            value={value.entityType ?? ANY}
-                            onValueChange={(v) =>
-                                onChange({ entityType: v === ANY ? undefined : v })
-                            }
-                        >
-                            <SelectTrigger>
-                                <SelectValue placeholder="Any resource" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value={ANY}>Any resource</SelectItem>
-                                {RESOURCE_OPTIONS.map((opt) => (
-                                    <SelectItem key={opt.value} value={opt.value}>
-                                        {opt.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </Field>
-                    <Field label="Activity">
-                        <Select
-                            value={value.action ?? ANY}
-                            onValueChange={(v) =>
-                                onChange({ action: v === ANY ? undefined : v })
-                            }
-                        >
-                            <SelectTrigger>
-                                <SelectValue placeholder="Any activity" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value={ANY}>Any activity</SelectItem>
-                                {ACTIVITY_OPTIONS.map((opt) => (
-                                    <SelectItem key={opt.value} value={opt.value}>
-                                        {opt.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </Field>
-                    <Field label="Performed by (user ID)">
-                        <Input
-                            placeholder="Paste a user ID"
-                            value={value.actorId ?? ''}
-                            onChange={(e) => onChange({ actorId: e.target.value || undefined })}
-                        />
-                    </Field>
-                    <Field label="From">
-                        <Input
-                            type="date"
-                            value={toDateInput(value.startDate)}
-                            onChange={(e) =>
-                                onChange({ startDate: fromDateInput(e.target.value) })
-                            }
-                        />
-                    </Field>
-                    <Field label="To">
-                        <Input
-                            type="date"
-                            value={toDateInput(value.endDate)}
-                            onChange={(e) => onChange({ endDate: fromDateInput(e.target.value) })}
-                        />
-                    </Field>
+                <div className="flex flex-wrap items-end gap-2">
+                    <MultiSelectFilter
+                        label="Any resource"
+                        icon={<Stack className="size-4 text-neutral-500" />}
+                        options={RESOURCE_OPTIONS}
+                        selected={value.entityTypes ?? []}
+                        onChange={(values) =>
+                            onChange({ entityTypes: values.length ? values : undefined })
+                        }
+                        placeholder="Search resources…"
+                        widthClass="w-48"
+                        showSelectedLabel
+                    />
+                    <MultiSelectFilter
+                        label="Any activity"
+                        icon={<Lightning className="size-4 text-neutral-500" />}
+                        options={ACTIVITY_OPTIONS}
+                        selected={value.actions ?? []}
+                        onChange={(values) =>
+                            onChange({ actions: values.length ? values : undefined })
+                        }
+                        placeholder="Search activities…"
+                        widthClass="w-48"
+                        showSelectedLabel
+                    />
+                    <MultiSelectFilter
+                        label={actorsQuery.isLoading ? 'Loading team…' : 'Anyone on the team'}
+                        icon={<UserCircle className="size-4 text-neutral-500" />}
+                        options={actorOptions}
+                        selected={value.actorIds ?? []}
+                        onChange={(values) =>
+                            onChange({ actorIds: values.length ? values : undefined })
+                        }
+                        placeholder="Search by name or email…"
+                        widthClass="w-56"
+                        showSelectedLabel
+                    />
+
+                    <div className="flex items-center gap-1 rounded-md border border-gray-200 p-0.5">
+                        {DATE_PRESETS.map((preset) => {
+                            const isActive = activePreset?.label === preset.label;
+                            return (
+                                <button
+                                    key={preset.label}
+                                    type="button"
+                                    onClick={() =>
+                                        isActive
+                                            ? onChange({
+                                                  startDate: undefined,
+                                                  endDate: undefined,
+                                              })
+                                            : onChange(preset.range())
+                                    }
+                                    className={cn(
+                                        'rounded px-2 py-1.5 text-xs font-medium transition-colors',
+                                        isActive
+                                            ? 'bg-primary-50 text-primary-500'
+                                            : 'text-gray-600 hover:bg-gray-100'
+                                    )}
+                                >
+                                    {preset.label}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    <div className="flex items-end gap-2">
+                        <Field label="From">
+                            <Input
+                                type="date"
+                                className="h-10 w-40"
+                                value={toDateInput(value.startDate)}
+                                onChange={(e) =>
+                                    onChange({ startDate: startOfDay(e.target.value) })
+                                }
+                            />
+                        </Field>
+                        <Field label="To">
+                            <Input
+                                type="date"
+                                className="h-10 w-40"
+                                value={toDateInput(value.endDate)}
+                                onChange={(e) => onChange({ endDate: endOfDay(e.target.value) })}
+                            />
+                        </Field>
+                    </div>
                 </div>
+
+                {activeCount > 0 && (
+                    <div className="flex flex-wrap items-center gap-1.5 border-t border-gray-100 pt-2.5">
+                        {(value.actorIds ?? []).map((id) => (
+                            <FilterChip
+                                key={`actor-${id}`}
+                                label={actorLabels[id] ?? id}
+                                onRemove={() => onChange({ actorIds: without(value.actorIds, id) })}
+                            />
+                        ))}
+                        {(value.entityTypes ?? []).map((type) => (
+                            <FilterChip
+                                key={`resource-${type}`}
+                                label={RESOURCE_LABELS[type] ?? type}
+                                onRemove={() =>
+                                    onChange({ entityTypes: without(value.entityTypes, type) })
+                                }
+                            />
+                        ))}
+                        {(value.actions ?? []).map((action) => (
+                            <FilterChip
+                                key={`action-${action}`}
+                                label={ACTIVITY_LABELS[action] ?? action}
+                                onRemove={() =>
+                                    onChange({ actions: without(value.actions, action) })
+                                }
+                            />
+                        ))}
+                        {(value.startDate || value.endDate) && (
+                            <FilterChip
+                                label={`${toDateInput(value.startDate) || 'Any'} → ${
+                                    toDateInput(value.endDate) || 'Now'
+                                }`}
+                                onRemove={() =>
+                                    onChange({ startDate: undefined, endDate: undefined })
+                                }
+                            />
+                        )}
+                    </div>
+                )}
             </CardContent>
         </Card>
     );
 }
 
+/**
+ * One applied filter, removable. Built on ChipsWrapper rather than Chips
+ * because the canonical Chips takes only a static trailing icon, and this chip
+ * needs that icon to be the remove control.
+ */
+function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+    return (
+        <ChipsWrapper className="max-w-xs rounded-full pr-1 text-caption">
+            <span className="truncate">{label}</span>
+            <button
+                type="button"
+                onClick={onRemove}
+                aria-label={`Remove filter ${label}`}
+                className="rounded-full p-0.5 text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+            >
+                <X className="size-3" />
+            </button>
+        </ChipsWrapper>
+    );
+}
+
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
     return (
-        <label className="flex flex-col gap-1.5 text-xs font-medium text-gray-600">
+        <label className="flex flex-col gap-1 text-xs font-medium text-gray-600">
             {label}
             {children}
         </label>

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
@@ -6,17 +6,13 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
-import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { Info, MagnifyingGlass } from '@phosphor-icons/react';
+import { MyPagination } from '@/components/design-system/pagination';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Info, MagnifyingGlass, WarningCircle } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
 import type {
     AdminActivityLog,
     AdminActivityLogPage,
@@ -30,13 +26,58 @@ interface Props {
     onPageChange: (page: number) => void;
 }
 
+// The audit log's actions are free-form strings, so a StatusChip (which renders
+// nothing for a status outside its fixed catalog) would leave the column blank.
+// A Badge with a tone chosen per action always renders something.
 const ACTION_VARIANT: Record<string, 'default' | 'destructive' | 'secondary' | 'outline'> = {
     CREATE: 'default',
+    ENROLL: 'default',
+    ASSIGN: 'default',
+    IMPORT: 'default',
+    RESTORE: 'default',
     UPDATE: 'secondary',
+    STATUS_CHANGE: 'secondary',
+    TIER_CHANGE: 'secondary',
+    SCORE_CHANGE: 'secondary',
+    REASSIGN: 'secondary',
+    BULK_UPDATE: 'secondary',
     DELETE: 'destructive',
     CANCEL: 'destructive',
-    ENROLL: 'default',
+    TERMINATE: 'destructive',
+    UNASSIGN: 'destructive',
+    REMOVE_MEMBER: 'destructive',
 };
+
+const RESOURCE_LABELS: Record<string, string> = {
+    AUDIENCE: 'Audience list',
+    LEAD: 'Lead',
+    LEAD_STATUS: 'Lead status',
+    LEAD_FOLLOWUP: 'Follow-up',
+    LEAD_SLA_CONFIG: 'Lead SLA',
+    LEAD_CONNECTOR: 'Lead connector',
+    ENQUIRY: 'Enquiry',
+    COUNSELLOR: 'Counsellor',
+    COUNSELLOR_POOL: 'Counsellor pool',
+    COUNSELLOR_TARGET: 'Counsellor target',
+    COUNSELLOR_WORKBENCH_CONFIG: 'Workbench settings',
+    TAG: 'Tag',
+    TELEPHONY_CONFIG: 'Calling settings',
+    TELEPHONY_NUMBER: 'Calling number',
+    ENGAGEMENT_ENGINE: 'Engagement engine',
+    AUTOMATION: 'Automation',
+    COURSE: 'Course',
+    LIVE_SESSION: 'Live session',
+    LEARNER: 'Learner',
+    GUARDIAN_LINK: 'Guardian link',
+    INSTITUTE_SETTING: 'Settings',
+};
+
+const resourceLabel = (entityType: string): string =>
+    RESOURCE_LABELS[entityType] ??
+    entityType
+        .toLowerCase()
+        .replace(/_/g, ' ')
+        .replace(/^./, (c) => c.toUpperCase());
 
 const formatAbsoluteTime = (iso: string | null | undefined) => {
     if (!iso) return '—';
@@ -100,56 +141,119 @@ const NAMED_DESCRIPTION_PATTERNS: RegExp[] = [
     /^(cancelled enrollment of )(.+)$/i,
     /^((?:deactivated|reactivated) )(.+)$/i,
 
+    // ── CRM ──────────────────────────────────────────────────────────
+    /^((?:created|updated|deleted) audience )(.+)$/i,
+    /^(sent a message to audience )(.+)$/i,
+    /^(recalculated lead scores for audience )(.+)$/i,
+    /^(imported )(\d+ lead\(s\))( into )(.+)$/i,
+    /^(imported )(\d+ lead\(s\))$/i,
+    /^((?:added|updated|deleted|restored) lead )(.+)$/i,
+    /^(registered walk-in lead )(.+)$/i,
+    /^(marked lead )(.+?)( as converted)$/i,
+    /^(changed lead (?:status|tier|score) of )(.+?)( to )(.+)$/i,
+    /^(assigned lead )(.+?)( to )(.+)$/i,
+    /^(unassigned counsellor from lead )(.+)$/i,
+    /^((?:assigned|reassigned) )(\d+ lead\(s\))( (?:to|from) )(.+)$/i,
+    /^((?:assigned|reassigned) )(\d+ lead\(s\))$/i,
+    /^((?:created|updated|deleted) lead status )(.+)$/i,
+    /^((?:scheduled|rescheduled|closed) a follow-up for lead )(.+)$/i,
+    /^(connected Meta lead form )(.+?)( to audience )(.+)$/i,
+    /^(connected Meta lead form )(.+)$/i,
+    /^(updated lead connector )(.+)$/i,
+    /^((?:created|updated) counsellor pool )(.+)$/i,
+    /^((?:added|removed) )(.+?)( (?:to|from) a counsellor pool)$/i,
+    /^(changed (?:pool )?status of (?:counsellor )?)(.+?)( to )(.+)$/i,
+    /^((?:set|removed) (?:a )?targets? for )(.+)$/i,
+    /^((?:created|deleted) tag )(.+)$/i,
+    /^(tagged )(\d+ contact\(s\))( with )(.+)$/i,
+    /^((?:tagged|removed tags from) )(\d+ contact\(s\))$/i,
+    /^((?:created|updated|deleted) automation )(.+)$/i,
+    /^(created engagement engine )(.+)$/i,
+    /^(changed status of engagement engine )(.+?)( to )(.+)$/i,
+    /^((?:paused|resumed) autonomous sending for engagement engine )(.+)$/i,
+    /^((?:added|updated) calling number )(.+)$/i,
+    /^(changed the status of )(\d+ enquiry\(s\))( to )(.+)$/i,
+    /^(changed the status of )(\d+ enquiry\(s\))$/i,
+
     /^(switched WhatsApp provider to )(.+)$/i,
     /^((?:updated|removed) WhatsApp credentials for )(.+)$/i,
 ];
+
+/**
+ * Splits a description into alternating connective / name fragments, or null
+ * when no pattern claims it. Exported for the test that pins which parts of
+ * each sentence get emphasised — a mis-ordered pattern bolds the wrong half,
+ * which is invisible to types and to a passing render.
+ */
+export const splitDescriptionParts = (description: string): string[] | null => {
+    for (const re of NAMED_DESCRIPTION_PATTERNS) {
+        const m = description.match(re);
+        if (m) return m.slice(1);
+    }
+    return null;
+};
+
+/** The sentence shown for a row when the backend left no description. */
+export const fallbackDescription = (
+    row: Pick<AdminActivityLog, 'action' | 'entity_type'>
+): string => `${row.action.toLowerCase()}d a ${row.entity_type.toLowerCase().replace(/_/g, ' ')}`;
 
 const renderActivitySentence = (row: AdminActivityLog): React.ReactNode => {
     const description =
         row.description && row.description.trim().length > 0
             ? row.description
-            : `${row.action.toLowerCase()}d a ${row.entity_type
-                  .toLowerCase()
-                  .replace(/_/g, ' ')}`;
+            : fallbackDescription(row);
 
-    for (const re of NAMED_DESCRIPTION_PATTERNS) {
-        const m = description.match(re);
-        if (!m) continue;
-        // Groups alternate connective / name, starting with connective.
-        return (
-            <>
-                {m.slice(1).map((part, i) =>
-                    i % 2 === 0 ? (
-                        <span key={i}>{part}</span>
-                    ) : (
-                        <span key={i} className="font-semibold text-gray-900">
-                            {part}
-                        </span>
-                    )
-                )}
-            </>
-        );
-    }
-    return description;
+    const parts = splitDescriptionParts(description);
+    if (!parts) return description;
+
+    // Groups alternate connective / name, starting with connective.
+    return (
+        <>
+            {parts.map((part, i) =>
+                i % 2 === 0 ? (
+                    <span key={i}>{part}</span>
+                ) : (
+                    <span key={i} className="font-semibold text-neutral-700">
+                        {part}
+                    </span>
+                )
+            )}
+        </>
+    );
 };
 
 const getActorLabel = (row: AdminActivityLog): string =>
     row.actor_name || row.actor_email || row.actor_id || 'Unknown user';
 
+const initialsOf = (label: string): string =>
+    label
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase() ?? '')
+        .join('') || '?';
+
 const statusTone = (status: number | null | undefined): string => {
-    if (status == null) return 'bg-gray-300';
-    if (status >= 200 && status < 300) return 'bg-emerald-500';
-    if (status >= 400 && status < 500) return 'bg-amber-500';
-    return 'bg-red-500';
+    if (status == null) return 'bg-neutral-300';
+    if (status >= 200 && status < 300) return 'bg-success-500';
+    if (status >= 400 && status < 500) return 'bg-warning-500';
+    return 'bg-danger-500';
 };
 
 export function ActivityLogTable({ page, isLoading, isError, onRowClick, onPageChange }: Props) {
     if (isError) {
         return (
-            <Card className="border-red-200 bg-red-50 p-4">
-                <p className="text-sm text-red-700">
-                    Failed to load activity logs. Try refreshing.
-                </p>
+            <Card className="flex items-start gap-2 border-danger-200 bg-danger-50 p-4">
+                <WarningCircle className="mt-0.5 size-5 shrink-0 text-danger-600" />
+                <div>
+                    <p className="text-body font-medium text-danger-600">
+                        Failed to load activity logs
+                    </p>
+                    <p className="text-caption text-neutral-600">
+                        The request did not complete. Use Refresh to try again.
+                    </p>
+                </div>
             </Card>
         );
     }
@@ -158,137 +262,163 @@ export function ActivityLogTable({ page, isLoading, isError, onRowClick, onPageC
     const currentPage = page?.number ?? 0;
     const totalPages = page?.totalPages ?? 0;
     const totalElements = page?.totalElements ?? 0;
+    const pageSize = page?.size ?? 20;
 
     return (
         <TooltipProvider delayDuration={150}>
-            <Card className="overflow-hidden border-gray-200 shadow-sm">
-                <Table>
-                    <TableHeader>
-                        <TableRow className="bg-gray-50/60 hover:bg-gray-50/60">
-                            <TableHead className="w-40 pl-4 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                When
-                            </TableHead>
-                            <TableHead className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                Activity
-                            </TableHead>
-                            <TableHead className="w-28 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                Action
-                            </TableHead>
-                            <TableHead className="w-28 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                <Tooltip>
-                                    <TooltipTrigger className="inline-flex items-center gap-1">
-                                        Latency
-                                        <Info className="size-3.5 text-gray-400" />
-                                    </TooltipTrigger>
-                                    <TooltipContent side="top" className="max-w-xs">
-                                        API call wall-time on the server. Includes business
-                                        logic + DB writes; excludes the audit-row write itself
-                                        (~1–3 ms).
-                                    </TooltipContent>
-                                </Tooltip>
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {isLoading && rows.length === 0 ? (
-                            Array.from({ length: 6 }).map((_, i) => (
-                                <TableRow key={`skeleton-${i}`}>
-                                    <TableCell colSpan={4} className="px-4">
-                                        <Skeleton className="h-6 w-full" />
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        ) : rows.length === 0 ? (
-                            <TableRow>
-                                <TableCell colSpan={4} className="py-12">
-                                    <EmptyState />
-                                </TableCell>
+            <Card className="overflow-hidden border-neutral-200 shadow-sm">
+                {/*
+                  The narrow columns never wrap, so the table asks for the width
+                  it actually needs and scrolls inside the card when the content
+                  column cannot give it — no fixed min-width, which would clip
+                  the same columns at 1024px where both sidebars are open. The
+                  page body itself never scrolls sideways.
+                */}
+                <div className="overflow-x-auto">
+                    <Table>
+                        <TableHeader>
+                            <TableRow className="bg-neutral-50 hover:bg-neutral-50">
+                                <TableHead className="w-32 whitespace-nowrap pl-4 text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                                    When
+                                </TableHead>
+                                <TableHead className="text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                                    Activity
+                                </TableHead>
+                                <TableHead className="whitespace-nowrap text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                                    Resource
+                                </TableHead>
+                                <TableHead className="whitespace-nowrap text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                                    Action
+                                </TableHead>
+                                <TableHead className="whitespace-nowrap pr-4 text-right text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                                    <Tooltip>
+                                        <TooltipTrigger className="inline-flex items-center gap-1">
+                                            Latency
+                                            <Info className="size-3.5 text-neutral-400" />
+                                        </TooltipTrigger>
+                                        <TooltipContent side="top" className="max-w-xs">
+                                            API call wall-time on the server. Includes business
+                                            logic + DB writes; excludes the audit-row write itself
+                                            (~1–3 ms).
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </TableHead>
                             </TableRow>
-                        ) : (
-                            rows.map((row) => (
-                                <TableRow
-                                    key={row.id}
-                                    onClick={() => onRowClick(row)}
-                                    className="cursor-pointer transition-colors hover:bg-gray-50"
-                                >
-                                    <TableCell className="pl-4 align-top">
-                                        <Tooltip>
-                                            <TooltipTrigger className="text-xs text-gray-600">
-                                                {formatRelativeTime(row.created_at)}
-                                            </TooltipTrigger>
-                                            <TooltipContent side="top">
-                                                {formatAbsoluteTime(row.created_at)}
-                                            </TooltipContent>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell className="align-top">
-                                        <div className="flex items-start gap-2">
-                                            <span
-                                                className={`mt-1.5 inline-block size-2 shrink-0 rounded-full ${statusTone(
-                                                    row.response_status
-                                                )}`}
-                                                title={
-                                                    row.response_status != null
-                                                        ? `HTTP ${row.response_status}`
-                                                        : ''
-                                                }
-                                            />
-                                            <div className="text-sm text-gray-800">
-                                                <span className="font-semibold text-gray-900">
-                                                    {getActorLabel(row)}
-                                                </span>{' '}
-                                                {renderActivitySentence(row)}
-                                                {row.actor_email &&
-                                                    row.actor_name &&
-                                                    row.actor_email !== row.actor_name && (
-                                                        <div className="mt-0.5 text-xs text-gray-500">
-                                                            {row.actor_email}
-                                                        </div>
-                                                    )}
-                                            </div>
-                                        </div>
-                                    </TableCell>
-                                    <TableCell className="align-top">
-                                        <Badge variant={ACTION_VARIANT[row.action] || 'outline'}>
-                                            {row.action}
-                                        </Badge>
-                                    </TableCell>
-                                    <TableCell className="pr-4 align-top text-right text-xs tabular-nums text-gray-600">
-                                        {row.response_time_ms != null
-                                            ? `${row.response_time_ms} ms`
-                                            : '—'}
+                        </TableHeader>
+                        <TableBody>
+                            {isLoading && rows.length === 0 ? (
+                                Array.from({ length: 8 }).map((_, i) => (
+                                    <TableRow key={`skeleton-${i}`}>
+                                        <TableCell colSpan={5} className="px-4">
+                                            <Skeleton className="h-6 w-full" />
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            ) : rows.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={5} className="py-12">
+                                        <EmptyState />
                                     </TableCell>
                                 </TableRow>
-                            ))
-                        )}
-                    </TableBody>
-                </Table>
-
-                <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50/30 px-4 py-2.5 text-xs text-gray-600">
-                    <span>
-                        {totalElements === 0
-                            ? 'No results'
-                            : `Page ${currentPage + 1} of ${totalPages} · ${totalElements.toLocaleString()} total`}
-                    </span>
-                    <div className="flex items-center gap-2">
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            disabled={currentPage <= 0 || isLoading}
-                            onClick={() => onPageChange(Math.max(0, currentPage - 1))}
-                        >
-                            Previous
-                        </Button>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            disabled={currentPage + 1 >= totalPages || isLoading}
-                            onClick={() => onPageChange(currentPage + 1)}
-                        >
-                            Next
-                        </Button>
-                    </div>
+                            ) : (
+                                rows.map((row) => (
+                                    <TableRow
+                                        key={row.id}
+                                        tabIndex={0}
+                                        role="button"
+                                        aria-label={`Open details for ${getActorLabel(row)} — ${
+                                            row.description ?? row.action
+                                        }`}
+                                        onClick={() => onRowClick(row)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter' || event.key === ' ') {
+                                                event.preventDefault();
+                                                onRowClick(row);
+                                            }
+                                        }}
+                                        className="cursor-pointer transition-colors hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                                    >
+                                        <TableCell className="whitespace-nowrap pl-4 align-top">
+                                            <Tooltip>
+                                                <TooltipTrigger className="text-caption text-neutral-600">
+                                                    {formatRelativeTime(row.created_at)}
+                                                </TooltipTrigger>
+                                                <TooltipContent side="top">
+                                                    {formatAbsoluteTime(row.created_at)}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </TableCell>
+                                        <TableCell className="align-top">
+                                            <div className="flex items-start gap-2.5">
+                                                <span
+                                                    className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-primary-50 text-caption font-semibold text-primary-500"
+                                                    aria-hidden="true"
+                                                >
+                                                    {initialsOf(getActorLabel(row))}
+                                                </span>
+                                                <div className="min-w-0 text-body text-neutral-600">
+                                                    <span className="inline-flex items-center gap-1.5">
+                                                        <span
+                                                            className={cn(
+                                                                'inline-block size-2 shrink-0 rounded-full',
+                                                                statusTone(row.response_status)
+                                                            )}
+                                                            title={
+                                                                row.response_status != null
+                                                                    ? `HTTP ${row.response_status}`
+                                                                    : ''
+                                                            }
+                                                        />
+                                                        <span className="font-semibold text-neutral-700">
+                                                            {getActorLabel(row)}
+                                                        </span>
+                                                    </span>{' '}
+                                                    {renderActivitySentence(row)}
+                                                    {row.actor_email &&
+                                                        row.actor_name &&
+                                                        row.actor_email !== row.actor_name && (
+                                                            <div className="mt-0.5 text-caption text-neutral-500">
+                                                                {row.actor_email}
+                                                            </div>
+                                                        )}
+                                                </div>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="whitespace-nowrap align-top">
+                                            <span className="inline-block rounded-md bg-neutral-100 px-2 py-0.5 text-caption text-neutral-600">
+                                                {resourceLabel(row.entity_type)}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell className="whitespace-nowrap align-top">
+                                            <Badge
+                                                variant={ACTION_VARIANT[row.action] || 'outline'}
+                                            >
+                                                {row.action.replace(/_/g, ' ')}
+                                            </Badge>
+                                        </TableCell>
+                                        <TableCell className="whitespace-nowrap pr-4 text-right align-top text-caption tabular-nums text-neutral-600">
+                                            {row.response_time_ms != null
+                                                ? `${row.response_time_ms} ms`
+                                                : '—'}
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
                 </div>
+
+                {totalElements > 0 && (
+                    <div className="border-t border-neutral-200 bg-neutral-50 px-4 py-2.5">
+                        <MyPagination
+                            currentPage={currentPage}
+                            totalPages={totalPages}
+                            totalElements={totalElements}
+                            pageSize={pageSize}
+                            onPageChange={onPageChange}
+                        />
+                    </div>
+                )}
             </Card>
         </TooltipProvider>
     );
@@ -297,12 +427,12 @@ export function ActivityLogTable({ page, isLoading, isError, onRowClick, onPageC
 function EmptyState() {
     return (
         <div className="flex flex-col items-center justify-center gap-2 text-center">
-            <span className="inline-flex size-10 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+            <span className="inline-flex size-10 items-center justify-center rounded-full bg-neutral-100 text-neutral-400">
                 <MagnifyingGlass className="size-5" />
             </span>
-            <p className="text-sm font-medium text-gray-700">No audit entries</p>
-            <p className="text-xs text-gray-500">
-                Nothing matches the current filters. Try clearing them or widen the date range.
+            <p className="text-body font-medium text-neutral-700">No audit entries</p>
+            <p className="text-caption text-neutral-500">
+                Nothing matches the current filters. Try clearing them or widening the date range.
             </p>
         </div>
     );

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/PayloadDrawer.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/PayloadDrawer.tsx
@@ -1,22 +1,17 @@
-import { useState } from 'react';
-import {
-    Sheet,
-    SheetContent,
-    SheetDescription,
-    SheetHeader,
-    SheetTitle,
-} from '@/components/ui/sheet';
+import { useMemo, useState } from 'react';
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
-import { Copy, Check } from '@phosphor-icons/react';
+import { MyButton } from '@/components/design-system/button';
+import { Copy, Check, CaretRight, User, Globe, Database } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
 import type { AdminActivityLog } from '@/services/admin-activity-logs/getActivityLogs';
 
 interface Props {
     log: AdminActivityLog | null;
     open: boolean;
     onClose: () => void;
+    /** Narrow the list to this actor — the drawer's one shortcut back into the log. */
+    onFilterByActor?: (actorId: string) => void;
 }
 
 const ACTION_VARIANT: Record<string, 'default' | 'destructive' | 'secondary' | 'outline'> = {
@@ -24,186 +19,180 @@ const ACTION_VARIANT: Record<string, 'default' | 'destructive' | 'secondary' | '
     UPDATE: 'secondary',
     DELETE: 'destructive',
     CANCEL: 'destructive',
+    TERMINATE: 'destructive',
+    UNASSIGN: 'destructive',
     ENROLL: 'default',
+    ASSIGN: 'default',
 };
 
 const statusTone = (status: number | null | undefined): string => {
-    if (status == null) return 'text-gray-500';
-    if (status >= 200 && status < 300) return 'text-emerald-600';
-    if (status >= 400 && status < 500) return 'text-amber-600';
-    return 'text-red-600';
+    if (status == null) return 'text-neutral-500';
+    if (status >= 200 && status < 300) return 'text-success-600';
+    if (status >= 400 && status < 500) return 'text-warning-600';
+    return 'text-danger-600';
 };
 
-export function PayloadDrawer({ log, open, onClose }: Props) {
+/** "lead_status_id" → "Lead status id". Audit payloads are snake_case. */
+const humanizeKey = (key: string): string => {
+    const spaced = key.replace(/_/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isEmptyPayload = (value: unknown): boolean =>
+    value == null ||
+    (isPlainObject(value) && Object.keys(value).length === 0) ||
+    (Array.isArray(value) && value.length === 0);
+
+export function PayloadDrawer({ log, open, onClose, onFilterByActor }: Props) {
     return (
         <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
-            <SheetContent className="w-full overflow-y-auto sm:max-w-2xl">
-                {log && (
-                    <>
-                        <SheetHeader className="space-y-2">
-                            <div className="flex items-center gap-2">
-                                <Badge variant={ACTION_VARIANT[log.action] || 'outline'}>
-                                    {log.action}
-                                </Badge>
-                                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                                    {log.entity_type}
-                                </span>
-                            </div>
-                            <SheetTitle className="text-lg leading-tight">
-                                {log.description || `${log.action.toLowerCase()}d ${log.entity_type.toLowerCase()}`}
-                            </SheetTitle>
-                            <SheetDescription>
-                                <span className="font-medium text-gray-700">
-                                    {log.actor_name || log.actor_email || 'Unknown user'}
-                                </span>
-                                {' · '}
-                                {log.created_at && new Date(log.created_at).toLocaleString()}
-                            </SheetDescription>
-                        </SheetHeader>
-
-                        <Separator className="my-4" />
-
-                        <div className="space-y-5 text-sm">
-                            <Section title="Actor">
-                                <KeyValue label="Name" value={log.actor_name} />
-                                <KeyValue label="Email" value={log.actor_email} />
-                                <KeyValue label="User ID" value={log.actor_id} mono />
-                            </Section>
-
-                            <Section title="Request">
-                                <KeyValue label="HTTP" value={log.http_method} />
-                                <KeyValue label="Endpoint" value={log.endpoint} mono />
-                                <KeyValue label="IP" value={log.ip_address} mono />
-                                <KeyValue
-                                    label="Status"
-                                    value={log.response_status?.toString() ?? null}
-                                    valueClassName={statusTone(log.response_status)}
-                                />
-                                <KeyValue
-                                    label="Latency"
-                                    value={
-                                        log.response_time_ms != null
-                                            ? `${log.response_time_ms} ms`
-                                            : null
-                                    }
-                                />
-                                {log.entity_id && (
-                                    <KeyValue label="Entity ID" value={log.entity_id} mono />
-                                )}
-                            </Section>
-
-                            {log.before_payload != null ? (
-                                <Section title="Before → After">
-                                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                                        <JsonBlock
-                                            label="Before"
-                                            value={log.before_payload}
-                                            tone="muted"
-                                        />
-                                        <JsonBlock
-                                            label="After (request)"
-                                            value={log.request_payload}
-                                            tone="accent"
-                                        />
-                                    </div>
-                                </Section>
-                            ) : (
-                                <Section title="Payload">
-                                    {log.request_payload != null ? (
-                                        <JsonBlock value={log.request_payload} />
-                                    ) : (
-                                        <p className="text-xs italic text-gray-500">
-                                            No payload captured.
-                                        </p>
-                                    )}
-                                </Section>
-                            )}
-                        </div>
-                    </>
-                )}
+            {/*
+              Explicit flex column with a min-h-0 scroll body. The previous
+              `overflow-y-auto` on the panel itself left a long payload clipped
+              at the bottom of the viewport with nothing to scroll, because the
+              nested payload box swallowed the wheel and the panel's own content
+              had no bounded height to scroll within.
+            */}
+            <SheetContent className="flex size-full flex-col gap-0 p-0 sm:max-w-2xl">
+                {log && <DrawerBody log={log} onFilterByActor={onFilterByActor} />}
             </SheetContent>
         </Sheet>
     );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function DrawerBody({
+    log,
+    onFilterByActor,
+}: {
+    log: AdminActivityLog;
+    onFilterByActor?: (actorId: string) => void;
+}) {
+    const hasBefore = !isEmptyPayload(log.before_payload);
+    const hasPayload = !isEmptyPayload(log.request_payload);
+
     return (
-        <div>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        <>
+            <header className="shrink-0 border-b border-neutral-200 px-6 py-4 pr-14">
+                <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={ACTION_VARIANT[log.action] || 'outline'}>{log.action}</Badge>
+                    <span className="text-caption font-medium uppercase tracking-wide text-neutral-500">
+                        {log.entity_type.replace(/_/g, ' ')}
+                    </span>
+                </div>
+                <SheetTitle className="mt-2 text-subtitle font-semibold leading-snug text-neutral-700">
+                    {log.description ||
+                        `${log.action.toLowerCase()} ${log.entity_type.toLowerCase().replace(/_/g, ' ')}`}
+                </SheetTitle>
+                <SheetDescription className="mt-1 text-body text-neutral-500">
+                    <span className="font-medium text-neutral-600">
+                        {log.actor_name || log.actor_email || 'Unknown user'}
+                    </span>
+                    {' · '}
+                    {log.created_at && new Date(log.created_at).toLocaleString()}
+                </SheetDescription>
+            </header>
+
+            {/* The only scroll container in the drawer. */}
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+                <div className="flex flex-col gap-6">
+                    <Section title="Performed by" icon={<User className="size-4" />}>
+                        <KeyValue label="Name" value={log.actor_name} />
+                        <KeyValue label="Email" value={log.actor_email} />
+                        <KeyValue label="User ID" value={log.actor_id} mono />
+                        {log.actor_id && onFilterByActor && (
+                            <div className="pt-1">
+                                <MyButton
+                                    buttonType="secondary"
+                                    scale="small"
+                                    className="sm:!min-w-0"
+                                    onClick={() => onFilterByActor(log.actor_id as string)}
+                                >
+                                    See everything this person did
+                                </MyButton>
+                            </div>
+                        )}
+                    </Section>
+
+                    <Section title="Request" icon={<Globe className="size-4" />}>
+                        <KeyValue label="Method" value={log.http_method} />
+                        <KeyValue label="Endpoint" value={log.endpoint} mono />
+                        <KeyValue label="IP address" value={log.ip_address} mono />
+                        <KeyValue
+                            label="Response"
+                            value={log.response_status?.toString() ?? null}
+                            valueClassName={statusTone(log.response_status)}
+                        />
+                        <KeyValue
+                            label="Latency"
+                            value={
+                                log.response_time_ms != null ? `${log.response_time_ms} ms` : null
+                            }
+                        />
+                        <KeyValue label="Entity ID" value={log.entity_id} mono />
+                        <KeyValue label="Log ID" value={log.id} mono />
+                        <KeyValue label="Device" value={log.user_agent} />
+                    </Section>
+
+                    {hasBefore ? (
+                        <Section title="What changed" icon={<Database className="size-4" />}>
+                            <div className="flex flex-col gap-4">
+                                <PayloadBlock
+                                    label="Before"
+                                    value={log.before_payload}
+                                    tone="muted"
+                                />
+                                <PayloadBlock
+                                    label="After (submitted)"
+                                    value={log.request_payload}
+                                    tone="accent"
+                                />
+                            </div>
+                        </Section>
+                    ) : (
+                        <Section title="Submitted data" icon={<Database className="size-4" />}>
+                            {hasPayload ? (
+                                <PayloadBlock value={log.request_payload} />
+                            ) : (
+                                <p className="text-body italic text-neutral-500">
+                                    No payload captured for this action.
+                                </p>
+                            )}
+                        </Section>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+}
+
+function Section({
+    title,
+    icon,
+    children,
+}: {
+    title: string;
+    icon?: React.ReactNode;
+    children: React.ReactNode;
+}) {
+    return (
+        <section>
+            <h3 className="mb-2 flex items-center gap-1.5 text-caption font-semibold uppercase tracking-wide text-neutral-500">
+                {icon}
                 {title}
             </h3>
-            <div className="space-y-1.5">{children}</div>
-        </div>
+            <div className="flex flex-col gap-1.5">{children}</div>
+        </section>
     );
 }
 
-function JsonBlock({
-    value,
-    label,
-    tone = 'default',
-}: {
-    value: unknown;
-    label?: string;
-    tone?: 'default' | 'muted' | 'accent';
-}) {
-    const toneClasses =
-        tone === 'accent'
-            ? 'bg-blue-50/60 border-blue-200'
-            : tone === 'muted'
-              ? 'bg-gray-50 border-gray-200'
-              : 'bg-gray-50 border-gray-200';
-
-    const formatted = JSON.stringify(value, null, 2);
-    const [copied, setCopied] = useState(false);
-
-    const copy = async () => {
-        try {
-            await navigator.clipboard.writeText(formatted);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-        } catch {
-            /* clipboard blocked — no-op */
-        }
-    };
-
-    return (
-        <div>
-            <div className="mb-1 flex items-center justify-between">
-                {label ? (
-                    <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                        {label}
-                    </span>
-                ) : (
-                    <span />
-                )}
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-xs text-gray-500 hover:text-gray-800"
-                    onClick={copy}
-                >
-                    {copied ? (
-                        <>
-                            <Check className="mr-1 size-3.5" />
-                            Copied
-                        </>
-                    ) : (
-                        <>
-                            <Copy className="mr-1 size-3.5" />
-                            Copy
-                        </>
-                    )}
-                </Button>
-            </div>
-            <ScrollArea className={`max-h-80 rounded border p-3 ${toneClasses}`}>
-                <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-snug text-gray-800">
-                    {formatted}
-                </pre>
-            </ScrollArea>
-        </div>
-    );
-}
-
+/**
+ * Two-column row that WRAPS instead of truncating. Endpoints, user agents and
+ * ids are the values an auditor actually needs to read in full; the previous
+ * version cut them off at 60% of the drawer width with only a title tooltip.
+ */
 function KeyValue({
     label,
     value,
@@ -217,16 +206,183 @@ function KeyValue({
 }) {
     if (!value) return null;
     return (
-        <div className="flex justify-between gap-3 text-sm">
-            <span className="text-gray-500">{label}</span>
+        <div className="grid grid-cols-[9rem_1fr] gap-3 text-body">
+            <span className="text-neutral-500">{label}</span>
             <span
-                className={`max-w-[60%] truncate text-right text-gray-800 ${
-                    mono ? 'font-mono text-xs' : ''
-                } ${valueClassName ?? ''}`}
-                title={value}
+                className={cn(
+                    'min-w-0 break-words text-neutral-700',
+                    mono && 'font-mono text-caption',
+                    valueClassName
+                )}
             >
                 {value}
             </span>
         </div>
     );
+}
+
+/**
+ * A payload rendered as readable fields, with the raw JSON one click away.
+ * Admins read these to answer "what did they actually change?", and a wall of
+ * braces is a poor answer.
+ */
+function PayloadBlock({
+    value,
+    label,
+    tone = 'default',
+}: {
+    value: unknown;
+    label?: string;
+    tone?: 'default' | 'muted' | 'accent';
+}) {
+    const [showRaw, setShowRaw] = useState(false);
+    const [copied, setCopied] = useState(false);
+    const formatted = useMemo(() => JSON.stringify(value, null, 2), [value]);
+
+    const copy = async () => {
+        try {
+            await navigator.clipboard.writeText(formatted);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch {
+            /* clipboard blocked — no-op */
+        }
+    };
+
+    const toneClasses =
+        tone === 'accent'
+            ? 'border-primary-200 bg-primary-50/40'
+            : tone === 'muted'
+              ? 'border-neutral-200 bg-neutral-50'
+              : 'border-neutral-200 bg-neutral-50';
+
+    return (
+        <div>
+            <div className="mb-1 flex items-center justify-between gap-2">
+                {label ? (
+                    <span className="text-caption font-medium uppercase tracking-wide text-neutral-500">
+                        {label}
+                    </span>
+                ) : (
+                    <span />
+                )}
+                <div className="flex items-center gap-1">
+                    <MyButton
+                        buttonType="text"
+                        scale="small"
+                        className="sm:!min-w-0"
+                        onClick={() => setShowRaw((prev) => !prev)}
+                    >
+                        {showRaw ? 'Fields' : 'Raw JSON'}
+                    </MyButton>
+                    <MyButton
+                        buttonType="text"
+                        scale="small"
+                        className="sm:!min-w-0"
+                        onClick={copy}
+                    >
+                        {copied ? (
+                            <>
+                                <Check className="mr-1 size-3.5" />
+                                Copied
+                            </>
+                        ) : (
+                            <>
+                                <Copy className="mr-1 size-3.5" />
+                                Copy
+                            </>
+                        )}
+                    </MyButton>
+                </div>
+            </div>
+            <div className={cn('overflow-x-auto rounded-lg border p-3', toneClasses)}>
+                {showRaw ? (
+                    <pre className="whitespace-pre-wrap break-words font-mono text-caption leading-snug text-neutral-700">
+                        {formatted}
+                    </pre>
+                ) : (
+                    <JsonFields value={value} />
+                )}
+            </div>
+        </div>
+    );
+}
+
+/** Recursive field renderer: objects become labelled rows, arrays become lists. */
+function JsonFields({ value, depth = 0 }: { value: unknown; depth?: number }) {
+    if (value == null) {
+        return <span className="text-body italic text-neutral-500">null</span>;
+    }
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return <span className="text-body italic text-neutral-500">empty list</span>;
+        }
+        return (
+            <ol className="flex list-none flex-col gap-2">
+                {value.map((item, index) => (
+                    <li key={index} className="flex gap-2">
+                        <span className="shrink-0 font-mono text-caption text-neutral-400">
+                            {index + 1}.
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <JsonFields value={item} depth={depth + 1} />
+                        </div>
+                    </li>
+                ))}
+            </ol>
+        );
+    }
+
+    if (isPlainObject(value)) {
+        const entries = Object.entries(value);
+        if (entries.length === 0) {
+            return <span className="text-body italic text-neutral-500">no fields</span>;
+        }
+        return (
+            <dl className="flex flex-col gap-1.5">
+                {entries.map(([key, child]) => {
+                    const nested = isPlainObject(child) || Array.isArray(child);
+                    return (
+                        <div
+                            key={key}
+                            className={cn(
+                                nested
+                                    ? 'flex flex-col gap-1'
+                                    : 'grid grid-cols-[9rem_1fr] items-start gap-3'
+                            )}
+                        >
+                            <dt
+                                className={cn(
+                                    'text-body text-neutral-500',
+                                    nested && 'flex items-center gap-1 font-medium'
+                                )}
+                            >
+                                {nested && <CaretRight className="size-3 text-neutral-400" />}
+                                {humanizeKey(key)}
+                            </dt>
+                            <dd
+                                className={cn(
+                                    'min-w-0 break-words text-body text-neutral-700',
+                                    nested && 'border-l border-neutral-200 pl-3'
+                                )}
+                            >
+                                <JsonFields value={child} depth={depth + 1} />
+                            </dd>
+                        </div>
+                    );
+                })}
+            </dl>
+        );
+    }
+
+    if (typeof value === 'boolean') {
+        return (
+            <span className={value ? 'text-success-600' : 'text-neutral-500'}>
+                {value ? 'Yes' : 'No'}
+            </span>
+        );
+    }
+
+    return <span className="break-words">{String(value)}</span>;
 }

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/activity-log-sentence.test.ts
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/activity-log-sentence.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { fallbackDescription, splitDescriptionParts } from './ActivityLogTable';
+
+/**
+ * The audit table bolds the *names* inside each sentence by matching the
+ * description against an ordered list of patterns whose capture groups
+ * alternate connective / name. Two things go wrong silently there:
+ *
+ *  - a looser pattern placed before a specific one swallows the specific case,
+ *    so "assigned 5 lead(s) to Riya" bolds the wrong half;
+ *  - a pattern with an even number of groups shifts the alternation and bolds
+ *    the connective text instead of the name.
+ *
+ * Neither is a type error and neither makes a render fail — the row just reads
+ * wrong. So the split is asserted directly.
+ */
+describe('splitDescriptionParts', () => {
+    const nameParts = (description: string): string[] => {
+        const parts = splitDescriptionParts(description);
+        expect(parts, `no pattern matched: "${description}"`).not.toBeNull();
+        // Odd indexes are the emphasised fragments.
+        return (parts as string[]).filter((_, index) => index % 2 === 1);
+    };
+
+    it('bolds the audience name on campaign actions', () => {
+        expect(nameParts('created audience Winter Admissions 2026')).toEqual([
+            'Winter Admissions 2026',
+        ]);
+        expect(nameParts('deleted audience Winter Admissions 2026')).toEqual([
+            'Winter Admissions 2026',
+        ]);
+        expect(nameParts('sent a message to audience Winter Admissions 2026')).toEqual([
+            'Winter Admissions 2026',
+        ]);
+    });
+
+    it('bolds both the lead and the counsellor on an assignment', () => {
+        expect(nameParts('assigned lead Amit Kumar to Riya Sharma')).toEqual([
+            'Amit Kumar',
+            'Riya Sharma',
+        ]);
+        expect(nameParts('unassigned counsellor from lead Amit Kumar')).toEqual(['Amit Kumar']);
+    });
+
+    it('bolds the count on bulk lead actions, with and without a target', () => {
+        expect(nameParts('assigned 12 lead(s) to Riya Sharma')).toEqual([
+            '12 lead(s)',
+            'Riya Sharma',
+        ]);
+        expect(nameParts('reassigned 12 lead(s) from Riya Sharma')).toEqual([
+            '12 lead(s)',
+            'Riya Sharma',
+        ]);
+        expect(nameParts('assigned 12 lead(s)')).toEqual(['12 lead(s)']);
+        expect(nameParts('imported 340 lead(s) into Winter Admissions 2026')).toEqual([
+            '340 lead(s)',
+            'Winter Admissions 2026',
+        ]);
+    });
+
+    it('bolds the lead and the new value on status, tier and score changes', () => {
+        expect(nameParts('changed lead status of Amit Kumar to Interested')).toEqual([
+            'Amit Kumar',
+            'Interested',
+        ]);
+        expect(nameParts('changed lead tier of Amit Kumar to HOT')).toEqual(['Amit Kumar', 'HOT']);
+        expect(nameParts('changed lead score of Amit Kumar to 75')).toEqual(['Amit Kumar', '75']);
+    });
+
+    it('handles the remaining CRM sentences the backend emits', () => {
+        expect(nameParts('added lead Sneha Rao')).toEqual(['Sneha Rao']);
+        expect(nameParts('registered walk-in lead Sneha Rao')).toEqual(['Sneha Rao']);
+        expect(nameParts('marked lead Sneha Rao as converted')).toEqual(['Sneha Rao']);
+        expect(nameParts('scheduled a follow-up for lead Sneha Rao')).toEqual(['Sneha Rao']);
+        expect(nameParts('closed a follow-up for lead Sneha Rao')).toEqual(['Sneha Rao']);
+        expect(nameParts('created lead status Interested')).toEqual(['Interested']);
+        expect(nameParts('tagged 48 contact(s) with Hot Leads')).toEqual([
+            '48 contact(s)',
+            'Hot Leads',
+        ]);
+        expect(nameParts('removed tags from 48 contact(s)')).toEqual(['48 contact(s)']);
+        expect(nameParts('created tag Hot Leads')).toEqual(['Hot Leads']);
+        expect(nameParts('created automation Fee reminder')).toEqual(['Fee reminder']);
+        expect(nameParts('created engagement engine Winback')).toEqual(['Winback']);
+        expect(
+            nameParts('connected Meta lead form Admissions Enquiry to audience Winter Admissions')
+        ).toEqual(['Admissions Enquiry', 'Winter Admissions']);
+        expect(nameParts('changed the status of 6 enquiry(s) to CLOSED')).toEqual([
+            '6 enquiry(s)',
+            'CLOSED',
+        ]);
+    });
+
+    it('still bolds the learning-side sentences that shipped first', () => {
+        expect(nameParts('created course Mathematics 101')).toEqual(['Mathematics 101']);
+        expect(nameParts('scheduled live session Demo')).toEqual(['Demo']);
+        expect(nameParts('enrolled learner Amit Kumar in Physics 201')).toEqual([
+            'Amit Kumar',
+            'Physics 201',
+        ]);
+        expect(nameParts('terminated Amit Kumar from Physics 201')).toEqual([
+            'Amit Kumar',
+            'Physics 201',
+        ]);
+        expect(nameParts('moved Amit Kumar from Batch A to Batch B')).toEqual([
+            'Amit Kumar',
+            'Batch A',
+            'Batch B',
+        ]);
+    });
+
+    it('leaves a sentence it does not recognise entirely unstyled', () => {
+        expect(splitDescriptionParts('updated TAT and follow-up SLA settings')).toBeNull();
+        expect(splitDescriptionParts('disconnected a lead connector')).toBeNull();
+        expect(splitDescriptionParts('deleted a counsellor pool')).toBeNull();
+    });
+
+    it('every emphasised fragment sits at an odd index', () => {
+        const parts = splitDescriptionParts('assigned lead Amit Kumar to Riya Sharma');
+        expect(parts).toEqual(['assigned lead ', 'Amit Kumar', ' to ', 'Riya Sharma']);
+    });
+});
+
+describe('fallbackDescription', () => {
+    it('reads as a sentence when the backend stored no description', () => {
+        expect(fallbackDescription({ action: 'CREATE', entity_type: 'LEAD_FOLLOWUP' })).toBe(
+            'created a lead followup'
+        );
+    });
+});

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/index.lazy.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/index.lazy.tsx
@@ -7,6 +7,7 @@ import { useNavHeadingStore } from '@/stores/layout-container/useNavHeadingStore
 import {
     useActivityLogs,
     type AdminActivityLog,
+    type AdminActivityLogFilters,
 } from '@/services/admin-activity-logs/getActivityLogs';
 import { ActivityLogFilters } from './-components/ActivityLogFilters';
 import { ActivityLogTable } from './-components/ActivityLogTable';
@@ -15,6 +16,20 @@ import { PayloadDrawer } from './-components/PayloadDrawer';
 export const Route = createLazyFileRoute('/admin-activity-logs/')({
     component: AdminActivityLogsPage,
 });
+
+/** URL scalar → filter array. `?actorId=a,b` selects two people. */
+const splitParam = (value: string | undefined): string[] | undefined => {
+    if (!value) return undefined;
+    const parts = value
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+    return parts.length > 0 ? parts : undefined;
+};
+
+/** Filter array → URL scalar. An empty selection drops the param entirely. */
+const joinParam = (values: string[] | undefined): string | undefined =>
+    values && values.length > 0 ? values.join(',') : undefined;
 
 function AdminActivityLogsPage() {
     return (
@@ -31,16 +46,16 @@ function AdminActivityLogsView() {
     const [selectedLog, setSelectedLog] = useState<AdminActivityLog | null>(null);
 
     useEffect(() => {
-        setNavHeading(<h1 className="text-md font-medium">Admin Activity Logs</h1>);
+        setNavHeading(<h1 className="text-subtitle font-medium">Admin Activity Logs</h1>);
     }, [setNavHeading]);
 
-    const filters = useMemo(
+    const filters: AdminActivityLogFilters = useMemo(
         () => ({
             page: search.page ?? 0,
             size: search.size ?? 20,
-            entityType: search.entityType,
-            action: search.action,
-            actorId: search.actorId,
+            entityTypes: splitParam(search.entityType),
+            actions: splitParam(search.action),
+            actorIds: splitParam(search.actorId),
             startDate: search.startDate,
             endDate: search.endDate,
         }),
@@ -49,9 +64,23 @@ function AdminActivityLogsView() {
 
     const { data, isLoading, isFetching, isError, refetch } = useActivityLogs(filters);
 
-    const updateSearch = (next: Partial<typeof search>) => {
+    /**
+     * The filter bar speaks arrays; the URL speaks comma-separated scalars.
+     * Translating here keeps every filtered view shareable as a plain link and
+     * avoids bracketed array params, which the ingress rejects with a 400.
+     */
+    const updateFilters = (next: Partial<AdminActivityLogFilters>) => {
         navigate({
-            search: (prev) => ({ ...prev, ...next, page: next.page ?? 0 }),
+            search: (prev) => ({
+                ...prev,
+                ...('entityTypes' in next ? { entityType: joinParam(next.entityTypes) } : {}),
+                ...('actions' in next ? { action: joinParam(next.actions) } : {}),
+                ...('actorIds' in next ? { actorId: joinParam(next.actorIds) } : {}),
+                ...('startDate' in next ? { startDate: next.startDate } : {}),
+                ...('endDate' in next ? { endDate: next.endDate } : {}),
+                // Any filter change invalidates the current page offset.
+                page: next.page ?? 0,
+            }),
             replace: true,
         });
     };
@@ -67,23 +96,23 @@ function AdminActivityLogsView() {
             </Helmet>
 
             {/* Page header */}
-            <header className="mb-6 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <header className="mb-5 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-start gap-3">
                     <span className="mt-0.5 inline-flex size-10 items-center justify-center rounded-lg bg-primary-50 text-primary-500">
                         <Notebook className="size-5" weight="fill" />
                     </span>
                     <div>
-                        <h1 className="text-xl font-semibold tracking-tight text-gray-900">
+                        <h1 className="text-h3 font-semibold tracking-tight text-neutral-700">
                             Admin Activity Logs
                         </h1>
-                        <p className="mt-0.5 text-sm text-gray-600">
+                        <p className="mt-0.5 text-body text-neutral-600">
                             Forensic record of admin actions — who did what, when, and on which
                             resource.
                         </p>
                     </div>
                 </div>
                 {data?.totalElements != null && (
-                    <div className="mt-2 text-xs text-gray-500 sm:mt-0">
+                    <div className="mt-2 text-caption text-neutral-500 sm:mt-0">
                         {data.totalElements.toLocaleString()} total{' '}
                         {data.totalElements === 1 ? 'entry' : 'entries'}
                     </div>
@@ -92,7 +121,7 @@ function AdminActivityLogsView() {
 
             <ActivityLogFilters
                 value={filters}
-                onChange={updateSearch}
+                onChange={updateFilters}
                 onRefresh={() => refetch()}
                 isFetching={isFetching}
             />
@@ -103,7 +132,7 @@ function AdminActivityLogsView() {
                     isLoading={isLoading}
                     isError={isError}
                     onRowClick={setSelectedLog}
-                    onPageChange={(page) => updateSearch({ page })}
+                    onPageChange={(page) => updateFilters({ page })}
                 />
             </div>
 
@@ -111,6 +140,10 @@ function AdminActivityLogsView() {
                 log={selectedLog}
                 open={!!selectedLog}
                 onClose={() => setSelectedLog(null)}
+                onFilterByActor={(actorId) => {
+                    updateFilters({ actorIds: [actorId] });
+                    setSelectedLog(null);
+                }}
             />
         </>
     );

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/index.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/index.tsx
@@ -2,6 +2,12 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 import { getActiveRoleDisplaySettingsKey } from '@/lib/auth/instituteUtils';
 import { getDisplaySettingsFromCache } from '@/services/display-settings';
 
+/**
+ * The three list filters are multi-select but travel as ONE comma-separated
+ * value each (`?actorId=a,b`). Keeping them as scalars means every link that
+ * was already shared with a single value still resolves, and it sidesteps the
+ * ingress rejecting bracketed `actorId[]=` array params with a 400.
+ */
 export interface AdminActivityLogsSearchParams {
     page?: number;
     size?: number;

--- a/frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogActors.ts
+++ b/frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogActors.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { getInstituteId } from '@/constants/helper';
+import {
+    fetchEligibleOrgUsers,
+    type InstituteUser,
+} from '@/routes/manage-institute/teams/-services/institute-users-service';
+
+export interface ActivityLogActor {
+    id: string;
+    fullName: string;
+    email: string | null;
+    roles: string[];
+}
+
+/**
+ * The institute's team — the people who can appear as an actor in the audit
+ * log — for the "Performed by" filter.
+ *
+ * <p>Deliberately the same roster the Teams page shows (every non-student
+ * member, custom roles included) rather than a DISTINCT over the log table:
+ * an admin picks the person they have in mind, and the query stays a cheap,
+ * cached read instead of an aggregate over every audit row the institute has
+ * ever written.
+ *
+ * <p>A person who has since left the institute is therefore not offered here.
+ * The URL still carries raw actor ids, so an old filtered link keeps resolving
+ * — it simply shows the id rather than a name.
+ */
+export const useActivityLogActors = (enabled = true) => {
+    const instituteId = getInstituteId();
+
+    return useQuery({
+        queryKey: ['admin-activity-logs', 'actors', instituteId],
+        enabled: enabled && !!instituteId,
+        queryFn: async (): Promise<ActivityLogActor[]> => {
+            const users: InstituteUser[] = await fetchEligibleOrgUsers(instituteId as string);
+            return users
+                .filter((user) => !!user.id)
+                .map((user) => ({
+                    id: user.id,
+                    fullName: user.full_name?.trim() || user.email || user.id,
+                    email: user.email ?? null,
+                    roles: user.roles ?? [],
+                }))
+                .sort((a, b) => a.fullName.localeCompare(b.fullName));
+        },
+        // The team roster changes rarely; the log page re-reads it far more
+        // often than it changes.
+        staleTime: 5 * 60_000,
+    });
+};

--- a/frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogs.ts
+++ b/frontend-admin-dashboard/src/services/admin-activity-logs/getActivityLogs.ts
@@ -40,27 +40,57 @@ export interface AdminActivityLogPage {
 export interface AdminActivityLogFilters {
     startDate?: number;
     endDate?: number;
-    actorId?: string;
-    entityType?: string;
+    /** Actors to include. Empty/undefined means every actor. */
+    actorIds?: string[];
+    /** Resources to include. Empty/undefined means every resource. */
+    entityTypes?: string[];
     entityId?: string;
-    action?: string;
+    /** Activities to include. Empty/undefined means every activity. */
+    actions?: string[];
     page?: number;
     size?: number;
 }
 
+/**
+ * Multi-value filters travel as ONE comma-separated param (`actorId=a,b,c`),
+ * never as repeated `actorId[]=` keys: the ingress rejects raw brackets in a
+ * query string with a 400 before the request reaches the service. The backend
+ * splits on commas and falls back to a plain equality when there is one value.
+ */
+const csvParam = (values: string[] | undefined): string | undefined => {
+    if (!values || values.length === 0) return undefined;
+    const cleaned = values.map((v) => v.trim()).filter(Boolean);
+    return cleaned.length > 0 ? cleaned.join(',') : undefined;
+};
+
+const toQueryParams = (
+    filters: Omit<AdminActivityLogFilters, 'page' | 'size'>
+): Record<string, string | number> => {
+    const params: Record<string, string | number> = {};
+    if (filters.startDate !== undefined) params.startDate = filters.startDate;
+    if (filters.endDate !== undefined) params.endDate = filters.endDate;
+
+    const actorId = csvParam(filters.actorIds);
+    if (actorId) params.actorId = actorId;
+
+    const entityType = csvParam(filters.entityTypes);
+    if (entityType) params.entityType = entityType;
+
+    const action = csvParam(filters.actions);
+    if (action) params.action = action;
+
+    if (filters.entityId) params.entityId = filters.entityId;
+    return params;
+};
+
 const fetchActivityLogs = async (
     filters: AdminActivityLogFilters
 ): Promise<AdminActivityLogPage> => {
-    const params: Record<string, string | number> = {
+    const params = {
+        ...toQueryParams(filters),
         page: filters.page ?? 0,
         size: filters.size ?? 20,
     };
-    if (filters.startDate !== undefined) params.startDate = filters.startDate;
-    if (filters.endDate !== undefined) params.endDate = filters.endDate;
-    if (filters.actorId) params.actorId = filters.actorId;
-    if (filters.entityType) params.entityType = filters.entityType;
-    if (filters.entityId) params.entityId = filters.entityId;
-    if (filters.action) params.action = filters.action;
 
     const response = await authenticatedAxiosInstance.get<AdminActivityLogPage>(
         ADMIN_ACTIVITY_LOGS_LIST,
@@ -100,26 +130,17 @@ export const useActivityLogById = (id: string | null) =>
 export const exportActivityLogsCsv = async (
     filters: Omit<AdminActivityLogFilters, 'page' | 'size'>
 ): Promise<void> => {
-    const params: Record<string, string | number> = {};
-    if (filters.startDate !== undefined) params.startDate = filters.startDate;
-    if (filters.endDate !== undefined) params.endDate = filters.endDate;
-    if (filters.actorId) params.actorId = filters.actorId;
-    if (filters.entityType) params.entityType = filters.entityType;
-    if (filters.entityId) params.entityId = filters.entityId;
-    if (filters.action) params.action = filters.action;
-
-    const response = await authenticatedAxiosInstance.get<Blob>(
-        ADMIN_ACTIVITY_LOGS_EXPORT_CSV,
-        { params, responseType: 'blob' }
-    );
+    const response = await authenticatedAxiosInstance.get<Blob>(ADMIN_ACTIVITY_LOGS_EXPORT_CSV, {
+        params: toQueryParams(filters),
+        responseType: 'blob',
+    });
 
     // Prefer the filename the backend hints at via Content-Disposition; fall
     // back to a sensible date-stamped name.
     const disposition = response.headers['content-disposition'] as string | undefined;
     const match = disposition?.match(/filename="?([^"]+)"?/);
     const filename =
-        match?.[1] ||
-        `admin-activity-logs-${new Date().toISOString().slice(0, 10)}.csv`;
+        match?.[1] || `admin-activity-logs-${new Date().toISOString().slice(0, 10)}.csv`;
 
     const url = window.URL.createObjectURL(response.data);
     const link = document.createElement('a');


### PR DESCRIPTION
…e by person

The CRM was the largest unaudited surface in admin_core_service: creating an audience list, deleting leads, assigning a counsellor or tagging contacts left no trace, so "who did this?" was unanswerable for the whole module.

Backend
- ~45 @Auditable annotations across audience, lead status/follow-up/SLA, Meta and Google connectors, counsellor pool/targets/workbench, enquiry, tags, telephony config and numbers, engagement engines and automations.
- CrmAuditNarrator resolves audience/lead/status/follow-up/counsellor ids to names, degrading to a count or an id and never throwing.
- Rows are not written for actions that did not happen: workbench dry-run previews, deletes/restores that matched nothing, connector saves that were rejected with a 400, and removing a counsellor from a lead that had none.
- Bodies carrying credentials or unbounded PII (connector saves, telephony config, CSV lead import, workflow builder) capture no payload.
- The log endpoints now take actorId/entityType/action as comma-separated lists — one value still emits `=`, several emit `IN`, both served by the existing indexes. No migration.

Frontend
- Resource, Activity and Performed-by are multi-selects; Performed-by lists the institute's team by full name and email instead of asking for a pasted id.
- The payload drawer is a fixed header over one scrolling body, so a long payload no longer clips at the bottom of the viewport; values wrap instead of truncating and payloads render as labelled fields with a raw-JSON toggle.
- Applied-filter chips, date presets, a Resource column, actor initials and MyPagination. The "To" date now means end-of-day, which it never did.

Tests
- AuditableAnnotationContractTest: every @Auditable expression parses, its #vars are real parameters, its @beans exist, and its entityType/action is offered by the UI's filters (this caught HR_FORM16/HR_FORM24Q, and the whole HR/ERP/mentorship set that had never been filterable).
- AuditableExpressionSemanticsTest: the three guards that decide whether a row is written at all.
- activity-log-sentence.test.ts: which fragment of each description is bolded (this caught "updated lead **TAT and follow-up SLA settings**").

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
