### PR TITLE
fix(audience): name people in CRM audit rows instead of printing thei…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/CrmAuditNarrator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/admin_activity_logs/service/CrmAuditNarrator.java
@@ -12,9 +12,10 @@ import vacademy.io.admin_core_service.features.audience.repository.AudienceRepos
 import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
 import vacademy.io.admin_core_service.features.audience.repository.LeadFollowupRepository;
 import vacademy.io.admin_core_service.features.audience.repository.LeadStatusRepository;
+import vacademy.io.admin_core_service.features.audience.entity.UserLeadProfile;
 import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
-import vacademy.io.common.auth.entity.User;
-import vacademy.io.common.auth.repository.UserRepository;
+import vacademy.io.admin_core_service.features.institute_learner.entity.Student;
+import vacademy.io.admin_core_service.features.institute_learner.repository.InstituteStudentRepository;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -61,7 +62,7 @@ public class CrmAuditNarrator {
     private UserLeadProfileRepository userLeadProfileRepository;
 
     @Autowired
-    private UserRepository userRepository;
+    private InstituteStudentRepository instituteStudentRepository;
 
     // ── Audiences (campaigns) ─────────────────────────────────────────────
 
@@ -129,8 +130,8 @@ public class CrmAuditNarrator {
     // ── Leads ─────────────────────────────────────────────────────────────
 
     /**
-     * Display name for one lead (an {@code audience_response} row): the lead's
-     * own user record first, then the parent/guardian name captured on the
+     * Display name for one lead (an {@code audience_response} row): their
+     * learner record if they have one, then the contact details captured on the
      * form, then the raw id.
      */
     public String leadFor(String audienceResponseId) {
@@ -142,23 +143,84 @@ public class CrmAuditNarrator {
             if (response == null) {
                 return audienceResponseId;
             }
-            String name = personFor(response.getUserId());
-            if (!isBlank(name) && !name.equals(response.getUserId())) {
-                return name;
+            String learnerName = studentNameFor(response.getUserId());
+            if (learnerName != null) {
+                return learnerName;
             }
-            if (!isBlank(response.getParentName())) {
-                return response.getParentName().trim();
-            }
-            if (!isBlank(response.getParentEmail())) {
-                return response.getParentEmail().trim();
-            }
-            if (!isBlank(response.getParentMobile())) {
-                return response.getParentMobile().trim();
-            }
-            return audienceResponseId;
+            String contact = contactLabel(response);
+            return contact != null ? contact : audienceResponseId;
         } catch (Exception e) {
             logger.warn("Could not resolve lead name for {}: {}", audienceResponseId, e.getMessage());
             return audienceResponseId;
+        }
+    }
+
+    /**
+     * Display name for a lead identified by their <em>user</em> id, which is
+     * how the lead-profile endpoints (status, tier, conversion, counsellor
+     * assignment) address them.
+     *
+     * <p>Note what this deliberately does not do: look the person up in
+     * {@code users}. That table belongs to auth_service and does not exist in
+     * this service's database, so the query throws, the catch swallows it, and
+     * every description ends up naming a raw UUID — which is exactly what
+     * shipped and what this replaces. Everything below is inside admin_core's
+     * own schema.
+     */
+    public String leadUserFor(String leadUserId) {
+        if (isBlank(leadUserId)) {
+            return null;
+        }
+        String learnerName = studentNameFor(leadUserId);
+        if (learnerName != null) {
+            return learnerName;
+        }
+        try {
+            return audienceResponseRepository.findByUserId(leadUserId).stream()
+                    .filter(Objects::nonNull)
+                    .map(this::contactLabel)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(leadUserId);
+        } catch (Exception e) {
+            logger.warn("Could not resolve lead name for user {}: {}", leadUserId, e.getMessage());
+            return leadUserId;
+        }
+    }
+
+    /** Name, email or phone off a lead's own form submission, in that order. */
+    private String contactLabel(AudienceResponse response) {
+        if (response == null) {
+            return null;
+        }
+        if (!isBlank(response.getParentName())) {
+            return response.getParentName().trim();
+        }
+        if (!isBlank(response.getParentEmail())) {
+            return response.getParentEmail().trim();
+        }
+        if (!isBlank(response.getParentMobile())) {
+            return response.getParentMobile().trim();
+        }
+        return null;
+    }
+
+    /** Learner name for a user id, or null when they are not enrolled here. */
+    private String studentNameFor(String userId) {
+        if (isBlank(userId)) {
+            return null;
+        }
+        try {
+            return instituteStudentRepository.findByUserId(userId).stream()
+                    .filter(Objects::nonNull)
+                    .map(Student::getFullName)
+                    .filter(name -> !isBlank(name))
+                    .map(String::trim)
+                    .findFirst()
+                    .orElse(null);
+        } catch (Exception e) {
+            logger.warn("Could not resolve learner name for {}: {}", userId, e.getMessage());
+            return null;
         }
     }
 
@@ -236,21 +298,37 @@ public class CrmAuditNarrator {
 
     // ── People (counsellors, staff) ───────────────────────────────────────
 
-    /** Full name of any platform user (counsellor, staff), falling back to the id. */
+    /**
+     * Name of a staff member — a counsellor, a pool member, whoever a target
+     * was set for — falling back to the id.
+     *
+     * <p>The only record of a staff name inside admin_core's own database is
+     * the denormalized {@code assigned_counselor_name} the CRM writes onto a
+     * lead profile, so that is what this reads. A staff member who has never
+     * been assigned a lead is named by their learner record if they happen to
+     * have one, and otherwise stays an id — better than the previous behaviour,
+     * which was an id every single time because the lookup queried a table this
+     * service cannot see.
+     */
     public String personFor(String userId) {
         if (isBlank(userId)) {
             return null;
         }
         try {
-            return userRepository.findById(userId)
-                    .map(User::getFullName)
+            String counsellorName = userLeadProfileRepository
+                    .findFirstByAssignedCounselorIdAndAssignedCounselorNameIsNotNull(userId)
+                    .map(UserLeadProfile::getAssignedCounselorName)
                     .filter(name -> !isBlank(name))
                     .map(String::trim)
-                    .orElse(userId);
+                    .orElse(null);
+            if (counsellorName != null) {
+                return counsellorName;
+            }
         } catch (Exception e) {
-            logger.warn("Could not resolve user name for {}: {}", userId, e.getMessage());
-            return userId;
+            logger.warn("Could not resolve counsellor name for {}: {}", userId, e.getMessage());
         }
+        String learnerName = studentNameFor(userId);
+        return learnerName != null ? learnerName : userId;
     }
 
     /** Names one person, or counts several — for bulk assign/target actions. */
@@ -294,7 +372,7 @@ public class CrmAuditNarrator {
      * callers only send the id, which we then resolve.
      */
     public String counsellorAssignment(String leadUserId, String counsellorId, String counsellorName) {
-        String who = personFor(leadUserId);
+        String who = leadUserFor(leadUserId);
         if (isBlank(counsellorId)) {
             return who == null ? null : "unassigned counsellor from lead " + who;
         }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/controller/AudienceController.java
@@ -459,7 +459,7 @@ public class AudienceController {
             entityType = "LEAD",
             action = "CONVERT",
             entityIdExpr = "#userId",
-            descriptionExpr = "'marked lead ' + @crmAuditNarrator.personFor(#userId) + ' as converted'")
+            descriptionExpr = "'marked lead ' + @crmAuditNarrator.leadUserFor(#userId) + ' as converted'")
     public ResponseEntity<UserLeadProfileDTO> markLeadConverted(
             @RequestParam String userId,
             @RequestParam String instituteId) {
@@ -476,7 +476,7 @@ public class AudienceController {
             entityType = "LEAD",
             action = "STATUS_CHANGE",
             entityIdExpr = "#userId",
-            descriptionExpr = "'changed lead status of ' + @crmAuditNarrator.personFor(#userId) + ' to ' + #status")
+            descriptionExpr = "'changed lead status of ' + @crmAuditNarrator.leadUserFor(#userId) + ' to ' + #status")
     public ResponseEntity<UserLeadProfileDTO> updateLeadStatus(
             @RequestParam String userId,
             @RequestParam String instituteId,
@@ -520,7 +520,7 @@ public class AudienceController {
             entityType = "LEAD",
             action = "TIER_CHANGE",
             entityIdExpr = "#userId",
-            descriptionExpr = "'changed lead tier of ' + @crmAuditNarrator.personFor(#userId) + ' to ' + #tier")
+            descriptionExpr = "'changed lead tier of ' + @crmAuditNarrator.leadUserFor(#userId) + ' to ' + #tier")
     public ResponseEntity<UserLeadProfileDTO> updateLeadTier(
             @RequestParam String userId,
             @RequestParam String instituteId,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/UserLeadProfileRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/UserLeadProfileRepository.java
@@ -16,6 +16,15 @@ public interface UserLeadProfileRepository extends JpaRepository<UserLeadProfile
 
     Optional<UserLeadProfile> findByUserId(String userId);
 
+    /**
+     * Any profile this person is the counsellor on, used only to read the
+     * denormalized {@code assigned_counselor_name}: admin_core cannot see
+     * auth_service's users table, so this is the one place inside its own
+     * database where a staff member's name is written down.
+     */
+    Optional<UserLeadProfile> findFirstByAssignedCounselorIdAndAssignedCounselorNameIsNotNull(
+            String assignedCounselorId);
+
     Optional<UserLeadProfile> findByUserIdAndInstituteId(String userId, String instituteId);
 
     List<UserLeadProfile> findByUserIdIn(List<String> userIds);

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/CrmAuditNarratorNamingTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/admin_activity_logs/CrmAuditNarratorNamingTest.java
@@ -1,0 +1,182 @@
+package vacademy.io.admin_core_service.features.admin_activity_logs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.test.util.ReflectionTestUtils;
+import vacademy.io.admin_core_service.features.admin_activity_logs.service.CrmAuditNarrator;
+import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
+import vacademy.io.admin_core_service.features.audience.entity.UserLeadProfile;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceRepository;
+import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
+import vacademy.io.admin_core_service.features.audience.repository.LeadFollowupRepository;
+import vacademy.io.admin_core_service.features.audience.repository.LeadStatusRepository;
+import vacademy.io.admin_core_service.features.audience.repository.UserLeadProfileRepository;
+import vacademy.io.admin_core_service.features.institute_learner.entity.Student;
+import vacademy.io.admin_core_service.features.institute_learner.repository.InstituteStudentRepository;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * How a CRM audit row gets a person's name.
+ *
+ * <p>Written after the first version shipped and wrote UUIDs into production:
+ * it resolved people through {@code UserRepository}, and the {@code users} table
+ * belongs to auth_service — it does not exist in admin_core's database. Every
+ * lookup threw, the narrator's own catch swallowed it (correctly — audit must
+ * never break a mutation), and each description degraded to the raw id. Nothing
+ * failed loudly; the rows just read
+ * "changed lead tier of 664d3077-29b4-4dcb-8c64-d2ed9417f529".
+ *
+ * <p>So these tests pin two things: the fallback chain inside admin_core's own
+ * schema, and the structural rule that the narrator never reaches into another
+ * service's database again.
+ */
+class CrmAuditNarratorNamingTest {
+
+    private CrmAuditNarrator narrator;
+    private AudienceResponseRepository audienceResponses;
+    private InstituteStudentRepository students;
+    private UserLeadProfileRepository leadProfiles;
+
+    @BeforeEach
+    void setUp() {
+        narrator = new CrmAuditNarrator();
+        audienceResponses = mock(AudienceResponseRepository.class);
+        students = mock(InstituteStudentRepository.class);
+        leadProfiles = mock(UserLeadProfileRepository.class);
+
+        ReflectionTestUtils.setField(narrator, "audienceRepository", mock(AudienceRepository.class));
+        ReflectionTestUtils.setField(narrator, "audienceResponseRepository", audienceResponses);
+        ReflectionTestUtils.setField(narrator, "leadStatusRepository", mock(LeadStatusRepository.class));
+        ReflectionTestUtils.setField(narrator, "leadFollowupRepository", mock(LeadFollowupRepository.class));
+        ReflectionTestUtils.setField(narrator, "userLeadProfileRepository", leadProfiles);
+        ReflectionTestUtils.setField(narrator, "instituteStudentRepository", students);
+
+        when(students.findByUserId(anyString())).thenReturn(List.of());
+        when(audienceResponses.findByUserId(anyString())).thenReturn(List.of());
+        when(leadProfiles.findFirstByAssignedCounselorIdAndAssignedCounselorNameIsNotNull(anyString()))
+                .thenReturn(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("a lead who enrolled is named by their learner record")
+    void namesAnEnrolledLeadFromTheStudentRecord() {
+        Student student = new Student();
+        student.setFullName("Amit Kumar");
+        when(students.findByUserId("user-1")).thenReturn(List.of(student));
+
+        assertEquals("Amit Kumar", narrator.leadUserFor("user-1"));
+    }
+
+    @Test
+    @DisplayName("a lead who only ever filled in a form is named by that form's contact details")
+    void fallsBackToTheContactOnTheForm() {
+        when(audienceResponses.findByUserId("user-2")).thenReturn(List.of(response(null, "kaif@example.com", null)));
+        assertEquals("kaif@example.com", narrator.leadUserFor("user-2"));
+
+        when(audienceResponses.findByUserId("user-3")).thenReturn(List.of(response("Chandrama", "c@example.com", null)));
+        assertEquals("Chandrama", narrator.leadUserFor("user-3"), "a name on the form beats the email");
+
+        when(audienceResponses.findByUserId("user-4")).thenReturn(List.of(response(null, null, "917355167749")));
+        assertEquals("917355167749", narrator.leadUserFor("user-4"));
+    }
+
+    @Test
+    @DisplayName("a lead with nothing recorded degrades to the id, and a blank id to null")
+    void degradesToTheIdRatherThanThrowing() {
+        assertEquals("user-unknown", narrator.leadUserFor("user-unknown"));
+        assertNull(narrator.leadUserFor(null));
+        assertNull(narrator.leadUserFor("  "));
+    }
+
+    @Test
+    @DisplayName("a counsellor is named from the profile the CRM denormalized their name onto")
+    void namesStaffFromTheLeadProfile() {
+        UserLeadProfile profile = new UserLeadProfile();
+        profile.setAssignedCounselorId("counsellor-1");
+        profile.setAssignedCounselorName("Riya Sharma");
+        when(leadProfiles.findFirstByAssignedCounselorIdAndAssignedCounselorNameIsNotNull("counsellor-1"))
+                .thenReturn(Optional.of(profile));
+
+        assertEquals("Riya Sharma", narrator.personFor("counsellor-1"));
+        assertEquals("counsellor-unknown", narrator.personFor("counsellor-unknown"));
+    }
+
+    @Test
+    @DisplayName("an assignment phrase names the lead by contact, not by uuid")
+    void phrasesAnAssignmentWithRealNames() {
+        when(audienceResponses.findByUserId("lead-1")).thenReturn(List.of(response("Amit Kumar", null, null)));
+
+        assertEquals("assigned lead Amit Kumar to Riya Sharma",
+                narrator.counsellorAssignment("lead-1", "counsellor-1", "Riya Sharma"));
+        assertEquals("unassigned counsellor from lead Amit Kumar",
+                narrator.counsellorAssignment("lead-1", null, null));
+    }
+
+    @Test
+    @DisplayName("a repository that blows up degrades to an id — it never propagates")
+    void survivesARepositoryFailure() {
+        when(students.findByUserId(anyString())).thenThrow(new IllegalStateException("relation \"users\" does not exist"));
+        when(audienceResponses.findByUserId(anyString())).thenThrow(new IllegalStateException("boom"));
+        when(leadProfiles.findFirstByAssignedCounselorIdAndAssignedCounselorNameIsNotNull(anyString()))
+                .thenThrow(new IllegalStateException("boom"));
+
+        assertEquals("user-9", narrator.leadUserFor("user-9"));
+        assertEquals("user-9", narrator.personFor("user-9"));
+    }
+
+    @Test
+    @DisplayName("the derived queries on the repository it uses resolve against the entity")
+    void derivedQueriesResolve() {
+        // Spring validates derived query names when it builds the repository —
+        // at context startup, in the pod, where a typo is not a failed test but
+        // an admin_core_service that will not boot for anyone. PartTree is that
+        // same parser without a database, so the mistake surfaces here instead.
+        for (Method method : UserLeadProfileRepository.class.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Query.class)) {
+                continue; // hand-written JPQL, not derived from the name
+            }
+            String name = method.getName();
+            if (!name.startsWith("find") && !name.startsWith("count") && !name.startsWith("delete")) {
+                continue;
+            }
+            assertDoesNotThrow(() -> new PartTree(name, UserLeadProfile.class),
+                    () -> "UserLeadProfileRepository." + name + " does not resolve against "
+                            + "UserLeadProfile — this would fail every pod at startup");
+        }
+    }
+
+    @Test
+    @DisplayName("the narrator never queries another service's database")
+    void staysInsideItsOwnSchema() {
+        for (Field field : CrmAuditNarrator.class.getDeclaredFields()) {
+            String type = field.getType().getName();
+            assertFalse(type.startsWith("vacademy.io.common.auth.repository"),
+                    "CrmAuditNarrator must not depend on " + type + ": auth_service's tables "
+                            + "(users, user_role, …) are not in admin_core's database, so every query "
+                            + "throws and the description silently degrades to a raw id");
+        }
+    }
+
+    private static AudienceResponse response(String name, String email, String mobile) {
+        AudienceResponse response = new AudienceResponse();
+        response.setParentName(name);
+        response.setParentEmail(email);
+        response.setParentMobile(mobile);
+        return response;
+    }
+}

--- a/docs/ADMIN_ACTIVITY_LOGS.md
+++ b/docs/ADMIN_ACTIVITY_LOGS.md
@@ -504,6 +504,26 @@ Display-settings integration: `sidebar/constant.ts` (`controlledTabs`), `sidebar
 
 9. **The `clientId` header is required.** The axios interceptor in [axiosInstance.ts](../frontend-admin-dashboard/src/lib/auth/axiosInstance.ts) attaches it automatically from `getInstituteId()`. If you ever build a non-axios request path (e.g., a worker-side fetch), make sure that header is included or audit silently drops the row.
 
+10. **A narrator can only read admin_core's own database.** `users` (and the rest
+    of auth_service's schema) does **not** exist in `admin_core_service`. Resolving a
+    person through `vacademy.io.common.auth.repository.UserRepository` compiles,
+    starts, and then throws `relation "users" does not exist` on every call — which
+    the narrator's catch swallows, exactly as it must, leaving the description
+    naming a raw UUID. That shipped on 2026-09-08 and produced live rows reading
+    *"changed lead tier of 664d3077-29b4-4dcb-8c64-d2ed9417f529"*. Inside admin_core
+    the name sources are: `student.full_name` (enrolled learners),
+    `audience_response.parent_name/email/mobile` (a lead's own form), and
+    `user_lead_profile.assigned_counselor_name` (the only staff name written down
+    here). `CrmAuditNarratorNamingTest` fails the build if the narrator ever takes a
+    dependency on `common.auth.repository` again.
+
+11. **A derived query name is validated at pod startup, not at compile time.** A typo
+    in `findFirstByAssignedCounselorIdAnd…` does not fail a build — it fails every
+    pod's context refresh, taking the whole service down for every institute. There
+    is no in-memory database on this module's test classpath, so
+    `CrmAuditNarratorNamingTest#derivedQueriesResolve` runs Spring's own `PartTree`
+    parser over the repository's derived methods to catch it without one.
+
 ---
 
 ## CRM coverage (added 2026-09-08)


### PR DESCRIPTION
…r UUID

Live rows since this morning's rollout read "changed lead tier of 664d3077-29b4-4dcb-8c64-d2ed9417f529". The narrator resolved people through common's UserRepository, and the users table belongs to auth_service — it does not exist in admin_core's database. Every lookup threw `relation "users" does not exist`, the catch swallowed it (as it must, so audit can never break a mutation), and the description fell back to the raw id. The pods logged it as a WARN and nothing else complained.

Names now come from what this service can actually see:
- leadUserFor(userId): the learner record, then the contact details on the lead's own form (name, then email, then mobile), then the id;
- personFor(userId): the assigned_counselor_name the CRM denormalizes onto a lead profile — the one place a staff name is written down in this schema;
- leadFor(responseId) drops its users lookup for the same chain.

The lead-profile endpoints (status, tier, conversion) and the assignment phrase switch from personFor to leadUserFor, since they address a lead, not staff.

CrmAuditNarratorNamingTest pins the fallback chain, that a failing repository still degrades to an id rather than propagating, and — structurally — that this class never depends on common.auth.repository again. It also runs Spring's PartTree parser over the repository's derived queries: this module has no in-memory database, and a typo in a derived name is a startup failure for every pod, not a failing test.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
