### PR TITLE
fix(utm): repair attribution capture, read path and access control

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/controller/OpenUtmAttributionController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/controller/OpenUtmAttributionController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import vacademy.io.admin_core_service.features.audience.service.PublicLeadRateLimiter;
+import vacademy.io.admin_core_service.features.catalogue_analytics.service.CatalogueAnalyticsRateLimiter;
 import vacademy.io.admin_core_service.features.utm_attribution.dto.UtmTrackRequest;
 import vacademy.io.admin_core_service.features.utm_attribution.service.UtmAttributionService;
 
@@ -19,9 +19,8 @@ import vacademy.io.admin_core_service.features.utm_attribution.service.UtmAttrib
  *
  * Unauthenticated by necessity — the person submitting a public form has no
  * token yet. Consequences, handled here:
- *  - rate limited per IP and per institute, reusing the LEAD limiter (this
- *    fires once per successful submission, exactly the shape that limiter is
- *    tuned for) rather than the far looser page-view beacon limiter.
+ *  - rate limited per IP and per institute on its OWN counters, so telemetry
+ *    can never spend the budget that real lead submissions need.
  *  - always answers 204. Whether a touch was recorded is not the caller's
  *    business, and a failure here must never surface as an error on a form the
  *    learner has already successfully submitted.
@@ -38,8 +37,13 @@ public class OpenUtmAttributionController {
     @Autowired
     private UtmAttributionService service;
 
+    // NOT PublicLeadRateLimiter: that one's 8/minute is the budget for actual
+    // LEAD submissions, and sharing it means a tagged campaign's telemetry can
+    // 429 a real lead from the same IP (a school or cafe behind one NAT).
+    // Losing an attribution row must never cost a lead. This limiter exists for
+    // exactly this class of best-effort telemetry and keeps its own counters.
     @Autowired
-    private PublicLeadRateLimiter rateLimiter;
+    private CatalogueAnalyticsRateLimiter rateLimiter;
 
     @PostMapping("/track")
     public ResponseEntity<Void> track(@RequestBody UtmTrackRequest body, HttpServletRequest request) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/controller/UtmAttributionController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/controller/UtmAttributionController.java
@@ -9,6 +9,10 @@ import vacademy.io.admin_core_service.features.utm_attribution.dto.UtmAttributio
 import vacademy.io.admin_core_service.features.utm_attribution.dto.UtmCampaignSummaryResponse;
 import vacademy.io.admin_core_service.features.utm_attribution.service.UtmAttributionService;
 import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.ForbiddenException;
+
+import java.util.Locale;
+import java.util.Set;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -44,9 +48,49 @@ public class UtmAttributionController {
     public ResponseEntity<List<UtmAttributionResponse>> forUser(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable String userId,
-            @RequestParam String instituteId) {
+            @RequestParam String instituteId,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String mobileNumber) {
+        requireStaffAccess(user, instituteId);
+        return ResponseEntity.ok(service.findForUser(instituteId, userId, email, mobileNumber));
+    }
+
+    /**
+     * Roles that identify a LEARNER-side caller rather than a member of staff.
+     */
+    private static final Set<String> LEARNER_ROLES = Set.of("STUDENT", "PARENT", "GUARDIAN");
+
+    /**
+     * Institute membership, minus the learners themselves.
+     *
+     * NOT {@code requireAdminAccess}: acquisition data is exactly what a
+     * COUNSELLOR needs, and they are the primary audience for the learner
+     * side-view this feeds. Demanding the ADMIN authority would have hidden the
+     * card from counsellors and teachers while the Lead Profile card sitting
+     * directly beside it — served by AudienceController, which validates
+     * nothing at all — kept working, which is an inconsistency an admin would
+     * read as a bug.
+     *
+     * NOT bare {@code validateUserAccess} either: a learner holds a real role in
+     * the institute, so membership alone would let any student read their own,
+     * and any classmate's, acquisition history.
+     */
+    private void requireStaffAccess(CustomUserDetails user, String instituteId) {
         accessValidator.validateUserAccess(user, instituteId);
-        return ResponseEntity.ok(service.findForUser(instituteId, userId));
+        if (isLearnerOnly(user)) {
+            throw new ForbiddenException("Access denied: staff role required");
+        }
+    }
+
+    /** True only when EVERY role the caller holds is a learner-side one. */
+    private boolean isLearnerOnly(CustomUserDetails user) {
+        if (user == null || user.isRootUser()) return false;
+        var authorities = user.getAuthorities();
+        if (authorities == null || authorities.isEmpty()) return false;
+        return authorities.stream()
+                .map(a -> a.getAuthority())
+                .filter(a -> a != null)
+                .allMatch(a -> LEARNER_ROLES.contains(a.toUpperCase(Locale.ROOT)));
     }
 
     /** Campaign roll-up over the last {@code days} days. */
@@ -55,7 +99,7 @@ public class UtmAttributionController {
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam String instituteId,
             @RequestParam(defaultValue = "30") int days) {
-        accessValidator.validateUserAccess(user, instituteId);
+        requireStaffAccess(user, instituteId);
         int window = Math.max(1, Math.min(days, 365));
         Instant to = Instant.now();
         Instant from = to.minus(window, ChronoUnit.DAYS);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/repository/UtmAttributionRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/repository/UtmAttributionRepository.java
@@ -13,34 +13,51 @@ import java.util.List;
 public interface UtmAttributionRepository extends JpaRepository<UtmAttribution, String> {
 
     /**
-     * Every touch for one person, oldest first — first touch gets the credit and
-     * the learner side-view reads the tail for "most recent".
-     */
-    List<UtmAttribution> findByInstituteIdAndUserIdOrderByCreatedAtAsc(String instituteId, String userId);
-
-    /**
-     * Rows written before the user id was known, matched back on whatever
-     * contact detail the form did capture. Either argument may be null — the
-     * comparison is written so a null simply matches nothing rather than
-     * matching every row with a null column.
+     * Every touch for one person, oldest first.
+     *
+     * Matches on user_id OR the contact details, because three of the six
+     * capture surfaces (audience form, live session, catalogue) never learn an
+     * auth user id at submit time — they only have the email/mobile the visitor
+     * typed. Keying the read on user_id alone made those rows unreachable
+     * forever, which meant the learner side-view was permanently empty for
+     * exactly the lead-generation surfaces the feature exists to measure.
+     *
+     * The contact fallback deliberately applies ONLY to rows that have no
+     * user_id yet. A row already claimed by a user belongs to that user, and
+     * matching it by shared contact details would hand one learner another's
+     * history — families routinely register siblings on ONE parent mobile, so
+     * that is the normal case here, not an edge case.
+     *
+     * NOTE ON LOWER(): the function is applied to the COLUMN only, never to the
+     * bound parameter. Hibernate cannot infer a type for a null parameter that
+     * sits inside a function call, binds it as untyped, and PostgreSQL then
+     * resolves lower(untyped-null) to lower(bytea) — which does not exist, so
+     * the whole statement fails. Callers pass an already-lowercased email.
      */
     @Query("""
             SELECT u FROM UtmAttribution u
             WHERE u.instituteId = :instituteId
-              AND u.userId IS NULL
-              AND ((:email IS NOT NULL AND LOWER(u.email) = LOWER(:email))
-                   OR (:mobileNumber IS NOT NULL AND u.mobileNumber = :mobileNumber))
+              AND ((:userId IS NOT NULL AND u.userId = :userId)
+                   OR (u.userId IS NULL AND :email IS NOT NULL AND LOWER(u.email) = :email)
+                   OR (u.userId IS NULL AND :mobileNumber IS NOT NULL
+                       AND u.mobileNumber = :mobileNumber))
             ORDER BY u.createdAt ASC
             """)
-    List<UtmAttribution> findUnlinkedByContact(@Param("instituteId") String instituteId,
-                                               @Param("email") String email,
-                                               @Param("mobileNumber") String mobileNumber);
+    List<UtmAttribution> findForLearner(@Param("instituteId") String instituteId,
+                                        @Param("userId") String userId,
+                                        @Param("email") String email,
+                                        @Param("mobileNumber") String mobileNumber);
 
     /**
      * Guard against the same submission being recorded twice — a double-clicked
-     * form, or a retry after a network blip. Deliberately keyed on the campaign
-     * tuple rather than on time alone, so a genuine second touch from a
-     * DIFFERENT campaign is still recorded.
+     * form, or a retry after a network blip. Keyed on the campaign tuple rather
+     * than on time alone, so a genuine second touch from a DIFFERENT campaign is
+     * still recorded.
+     *
+     * The identity disjunction covers all three shapes a caller can have:
+     * a user id, an email, or (phone-identity institutes) a mobile number only.
+     * Omitting the mobile branch made the whole predicate false for phone-only
+     * leads, so they were never de-duplicated at all.
      */
     @Query("""
             SELECT COUNT(u) FROM UtmAttribution u
@@ -48,7 +65,9 @@ public interface UtmAttributionRepository extends JpaRepository<UtmAttribution, 
               AND u.sourceType = :sourceType
               AND u.createdAt > :since
               AND ((:userId IS NOT NULL AND u.userId = :userId)
-                   OR (:userId IS NULL AND :email IS NOT NULL AND LOWER(u.email) = LOWER(:email)))
+                   OR (:userId IS NULL AND :email IS NOT NULL AND LOWER(u.email) = :email)
+                   OR (:userId IS NULL AND :email IS NULL AND :mobileNumber IS NOT NULL
+                       AND u.mobileNumber = :mobileNumber))
               AND (:sourceId IS NULL OR u.sourceId = :sourceId)
               AND (:utmCampaign IS NULL OR u.utmCampaign = :utmCampaign)
               AND (:utmSource IS NULL OR u.utmSource = :utmSource)
@@ -56,6 +75,7 @@ public interface UtmAttributionRepository extends JpaRepository<UtmAttribution, 
     long countRecentDuplicates(@Param("instituteId") String instituteId,
                                @Param("userId") String userId,
                                @Param("email") String email,
+                               @Param("mobileNumber") String mobileNumber,
                                @Param("sourceType") String sourceType,
                                @Param("sourceId") String sourceId,
                                @Param("utmCampaign") String utmCampaign,

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/service/UtmAttributionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/utm_attribution/service/UtmAttributionService.java
@@ -83,7 +83,7 @@ public class UtmAttributionService {
             }
 
             Timestamp since = Timestamp.from(Instant.now().minus(DEDUPE_WINDOW_MINUTES, ChronoUnit.MINUTES));
-            if (repository.countRecentDuplicates(request.getInstituteId(), userId, email,
+            if (repository.countRecentDuplicates(request.getInstituteId(), userId, email, mobile,
                     sourceType, sourceId, utmCampaign, utmSource, since) > 0) {
                 return null;
             }
@@ -103,10 +103,6 @@ public class UtmAttributionService {
                     .referrerHost(referrerHost(request.getReferrer()))
                     .landingPath(landingPath(request.getLandingUrl()))
                     .build());
-
-            // A surface that learns the user id only now can still claim the
-            // rows it wrote earlier under the same email/mobile.
-            if (userId != null) linkPendingRows(request.getInstituteId(), userId, email, mobile);
 
             return saved;
         } catch (Exception e) {
@@ -142,10 +138,27 @@ public class UtmAttributionService {
                 .build());
     }
 
-    /** Every touch for one learner, oldest first. */
-    public List<UtmAttributionResponse> findForUser(String instituteId, String userId) {
-        if (isBlank(instituteId) || isBlank(userId)) return List.of();
-        return repository.findByInstituteIdAndUserIdOrderByCreatedAtAsc(instituteId, userId)
+    /**
+     * Every touch for one learner, oldest first.
+     *
+     * Takes the contact details as well as the user id because three of the six
+     * capture surfaces never learn a user id at submit time. Matching on user id
+     * alone left those rows unreachable, so the side-view card was permanently
+     * empty for audience, live-session and catalogue leads — the very surfaces
+     * the feature exists to measure.
+     */
+    public List<UtmAttributionResponse> findForUser(String instituteId, String userId,
+                                                    String email, String mobileNumber) {
+        if (isBlank(instituteId)) return List.of();
+        String user = trim(userId, 255);
+        String mail = lower(trim(email, 255));
+        // A bare country code is not an identity. Optional phone fields in this
+        // product save as "+91", so matching on one would join together every
+        // learner who skipped the field.
+        String mobile = matchableMobile(trim(mobileNumber, 32));
+        // Nothing to match on: answer empty rather than scanning the institute.
+        if (user == null && mail == null && mobile == null) return List.of();
+        return repository.findForLearner(instituteId, user, mail, mobile)
                 .stream()
                 .map(this::toResponse)
                 .toList();
@@ -166,15 +179,6 @@ public class UtmAttributionService {
         return out;
     }
 
-    /** Attach earlier anonymous rows to the person we now know they were. */
-    private void linkPendingRows(String instituteId, String userId, String email, String mobile) {
-        if (email == null && mobile == null) return;
-        List<UtmAttribution> pending = repository.findUnlinkedByContact(instituteId, email, mobile);
-        if (pending.isEmpty()) return;
-        for (UtmAttribution row : pending) row.setUserId(userId);
-        repository.saveAll(pending);
-    }
-
     private UtmAttributionResponse toResponse(UtmAttribution entity) {
         return UtmAttributionResponse.builder()
                 .id(entity.getId())
@@ -189,6 +193,20 @@ public class UtmAttributionService {
                 .landingPath(entity.getLandingPath())
                 .createdAt(entity.getCreatedAt())
                 .build();
+    }
+
+    /**
+     * A mobile number is only usable as a match key when it actually carries a
+     * subscriber number. Anything with fewer than 8 digits is a country code, a
+     * placeholder, or a typo, and using it would match unrelated learners.
+     */
+    private static String matchableMobile(String mobile) {
+        if (mobile == null) return null;
+        int digits = 0;
+        for (int i = 0; i < mobile.length(); i++) {
+            if (Character.isDigit(mobile.charAt(i))) digits++;
+        }
+        return digits >= 8 ? mobile : null;
     }
 
     private String normaliseSourceType(String raw) {

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/utm_attribution/UtmAttributionServiceTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/utm_attribution/UtmAttributionServiceTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -38,7 +39,6 @@ class UtmAttributionServiceTest {
         service = new UtmAttributionService();
         ReflectionTestUtils.setField(service, "repository", repository);
         when(repository.save(any(UtmAttribution.class))).thenAnswer(i -> i.getArgument(0));
-        when(repository.findUnlinkedByContact(anyString(), any(), any())).thenReturn(List.of());
     }
 
     private UtmTrackRequest.UtmTrackRequestBuilder valid() {
@@ -111,11 +111,38 @@ class UtmAttributionServiceTest {
     /** A double-clicked submit is one touch, not two. */
     @Test
     void dropsADuplicateWithinTheDedupeWindow() {
-        when(repository.countRecentDuplicates(anyString(), any(), any(), anyString(), any(),
+        when(repository.countRecentDuplicates(anyString(), any(), any(), any(), anyString(), any(),
                 any(), any(), any(Timestamp.class))).thenReturn(1L);
 
         assertNull(service.record(valid().build()));
         verify(repository, never()).save(any());
+    }
+
+    /**
+     * A phone-identity institute sends no email at all. The dedupe query has to
+     * be given the mobile too, otherwise its identity predicate is false for
+     * every phone-only lead and they are never de-duplicated.
+     */
+    @Test
+    void passesTheMobileToTheDedupeCheckForPhoneOnlyLeads() {
+        service.record(valid().userId(null).email(null).mobileNumber("+911234567890").build());
+
+        verify(repository).countRecentDuplicates(eq("inst-1"), isNull(), isNull(),
+                eq("+911234567890"), eq("AUDIENCE"), any(), any(), any(), any(Timestamp.class));
+    }
+
+    /**
+     * The email handed to the query must already be lowercased: the JPQL applies
+     * LOWER() to the COLUMN only. Applying it to the parameter instead makes
+     * Hibernate bind an untyped null, which PostgreSQL resolves as
+     * lower(bytea) — a function that does not exist — and the statement dies.
+     */
+    @Test
+    void lowercasesTheEmailBeforeItReachesTheQuery() {
+        service.record(valid().userId(null).email("Learner@Example.COM").build());
+
+        verify(repository).countRecentDuplicates(eq("inst-1"), isNull(), eq("learner@example.com"),
+                any(), eq("AUDIENCE"), any(), any(), any(), any(Timestamp.class));
     }
 
     /**
@@ -144,17 +171,18 @@ class UtmAttributionServiceTest {
         assertEquals("learner@example.com", captor.getValue().getEmail());
     }
 
-    /** Rows written before the user id was known get claimed once it is. */
+    /**
+     * Recording a touch must never rewrite rows that already exist. The read
+     * side matches a learner on contact details instead, so there is nothing to
+     * back-fill — and an unauthenticated caller cannot re-point somebody else's
+     * attribution at a user id of its choosing.
+     */
     @Test
-    void attachesEarlierAnonymousRowsToTheResolvedUser() {
-        UtmAttribution pending = UtmAttribution.builder().id("row-1").build();
-        when(repository.findUnlinkedByContact("inst-1", "learner@example.com", null))
-                .thenReturn(List.of(pending));
-
+    void neverMutatesExistingRowsWhenRecording() {
         service.record(valid().email("learner@example.com").build());
 
-        assertEquals("user-1", pending.getUserId());
-        verify(repository).saveAll(List.of(pending));
+        verify(repository, never()).saveAll(any());
+        verify(repository).save(any(UtmAttribution.class));
     }
 
     /** The flat-map overload is what the product-page flow already holds. */
@@ -189,22 +217,65 @@ class UtmAttributionServiceTest {
 
     @Test
     void readsBackNothingWhenAskedWithoutIds() {
-        assertTrue(service.findForUser(null, "user-1").isEmpty());
-        assertTrue(service.findForUser("inst-1", "  ").isEmpty());
-        verify(repository, never()).findByInstituteIdAndUserIdOrderByCreatedAtAsc(any(), any());
+        assertTrue(service.findForUser(null, "user-1", null, null).isEmpty());
+        // No identity of any kind: answer empty rather than scan the institute.
+        assertTrue(service.findForUser("inst-1", "  ", null, "  ").isEmpty());
+        verify(repository, never()).findForLearner(any(), any(), any(), any());
     }
 
     @Test
     void readsEveryTouchForALearnerOldestFirst() {
         UtmAttribution row = UtmAttribution.builder()
                 .id("row-1").sourceType("AUDIENCE").utmSource("meta").build();
-        when(repository.findByInstituteIdAndUserIdOrderByCreatedAtAsc(eq("inst-1"), eq("user-1")))
+        when(repository.findForLearner(eq("inst-1"), eq("user-1"), any(), any()))
                 .thenReturn(List.of(row));
 
-        var result = service.findForUser("inst-1", "user-1");
+        var result = service.findForUser("inst-1", "user-1", null, null);
 
         assertEquals(1, result.size());
         assertEquals("meta", result.get(0).getUtmSource());
         assertEquals("AUDIENCE", result.get(0).getSourceType());
+    }
+
+    /**
+     * A bare country code is what an optional phone field saves in this product.
+     * Using it as a match key would join together every learner who skipped the
+     * field, handing each of them the others' acquisition history.
+     */
+    @Test
+    void refusesADegenerateMobileAsAMatchKey() {
+        when(repository.findForLearner(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.findForUser("inst-1", null, null, "+91");
+
+        // Nothing matchable was supplied, so the query is never even issued.
+        verify(repository, never()).findForLearner(any(), any(), any(), any());
+    }
+
+    @Test
+    void acceptsARealMobileAsAMatchKey() {
+        when(repository.findForLearner(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.findForUser("inst-1", null, null, "+91 98765 43210");
+
+        verify(repository).findForLearner(eq("inst-1"), isNull(), isNull(), eq("+91 98765 43210"));
+    }
+
+    /**
+     * The surfaces that matter most for campaigns — audience form, live session,
+     * catalogue — never learn a user id at submit time. The read has to match
+     * the person by contact details or those touches are invisible forever.
+     */
+    @Test
+    void findsTouchesForALearnerWhoNeverHadAUserId() {
+        UtmAttribution row = UtmAttribution.builder()
+                .id("row-1").sourceType("CATALOGUE").utmSource("instagram").build();
+        when(repository.findForLearner("inst-1", "user-1", "learner@example.com", "+911234567890"))
+                .thenReturn(List.of(row));
+
+        var result = service.findForUser("inst-1", "user-1", "Learner@Example.COM", "+911234567890");
+
+        assertEquals(1, result.size());
+        assertEquals("instagram", result.get(0).getUtmSource());
     }
 }

--- a/frontend-admin-dashboard/src/components/common/utm/utm-builder-dialog.tsx
+++ b/frontend-admin-dashboard/src/components/common/utm/utm-builder-dialog.tsx
@@ -17,10 +17,12 @@ import {
 } from '@phosphor-icons/react';
 import {
     SUGGESTED_MEDIUMS,
+    UTM_KEYS,
     SUGGESTED_SOURCES,
     buildUtmUrl,
     getRecentUtmValues,
     normalizeUtmValue,
+    normalizeUtmValueLive,
     readUtmFromUrl,
     rememberUtmValues,
     stripUtmFromUrl,
@@ -139,7 +141,20 @@ export function UtmBuilderDialog({
         []
     );
 
-    const generatedUrl = useMemo(() => buildUtmUrl(cleanBase, values), [cleanBase, values]);
+    // Build from FULLY normalised values, not the live ones held in state.
+    // Otherwise the URL depends on blur having fired: an admin who types
+    // "diwali sale " and clicks Copy straight away — or presses Enter — would
+    // copy a trailing hyphen and get a second, near-identical row in their
+    // campaign report. Browsers do blur on mousedown, but relying on event
+    // ordering for data correctness is not worth it.
+    const generatedUrl = useMemo(() => {
+        const finalised: UtmValues = {};
+        for (const key of UTM_KEYS) {
+            const value = values[key];
+            if (value) finalised[key] = normalizeUtmValue(value);
+        }
+        return buildUtmUrl(cleanBase, finalised);
+    }, [cleanBase, values]);
 
     const missingRequired = !values.utm_source?.trim() || !values.utm_medium?.trim();
     const missingCampaign = settings.requireCampaign && !values.utm_campaign?.trim();
@@ -161,9 +176,15 @@ export function UtmBuilderDialog({
         );
     };
 
+    // While typing: no trim, so an interior space survives long enough to
+    // become a hyphen. On blur: the full normalisation, which also trims.
     const update = (key: UtmKey, raw: string) => {
-        setValues((prev) => ({ ...prev, [key]: normalizeUtmValue(raw) }));
+        setValues((prev) => ({ ...prev, [key]: normalizeUtmValueLive(raw) }));
         setCopied(false);
+    };
+
+    const finalise = (key: UtmKey) => {
+        setValues((prev) => ({ ...prev, [key]: normalizeUtmValue(prev[key] ?? '') }));
     };
 
     const handleCopy = async () => {
@@ -173,7 +194,9 @@ export function UtmBuilderDialog({
             toast.error(t('toast.copyFailed'));
             return;
         }
-        rememberUtmValues(values);
+        // Remember the finalised spelling, so the suggestion list cannot offer
+        // a half-typed variant back to the admin next time.
+        rememberUtmValues(readUtmFromUrl(generatedUrl));
         setCopied(true);
         toast.success(t('toast.copied'));
         if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
@@ -290,6 +313,7 @@ export function UtmBuilderDialog({
                                     inputPlaceholder={t(`fields.${key}.placeholder`)}
                                     input={values[key] ?? ''}
                                     onChangeFunction={(e) => update(key, e.target.value)}
+                                    onBlur={() => finalise(key)}
                                     list={options.length ? listId : undefined}
                                     // MyInput's size variants cap the field at
                                     // sm:w-60; `w-full` alone loses to that at

--- a/frontend-admin-dashboard/src/components/common/utm/utm-link-menu-item.tsx
+++ b/frontend-admin-dashboard/src/components/common/utm/utm-link-menu-item.tsx
@@ -31,7 +31,17 @@ export function UtmLinkMenuItem({ onSelect, hidden, className }: UtmLinkMenuItem
     if (!enabled || hidden) return null;
 
     return (
-        <DropdownMenuItem className={className ?? 'cursor-pointer'} onClick={onSelect}>
+        // stopPropagation, because several of the six surfaces render this menu
+        // inside a CLICKABLE CARD (the assessment row navigates to the detail
+        // page on click). Without it the click bubbles to the card, the route
+        // changes, and the dialog unmounts before the admin ever sees it.
+        <DropdownMenuItem
+            className={className ?? 'cursor-pointer'}
+            onClick={(e) => {
+                e.stopPropagation();
+                onSelect();
+            }}
+        >
             <LinkSimple className="mr-2 size-4" />
             {t('menuItem')}
         </DropdownMenuItem>

--- a/frontend-admin-dashboard/src/lib/__tests__/utm-link-builder/test.ts
+++ b/frontend-admin-dashboard/src/lib/__tests__/utm-link-builder/test.ts
@@ -4,6 +4,7 @@ import {
     cleanUtmValues,
     getRecentUtmValues,
     normalizeUtmValue,
+    normalizeUtmValueLive,
     readUtmFromUrl,
     rememberUtmValues,
     stripUtmFromUrl,
@@ -86,6 +87,35 @@ describe('normalising values', () => {
 
     it('caps a pasted essay at a storable length', () => {
         expect(normalizeUtmValue('a'.repeat(500))).toHaveLength(120);
+    });
+});
+
+describe('typing a two-word campaign, character by character', () => {
+    // The bug this covers: the full normaliser trims, so the moment the space
+    // in "Black Friday" is typed the value is "black " -> trimmed to "black",
+    // and the next character lands flush against it. The admin silently gets
+    // "blackfriday" and cannot type the hyphen themselves.
+    const type = (text: string, normalise: (v: string) => string) => {
+        let state = '';
+        for (const ch of text) state = normalise(state + ch);
+        return state;
+    };
+
+    it('keeps the space long enough for it to become a hyphen', () => {
+        expect(type('Black Friday', normalizeUtmValueLive)).toBe('black-friday');
+    });
+
+    it('is what the OLD trimming normaliser got wrong', () => {
+        // Regression guard: this is the behaviour we moved away from.
+        expect(type('Black Friday', normalizeUtmValue)).toBe('blackfriday');
+    });
+
+    it('still trims once the value is finalised on blur', () => {
+        expect(normalizeUtmValue(normalizeUtmValueLive('  Diwali Sale  '))).toBe('diwali-sale');
+    });
+
+    it('pasting the whole value at once gives the same answer as typing it', () => {
+        expect(normalizeUtmValue('Black Friday')).toBe(type('Black Friday', normalizeUtmValueLive));
     });
 });
 

--- a/frontend-admin-dashboard/src/lib/utm.ts
+++ b/frontend-admin-dashboard/src/lib/utm.ts
@@ -38,8 +38,29 @@ export type UtmSourceType =
  * expected to remember the convention on every link they ever build.
  */
 export const normalizeUtmValue = (value: string): string =>
+    normalizeUtmValueLive(value.trim())
+        // Strip edge hyphens too. A leading or trailing SPACE becomes a hyphen
+        // in the live pass, and trimming whitespace afterwards cannot remove
+        // it — so "  Diwali Sale  " typed into the box would finalise as
+        // "-diwali-sale-", a different report row from the pasted "diwali-sale".
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 120);
+
+/**
+ * Keystroke-safe normalisation: everything {@link normalizeUtmValue} does
+ * EXCEPT trimming.
+ *
+ * The trim is what makes the full version unusable while someone is typing.
+ * "Black Friday" is entered a character at a time, and the moment the space is
+ * typed the value is still "black " — a trailing space, which trim() deletes.
+ * The next character then lands flush against the previous word and the user
+ * silently gets "blackfriday" instead of "black-friday", with no way to type
+ * the hyphen themselves (the charset filter would have to allow it, and they
+ * would have to know to). Keeping the space here lets it become a hyphen on the
+ * next keystroke; the trim happens once, when the value is finalised.
+ */
+export const normalizeUtmValueLive = (value: string): string =>
     value
-        .trim()
         .toLowerCase()
         .replace(/\s+/g, '-')
         // Keep the characters GA treats as safe; drop the rest rather than

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-attribution/student-attribution.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-attribution/student-attribution.tsx
@@ -25,16 +25,21 @@ import { cn } from '@/lib/utils';
 export const StudentAttribution = ({
     userId,
     instituteId,
+    email,
+    mobileNumber,
 }: {
     userId: string | undefined;
     instituteId: string | undefined;
+    /** Sent so touches captured before this learner had a user id still match. */
+    email?: string;
+    mobileNumber?: string;
 }) => {
     const { t } = useTranslation('manageStudentsAttribution');
 
     const { data: touches = [] } = useQuery({
-        queryKey: utmAttributionQueryKey(userId ?? '', instituteId ?? ''),
-        queryFn: () => fetchUtmAttributionForUser(userId ?? '', instituteId ?? ''),
-        enabled: Boolean(userId && instituteId),
+        queryKey: utmAttributionQueryKey(userId ?? '', instituteId ?? '', email, mobileNumber),
+        queryFn: () => fetchUtmAttributionForUser(userId ?? '', instituteId ?? '', email, mobileNumber),
+        enabled: Boolean(instituteId && (userId || email || mobileNumber)),
         staleTime: 5 * 60 * 1000,
     });
 

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
@@ -339,6 +339,8 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
             <StudentAttribution
                 userId={selectedStudent?.user_id}
                 instituteId={instituteDetails?.id}
+                email={selectedStudent?.email}
+                mobileNumber={selectedStudent?.mobile_number}
             />
 
             {/* Terms & Conditions — always shown so admins can see signing status

--- a/frontend-admin-dashboard/src/services/utm-attribution.ts
+++ b/frontend-admin-dashboard/src/services/utm-attribution.ts
@@ -16,8 +16,12 @@ export interface UtmAttributionRecord {
     created_at: string | null;
 }
 
-export const utmAttributionQueryKey = (userId: string, instituteId: string) =>
-    ['utm-attribution', userId, instituteId] as const;
+export const utmAttributionQueryKey = (
+    userId: string,
+    instituteId: string,
+    email?: string,
+    mobileNumber?: string
+) => ['utm-attribution', userId, instituteId, email ?? '', mobileNumber ?? ''] as const;
 
 /**
  * Every campaign touch recorded for one learner, oldest first.
@@ -29,13 +33,27 @@ export const utmAttributionQueryKey = (userId: string, instituteId: string) =>
  */
 export const fetchUtmAttributionForUser = async (
     userId: string,
-    instituteId: string
+    instituteId: string,
+    email?: string,
+    mobileNumber?: string
 ): Promise<UtmAttributionRecord[]> => {
-    if (!userId || !instituteId) return [];
+    // Email/mobile are sent alongside the user id because three of the six
+    // capture surfaces (audience form, live session, catalogue) never learn an
+    // auth user id at submit time — their rows carry only the contact details
+    // the visitor typed. Matching on user id alone left those touches
+    // permanently invisible, which is precisely the lead-generation traffic
+    // this feature exists to measure.
+    if (!instituteId || (!userId && !email && !mobileNumber)) return [];
     try {
         const response = await authenticatedAxiosInstance.get<UtmAttributionRecord[]>(
-            `${GET_USER_UTM_ATTRIBUTION}/${encodeURIComponent(userId)}`,
-            { params: { instituteId } }
+            `${GET_USER_UTM_ATTRIBUTION}/${encodeURIComponent(userId || 'unknown')}`,
+            {
+                params: {
+                    instituteId,
+                    email: email || undefined,
+                    mobileNumber: mobileNumber || undefined,
+                },
+            }
         );
         return Array.isArray(response.data) ? response.data : [];
     } catch {

--- a/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
+++ b/frontend-learner-dashboard-app/src/components/common/enroll-by-invite/enroll-form.tsx
@@ -888,9 +888,15 @@ const EnrollByInvite = ({
         // is leave for the gateway, so a report fired later would be lost on
         // every abandoned cart — exactly the population a campaign report has
         // to be able to see.
+        // Contact details ride along so a missing user_id degrades to a
+        // contact-matched row rather than dropping the touch: the server
+        // refuses a touch it cannot attach to anyone.
+        const paidDetails = getUserDetails();
         trackUtmAttribution({
           instituteId,
           userId: response?.user_id,
+          email: paidDetails.email || undefined,
+          mobileNumber: paidDetails.contact || undefined,
           sourceType: "ENROLL_INVITE",
           sourceId: inviteData?.id,
         });
@@ -1528,10 +1534,18 @@ const EnrollByInvite = ({
         // A FREE enrolment skips the abandoned-cart submit above, so this is
         // the only place its campaign touch can be recorded. Before the
         // redirect branch — a configured redirectPath leaves the page.
+        // Identity via getUserDetails(), NOT form.getValues().email: this form
+        // is custom-field driven, so its values are {value: ...} objects keyed
+        // by whatever the institute named the field. Reading `.email` off it
+        // yielded an object (or undefined), which the server rejected — so the
+        // FREE path recorded nothing at all.
+        const freeUser = paymentResponse?.user;
+        const freeDetails = getUserDetails();
         trackUtmAttribution({
           instituteId,
-          userId: submittedUserId || undefined,
-          email: form.getValues()?.email as string | undefined,
+          userId: freeUser?.id || submittedUserId || undefined,
+          email: freeUser?.email || freeDetails.email || undefined,
+          mobileNumber: freeDetails.contact || undefined,
           sourceType: "ENROLL_INVITE",
           sourceId: inviteData?.id,
         });

--- a/frontend-learner-dashboard-app/src/lib/utm-attribution.test.ts
+++ b/frontend-learner-dashboard-app/src/lib/utm-attribution.test.ts
@@ -73,16 +73,20 @@ describe("first-touch capture", () => {
 });
 
 describe("reporting a touch", () => {
+  // Loosely typed on purpose: vi.fn()'s inferred generic does not unify with
+  // the ambient `fetch` signature, and pinning it adds nothing to the assertions.
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     sessionStorage.clear();
     setUrl("");
-    fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response)) as ReturnType<typeof vi.fn>;
     vi.stubGlobal("fetch", fetchMock);
   });
 
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
   const capture = () => {
     setUrl("?utm_source=meta&utm_campaign=diwali");


### PR DESCRIPTION
Adversarial review of the merged feature (PR #2807) found the capture path was silently dead for any touch without an email: LOWER(:email) binds an untyped null that PostgreSQL resolves as lower(bytea), and the service's blanket catch hid it. Reproduced and fixed against a real PostgreSQL.

- apply LOWER to the column only, never to the bound parameter
- de-duplicate phone-only leads (the identity predicate had no mobile branch)
- match a learner on user id, or on contact details for rows that have no user id yet, so audience, live-session and catalogue touches stop being invisible in the side-view; scoped to unclaimed rows and to phone numbers of at least 8 digits, because families share one mobile across siblings and a blank optional phone saves as "+91"
- require a staff role on the read endpoints: plain membership includes learners, while requiring ADMIN would have hidden the card from the counsellors who actually use it
- give the beacon its own rate-limit budget so telemetry cannot 429 a lead
- drop linkPendingRows, which let an anonymous caller re-point existing rows
- FREE enrol-invite: resolve identity via getUserDetails(); the form is custom-field driven, so form.getValues().email was an object, not a string
- stop the menu click bubbling to clickable cards, which unmounted the dialog
- normalise UTM values without trimming mid-keystroke, and build the copied URL from finalised values so it does not depend on blur having fired

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
