### PR TITLE
Meter the Automations chatbot on AI credits

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/dto/ChatbotAiRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/dto/ChatbotAiRequest.java
@@ -20,4 +20,22 @@ public class ChatbotAiRequest {
     private String userMessage;
     private int maxTokens;
     private double temperature;
+
+    // ── Billing attribution (sent by notification_service's AI_RESPONSE executor) ──
+    // The turn is charged to the institute but attributed to the person the bot is
+    // talking to, so chatbot spend shows up against a real learner in the AI usage
+    // screens instead of as an unattributed system charge. All optional: an unresolved
+    // WhatsApp number simply produces an institute-level row.
+
+    /** The platform user behind the conversation, when the number resolved to one. */
+    private String userId;
+
+    /** chatbot_flow_session id — groups the turns of one conversation. */
+    private String sessionId;
+
+    /** chatbot_flow id — carried as the credit transaction's batch_id, for per-flow rollups. */
+    private String flowId;
+
+    /** Flow name, for a readable description on the credit transaction. */
+    private String flowName;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/dto/ChatbotAiResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/dto/ChatbotAiResponse.java
@@ -14,4 +14,12 @@ public class ChatbotAiResponse {
     private int promptTokens;
     private int completionTokens;
     private boolean exitIntent;
+
+    /**
+     * True when the institute cannot pay for this turn — no model was called and
+     * {@code assistantMessage} is null. The caller must NOT send this to the learner as
+     * an answer; it hands the conversation to a human instead. Distinct from a failure:
+     * retrying will not help until the institute tops up.
+     */
+    private boolean insufficientCredits;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/service/ChatbotAiService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/service/ChatbotAiService.java
@@ -6,16 +6,41 @@ import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.agent.dto.ChatbotAiRequest;
 import vacademy.io.admin_core_service.features.agent.dto.ChatbotAiResponse;
 import vacademy.io.admin_core_service.features.agent.dto.ConversationSession;
+import vacademy.io.admin_core_service.features.ai_usage.enums.RequestType;
+import vacademy.io.admin_core_service.features.credits.client.CreditClient;
 
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * One AI turn of an Automations chatbot flow (notification_service's AI_RESPONSE node).
+ *
+ * <p>Metered like every other AI surface on the platform:
+ * <ol>
+ *   <li>pre-flight affordability, failing CLOSED — an institute with no credits gets no
+ *       model call at all, and the flow hands the learner to a human instead;</li>
+ *   <li>the turn's real token counts are written to ai_token_usage as {@code chatbot};</li>
+ *   <li>credits are charged against that usage row, attributed to the learner the bot is
+ *       talking to and batched by flow id, so it shows up in the AI usage history
+ *       alongside every other AI activity.</li>
+ * </ol>
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class ChatbotAiService {
 
+    private static final String DEFAULT_MODEL = "google/gemini-2.5-flash";
+
+    /**
+     * Attribution role on the credit transaction. The bot is answering a learner/lead over
+     * WhatsApp, not an admin operating the dashboard, so the spend is rolled up under the
+     * learner in the per-user usage screens.
+     */
+    private static final String CREDIT_USER_ROLE = "LEARNER";
+
     private final LLMService llmService;
+    private final CreditClient creditClient;
 
     public ChatbotAiResponse respond(ChatbotAiRequest request) {
         log.info("Chatbot AI request: institute={}, model={}", request.getInstituteId(), request.getModelId());
@@ -27,14 +52,33 @@ public class ChatbotAiService {
                     .build();
         }
 
+        // 1. Affordability, fail CLOSED. hasActiveCredits already returns false when the
+        // balance cannot be read, so an unreachable credits service pauses the bot rather
+        // than letting it keep spending at the provider un-metered. Same posture as the
+        // Engagement Engine's autonomous sends and AI calling.
+        if (!hasCredits(request.getInstituteId())) {
+            log.warn("Chatbot AI turn refused — institute {} has no AI credits", request.getInstituteId());
+            return ChatbotAiResponse.builder()
+                    .insufficientCredits(true)
+                    .exitIntent(false)
+                    .build();
+        }
+
+        String model = request.getModelId() != null ? request.getModelId() : DEFAULT_MODEL;
+
         // Build a ConversationSession from the request
         ConversationSession session = ConversationSession.create(
-                UUID.randomUUID().toString(),
-                null,
+                request.getSessionId() != null ? request.getSessionId() : UUID.randomUUID().toString(),
+                request.getUserId(),
                 request.getInstituteId(),
-                request.getModelId() != null ? request.getModelId() : "google/gemini-2.5-flash",
+                model,
                 null
         );
+
+        // Bucket this call as CHATBOT (not AGENT) and write the usage row synchronously so
+        // its id can link the credit transaction back to the tokens that caused it.
+        session.getContext().put(LLMService.CTX_REQUEST_TYPE, RequestType.CHATBOT);
+        session.getContext().put(LLMService.CTX_USAGE_LOG_SYNC, Boolean.TRUE);
 
         // Add system prompt
         session.addMessage(ConversationSession.ChatMessage.system(
@@ -57,22 +101,28 @@ public class ChatbotAiService {
         session.addMessage(ConversationSession.ChatMessage.user(request.getUserMessage()));
 
         // Set max tokens and temperature in context
-        session.getContext().put("max_tokens", request.getMaxTokens() > 0 ? request.getMaxTokens() : 500);
+        int maxTokens = request.getMaxTokens() > 0 ? request.getMaxTokens() : 500;
+        session.getContext().put("max_tokens", maxTokens);
         session.getContext().put("temperature", request.getTemperature() > 0 ? request.getTemperature() : 0.7);
+        // buildChatRequest reads the field, not the context entry — without this the node's
+        // configured ceiling was ignored and every turn ran at the 4096 default. That is
+        // billable output now, so the author's budget has to actually reach the provider.
+        session.setMaxTokens(maxTokens);
 
         try {
-            // LLMResponse is an inner class of LLMService — no promptTokens/completionTokens fields
-            // Token usage is already logged internally by LLMService.logTokenUsage()
             LLMService.LLMResponse response = llmService.generateChatCompletion(session);
 
-            String assistantMessage = response.getContent();
+            // 2. Charge for the tokens actually burned. Fire-and-forget: the reply is
+            // already generated and must not wait on (or be lost to) the billing hop.
+            charge(request, model, response);
 
-            log.info("Chatbot AI response generated successfully");
+            log.info("Chatbot AI response generated successfully ({} prompt / {} completion tokens)",
+                    response.getPromptTokens(), response.getCompletionTokens());
 
             return ChatbotAiResponse.builder()
-                    .assistantMessage(assistantMessage)
-                    .promptTokens(0)  // Tracked internally by LLMService
-                    .completionTokens(0)
+                    .assistantMessage(response.getContent())
+                    .promptTokens(response.getPromptTokens())
+                    .completionTokens(response.getCompletionTokens())
                     .exitIntent(false)
                     .build();
 
@@ -85,5 +135,55 @@ public class ChatbotAiService {
                     .exitIntent(false)
                     .build();
         }
+    }
+
+    /** Balance gate. Never throws — an error here is "cannot confirm funds", i.e. no. */
+    private boolean hasCredits(String instituteId) {
+        try {
+            return creditClient.hasActiveCredits(instituteId);
+        } catch (Exception e) {
+            log.warn("Credit check failed for institute {} — pausing chatbot AI: {}",
+                    instituteId, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Charge one chatbot turn. Nothing here may throw: the learner already has the reply,
+     * so a billing hiccup must not turn a delivered answer into an error path.
+     */
+    private void charge(ChatbotAiRequest request, String model, LLMService.LLMResponse response) {
+        if (response.getPromptTokens() <= 0 && response.getCompletionTokens() <= 0) {
+            // Provider returned no usage block — nothing to price, and a zero-token charge
+            // would still bill the request_type's minimum. Skip rather than over-charge.
+            return;
+        }
+        try {
+            creditClient.deductAttributedTokenUsageAsync(
+                    request.getInstituteId(),
+                    RequestType.CHATBOT.getValue(),
+                    model,
+                    response.getPromptTokens(),
+                    response.getCompletionTokens(),
+                    response.getUsageLogId(),
+                    request.getUserId(),
+                    request.getUserId() != null ? CREDIT_USER_ROLE : "SYSTEM",
+                    // Actor and subject are the same person here; sending it explicitly keeps
+                    // the COALESCE(subject_user_id, user_id) attribution stable if the actor
+                    // ever becomes the bot rather than the learner.
+                    request.getUserId(),
+                    describe(request),
+                    request.getFlowId());
+        } catch (Exception e) {
+            log.error("Chatbot credit charge failed for institute {} (flow {}): {}",
+                    request.getInstituteId(), request.getFlowId(), e.getMessage());
+        }
+    }
+
+    private static String describe(ChatbotAiRequest request) {
+        String flow = (request.getFlowName() != null && !request.getFlowName().isBlank())
+                ? request.getFlowName()
+                : request.getFlowId();
+        return flow != null ? "Chatbot AI reply — " + flow : "Chatbot AI reply";
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/service/LLMService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/agent/service/LLMService.java
@@ -86,8 +86,9 @@ public class LLMService {
 
             LLMResponse llmResponse = parseResponse(response.getBody());
 
-            // Log token usage asynchronously
-            logTokenUsage(response.getBody(), session);
+            // Record the usage row (async by default; see logTokenUsage for the
+            // synchronous variant callers that need to BILL the call opt into)
+            logTokenUsage(llmResponse, session);
 
             return llmResponse;
 
@@ -98,33 +99,92 @@ public class LLMService {
     }
 
     /**
-     * Log token usage from the API response.
+     * Context key a caller sets to bucket its usage under something other than
+     * {@link RequestType#AGENT} — e.g. the Automations chatbot bills as CHATBOT so its
+     * spend is separable from admin agent use in the AI usage screens. Value may be a
+     * {@link RequestType} or its string value.
      */
-    private void logTokenUsage(String responseBody, ConversationSession session) {
+    public static final String CTX_REQUEST_TYPE = "request_type";
+
+    /**
+     * Context flag (Boolean TRUE) asking for the usage row to be written SYNCHRONOUSLY so
+     * its id lands on {@link LLMResponse#getUsageLogId()}. Callers that go on to charge
+     * credits need that id: it is the {@code usage_log_id} on the deduction, which is what
+     * links a credit_transactions row back to the tokens that produced it. Default (absent)
+     * stays fire-and-forget, so the agent path is unchanged.
+     */
+    public static final String CTX_USAGE_LOG_SYNC = "usage_log_sync";
+
+    /**
+     * Record the usage row for a completed call.
+     *
+     * <p>Token counts are already on the response (parsed in {@link #parseResponse}); this
+     * only decides which bucket they land in and whether the write blocks.
+     */
+    private void logTokenUsage(LLMResponse llmResponse, ConversationSession session) {
         try {
-            JsonNode root = objectMapper.readTree(responseBody);
-            JsonNode usage = root.get("usage");
+            if (llmResponse.getPromptTokens() <= 0 && llmResponse.getCompletionTokens() <= 0) {
+                return; // provider returned no usage block — nothing to record
+            }
 
-            if (usage != null) {
-                int promptTokens = usage.has("prompt_tokens") ? usage.get("prompt_tokens").asInt() : 0;
-                int completionTokens = usage.has("completion_tokens") ? usage.get("completion_tokens").asInt() : 0;
+            // Parse each id independently: a caller with a non-UUID user id (an external
+            // chat participant, say) must still get its institute-level usage recorded.
+            UUID instituteId = toUuid(session.getInstituteId());
+            UUID userId = toUuid(session.getUserId());
 
-                // Convert String IDs to UUIDs
-                UUID instituteId = session.getInstituteId() != null ? UUID.fromString(session.getInstituteId()) : null;
-                UUID userId = session.getUserId() != null ? UUID.fromString(session.getUserId()) : null;
+            Map<String, Object> ctx = session.getContext();
+            RequestType requestType = resolveRequestType(ctx);
 
-                aiTokenUsageService.recordUsageAsync(
+            if (ctx != null && Boolean.TRUE.equals(ctx.get(CTX_USAGE_LOG_SYNC))) {
+                var saved = aiTokenUsageService.recordUsage(
                         ApiProvider.OPENAI,
-                        RequestType.AGENT,
+                        requestType,
                         session.getModel(),
-                        promptTokens,
-                        completionTokens,
+                        llmResponse.getPromptTokens(),
+                        llmResponse.getCompletionTokens(),
                         instituteId,
                         userId);
+                if (saved != null && saved.getId() != null) {
+                    llmResponse.setUsageLogId(saved.getId().toString());
+                }
+                return;
             }
+
+            aiTokenUsageService.recordUsageAsync(
+                    ApiProvider.OPENAI,
+                    requestType,
+                    session.getModel(),
+                    llmResponse.getPromptTokens(),
+                    llmResponse.getCompletionTokens(),
+                    instituteId,
+                    userId);
         } catch (Exception e) {
             // Never fail the main request due to usage logging issues
             log.warn("[LLMService] Failed to log token usage: {}", e.getMessage());
+        }
+    }
+
+    /** {@link #CTX_REQUEST_TYPE} from the session context, defaulting to AGENT. */
+    private static RequestType resolveRequestType(Map<String, Object> ctx) {
+        Object configured = ctx == null ? null : ctx.get(CTX_REQUEST_TYPE);
+        if (configured instanceof RequestType rt) return rt;
+        if (configured instanceof String s && !s.isBlank()) {
+            try {
+                return RequestType.fromValue(s);
+            } catch (IllegalArgumentException ignored) {
+                // Unknown value — fall through to AGENT rather than losing the row to the
+                // ai_token_usage request_type CHECK.
+            }
+        }
+        return RequestType.AGENT;
+    }
+
+    private static UUID toUuid(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 
@@ -296,11 +356,19 @@ public class LLMService {
                 ? choices.get(0).get("finish_reason").asText()
                 : "stop";
 
+        // Real token counts — needed both for the usage row and for pricing the charge.
+        JsonNode usage = root.get("usage");
+        int promptTokens = usage != null && usage.has("prompt_tokens") ? usage.get("prompt_tokens").asInt() : 0;
+        int completionTokens = usage != null && usage.has("completion_tokens")
+                ? usage.get("completion_tokens").asInt() : 0;
+
         return LLMResponse.builder()
                 .content(content)
                 .toolCalls(toolCalls)
                 .finishReason(finishReason)
                 .hasToolCalls(!toolCalls.isEmpty())
+                .promptTokens(promptTokens)
+                .completionTokens(completionTokens)
                 .build();
     }
 
@@ -322,6 +390,17 @@ public class LLMService {
         private List<ToolCall> toolCalls;
         private String finishReason;
         private boolean hasToolCalls;
+
+        /** Real usage from the provider's response — 0 when it returned no usage block. */
+        private int promptTokens;
+        private int completionTokens;
+
+        /**
+         * id of the ai_token_usage row this call wrote, set only when the caller asked
+         * for a synchronous write via {@link LLMService#CTX_USAGE_LOG_SYNC}. Passed on as
+         * {@code usage_log_id} so the credit transaction points back at the tokens.
+         */
+        private String usageLogId;
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/controller/CreditUsageController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/controller/CreditUsageController.java
@@ -18,6 +18,8 @@ import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.Conv
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatLogRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatMessageRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatSessionRow;
+import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlowAiUsageLogRow;
+import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlowAiUsageSummary;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.RoleSummaryRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.UsageLogRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.UserUsageRow;
@@ -43,6 +45,8 @@ import java.util.List;
  *   GET /ai-usage/v1/conversations/{id}/messages    full transcript (prompts + AI answers)
  *   GET /ai-usage/v1/chatbot/summary                Student-AI aggregate data points (Chatbot Analysis)
  *   GET /ai-usage/v1/chatbot/sessions               institute-wide chats, paginated + searchable
+ *   GET /ai-usage/v1/chatbot-flows/usage            Automations chatbot AI spend + balance state
+ *   GET /ai-usage/v1/chatbot-flows/logs             per-turn charge log for those flows
  *
  * Dates are epoch millis; default window is the last 30 days.
  */
@@ -198,6 +202,37 @@ public class CreditUsageController {
         return ResponseEntity.ok(conversationService.instituteSessions(
                 instituteId, from(startDate), to(endDate), status, sessionMode, search,
                 onlyWithMessages, pageable));
+    }
+
+    // ── Automations chatbot AI credits (Automations -> Chatbot Flows) ───────
+
+    /**
+     * What the Automations chatbot's AI replies have cost in the window, per flow,
+     * plus the institute's balance and whether the feature is currently funded.
+     */
+    @GetMapping("/chatbot-flows/usage")
+    public ResponseEntity<FlowAiUsageSummary> chatbotFlowUsage(
+            HttpServletRequest request,
+            @RequestParam(required = false) Long startDate,
+            @RequestParam(required = false) Long endDate) {
+        String instituteId = requireInstituteId(request);
+        return ResponseEntity.ok(service.chatbotFlowUsage(instituteId, from(startDate), to(endDate)));
+    }
+
+    /** Per-turn charge log behind those figures, newest first; optionally one flow. */
+    @GetMapping("/chatbot-flows/logs")
+    public ResponseEntity<Page<FlowAiUsageLogRow>> chatbotFlowLogs(
+            HttpServletRequest request,
+            @RequestParam(required = false) String flowId,
+            @RequestParam(required = false) Long startDate,
+            @RequestParam(required = false) Long endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        String instituteId = requireInstituteId(request);
+        String flowFilter = (flowId == null || flowId.isBlank()) ? null : flowId;
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(
+                service.chatbotFlowLogs(instituteId, flowFilter, from(startDate), to(endDate), pageable));
     }
 
     private Timestamp from(Long startDate) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/dto/CreditUsageDtos.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/dto/CreditUsageDtos.java
@@ -263,4 +263,69 @@ public class CreditUsageDtos {
         private List<TopicCount> topTopics;
         private List<DailyActivityRow> dailyActivity;
     }
+
+    // ── Automations chatbot (WhatsApp flow AI replies) credit usage ──────────
+    // Distinct from the ChatbotSummary/ChatbotSessionRow types above, which
+    // describe the in-app Student AI. These read credit_transactions rows with
+    // request_type='chatbot', written by ChatbotAiService when a flow's
+    // AI_RESPONSE node answers someone.
+
+    /** Credits one Automations flow's AI replies consumed in the window. */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FlowAiUsageRow {
+        /** chatbot_flow id — carried on the transaction as batch_id. Null for pre-V495 rows. */
+        private String flowId;
+        /** Flow name as it was when the turn was charged (parsed from the description). */
+        private String flowName;
+        private double totalCredits;
+        /** Number of AI turns charged. */
+        private long turnCount;
+        /** Distinct people the bot replied to. */
+        private long userCount;
+        /** Epoch millis of the most recent charged turn. */
+        private Long lastUsedAt;
+    }
+
+    /** One charged AI turn in the Automations chatbot drill-down. */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FlowAiUsageLogRow {
+        private String id;
+        /** Epoch millis. */
+        private Long createdAt;
+        private String flowId;
+        private String userId;
+        /** Resolved from auth-service; null when the number never matched a user. */
+        private String name;
+        private String email;
+        private String model;
+        private double credits;
+        private String description;
+    }
+
+    /** Header figures for the Automations chatbot AI usage panel. */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FlowAiUsageSummary {
+        private double totalCredits;
+        private long turnCount;
+        private long userCount;
+        private long flowCount;
+        /** Current institute balance, so the panel can show the funding state in one call. */
+        private Double currentBalance;
+        /**
+         * False when the balance is exhausted (or unreadable) — the same gate
+         * ChatbotAiService applies, so the UI can show the feature as paused
+         * instead of guessing from the number.
+         */
+        private boolean aiEnabled;
+        private List<FlowAiUsageRow> byFlow;
+    }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/enums/RequestType.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/enums/RequestType.java
@@ -23,7 +23,8 @@ public enum RequestType {
     AGENT("agent"), // AI Agent interactions
     ANALYTICS("analytics"), // Student analytics
     COPILOT("copilot"), // Instructor copilot
-    CALL_INTELLIGENCE("call_intelligence"); // CRM call recording transcription + analysis
+    CALL_INTELLIGENCE("call_intelligence"), // CRM call recording transcription + analysis
+    CHATBOT("chatbot"); // Automations chatbot flow AI_RESPONSE turn (WhatsApp)
 
     private final String value;
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/repository/CreditUsageRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/repository/CreditUsageRepository.java
@@ -77,4 +77,69 @@ public interface CreditUsageRepository extends Repository<AiTokenUsage, UUID> {
                                @Param("fromTs") Timestamp fromTs,
                                @Param("toTs") Timestamp toTs,
                                Pageable pageable);
+
+    // ── Automations chatbot (request_type='chatbot') ────────────────────────
+    // ChatbotAiService stamps batch_id with the chatbot_flow id and puts the
+    // flow name in the description, so a per-flow rollup needs no cross-service
+    // join (chatbot_flow lives in the notification-service database).
+
+    // Per-flow rollup for the window.
+    // Object[]{ flow_id, net_credits, turn_count, user_count, last_used_at, sample_description }.
+    @Query(value = "SELECT ct.batch_id AS flow_id, " +
+            "       SUM(ABS(ct.amount)) AS net_credits, " +
+            "       COUNT(*) AS turn_count, " +
+            "       COUNT(DISTINCT COALESCE(ct.subject_user_id, ct.user_id)) AS user_count, " +
+            "       MAX(ct.created_at) AS last_used_at, " +
+            "       (array_agg(ct.description ORDER BY ct.created_at DESC))[1] AS sample_description " +
+            "FROM credit_transactions ct " +
+            "WHERE ct.institute_id = :instituteId " +
+            "  AND ct.request_type = 'chatbot' " +
+            "  AND ct.transaction_type = 'USAGE_DEDUCTION' " +
+            "  AND ct.created_at >= :fromTs AND ct.created_at < :toTs " +
+            "GROUP BY ct.batch_id " +
+            "ORDER BY net_credits DESC",
+            nativeQuery = true)
+    List<Object[]> findChatbotUsageByFlow(@Param("instituteId") String instituteId,
+                                          @Param("fromTs") Timestamp fromTs,
+                                          @Param("toTs") Timestamp toTs);
+
+    // Institute-wide totals for the window. Object[]{ net_credits, turn_count, user_count }.
+    @Query(value = "SELECT COALESCE(SUM(ABS(ct.amount)), 0) AS net_credits, " +
+            "       COUNT(*) AS turn_count, " +
+            "       COUNT(DISTINCT COALESCE(ct.subject_user_id, ct.user_id)) AS user_count " +
+            "FROM credit_transactions ct " +
+            "WHERE ct.institute_id = :instituteId " +
+            "  AND ct.request_type = 'chatbot' " +
+            "  AND ct.transaction_type = 'USAGE_DEDUCTION' " +
+            "  AND ct.created_at >= :fromTs AND ct.created_at < :toTs",
+            nativeQuery = true)
+    List<Object[]> findChatbotTotals(@Param("instituteId") String instituteId,
+                                     @Param("fromTs") Timestamp fromTs,
+                                     @Param("toTs") Timestamp toTs);
+
+    // Paginated per-turn log, optionally narrowed to one flow.
+    // Object[]{ id, created_at, batch_id, uid, model_name, amount, description }.
+    // :flowId is nullable — CAST keeps Postgres from erroring on an untyped NULL parameter.
+    @Query(value = "SELECT ct.id, ct.created_at, ct.batch_id, " +
+            "       COALESCE(ct.subject_user_id, ct.user_id) AS uid, " +
+            "       ct.model_name, ABS(ct.amount), ct.description " +
+            "FROM credit_transactions ct " +
+            "WHERE ct.institute_id = :instituteId " +
+            "  AND ct.request_type = 'chatbot' " +
+            "  AND ct.transaction_type = 'USAGE_DEDUCTION' " +
+            "  AND (CAST(:flowId AS TEXT) IS NULL OR ct.batch_id = CAST(:flowId AS TEXT)) " +
+            "  AND ct.created_at >= :fromTs AND ct.created_at < :toTs " +
+            "ORDER BY ct.created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM credit_transactions ct " +
+                    "WHERE ct.institute_id = :instituteId " +
+                    "  AND ct.request_type = 'chatbot' " +
+                    "  AND ct.transaction_type = 'USAGE_DEDUCTION' " +
+                    "  AND (CAST(:flowId AS TEXT) IS NULL OR ct.batch_id = CAST(:flowId AS TEXT)) " +
+                    "  AND ct.created_at >= :fromTs AND ct.created_at < :toTs",
+            nativeQuery = true)
+    Page<Object[]> findChatbotLogs(@Param("instituteId") String instituteId,
+                                   @Param("flowId") String flowId,
+                                   @Param("fromTs") Timestamp fromTs,
+                                   @Param("toTs") Timestamp toTs,
+                                   Pageable pageable);
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/service/CreditUsageService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/ai_usage/service/CreditUsageService.java
@@ -1,5 +1,6 @@
 package vacademy.io.admin_core_service.features.ai_usage.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -9,12 +10,16 @@ import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatLogRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatMessageRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlatSessionRow;
+import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlowAiUsageLogRow;
+import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlowAiUsageRow;
+import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.FlowAiUsageSummary;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.RoleSummaryRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.UsageLogRow;
 import vacademy.io.admin_core_service.features.ai_usage.dto.CreditUsageDtos.UserUsageRow;
 import vacademy.io.admin_core_service.features.ai_usage.repository.ConversationRepository;
 import vacademy.io.admin_core_service.features.ai_usage.repository.CreditUsageRepository;
 import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.credits.client.CreditClient;
 import vacademy.io.common.auth.dto.UserDTO;
 
 import java.sql.Timestamp;
@@ -33,6 +38,7 @@ import java.util.stream.Collectors;
  * bounded, so role-filter + sort + pagination happen in memory after enrichment.
  */
 @Service
+@Slf4j
 public class CreditUsageService {
 
     @Autowired
@@ -43,6 +49,10 @@ public class CreditUsageService {
 
     @Autowired
     private AuthService authService;
+
+    /** Only for the live balance shown next to the Automations chatbot usage figures. */
+    @Autowired
+    private CreditClient creditClient;
 
     public Page<UserUsageRow> listUsers(String instituteId, Timestamp from, Timestamp to,
                                         String role, String name, Pageable pageable) {
@@ -236,6 +246,91 @@ public class CreditUsageService {
                     .build());
         }
         return out;
+    }
+
+    // ── Automations chatbot AI usage (request_type='chatbot') ───────────────
+
+    /**
+     * Header figures + per-flow rollup for the Automations chatbot's AI spend, plus the
+     * institute's live balance so the panel can render the "paused, out of credits" state
+     * from the same call the numbers come from.
+     */
+    public FlowAiUsageSummary chatbotFlowUsage(String instituteId, Timestamp from, Timestamp to) {
+        List<Object[]> totals = repository.findChatbotTotals(instituteId, from, to);
+        Object[] t = totals.isEmpty() ? new Object[]{0, 0L, 0L} : totals.get(0);
+
+        List<FlowAiUsageRow> byFlow = repository.findChatbotUsageByFlow(instituteId, from, to).stream()
+                .map(r -> FlowAiUsageRow.builder()
+                        .flowId(str(r[0]))
+                        .flowName(flowNameFromDescription(str(r[5])))
+                        .totalCredits(round(dbl(r[1])))
+                        .turnCount(lng(r[2]))
+                        .userCount(lng(r[3]))
+                        .lastUsedAt(millis(r[4]))
+                        .build())
+                .toList();
+
+        Double balance = null;
+        boolean enabled = false;
+        try {
+            Map<String, Object> b = creditClient.getBalance(instituteId);
+            if (b != null && b.get("current_balance") != null) {
+                balance = dbl(b.get("current_balance"));
+                enabled = balance > 0d;
+            }
+        } catch (Exception e) {
+            // Unreadable balance reads as "cannot confirm funds" — the same fail-closed
+            // answer ChatbotAiService gives, so the UI never promises a working bot the
+            // engine would refuse to run.
+            log.warn("Balance lookup failed for institute {}: {}", instituteId, e.getMessage());
+        }
+
+        return FlowAiUsageSummary.builder()
+                .totalCredits(round(dbl(t[0])))
+                .turnCount(lng(t[1]))
+                .userCount(lng(t[2]))
+                .flowCount(byFlow.size())
+                .currentBalance(balance)
+                .aiEnabled(enabled)
+                .byFlow(byFlow)
+                .build();
+    }
+
+    /** Paginated per-turn charge log, optionally narrowed to one flow. */
+    public Page<FlowAiUsageLogRow> chatbotFlowLogs(String instituteId, String flowId, Timestamp from,
+                                                   Timestamp to, Pageable pageable) {
+        Page<Object[]> page = repository.findChatbotLogs(instituteId, flowId, from, to, pageable);
+        List<String> ids = page.getContent().stream()
+                .map(r -> str(r[3])).filter(Objects::nonNull).distinct().toList();
+        Map<String, UserDTO> users = resolveUsersByIds(ids);
+        return page.map(r -> {
+            String uid = str(r[3]);
+            UserDTO u = users.get(uid);
+            return FlowAiUsageLogRow.builder()
+                    .id(str(r[0]))
+                    .createdAt(millis(r[1]))
+                    .flowId(str(r[2]))
+                    .userId(uid)
+                    .name(u != null ? u.getFullName() : null)
+                    .email(u != null ? u.getEmail() : null)
+                    .model(str(r[4]))
+                    .credits(round(dbl(r[5])))
+                    .description(str(r[6]))
+                    .build();
+        });
+    }
+
+    /**
+     * Pull the flow name back out of "Chatbot AI reply — {flow}". The name is snapshotted
+     * into the description at charge time precisely because chatbot_flow lives in another
+     * service's database and cannot be joined here.
+     */
+    private static String flowNameFromDescription(String description) {
+        if (description == null) return null;
+        int sep = description.indexOf('—');
+        if (sep < 0 || sep + 1 >= description.length()) return null;
+        String name = description.substring(sep + 1).trim();
+        return name.isEmpty() ? null : name;
     }
 
     /** Excel cells cap at 32767 chars; keep the session preview short anyway. */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/credits/client/CreditClient.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/credits/client/CreditClient.java
@@ -209,6 +209,108 @@ public class CreditClient {
     }
 
     /**
+     * Token-metered deduction WITH per-user attribution (academy-credits Phase 3).
+     *
+     * <p>Same pricing path as {@link #deductCredits} — ai_service prices the real token
+     * counts against the model's USD rates — but it also carries who the spend belongs
+     * to, so the row shows up in the per-user AI usage screens instead of as an
+     * unattributed system charge, and a {@code batchId} so related charges can be
+     * grouped (the chatbot passes the flow id).
+     *
+     * <p>{@code allow_negative} is true: the tokens were already burned at the provider
+     * by the time we get here, so a charge for delivered work must never be silently
+     * dropped because a concurrent spend slipped the balance below the pre-flight
+     * estimate. Affordability is gated BEFORE the call (see hasActiveCredits).
+     *
+     * @param subjectUserId who the work was about when that differs from the actor
+     *                      (a chatbot reply is FOR the learner, not the bot)
+     * @return true when ai_service acknowledged the deduction
+     */
+    public boolean deductAttributedTokenUsage(
+            String instituteId,
+            String requestType,
+            String model,
+            int promptTokens,
+            int completionTokens,
+            String usageLogId,
+            String userId,
+            String userRole,
+            String subjectUserId,
+            String description,
+            String batchId) {
+        try {
+            String url = aiServiceUrl + "/ai-service/credits/v1/deduct";
+
+            HttpHeaders headers = buildInternalHeaders();
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("institute_id", instituteId);
+            body.put("request_type", requestType != null ? requestType : "content");
+            body.put("model", model != null ? model : "unknown");
+            body.put("prompt_tokens", promptTokens);
+            body.put("completion_tokens", completionTokens);
+            body.put("allow_negative", true);
+            // Null-safe puts: HashMap (not Map.of) precisely so the optional
+            // attribution fields can be omitted rather than sent as "".
+            if (usageLogId != null && !usageLogId.isBlank()) body.put("usage_log_id", usageLogId);
+            if (userId != null && !userId.isBlank()) body.put("user_id", userId);
+            if (userRole != null && !userRole.isBlank()) body.put("user_role", userRole);
+            if (subjectUserId != null && !subjectUserId.isBlank()) body.put("subject_user_id", subjectUserId);
+            if (description != null && !description.isBlank()) body.put("description", clampDescription(description));
+            if (batchId != null && !batchId.isBlank()) body.put("batch_id", batchId);
+
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+            @SuppressWarnings("unchecked")
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    request,
+                    (Class<Map<String, Object>>) (Class<?>) Map.class);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                if (Boolean.TRUE.equals(response.getBody().get("success"))) {
+                    return true;
+                }
+                log.warn("Attributed deduction not applied for institute {} ({}): {}",
+                        instituteId, requestType, response.getBody().get("message"));
+                return false;
+            }
+            log.warn("Attributed deduction HTTP {} for institute {} ({})",
+                    response.getStatusCode(), instituteId, requestType);
+            return false;
+        } catch (Exception e) {
+            log.error("Error in attributed deduction for institute {} ({}): {}",
+                    instituteId, requestType, e.getMessage());
+            return false;
+        }
+    }
+
+    /** Fire-and-forget variant of {@link #deductAttributedTokenUsage}. */
+    @Async
+    public CompletableFuture<Void> deductAttributedTokenUsageAsync(
+            String instituteId,
+            String requestType,
+            String model,
+            int promptTokens,
+            int completionTokens,
+            String usageLogId,
+            String userId,
+            String userRole,
+            String subjectUserId,
+            String description,
+            String batchId) {
+        return CompletableFuture.runAsync(() -> deductAttributedTokenUsage(
+                instituteId, requestType, model, promptTokens, completionTokens,
+                usageLogId, userId, userRole, subjectUserId, description, batchId));
+    }
+
+    /** ai_service validates description at 500 chars; an over-long one fails the whole charge. */
+    private static String clampDescription(String description) {
+        return description.length() <= 500 ? description : description.substring(0, 499) + "…";
+    }
+
+    /**
      * Deduct a PRECOMPUTED credit amount (the caller already priced the work — e.g.
      * per-minute call metering) with an idempotency key. ai_service short-circuits a
      * repeated key against credit_transactions.external_reference_id (V243 partial

--- a/admin_core_service/src/main/resources/db/migration/V501__Chatbot_flow_ai_credits.sql
+++ b/admin_core_service/src/main/resources/db/migration/V501__Chatbot_flow_ai_credits.sql
@@ -1,0 +1,75 @@
+-- ================================================================================
+-- V501: Meter the Automations chatbot (WhatsApp flow AI_RESPONSE nodes) on AI credits.
+--
+-- Until now the chatbot flow's AI node was the only LLM surface on the platform that
+-- ran for free: notification_service -> /internal/chatbot-ai/respond -> LLMService
+-- logged an ai_token_usage row (bucketed as 'agent') and never called /credits/v1/deduct.
+-- An institute with a zero balance could still burn OpenRouter spend on every inbound
+-- WhatsApp message, and none of it showed up in the AI usage screens as chatbot spend.
+--
+-- Two things this migration has to do:
+--   1. Allow request_type='chatbot' on ai_token_usage. The billing path writes the
+--      usage row FIRST, so a value missing from this CHECK throws a CheckViolation,
+--      the whole charge is swallowed by best-effort billing, and NO credits move.
+--      Exactly the trap fixed in V102 / V217 / V225 / V325 / V345 / V384 / V435.
+--   2. Seed credit_pricing so the charge is bucketed as 'chatbot' rather than falling
+--      back to the 'content' row (see CreditService._get_pricing).
+--
+-- Expand-only on the CHECK: the value set is a strict superset of V435's, so
+-- validation cannot fail on existing rows.
+-- ================================================================================
+
+-- --------------------------------------------------------------------------------
+-- 1. ai_token_usage.request_type CHECK — V435's set plus 'chatbot'.
+-- --------------------------------------------------------------------------------
+ALTER TABLE ai_token_usage DROP CONSTRAINT IF EXISTS ai_token_usage_request_type_check;
+
+ALTER TABLE ai_token_usage ADD CONSTRAINT ai_token_usage_request_type_check
+    CHECK (request_type IN (
+        'outline',
+        'image',
+        'content',
+        'video',
+        'tts',
+        'tts_premium',
+        'embedding',
+        'evaluation',
+        'presentation',
+        'conversation',
+        'lecture',
+        'course_content',
+        'pdf_questions',
+        'agent',
+        'analytics',
+        'copilot',
+        'incident',
+        'question_metadata',
+        'stock',
+        'avatar_video',
+        'reels_preview',
+        'ai_video',
+        'assessment',
+        'notes',
+        'transcription',
+        'call_intelligence',
+        'coding_question',
+        'translation',
+        'knowledge_base',
+        'chatbot'
+    ));
+
+COMMENT ON COLUMN ai_token_usage.request_type IS
+    'Type of AI request. Keep in sync with RequestType in ai_service/app/models/ai_token_usage.py — adding a new value REQUIRES expanding this CHECK (see V102/V217/V225/V325/V435/V501).';
+
+-- --------------------------------------------------------------------------------
+-- 2. credit_pricing row for the chatbot bucket.
+--
+-- Same shape as the other token-metered LLM buckets on the V190 scale: the real
+-- charge comes from the model's own USD pricing in ai_models (the "real-cost path"
+-- in CreditService.calculate_credits), and base_cost/min_charge only floor it. A
+-- WhatsApp turn is a few hundred tokens, so the 0.05 floor is what most turns pay.
+-- --------------------------------------------------------------------------------
+INSERT INTO credit_pricing (request_type, base_cost, token_rate, minimum_charge, unit_type, description, is_active)
+VALUES ('chatbot', 0.05, 0.00001, 0.05, 'tokens',
+        'Automations chatbot AI reply (one WhatsApp/flow AI_RESPONSE turn)', TRUE)
+ON CONFLICT (request_type) DO NOTHING;

--- a/ai_service/app/models/ai_token_usage.py
+++ b/ai_service/app/models/ai_token_usage.py
@@ -124,6 +124,7 @@ class RequestType(str, enum.Enum):
     CALL_INTELLIGENCE = "call_intelligence"  # CRM call recording transcription + LLM analysis (per minute)
     TRANSLATION = "translation"      # Content/UI translation (i18n Phase 1) — parametric via ai_tool_pricing (V384)
     KNOWLEDGE_BASE = "knowledge_base"  # KB ingestion (per page), URL ingest, and grounded Q&A — parametric via ai_tool_pricing (V435)
+    CHATBOT = "chatbot"              # Automations chatbot flow AI_RESPONSE turn — token-metered (V501)
 
 
 class AiTokenUsage(Base):

--- a/ai_service/app/services/credit_service.py
+++ b/ai_service/app/services/credit_service.py
@@ -88,6 +88,10 @@ MODEL_TIER_MAPPING = {
 DEFAULT_PRICING = {
     "content": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},
     "agent": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},
+    # Automations chatbot (WhatsApp flow AI_RESPONSE turn). Same rates as `agent`
+    # but bucketed separately so usage analytics can tell "the bot replied to a
+    # learner" apart from "an admin used the agent". Seeded in credit_pricing by V501.
+    "chatbot": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},
     "copilot": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},
     "analytics": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},
     "outline": {"base_cost": Decimal("0.05"), "token_rate": Decimal("0.00001"), "min_charge": Decimal("0.05"), "unit": "tokens"},

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -1005,6 +1005,12 @@ export const NOTIFICATION_SERVICE_BASE = `${BASE_URL}/notification-service/v1`;
 // Chatbot Flow Builder
 export const CHATBOT_FLOW_BASE = `${NOTIFICATION_SERVICE_BASE}/chatbot-flow`;
 
+// AI credits consumed by those flows' AI_RESPONSE nodes. Lives in admin-core, not
+// notification-service: credit_transactions is in the admin-core database, and the
+// flow id travels on the transaction as batch_id so the rollup needs no join.
+export const CHATBOT_FLOW_AI_USAGE = `${BASE_URL}/admin-core-service/ai-usage/v1/chatbot-flows/usage`;
+export const CHATBOT_FLOW_AI_USAGE_LOGS = `${BASE_URL}/admin-core-service/ai-usage/v1/chatbot-flows/logs`;
+
 // WhatsApp Inbox
 export const WHATSAPP_INBOX_BASE = `${NOTIFICATION_SERVICE_BASE}/inbox`;
 

--- a/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/flow-ai-usage-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/flow-ai-usage-panel.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react';
+import { Lightning, Warning, ArrowClockwise } from '@phosphor-icons/react';
+import {
+    fetchChatbotFlowAiUsage,
+    fetchChatbotFlowAiLogs,
+    FlowAiUsageSummary,
+    FlowAiUsageLogRow,
+} from '../-services/chatbot-flow-api';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WINDOWS = [
+    { label: '7 days', days: 7 },
+    { label: '30 days', days: 30 },
+    { label: '90 days', days: 90 },
+];
+
+const fmtCredits = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '0.00');
+const fmtWhen = (ms: number | null) => (ms ? new Date(ms).toLocaleString() : '—');
+
+/**
+ * AI credit consumption of the chatbot flows' AI_RESPONSE nodes.
+ *
+ * Every AI reply is charged to the institute's AI credits, the same wallet the rest
+ * of the platform's AI features draw on, so this reads the shared credit ledger
+ * rather than anything chatbot-specific. When the balance runs out the engine stops
+ * calling the model and hands those conversations to a human — the banner says so,
+ * because from the admin's side the bot simply going quiet is otherwise a mystery.
+ */
+export function FlowAiUsagePanel({ flowId }: { flowId?: string }) {
+    const [days, setDays] = useState(30);
+    const [summary, setSummary] = useState<FlowAiUsageSummary | null>(null);
+    const [logs, setLogs] = useState<FlowAiUsageLogRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [failed, setFailed] = useState(false);
+
+    const load = async (windowDays: number) => {
+        setLoading(true);
+        setFailed(false);
+        const startDate = Date.now() - windowDays * DAY_MS;
+        try {
+            const [usage, page] = await Promise.all([
+                fetchChatbotFlowAiUsage(startDate),
+                fetchChatbotFlowAiLogs(flowId, 0, 20, startDate),
+            ]);
+            setSummary(usage);
+            setLogs(page.content ?? []);
+        } catch {
+            // Usage reporting is never worth breaking the flows screen over.
+            setFailed(true);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load(days);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [days, flowId]);
+
+    if (loading && !summary) {
+        return <div className="py-8 text-center text-sm text-gray-400">Loading AI usage…</div>;
+    }
+
+    if (failed) {
+        return (
+            <div className="py-8 text-center text-sm text-gray-400">
+                Couldn&apos;t load AI usage right now.
+                <button onClick={() => load(days)} className="ml-2 text-blue-600 hover:underline">
+                    Retry
+                </button>
+            </div>
+        );
+    }
+
+    const rows = flowId ? (summary?.byFlow ?? []).filter((r) => r.flowId === flowId) : (summary?.byFlow ?? []);
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                    <Lightning size={16} className="text-amber-500" />
+                    AI credit usage
+                </div>
+                <div className="flex items-center gap-1">
+                    {WINDOWS.map((w) => (
+                        <button
+                            key={w.days}
+                            onClick={() => setDays(w.days)}
+                            className={`rounded px-2 py-1 text-xs ${
+                                days === w.days
+                                    ? 'bg-blue-50 font-medium text-blue-700'
+                                    : 'text-gray-500 hover:bg-gray-100'
+                            }`}
+                        >
+                            {w.label}
+                        </button>
+                    ))}
+                    <button
+                        onClick={() => load(days)}
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100"
+                        title="Refresh"
+                    >
+                        <ArrowClockwise size={14} />
+                    </button>
+                </div>
+            </div>
+
+            {summary && !summary.aiEnabled && (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                    <Warning size={18} className="mt-0.5 shrink-0 text-amber-600" />
+                    <div className="text-sm text-amber-800">
+                        <p className="font-medium">AI replies are paused — no AI credits left.</p>
+                        <p className="mt-0.5 text-amber-700">
+                            Flows keep running, but AI Reply steps stop calling the model and hand
+                            those conversations to a human in the WhatsApp Inbox. Top up AI credits
+                            to switch them back on.
+                        </p>
+                    </div>
+                </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <Stat label="Credits used" value={fmtCredits(summary?.totalCredits ?? 0)} />
+                <Stat label="AI replies" value={String(summary?.turnCount ?? 0)} />
+                <Stat label="People replied to" value={String(summary?.userCount ?? 0)} />
+                <Stat
+                    label="Balance"
+                    value={
+                        summary?.currentBalance != null ? fmtCredits(summary.currentBalance) : '—'
+                    }
+                    warn={summary != null && !summary.aiEnabled}
+                />
+            </div>
+
+            {!flowId && rows.length > 0 && (
+                <div className="overflow-hidden rounded-lg border">
+                    <table className="w-full text-sm">
+                        <thead className="bg-gray-50 text-xs uppercase text-gray-500">
+                            <tr>
+                                <th className="px-3 py-2 text-left font-medium">Flow</th>
+                                <th className="px-3 py-2 text-right font-medium">Credits</th>
+                                <th className="px-3 py-2 text-right font-medium">Replies</th>
+                                <th className="px-3 py-2 text-right font-medium">People</th>
+                                <th className="px-3 py-2 text-right font-medium">Last used</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y">
+                            {rows.map((r) => (
+                                <tr key={r.flowId ?? 'unattributed'}>
+                                    <td className="px-3 py-2 text-gray-800">
+                                        {r.flowName ?? r.flowId ?? 'Unattributed'}
+                                    </td>
+                                    <td className="px-3 py-2 text-right tabular-nums text-gray-800">
+                                        {fmtCredits(r.totalCredits)}
+                                    </td>
+                                    <td className="px-3 py-2 text-right tabular-nums text-gray-600">
+                                        {r.turnCount}
+                                    </td>
+                                    <td className="px-3 py-2 text-right tabular-nums text-gray-600">
+                                        {r.userCount}
+                                    </td>
+                                    <td className="px-3 py-2 text-right text-xs text-gray-500">
+                                        {fmtWhen(r.lastUsedAt)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            <div>
+                <p className="mb-2 text-xs font-medium uppercase text-gray-500">Recent AI replies</p>
+                {logs.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-gray-400">
+                        No AI replies charged in this window.
+                    </p>
+                ) : (
+                    <div className="overflow-hidden rounded-lg border">
+                        <table className="w-full text-sm">
+                            <thead className="bg-gray-50 text-xs uppercase text-gray-500">
+                                <tr>
+                                    <th className="px-3 py-2 text-left font-medium">When</th>
+                                    <th className="px-3 py-2 text-left font-medium">Replied to</th>
+                                    <th className="px-3 py-2 text-left font-medium">Model</th>
+                                    <th className="px-3 py-2 text-right font-medium">Credits</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y">
+                                {logs.map((l) => (
+                                    <tr key={l.id}>
+                                        <td className="whitespace-nowrap px-3 py-2 text-xs text-gray-500">
+                                            {fmtWhen(l.createdAt)}
+                                        </td>
+                                        <td className="px-3 py-2 text-gray-800">
+                                            {l.name ?? l.email ?? (
+                                                <span className="text-gray-400">Unidentified contact</span>
+                                            )}
+                                        </td>
+                                        <td className="px-3 py-2 text-xs text-gray-500">
+                                            {l.model ?? '—'}
+                                        </td>
+                                        <td className="px-3 py-2 text-right tabular-nums text-gray-800">
+                                            {fmtCredits(l.credits)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function Stat({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+    return (
+        <div className="rounded-lg border bg-white p-3">
+            <p className="text-xs text-gray-500">{label}</p>
+            <p
+                className={`mt-1 text-lg font-semibold tabular-nums ${
+                    warn ? 'text-amber-600' : 'text-gray-800'
+                }`}
+            >
+                {value}
+            </p>
+        </div>
+    );
+}

--- a/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/flow-list-page.tsx
+++ b/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/flow-list-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { Plus, Copy, Trash, Play, Pause, ChartBar } from '@phosphor-icons/react';
+import { Plus, Copy, Trash, Play, Pause, ChartBar, Warning } from '@phosphor-icons/react';
 import { toast } from 'sonner';
 import {
     listChatbotFlows,
@@ -8,15 +8,24 @@ import {
     duplicateChatbotFlow,
     activateChatbotFlow,
     deactivateChatbotFlow,
+    fetchChatbotFlowAiUsage,
 } from '../-services/chatbot-flow-api';
 import { ChatbotFlowDTO } from '@/types/chatbot-flow/chatbot-flow-types';
 import { getInstituteId } from '@/constants/helper';
 import { SessionViewer } from './session-viewer';
+import { FlowAiUsagePanel } from './flow-ai-usage-panel';
 
 export function FlowListPage() {
     const [flows, setFlows] = useState<ChatbotFlowDTO[]>([]);
     const [loading, setLoading] = useState(true);
     const [viewingSessionsFlow, setViewingSessionsFlow] = useState<ChatbotFlowDTO | null>(null);
+    const [tab, setTab] = useState<'flows' | 'usage'>('flows');
+    /**
+     * Null = not known yet (or the check failed). Only an explicit `false` means the
+     * institute is out of AI credits and the engine has stopped calling the model —
+     * an unknown state must not render as a scary banner.
+     */
+    const [aiEnabled, setAiEnabled] = useState<boolean | null>(null);
     const navigate = useNavigate();
     const instituteId = getInstituteId() || '';
 
@@ -34,6 +43,11 @@ export function FlowListPage() {
 
     useEffect(() => {
         loadFlows();
+        // Funding state for the AI Reply steps. Best effort — if the credits service
+        // can't be reached we say nothing rather than claiming the bot is broken.
+        fetchChatbotFlowAiUsage()
+            .then((usage) => setAiEnabled(usage.aiEnabled))
+            .catch(() => setAiEnabled(null));
     }, []);
 
     const handleCreate = () => {
@@ -124,7 +138,52 @@ export function FlowListPage() {
                 </button>
             </div>
 
-            {loading ? (
+            {aiEnabled === false && (
+                <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                    <Warning size={18} className="mt-0.5 shrink-0 text-amber-600" />
+                    <div className="text-sm text-amber-800">
+                        <p className="font-medium">
+                            AI Reply steps are paused — this institute has no AI credits.
+                        </p>
+                        <p className="mt-0.5 text-amber-700">
+                            The rest of every flow still runs. AI Reply steps stop calling the model
+                            and hand the conversation to a human in the WhatsApp Inbox until you top
+                            up.{' '}
+                            <button
+                                onClick={() => setTab('usage')}
+                                className="font-medium underline underline-offset-2"
+                            >
+                                See AI usage
+                            </button>
+                        </p>
+                    </div>
+                </div>
+            )}
+
+            <div className="mb-4 flex gap-1 border-b">
+                {(
+                    [
+                        ['flows', 'Flows'],
+                        ['usage', 'AI Usage'],
+                    ] as const
+                ).map(([key, label]) => (
+                    <button
+                        key={key}
+                        onClick={() => setTab(key)}
+                        className={`-mb-px border-b-2 px-3 py-2 text-sm ${
+                            tab === key
+                                ? 'border-blue-600 font-medium text-blue-700'
+                                : 'border-transparent text-gray-500 hover:text-gray-700'
+                        }`}
+                    >
+                        {label}
+                    </button>
+                ))}
+            </div>
+
+            {tab === 'usage' ? (
+                <FlowAiUsagePanel />
+            ) : loading ? (
                 <div className="text-center py-12 text-gray-400">Loading...</div>
             ) : flows.length === 0 ? (
                 <div className="text-center py-12">

--- a/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/node-config-panel.tsx
+++ b/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-components/node-config-panel.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useChatbotFlowStore } from '../-stores/chatbot-flow-store';
 import { NODE_TYPE_REGISTRY, VariableMapping } from '@/types/chatbot-flow/chatbot-flow-types';
-import { fetchWhatsAppTemplates, WhatsAppTemplateInfo } from '../-services/chatbot-flow-api';
+import {
+    fetchWhatsAppTemplates,
+    fetchChatbotFlowAiUsage,
+    WhatsAppTemplateInfo,
+} from '../-services/chatbot-flow-api';
 import { getInstituteId } from '@/constants/helper';
 import { Plus, Trash, CaretUp, CaretDown } from '@phosphor-icons/react';
 import { VariableMappingEditor } from './VariableMappingEditor';
@@ -699,10 +703,53 @@ function WebhookConfig({ config, onChange }: { config: Record<string, unknown>; 
 }
 
 // ==================== AI RESPONSE ====================
+/**
+ * Every reply this step generates is charged to the institute's AI credits, and the
+ * engine refuses to call the model once they run out — so the author needs to see the
+ * funding state here, next to the step that spends it, not only on the flows list.
+ */
+function AiCreditsNotice() {
+    const [state, setState] = useState<{ enabled: boolean; balance: number | null } | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetchChatbotFlowAiUsage()
+            .then((usage) => {
+                if (!cancelled) setState({ enabled: usage.aiEnabled, balance: usage.currentBalance });
+            })
+            // Unknown funding state renders nothing: a false alarm here would send admins
+            // hunting a billing problem they don't have.
+            .catch(() => undefined);
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (!state) return null;
+
+    if (!state.enabled) {
+        return (
+            <div className="mb-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+                <span className="font-medium">Out of AI credits.</span> This step will not call the
+                model — conversations that reach it are handed to a human in the WhatsApp Inbox
+                until the institute tops up.
+            </div>
+        );
+    }
+
+    return (
+        <p className="mb-2 text-xs text-gray-500">
+            Each reply spends AI credits
+            {state.balance != null && <> · balance {state.balance.toFixed(2)}</>}
+        </p>
+    );
+}
+
 function AiResponseConfig({ config, onChange }: { config: Record<string, unknown>; onChange: (keyOrBatch: string | Record<string, unknown>, value?: unknown) => void }) {
     return (
         <>
             <SectionLabel>AI Conversation</SectionLabel>
+            <AiCreditsNotice />
             <FieldLabel>Model</FieldLabel>
             <select value={(config.modelId as string) || 'google/gemini-2.0-flash'} onChange={(e) => onChange('modelId', e.target.value)} className="w-full px-2 py-1.5 text-sm border rounded">
                 <option value="google/gemini-2.0-flash">Gemini 2.0 Flash (fast)</option>

--- a/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-services/chatbot-flow-api.ts
+++ b/frontend-admin-dashboard/src/routes/automation/chatbot-flows/-services/chatbot-flow-api.ts
@@ -1,5 +1,10 @@
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
-import { BASE_URL, CHATBOT_FLOW_BASE } from '@/constants/urls';
+import {
+    BASE_URL,
+    CHATBOT_FLOW_BASE,
+    CHATBOT_FLOW_AI_USAGE,
+    CHATBOT_FLOW_AI_USAGE_LOGS,
+} from '@/constants/urls';
 import { ChatbotFlowDTO } from '@/types/chatbot-flow/chatbot-flow-types';
 
 export interface WhatsAppTemplateInfo {
@@ -198,4 +203,78 @@ export const fetchInstituteCustomFields = async (
             fieldType: String(row.field_type ?? row.fieldType ?? 'text'),
         }))
         .filter((f) => f.fieldName !== '');
+};
+
+// ==================== AI Credits (AI_RESPONSE nodes) ====================
+
+export interface FlowAiUsageRow {
+    flowId: string | null;
+    flowName: string | null;
+    totalCredits: number;
+    turnCount: number;
+    userCount: number;
+    lastUsedAt: number | null;
+}
+
+export interface FlowAiUsageSummary {
+    totalCredits: number;
+    turnCount: number;
+    userCount: number;
+    flowCount: number;
+    /** Null when the balance could not be read. */
+    currentBalance: number | null;
+    /**
+     * False when the institute cannot pay for AI replies. The engine applies the
+     * same gate server-side, so a false here means AI nodes are genuinely paused —
+     * not a warning we could choose to ignore.
+     */
+    aiEnabled: boolean;
+    byFlow: FlowAiUsageRow[];
+}
+
+export interface FlowAiUsageLogRow {
+    id: string;
+    createdAt: number | null;
+    flowId: string | null;
+    userId: string | null;
+    name: string | null;
+    email: string | null;
+    model: string | null;
+    credits: number;
+    description: string | null;
+}
+
+export interface PagedFlowAiUsageLogs {
+    content: FlowAiUsageLogRow[];
+    totalElements: number;
+    totalPages: number;
+    number: number;
+}
+
+/** Credits the flows' AI replies burned in the window, plus the funding state. */
+export const fetchChatbotFlowAiUsage = async (
+    startDate?: number,
+    endDate?: number
+): Promise<FlowAiUsageSummary> => {
+    const params: Record<string, number> = {};
+    if (startDate) params.startDate = startDate;
+    if (endDate) params.endDate = endDate;
+    const { data } = await authenticatedAxiosInstance.get(CHATBOT_FLOW_AI_USAGE, { params });
+    return data;
+};
+
+/** Per-turn charge history behind those figures. */
+export const fetchChatbotFlowAiLogs = async (
+    flowId?: string,
+    page = 0,
+    size = 20,
+    startDate?: number,
+    endDate?: number
+): Promise<PagedFlowAiUsageLogs> => {
+    const params: Record<string, string | number> = { page, size };
+    if (flowId) params.flowId = flowId;
+    if (startDate) params.startDate = startDate;
+    if (endDate) params.endDate = endDate;
+    const { data } = await authenticatedAxiosInstance.get(CHATBOT_FLOW_AI_USAGE_LOGS, { params });
+    return data;
 };

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/engine/executors/AiResponseNodeExecutor.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/engine/executors/AiResponseNodeExecutor.java
@@ -16,6 +16,7 @@ import vacademy.io.notification_service.features.chatbot_flow.entity.ChatbotFlow
 import vacademy.io.notification_service.features.chatbot_flow.entity.ChatbotFlowSession;
 import vacademy.io.notification_service.features.chatbot_flow.enums.ChatbotNodeType;
 import vacademy.io.notification_service.features.chatbot_flow.enums.EscalationReason;
+import vacademy.io.notification_service.features.chatbot_flow.repository.ChatbotFlowRepository;
 import vacademy.io.notification_service.features.chatbot_flow.service.ChatbotEscalationService;
 import vacademy.io.notification_service.features.chatbot_flow.service.WhatsAppSendFailureService;
 
@@ -41,6 +42,7 @@ public class AiResponseNodeExecutor implements ChatbotNodeExecutor {
     private final List<ChatbotMessageProvider> messageProviders;
     private final ChatbotEscalationService escalationService;
     private final WhatsAppSendFailureService sendFailureService;
+    private final ChatbotFlowRepository flowRepository;
 
     @Value("${admin.core.service.baseurl:http://localhost:8081}")
     private String adminCoreServiceUrl;
@@ -179,6 +181,20 @@ public class AiResponseNodeExecutor implements ChatbotNodeExecutor {
             aiRequest.put("userMessage", userText);
             aiRequest.put("maxTokens", maxTokens);
             aiRequest.put("temperature", temperature);
+            // Billing attribution — admin-core charges this turn's tokens to the institute
+            // but books them against the learner and the flow, so the spend is legible in
+            // the AI usage history instead of landing as an anonymous system charge.
+            if (context.getUserId() != null) {
+                aiRequest.put("userId", context.getUserId());
+            }
+            if (session != null) {
+                aiRequest.put("sessionId", session.getId());
+                aiRequest.put("flowId", session.getFlowId());
+                String flowName = resolveFlowName(session.getFlowId());
+                if (flowName != null) {
+                    aiRequest.put("flowName", flowName);
+                }
+            }
 
             String endpoint = "/admin-core-service/internal/chatbot-ai/respond";
 
@@ -188,6 +204,24 @@ public class AiResponseNodeExecutor implements ChatbotNodeExecutor {
             if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+                // Out of AI credits: no model was called and there is no answer to send.
+                // Say so honestly, hand the learner to a human, and stop the AI loop —
+                // retrying every turn would only re-pay the balance check and keep the
+                // learner talking to a bot that cannot reply.
+                if (Boolean.TRUE.equals(responseBody.get("insufficientCredits"))) {
+                    log.warn("Chatbot AI paused for institute {} — no AI credits", context.getInstituteId());
+                    String outOfCreditsMessage = resolveEscalationMessage(config);
+                    sendTextToUser(context, outOfCreditsMessage);
+                    raiseEscalation(node, session, context, config, EscalationReason.NO_CREDITS,
+                            userText, outOfCreditsMessage, "Institute has no AI credits");
+                    return NodeExecutionResult.builder()
+                            .success(true)
+                            .waitForInput(false)
+                            .outputVariables(Map.of("ai_last_response", outOfCreditsMessage))
+                            .build();
+                }
+
                 String assistantMessage = (String) responseBody.get("assistantMessage");
 
                 // "I don't have that context" → say so honestly, hand over to a human, and make
@@ -308,6 +342,20 @@ public class AiResponseNodeExecutor implements ChatbotNodeExecutor {
         } catch (Exception e) {
             log.warn("Failed to raise escalation for phone={}: {}",
                     context.getPhoneNumber(), e.getMessage());
+        }
+    }
+
+    /**
+     * Flow name for the credit transaction's description, so the AI usage history reads
+     * "Chatbot AI reply — Admissions bot" rather than a bare uuid. Best effort: a PK
+     * lookup that fails just means the description falls back to the flow id.
+     */
+    private String resolveFlowName(String flowId) {
+        if (flowId == null) return null;
+        try {
+            return flowRepository.findById(flowId).map(f -> f.getName()).orElse(null);
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/enums/EscalationReason.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/enums/EscalationReason.java
@@ -8,6 +8,12 @@ public enum EscalationReason {
     MAX_TURNS,
     /** The AI call itself failed (provider error, timeout, non-2xx). */
     AI_ERROR,
+    /**
+     * The institute is out of AI credits (or the balance could not be confirmed), so no
+     * model was called. Unlike AI_ERROR this will not clear on its own — an admin has to
+     * top up — which is why it is worth telling them apart in the Inbox.
+     */
+    NO_CREDITS,
     /** Raised by an admin from the Inbox rather than by the bot. */
     MANUAL
 }


### PR DESCRIPTION
The chatbot flow's AI_RESPONSE node was the last LLM surface on the platform that ran for free. notification_service called /internal/chatbot-ai/respond, LLMService logged an ai_token_usage row bucketed as 'agent', and nothing ever hit /credits/v1/deduct — so an institute with a zero balance could keep burning provider spend on every inbound WhatsApp message, and none of it was visible as chatbot spend in the AI usage screens.

Charge it like every other AI activity:

* V501 allows request_type='chatbot' on the ai_token_usage CHECK and seeds a credit_pricing row. The usage row is written before the charge, so a value missing from that CHECK silently swallows the whole deduction — the trap already fixed in V102/V217/V225/V325/V345/V435.
* ChatbotAiService gates on affordability BEFORE calling the model, failing closed the way the Engagement Engine and AI calling do, then charges the real token counts against the usage row it just wrote.
* The charge is attributed to the person the bot replied to and batched by flow id, so it rolls up per flow and per learner rather than as an anonymous system charge.
* LLMService now parses the provider's usage block onto LLMResponse and lets a caller pick its request-type bucket and ask for a synchronous usage write (needed for usage_log_id). The agent path is unchanged.

When the balance is out, the AI node sends the flow's configured hand-over message and raises a NO_CREDITS escalation instead of answering — the learner reaches a human in the Inbox rather than silence, and NO_CREDITS is kept distinct from AI_ERROR because it will not clear without a top-up.

Also fixes the node's maxTokens never reaching the provider (buildChatRequest reads the field, not the context entry, so every turn ran at the 4096 default). That is billable output now, so the author's budget has to be honoured.

Surfaces the history: GET /ai-usage/v1/chatbot-flows/{usage,logs} return the per-flow rollup, the funding state and the per-turn charge log, and Automations -> Chatbot Flows grows an AI Usage tab plus an out-of-credits banner on the list and in the AI Reply step's config.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
