### PR TITLE
fix(live-session): stop sending an invitation when attendance is reco…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/constants/AttendanceEmailBody.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/constants/AttendanceEmailBody.java
@@ -1,0 +1,85 @@
+package vacademy.io.admin_core_service.features.live_session.constants;
+
+/**
+ * Email sent to a learner when their attendance for a live class is recorded.
+ *
+ * <p>Deliberately separate from {@link LiveClassEmailBody}, which is an
+ * <em>invitation</em>: it opens "We're excited to invite you to our upcoming
+ * ...", carries a "Join the Live Class" button and closes "We look forward to
+ * seeing you there!". Attendance notifications reused it, so a learner marked
+ * absent for a class that had already finished was invited to attend it, given
+ * a button pointing at "#", and told the whole sentence explaining their
+ * absence inside the 24px header.
+ *
+ * <p>Placeholders: NAME, SESSION_TITLE, SESSION_DATE, STATUS, STATUS_COLOR,
+ * STATUS_NOTE, THEME_COLOR, INSTITUTE_NAME, YEAR. STATUS_NOTE may be empty.
+ */
+public class AttendanceEmailBody {
+
+    public static final String Attendance_Email_Body = """
+            <!DOCTYPE html>
+            <html>
+              <body style="margin:0; padding:0; font-family:Arial, Helvetica, sans-serif; background-color:#f4f5f7;">
+                <table role="presentation" style="width:100%; border-collapse:collapse; background-color:#f4f5f7; padding:40px 0;">
+                  <tr>
+                    <td align="center">
+                      <table role="presentation" style="width:600px; background:#ffffff; border-radius:10px; overflow:hidden; box-shadow:0 4px 10px rgba(0,0,0,0.08);">
+                        <tr>
+                          <td style="background:{{THEME_COLOR}}; padding:20px; text-align:center; color:#ffffff;">
+                            <h1 style="margin:0; font-size:22px;">Attendance Recorded</h1>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="padding:30px; color:#333333;">
+                            <p style="font-size:16px; margin:0 0 18px 0;">Hi <strong>{{NAME}}</strong>,</p>
+
+                            <p style="font-size:16px; line-height:1.6; margin:0 0 20px 0;">
+                              Your attendance for <strong>{{SESSION_TITLE}}</strong> on {{SESSION_DATE}} has been recorded as:
+                            </p>
+
+                            <table role="presentation" style="margin:0 0 20px 0; width:100%;">
+                              <tr>
+                                <td align="center" style="padding:14px; background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px;">
+                                  <span style="display:inline-block; padding:6px 18px; border-radius:999px; font-size:16px; font-weight:bold; color:#ffffff; background:{{STATUS_COLOR}};">
+                                    {{STATUS}}
+                                  </span>
+                                </td>
+                              </tr>
+                            </table>
+
+                            {{STATUS_NOTE}}
+
+                            <p style="font-size:14px; line-height:1.6; color:#64748b; margin:24px 0 0 0;">
+                              If you believe this is incorrect, please contact your instructor.
+                              If there is any discrepancy, please contact the faculty.
+                            </p>
+
+                            <p style="font-size:15px; line-height:1.6; margin-top:20px;">
+                              Best regards,<br/>
+                              <strong>{{INSTITUTE_NAME}}</strong>
+                            </p>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="background:#f1f5f9; text-align:center; padding:15px; font-size:12px; color:#777777;">
+                            &copy; {{YEAR}} {{INSTITUTE_NAME}}. All rights reserved.
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </body>
+            </html>
+            """;
+
+    /** Wraps the explanation in its own block; empty string when there is nothing to add. */
+    public static String noteBlock(String note) {
+        if (note == null || note.isBlank()) {
+            return "";
+        }
+        return "<div style=\"padding:12px 14px; background:#fff7ed; border:1px solid #fed7aa;"
+                + " border-radius:8px; font-size:14px; line-height:1.6; color:#9a3412;\">"
+                + note + "</div>";
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/live_session/scheduler/LiveSessionNotificationProcessor.java
@@ -13,6 +13,7 @@ import vacademy.io.admin_core_service.features.live_session.entity.ScheduleNotif
 import vacademy.io.admin_core_service.features.live_session.enums.LiveClassAction;
 import vacademy.io.admin_core_service.features.live_session.enums.NotificationStatusEnum;
 import vacademy.io.admin_core_service.features.live_session.enums.NotificationTypeEnum;
+import vacademy.io.admin_core_service.features.live_session.constants.AttendanceEmailBody;
 import vacademy.io.admin_core_service.features.live_session.constants.LiveClassEmailBody;
 import vacademy.io.admin_core_service.features.live_session.service.LiveClassTemplateService;
 import vacademy.io.admin_core_service.features.live_session.service.LiveClassTemplateService.ResolvedTemplate;
@@ -1031,8 +1032,15 @@ public class LiveSessionNotificationProcessor {
                 // Build a simple email notification for the student
                 Student student = studentRepository.findTopByUserId(userId).orElse(null);
                 if (student != null && student.getEmail() != null) {
+                    // An attendance record is not an invitation. LiveClassEmailBody is
+                    // the invitation body — it opens "We're excited to invite you to our
+                    // upcoming ...", renders a "Join the Live Class" button and closes
+                    // "We look forward to seeing you there!". Sent for attendance it
+                    // invited a learner to a class that had already finished, pointed the
+                    // button at "#", and left an empty orange card where
+                    // {{ALL_TIMEZONE_TIMES}} would have been.
                     NotificationDTO dto = new NotificationDTO();
-                    dto.setBody(LiveClassEmailBody.Live_Class_Email_Body);
+                    dto.setBody(AttendanceEmailBody.Attendance_Email_Body);
                     dto.setSubject(title + " - " + sessionTitle);
                     dto.setNotificationType("EMAIL");
                     dto.setSource("ADMIN_CORE");
@@ -1042,17 +1050,16 @@ public class LiveSessionNotificationProcessor {
                     Map<String, String> placeholders = new HashMap<>();
                     placeholders.put("NAME", student.getFullName() != null ? student.getFullName() : "Student");
                     placeholders.put("SESSION_TITLE", sessionTitle);
-                    // {{ACTION}} lands in the template's 24px <h1>, so it stays a
-                    // short label. The explanation reaches the learner through the
-                    // push/system body and the daily attendance report card.
-                    placeholders.put("ACTION", "Attendance: " + status);
+                    placeholders.put("STATUS", status);
+                    placeholders.put("STATUS_COLOR",
+                            "ABSENT".equalsIgnoreCase(status) ? "#dc2626" : "#16a34a");
+                    // A whole sentence belongs in the body, not interpolated into the
+                    // header. Empty note renders nothing at all.
+                    placeholders.put("STATUS_NOTE", AttendanceEmailBody.noteBlock(reasonDetail));
+                    placeholders.put("SESSION_DATE", sessionDateLabel(session));
                     placeholders.put("THEME_COLOR", getThemeColor(session.getInstituteId()));
                     placeholders.put("INSTITUTE_NAME", getInstituteName(session.getInstituteId()));
                     placeholders.put("YEAR", getCurrentYear());
-                    placeholders.put("LINK", "#");
-                    placeholders.put("ALL_TIMEZONE_TIMES", "");
-                    placeholders.put("DATE", "");
-                    placeholders.put("TIME", "");
                     u.setPlaceholders(placeholders);
                     u.setUserId(userId);
                     u.setChannelId(student.getEmail());
@@ -1066,6 +1073,21 @@ public class LiveSessionNotificationProcessor {
         }
     }
 
+
+    /** "26 August 2026" for the attendance mail, or an empty label if unknown. */
+    private String sessionDateLabel(LiveSession session) {
+        try {
+            var schedules = scheduleRepository.findBySessionId(session.getId());
+            if (schedules != null && !schedules.isEmpty()) {
+                var d = schedules.get(0).getMeetingDate();
+                if (d != null) {
+                    return new SimpleDateFormat("d MMMM yyyy").format(d);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return "";
+    }
 
     private String getThemeColor(String instituteId) {
         try {


### PR DESCRIPTION
…rded

The attendance mail hardcoded LiveClassEmailBody, which is the class INVITATION template (its <title> is literally "Live Class Invitation"). A learner marked ABSENT was therefore told:

  "We're excited to invite you to our upcoming Biology - Life Processes,
   designed to help you learn and grow with us."

followed by a "Join the Live Class" button pointing at "#", an empty orange card where {{ALL_TIMEZONE_TIMES}} would have gone (DATE/TIME were blanked), and "We look forward to seeing you there!" — an invitation to a class that had already finished and that they had just been marked absent for. The verdict itself only survived as "Attendance: ABSENT" interpolated into the invitation's 24px <h1>, so the sentence explaining the absence had nowhere to go and was dropped from email entirely.

Restores AttendanceEmailBody (reverted in 332bead1c5) and routes the attendance mail through it: a status pill, the session date, and reasonDetail rendered as a note block in the body rather than squeezed into a header. reasonDetail already existed and already reached push and system-alert; it now reaches email too. The threshold stays undisclosed to learners, as before.

Unlike the reverted version this is NOT gated on the minimum-attendance rule being active. That version limited the fix to criteria classes, noting "fixing that for every institute is a separate decision ... not ours to make here". The invitation body is wrong for every attendance notification, and that decision has now been made.

The revert's reasoning was that the explanation belongs in the daily attendance report card, which fetchBatchAttendanceReport renders through {{sessionsTableHtml}}. That holds only if the report runs after the verdict exists. It does not: the report fires at 21:00 IST the same day while the BBB callback that decides the verdict lands a median 21h later, so on Shiksha Nation 91% of evaluations (1,902 of 2,095 over 45 days) were written after that day's report had already been sent. The absenceReason block requires both status=ABSENT and a non-null attendance_evaluation_json, so it almost never rendered and the learner got no explanation anywhere.

The invitation mail itself is unchanged — it resolves its template through LiveClassTemplateService.getDefaultBody() and never went through this path.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
