### PR TITLE
feat(workflow): let getAbandonedCartPlans filter by plan status

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute_learner/repository/StudentSessionInstituteGroupMappingRepository.java
@@ -148,6 +148,10 @@ public interface StudentSessionInstituteGroupMappingRepository
   /**
    * Learners who started an enrolment but never completed checkout, one row per learner.
    *
+   * <p>The caller chooses which plan statuses count: PENDING_FOR_PAYMENT is an abandoned
+   * cart (payment never attempted), PAYMENT_FAILED is a payment that was tried and
+   * declined. Those want different follow-up copy, so they are queried separately.
+   *
    * <p>Each retry creates a fresh user_plan, so a naive per-plan query messages the same person
    * repeatedly -- DISTINCT ON (up.user_id) with the ORDER BY below keeps only their most recent
    * attempt, which also carries the invite they last chose rather than the one they first tried.
@@ -171,7 +175,7 @@ public interface StudentSessionInstituteGroupMappingRepository
       JOIN enroll_invite ei ON ei.id = up.enroll_invite_id
       JOIN student s        ON s.user_id = up.user_id
       WHERE ei.institute_id = :instituteId
-        AND up.status IN ('PENDING_FOR_PAYMENT', 'PAYMENT_FAILED')
+        AND up.status IN (:statuses)
         AND CAST(up.created_at AS date) BETWEEN CURRENT_DATE - CAST(:maxAgeDays AS int)
                                             AND CURRENT_DATE - CAST(:minAgeDays AS int)
         AND s.mobile_number IS NOT NULL
@@ -185,6 +189,7 @@ public interface StudentSessionInstituteGroupMappingRepository
       """, nativeQuery = true)
   List<Object[]> findAbandonedCartPlans(
       @Param("instituteId") String instituteId,
+      @Param("statuses") List<String> statuses,
       @Param("minAgeDays") int minAgeDays,
       @Param("maxAgeDays") int maxAgeDays);
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
@@ -325,7 +325,13 @@ public class QueryServiceImpl implements QueryNodeHandler.QueryService {
             int minAgeDays = readIntParam(params.get("minAgeDays"), 1);
             int maxAgeDays = readIntParam(params.get("maxAgeDays"), 3);
 
-            List<Object[]> rows = ssigmRepo.findAbandonedCartPlans(instituteId, minAgeDays, maxAgeDays);
+            // Default to both so existing workflows keep their audience; a caller that wants
+            // only abandoned carts or only failed payments passes the one it means.
+            List<String> statuses = params.get("statuses") instanceof List
+                    ? ((List<?>) params.get("statuses")).stream().map(String::valueOf).toList()
+                    : List.of("PENDING_FOR_PAYMENT", "PAYMENT_FAILED");
+
+            List<Object[]> rows = ssigmRepo.findAbandonedCartPlans(instituteId, statuses, minAgeDays, maxAgeDays);
             List<Map<String, Object>> abandonedList = new ArrayList<>();
             for (Object[] row : rows) {
                 Map<String, Object> item = new HashMap<>();


### PR DESCRIPTION
The query hardcoded PENDING_FOR_PAYMENT and PAYMENT_FAILED together, but those are different situations and want different follow-up copy:

  PENDING_FOR_PAYMENT  an abandoned cart -- payment was never attempted
  PAYMENT_FAILED       a payment was tried and declined, including an autopay
                       debit that failed at the bank

A learner whose mandate failed did nothing wrong and needs a manual payment link; a learner who closed the checkout chose not to finish. Telling both the same thing gets one of them wrong.

Adds an optional `statuses` param. Omitted, it keeps both, so the existing SuchBliss abandoned-cart workflow is unaffected.

Live counts on SuchBliss (1-3 day window): 1 payment-failed, 3 abandoned-cart, with all-time backlogs of 15 and 26.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
