### PR TITLE
fix(sub-org): resolve the practice's own leader, not whoever clicked …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgLearnerService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgLearnerService.java
@@ -456,7 +456,7 @@ public class SubOrgLearnerService {
 
         // Trigger workflow for each PS (existing per-PS contract).
         for (String psId : psIds) {
-            triggerEnrollmentWorkflow(request.getInstituteId(), user, psId, adminDTO);
+            triggerEnrollmentWorkflow(request.getInstituteId(), user, psId, request.getSubOrgId(), adminDTO);
         }
 
         return SubOrgEnrollResponseDTO.builder()
@@ -1083,7 +1083,7 @@ public class SubOrgLearnerService {
 
     @Async
     public void triggerEnrollmentWorkflow(String instituteId, UserDTO userDTO, String packageSessionId,
-            UserDTO adminDTO) {
+            String subOrgId, UserDTO enrolledBy) {
         Optional<PackageSession> optionalPackageSession = packageSessionRepository.findById(packageSessionId);
         if (optionalPackageSession.isEmpty()) {
             throw new VacademyException("PackageSession Not found");
@@ -1100,12 +1100,61 @@ public class SubOrgLearnerService {
             log.warn("Could not resolve lmsEditExistingUser for institute {} / package {} — defaulting to false: {}",
                     instituteId, optionalPackageSession.get().getPackageEntity().getId(), e.getMessage());
         }
+        // The sub-org's OWN leader, not whoever clicked enroll — see the javadoc on
+        // SubOrgMemberEnrollmentContext.build. This route is NOT only used by a practice admin
+        // adding their own staff: a Vet Education platform admin adds members on a practice's
+        // behalf, and their email resolves to no LearnDash group at all (get-leader-group 404s),
+        // so nt_vet_add_mem_03_find_leader_group failed and the member was never added to the
+        // practice group. Resolving the leader from the sub-org fixes that; a null leader makes
+        // the practice-group nodes skip, which beats filing someone under the wrong practice.
+        UserDTO subOrgLeader = resolveSubOrgLeader(subOrgId, packageSessionId);
         // Built centrally so this route and bulk/v3/assign publish an identical context —
         // see SubOrgMemberEnrollmentContext for why 'user' is published alongside 'member'.
         Map<String, Object> contextData = SubOrgMemberEnrollmentContext.build(
-                userDTO, adminDTO, optionalPackageSession.get(), mayEditExistingLmsUser);
+                userDTO, subOrgLeader, enrolledBy, optionalPackageSession.get(), mayEditExistingLmsUser);
         workflowTriggerService.handleTriggerEvents(WorkflowTriggerEvent.SUB_ORG_MEMBER_ENROLLMENT.name(),
                 packageSessionId, instituteId, contextData);
+    }
+
+    /**
+     * The sub-org's own leader — the practice admin whose email owns the practice's LearnDash
+     * group. Workflow nodes resolve that group with
+     * {@code get-leader-group?email=#ctx['subOrgAdmin']['email']}, so this must never be the
+     * acting platform admin.
+     *
+     * <p>Prefers the ROOT_ADMIN mapping for this batch and falls back to any active admin of the
+     * sub-org. Returns null when the sub-org has no resolvable leader: the practice-group nodes
+     * then skip, which is deliberate — no group beats the wrong group. Mirrors
+     * {@code BulkAssignmentService.resolveSubOrgLeader}, the other publisher of this event.
+     */
+    private UserDTO resolveSubOrgLeader(String subOrgId, String packageSessionId) {
+        if (!StringUtils.hasText(subOrgId)) {
+            return null;
+        }
+        try {
+            String leaderUserId = mappingRepository
+                    .findRootAdminMappingBySubOrgAndPackageSession(subOrgId, packageSessionId)
+                    .map(StudentSessionInstituteGroupMapping::getUserId)
+                    .orElse(null);
+
+            if (!StringUtils.hasText(leaderUserId)) {
+                List<String> adminIds = mappingRepository.findActiveAdminUserIdsBySubOrg(subOrgId);
+                leaderUserId = (adminIds == null || adminIds.isEmpty()) ? null : adminIds.get(0);
+            }
+
+            if (!StringUtils.hasText(leaderUserId)) {
+                log.warn("No leader found for sub-org {} — SUB_ORG_MEMBER_ENROLLMENT will carry a "
+                        + "null subOrgAdmin, so practice-group nodes will skip rather than enroll "
+                        + "into the wrong group", subOrgId);
+                return null;
+            }
+
+            List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(leaderUserId));
+            return (users == null || users.isEmpty()) ? null : users.get(0);
+        } catch (Exception e) {
+            log.warn("Failed to resolve leader for sub-org {}: {}", subOrgId, e.getMessage());
+            return null;
+        }
     }
 
     private String findRootAdminPlanId(String subOrgId, String packageSessionId) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContext.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/learner/service/SubOrgMemberEnrollmentContext.java
@@ -40,8 +40,15 @@ public final class SubOrgMemberEnrollmentContext {
     }
 
     /**
-     * Convenience overload for callers where the person acting IS the sub-org's leader — the
-     * /sub-org/v1/add-member route, where a practice admin adds their own staff.
+     * Convenience overload for callers that have already resolved the sub-org's leader and know
+     * that same person performed the enrollment.
+     *
+     * <p><b>Do not pass the acting platform admin here.</b> This overload files the one UserDTO
+     * as BOTH {@code subOrgAdmin} and {@code enrolledBy}. /sub-org/v1/add-member used to call it
+     * with the session user on the assumption that the caller is always the practice admin; that
+     * is false whenever a platform admin adds members on a practice's behalf, and the result was
+     * {@code get-leader-group} 404ing so members were never added to their practice's LearnDash
+     * group. Resolve the leader from the sub-org and use the {@code enrolledBy} overload instead.
      */
     public static Map<String, Object> build(UserDTO member, UserDTO subOrgAdmin,
                                             PackageSession packageSession) {
@@ -77,11 +84,14 @@ public final class SubOrgMemberEnrollmentContext {
     }
 
     /**
-     * add-member-route variant (actor IS the leader) that also carries the
+     * Leader-is-also-the-actor variant that additionally carries the
      * {@code lmsEditExistingUser} policy flag, so the edit-user node can run on the staff path
      * exactly as it does on {@code LEARNER_BATCH_ENROLLMENT}. See
      * {@link LmsExistingUserEditPolicyService} for how the flag is resolved (course → institute,
      * defaults false).
+     *
+     * <p>Carries the same warning as the three-argument overload above: {@code subOrgAdmin} must
+     * be the sub-org's resolved leader, never the acting platform admin.
      */
     public static Map<String, Object> build(UserDTO member, UserDTO subOrgAdmin,
                                             PackageSession packageSession, boolean mayEditExistingUser) {


### PR DESCRIPTION
…enrol

SUB_ORG_MEMBER_ENROLLMENT published #ctx['subOrgAdmin'] as the session user. nt_vet_add_mem_03_find_leader_group looks the practice's LearnDash group up with get-leader-group?email=#ctx['subOrgAdmin']['email'], so whenever a platform admin added members on a practice's behalf that call 404'd, node 04 extracted a null targetPracticeGroupId, and nt_vet_add_mem_10_enroll_practice_group skipped -- the member was enrolled in Vacademy and created on WordPress but never added to their practice's group. It only worked when the person clicking happened to own a group, which is why the node showed 106 SUCCESS / 31 FAILED rather than failing outright.

Verified on Vet-Ed prod: get-leader-group for the acting admin (events@veteducation.com.au) returns 404 no_user, while the practice's real leader (neeraj@vidyayatan.com) returns 200 {"groupId":79787}. Same practice, same moment.

SubOrgLearnerService now resolves the leader from the sub-org:
- triggerEnrollmentWorkflow takes subOrgId; adminDTO renamed enrolledBy, since it never was the sub-org admin and the old name made the call site read as correct.
- new resolveSubOrgLeader(): ROOT_ADMIN mapping for the batch, else any active admin of the sub-org, else null. Null is deliberate -- the practice-group nodes then skip, and no group beats filing someone under the wrong practice. The fallback is what carries the add-member route, which writes ADMIN rather than ROOT_ADMIN (that role comes from the registration path).
- context built with subOrgAdmin=leader, enrolledBy=caller. enrolledBy is unchanged in value, so nothing but subOrgAdmin shifts.

BulkAssignmentService already did this correctly; only this publisher was wrong. Its convenience overloads that collapse subOrgAdmin into enrolledBy are kept (tests use them) but no longer claim "actor IS the leader" -- that sentence was the trap.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
