### PR TITLE
fix(workflow): treat an empty statuses list as absent

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/QueryServiceImpl.java
@@ -327,9 +327,12 @@ public class QueryServiceImpl implements QueryNodeHandler.QueryService {
 
             // Default to both so existing workflows keep their audience; a caller that wants
             // only abandoned carts or only failed payments passes the one it means.
-            List<String> statuses = params.get("statuses") instanceof List
-                    ? ((List<?>) params.get("statuses")).stream().map(String::valueOf).toList()
-                    : List.of("PENDING_FOR_PAYMENT", "PAYMENT_FAILED");
+            // An explicitly empty list would expand to "IN ()" and fail as a SQL syntax
+            // error at runtime, so treat empty the same as absent.
+            List<String> statuses = List.of("PENDING_FOR_PAYMENT", "PAYMENT_FAILED");
+            if (params.get("statuses") instanceof List<?> raw && !raw.isEmpty()) {
+                statuses = raw.stream().map(String::valueOf).toList();
+            }
 
             List<Object[]> rows = ssigmRepo.findAbandonedCartPlans(instituteId, statuses, minAgeDays, maxAgeDays);
             List<Map<String, Object>> abandonedList = new ArrayList<>();


### PR DESCRIPTION
"IN (:statuses)" expands to "IN ()" for an empty list, which is a SQL syntax error at runtime rather than an empty result. A workflow node configured with "statuses": [] would have failed the whole run.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
