### PR TITLE
Let admins hold extensions, and call learners from the LMS side-view

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -1456,6 +1456,34 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
                         @Param("userIds") List<String> userIds);
 
         /**
+         * The newest ACTIVE lead row for one person inside one institute, as either
+         * the submitter or the child the submission was for.
+         *
+         * <p>Used by click-to-call from the LMS surfaces (students list / attendance /
+         * assessment side-view), where the frontend only knows a learner's user id.
+         * A learner who ALSO came through a form gets their call filed on the same
+         * lead — same call history, same timeline, disposition still works. A learner
+         * with no lead row simply yields nothing and the call is logged against the
+         * user alone.
+         *
+         * <p>Institute-scoped through the audience join for the same reason
+         * {@link #findAllByInstituteAndIds} is: a user id alone can't be allowed to
+         * reach another tenant's lead. Paged so the LIMIT 1 stays in SQL.
+         */
+        @Query("""
+                            SELECT ar.id FROM AudienceResponse ar
+                            JOIN Audience a ON a.id = ar.audienceId
+                            WHERE a.instituteId = :instituteId
+                            AND (ar.userId = :userId OR ar.studentUserId = :userId)
+                            AND ar.audienceStatus = 'ACTIVE'
+                            ORDER BY ar.createdAt DESC
+                        """)
+        List<String> findLatestResponseIdForUserInInstitute(
+                        @Param("instituteId") String instituteId,
+                        @Param("userId") String userId,
+                        org.springframework.data.domain.Pageable pageable);
+
+        /**
          * Find audience response by parent mobile number for pre-fill lookup
          */
         Optional<AudienceResponse> findFirstByParentMobileOrderByCreatedAtDesc(String parentMobile);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
@@ -644,6 +644,25 @@ public class AuthService {
      * down" and serve a stale value rather than silently flipping RBAC scope.
      */
     public List<String> getActiveUserIdsByRoles(String instituteId, List<String> roles) {
+        return getActiveUsersByRoles(instituteId, roles).stream()
+                .map(vacademy.io.common.auth.dto.UserWithRolesDTO::getId)
+                .filter(id -> id != null && !id.isEmpty())
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Full user records (name / email / mobile / roles) of everyone holding ANY
+     * of the given roles in the institute — the same users-of-status call
+     * {@link #getActiveUserIdsByRoles} makes, without the second round trip
+     * through {@code getUsersFromAuthServiceByUserIds} just to recover names.
+     *
+     * <p>Same STRICT failure contract: throws rather than returning an empty
+     * list, so a caller can tell "no such users" apart from "auth_service is
+     * down".
+     */
+    public List<vacademy.io.common.auth.dto.UserWithRolesDTO> getActiveUsersByRoles(
+            String instituteId, List<String> roles) {
         if (instituteId == null || instituteId.isBlank() || roles == null || roles.isEmpty()) {
             return List.of();
         }
@@ -662,13 +681,8 @@ public class AuthService {
             }
             ObjectMapper objectMapper = new ObjectMapper();
             objectMapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            List<vacademy.io.common.auth.dto.UserWithRolesDTO> users = objectMapper.readValue(response.getBody(),
+            return objectMapper.readValue(response.getBody(),
                     new TypeReference<List<vacademy.io.common.auth.dto.UserWithRolesDTO>>() {});
-            return users.stream()
-                    .map(vacademy.io.common.auth.dto.UserWithRolesDTO::getId)
-                    .filter(id -> id != null && !id.isEmpty())
-                    .distinct()
-                    .toList();
         } catch (VacademyException ve) {
             throw ve;
         } catch (Exception e) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/auth_service/service/AuthService.java
@@ -645,6 +645,15 @@ public class AuthService {
      */
     public List<String> getActiveUserIdsByRoles(String instituteId, List<String> roles) {
         return getActiveUsersByRoles(instituteId, roles).stream()
+                // Null-element guard: before this method delegated, the mapping ran
+                // INSIDE the try below, so a null row would have surfaced as a
+                // VacademyException like every other failure here. Out here it would
+                // instead escape as a raw NPE and be rendered as a 511 by the generic
+                // RuntimeException handler. Unreachable in practice — auth_service
+                // builds the list with map(UserWithRolesDTO::new), which cannot emit
+                // null — but this path decides RBAC scope, so it does not get to
+                // depend on a remote service's serialiser staying well-behaved.
+                .filter(java.util.Objects::nonNull)
                 .map(vacademy.io.common.auth.dto.UserWithRolesDTO::getId)
                 .filter(id -> id != null && !id.isEmpty())
                 .distinct()

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyCallController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyCallController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import vacademy.io.admin_core_service.features.telephony.core.CallOrchestrator;
+import vacademy.io.admin_core_service.features.telephony.core.dto.CallAvailabilityDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.CallLogDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.CallOptionsResponseDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.ConnectCallRequestDTO;
@@ -49,6 +50,20 @@ public class TelephonyCallController {
             @RequestBody ConnectCallRequestDTO req,
             @RequestAttribute("user") CustomUserDetails user) {
         return ResponseEntity.ok(orchestrator.connect(req, user));
+    }
+
+    /**
+     * Should a Call button render for this person, and can they actually dial?
+     *
+     * <p>Split out from {@code /options} because that one throws when calling is
+     * off, which is correct for a picker opened by a deliberate click but wrong
+     * for a page merely deciding whether to show a button. Always 200.
+     */
+    @GetMapping("/availability")
+    public ResponseEntity<CallAvailabilityDTO> availability(
+            @RequestParam("instituteId") String instituteId,
+            @RequestAttribute("user") CustomUserDetails user) {
+        return ResponseEntity.ok(orchestrator.computeAvailability(instituteId, user.getUserId()));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyCounsellorEndpointController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/TelephonyCounsellorEndpointController.java
@@ -4,22 +4,42 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
 import vacademy.io.admin_core_service.features.telephony.controller.dto.TelephonyCounsellorEndpointDTO;
+import vacademy.io.admin_core_service.features.telephony.controller.dto.TelephonyEndpointUserDTO;
 import vacademy.io.admin_core_service.features.telephony.persistence.entity.TelephonyCounsellorEndpoint;
 import vacademy.io.admin_core_service.features.telephony.persistence.repository.TelephonyCounsellorEndpointRepository;
 import vacademy.io.common.exceptions.VacademyException;
 
+import vacademy.io.common.auth.dto.UserRoleDTO;
+import vacademy.io.common.auth.dto.UserWithRolesDTO;
+
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 /**
- * Admin API to map counsellors to their per-provider endpoint (extension + DID)
- * for no-pool providers (Airtel). JWT-gated (not in the public allowlist).
+ * Admin API to map a platform user to their per-provider endpoint (extension +
+ * DID) for no-pool providers (Airtel). JWT-gated (not in the public allowlist).
+ *
+ * <p>The table column is still {@code counsellor_user_id} — it predates admins
+ * having extensions — but the row is just "the person who dials from this
+ * extension". Counsellors calling leads and admins calling learners from the LMS
+ * side-view both resolve through the same map, so no schema change was needed.
  */
 @RestController
 @RequestMapping("/admin-core-service/v1/telephony/counsellor-endpoints")
 public class TelephonyCounsellorEndpointController {
 
+    /** Both spellings, both casings: the seed data and the frontend gates disagree
+     *  on COUNSELLOR/COUNSELOR and on ADMIN vs "Admin" (role_id 1 is stored as
+     *  "Admin" on several institutes), and users-of-status matches role name
+     *  exactly. Querying the union is cheaper than being wrong on one institute. */
+    private static final List<String> ENDPOINT_ELIGIBLE_ROLES =
+            List.of("COUNSELLOR", "COUNSELOR", "ADMIN", "Admin");
+
     @Autowired private TelephonyCounsellorEndpointRepository repo;
+    @Autowired private AuthService authService;
 
     @GetMapping("/{instituteId}")
     public List<TelephonyCounsellorEndpointDTO> list(
@@ -50,6 +70,56 @@ public class TelephonyCounsellorEndpointController {
         if (body.getEnabled() != null) e.setEnabled(body.getEnabled());
 
         return TelephonyCounsellorEndpointDTO.from(repo.save(e));
+    }
+
+    /**
+     * The people an admin may hand an extension to: this institute's ACTIVE
+     * counsellors AND admins.
+     *
+     * <p>Not {@code /lead-counsellor-options}: that endpoint answers "who can a
+     * lead be assigned to", so it is COUNSELLOR-role only and hierarchy-scoped.
+     * An extension is a phone-system fact, not a lead-routing one — an admin who
+     * never touches the CRM still needs one to call a learner from the LMS
+     * side-view, and the counsellor picker could never offer them.
+     */
+    @GetMapping("/{instituteId}/eligible-users")
+    public List<TelephonyEndpointUserDTO> eligibleUsers(@PathVariable String instituteId) {
+        List<UserWithRolesDTO> users =
+                authService.getActiveUsersByRoles(instituteId, ENDPOINT_ELIGIBLE_ROLES);
+        return users.stream()
+                .filter(u -> u.getId() != null && !u.getId().isBlank())
+                .map(u -> TelephonyEndpointUserDTO.builder()
+                        .id(u.getId())
+                        .fullName(displayName(u))
+                        .email(u.getEmail())
+                        .roles(instituteRoles(u, instituteId))
+                        .build())
+                // Stable, human order — the picker is a flat list an admin scans by name.
+                .sorted(Comparator.comparing(TelephonyEndpointUserDTO::getFullName,
+                        String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    /** Role names this user holds IN THIS institute, uppercased and deduped. A
+     *  user's role set spans every institute they belong to, so filtering by
+     *  institute keeps the badge honest for multi-institute staff. */
+    private static List<String> instituteRoles(UserWithRolesDTO u, String instituteId) {
+        Set<UserRoleDTO> roles = u.getRoles();
+        if (roles == null) return List.of();
+        return roles.stream()
+                .filter(r -> r.getRoleName() != null)
+                .filter(r -> r.getInstituteId() == null || instituteId.equals(r.getInstituteId()))
+                .map(r -> r.getRoleName().toUpperCase())
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static String displayName(UserWithRolesDTO u) {
+        if (u.getFullName() != null && !u.getFullName().isBlank()) return u.getFullName();
+        if (u.getEmail() != null && !u.getEmail().isBlank()) return u.getEmail();
+        if (u.getUsername() != null && !u.getUsername().isBlank()) return u.getUsername();
+        return u.getId();
     }
 
     @DeleteMapping("/{id}")

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/dto/TelephonyEndpointUserDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/controller/dto/TelephonyEndpointUserDTO.java
@@ -1,0 +1,30 @@
+package vacademy.io.admin_core_service.features.telephony.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * A person who may be given a provider extension in Settings → Calling.
+ *
+ * <p>Deliberately not the counsellor picker's shape: the extension map is not a
+ * lead-assignment target list. Admins belong on it too — an admin who calls a
+ * learner from the LMS side-view needs an extension of their own, and before
+ * this the picker only offered COUNSELLOR-role users so there was no way to give
+ * one to an admin.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TelephonyEndpointUserDTO {
+    private String id;
+    private String fullName;
+    private String email;
+    /** Institute roles held, e.g. ["ADMIN"] — rendered as a badge so an admin
+     *  picking from a mixed list can tell who is who. */
+    private List<String> roles;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
@@ -2,11 +2,13 @@ package vacademy.io.admin_core_service.features.telephony.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import vacademy.io.admin_core_service.features.audience.entity.AudienceResponse;
 import vacademy.io.admin_core_service.features.audience.repository.AudienceResponseRepository;
+import vacademy.io.admin_core_service.features.institute_learner.repository.StudentSessionInstituteGroupMappingRepository;
 import vacademy.io.admin_core_service.features.telephony.core.dto.ConnectCallRequestDTO;
 import vacademy.io.admin_core_service.features.telephony.enums.CallDirection;
 import vacademy.io.admin_core_service.features.telephony.enums.CallStatus;
@@ -49,6 +51,7 @@ public class CallLifecycleTxOps {
 
     @Autowired private TelephonyCallLogRepository callLogRepo;
     @Autowired private AudienceResponseRepository audienceResponseRepo;
+    @Autowired private StudentSessionInstituteGroupMappingRepository studentMappingRepo;
     @Autowired private TelephonyProviderRegistry registry;
     @Autowired private UserMobileResolver userMobileResolver;
     @Autowired private TelephonyConfigCache configCache;
@@ -64,14 +67,15 @@ public class CallLifecycleTxOps {
                 .filter(r -> Boolean.TRUE.equals(r.getConfig().getEnabled()))
                 .orElseThrow(() -> new VacademyException("Calling is not configured for this institute"));
 
-        AudienceResponse lead = audienceResponseRepo.findById(req.getResponseId())
-                .orElseThrow(() -> new VacademyException("Lead not found"));
-
-        String leadPhone = firstNonBlank(lead.getParentMobile(),
-                userMobileResolver.findMobile(lead.getUserId()).orElse(null));
-        if (leadPhone == null) throw new VacademyException("Lead has no phone on file");
+        // Two entry points converge here: a CRM lead (responseId) and an enrolled
+        // learner called from the LMS side-view (userId only). Resolve both onto the
+        // same (responseId, subjectUserId, phone) triple so everything downstream —
+        // the call row, the CDR matcher, call history, the timeline — is identical.
+        Subject subject = resolveSubject(instituteId, req);
+        String leadPhone = subject.phone();
+        if (leadPhone == null) throw new VacademyException("This contact has no phone on file");
         if (!leadPhone.matches("^\\+?[0-9]{8,15}$")) {
-            throw new VacademyException("Lead phone number format not supported");
+            throw new VacademyException("Phone number format not supported");
         }
 
         String providerType = resolved.getConfig().getProviderType();
@@ -86,7 +90,7 @@ public class CallLifecycleTxOps {
                         .instituteId(instituteId)
                         .providerType(providerType)
                         .counsellorUserId(actor.getUserId())
-                        .leadUserId(lead.getUserId())
+                        .leadUserId(subject.userId())
                         .leadPhone(leadPhone)
                         .preferredNumberId(req.getPreferredNumberId())
                         .selectorKey(resolved.getConfig().getDefaultSelectorKey())
@@ -99,8 +103,8 @@ public class CallLifecycleTxOps {
                 .instituteId(instituteId)
                 .providerType(providerType)
                 .providerNumberId(plan.getProviderNumberId())
-                .responseId(lead.getId())
-                .userId(lead.getUserId())
+                .responseId(subject.responseId())
+                .userId(subject.userId())
                 .counsellorUserId(actor.getUserId())
                 .direction(CallDirection.OUTBOUND.name())
                 .fromNumber(plan.getFrom())
@@ -126,7 +130,49 @@ public class CallLifecycleTxOps {
                 .build();
 
         return new CallOrchestrator.Prepared(callLogId, providerType,
-                plan.getCallerId(), bridge, resolved);
+                plan.getCallerId(), subject.responseId(), bridge, resolved);
+    }
+
+    /** Who the call is for: the lead row it files under (may be null), the person's
+     *  user id, and the number to dial. */
+    private record Subject(String responseId, String userId, String phone) {}
+
+    /**
+     * Resolve the call subject from whichever identifier the caller sent.
+     *
+     * <p>CRM path (responseId): unchanged — the lead's own mobile wins, falling
+     * back to the auth record.
+     *
+     * <p>LMS path (userId only): the learner must be enrolled in THIS institute,
+     * checked against student_session_institute_group_mapping. Without that check a
+     * user id alone would let anyone with a calling-enabled institute dial any user
+     * in the platform, since the phone lookup is a global auth_service call. We then
+     * best-effort attach the learner's newest lead row so a learner who also came
+     * through a form keeps one unified call history + timeline.
+     */
+    private Subject resolveSubject(String instituteId, ConnectCallRequestDTO req) {
+        if (req.getResponseId() != null && !req.getResponseId().isBlank()) {
+            AudienceResponse lead = audienceResponseRepo.findById(req.getResponseId())
+                    .orElseThrow(() -> new VacademyException("Lead not found"));
+            String phone = firstNonBlank(lead.getParentMobile(),
+                    userMobileResolver.findMobile(lead.getUserId()).orElse(null));
+            return new Subject(lead.getId(), lead.getUserId(), phone);
+        }
+
+        String userId = req.getUserId();
+        if (userId == null || userId.isBlank()) {
+            throw new VacademyException("responseId or userId is required");
+        }
+        boolean enrolledHere = studentMappingRepo
+                .findLatestPackageSessionIdByUserIdAndInstituteId(userId, instituteId)
+                .isPresent();
+        if (!enrolledHere) {
+            throw new VacademyException("This learner is not enrolled in this institute");
+        }
+        String responseId = audienceResponseRepo
+                .findLatestResponseIdForUserInInstitute(instituteId, userId, PageRequest.of(0, 1))
+                .stream().findFirst().orElse(null);
+        return new Subject(responseId, userId, userMobileResolver.findMobile(userId).orElse(null));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallOrchestrator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallOrchestrator.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import vacademy.io.admin_core_service.features.telephony.core.dto.CallAvailabilityDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.CallOptionsResponseDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.ConnectCallRequestDTO;
 import vacademy.io.admin_core_service.features.telephony.core.dto.ConnectCallResponseDTO;
@@ -11,6 +12,7 @@ import vacademy.io.admin_core_service.features.telephony.enums.CallStatus;
 import vacademy.io.admin_core_service.features.telephony.enums.ProviderCapability;
 import vacademy.io.admin_core_service.features.telephony.persistence.entity.TelephonyProviderNumber;
 import vacademy.io.admin_core_service.features.telephony.persistence.repository.TelephonyCallLogRepository;
+import vacademy.io.admin_core_service.features.telephony.spi.OutboundOriginationResolver;
 import vacademy.io.admin_core_service.features.telephony.spi.ProviderNumberSelector;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.BridgeCallRequest;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.NormalizedCallEvent;
@@ -112,6 +114,62 @@ public class CallOrchestrator {
                 .eventsStreamUrl("/admin-core-service/v1/telephony/calls/" + p.callLogId() + "/events")
                 .realtimeEvents(realtimeEvents)
                 .responseId(p.responseId())
+                .build();
+    }
+
+    /**
+     * Can {@code callerUserId} place a call in this institute right now?
+     *
+     * <p>Never throws for the "no" cases — an absent/disabled config and an
+     * unprepared caller are both ordinary answers, not errors. Callers use this
+     * to decide whether to render a Call button, which happens on pages that
+     * have nothing to do with calling, so a thrown 510 there would be pure noise
+     * in the logs and a failure sample in the latency indicator.
+     *
+     * <p>Cheap: a config-cache read plus, at most, the provider's own per-caller
+     * lookup (one indexed row for Airtel, a cached auth_service record for
+     * Exotel/Plivo). No provider HTTP, no writes.
+     */
+    public CallAvailabilityDTO computeAvailability(String instituteId, String callerUserId) {
+        if (instituteId == null || instituteId.isBlank()) {
+            return CallAvailabilityDTO.builder().enabled(false).callerReady(false).build();
+        }
+        Optional<TelephonyConfigCache.Resolved> resolved = configCache.get(instituteId)
+                .filter(r -> Boolean.TRUE.equals(r.getConfig().getEnabled()));
+        if (resolved.isEmpty()) {
+            return CallAvailabilityDTO.builder().enabled(false).callerReady(false).build();
+        }
+        String providerType = resolved.get().getConfig().getProviderType();
+
+        // A provider with no registered resolver can't originate at all. Report it
+        // as "not enabled" rather than letting the UI offer a button that would
+        // throw at dial time.
+        OutboundOriginationResolver resolver;
+        try {
+            resolver = registry.originationResolver(providerType);
+        } catch (Exception e) {
+            log.warn("no origination resolver for provider {} (institute {})", providerType, instituteId);
+            return CallAvailabilityDTO.builder()
+                    .enabled(false).callerReady(false).providerType(providerType).build();
+        }
+
+        // The readiness probe is advisory; a provider that fails to answer must not
+        // take the button away from someone who could actually dial. Degrade to
+        // "ready" and let resolve() be the authority at dial time.
+        Optional<String> blocked;
+        try {
+            blocked = resolver.callerBlockedReason(instituteId, callerUserId);
+        } catch (Exception e) {
+            log.warn("caller-readiness probe failed for {} on {}; assuming ready",
+                    callerUserId, providerType, e);
+            blocked = Optional.empty();
+        }
+
+        return CallAvailabilityDTO.builder()
+                .enabled(true)
+                .callerReady(blocked.isEmpty())
+                .reason(blocked.orElse(null))
+                .providerType(providerType)
                 .build();
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallOrchestrator.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallOrchestrator.java
@@ -111,6 +111,7 @@ public class CallOrchestrator {
                 .callerId(p.callerId())
                 .eventsStreamUrl("/admin-core-service/v1/telephony/calls/" + p.callLogId() + "/events")
                 .realtimeEvents(realtimeEvents)
+                .responseId(p.responseId())
                 .build();
     }
 
@@ -218,6 +219,9 @@ public class CallOrchestrator {
             String callLogId,
             String providerType,
             String callerId,
+            /** audience_response the call was filed under — null for a learner
+             *  with no lead row. Echoed to the UI for disposition capture. */
+            String responseId,
             BridgeCallRequest bridge,
             TelephonyConfigCache.Resolved resolved
     ) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/CallAvailabilityDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/CallAvailabilityDTO.java
@@ -1,0 +1,42 @@
+package vacademy.io.admin_core_service.features.telephony.core.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Response for {@code GET /v1/telephony/calls/availability} — "can this person
+ * place a call right now, and if not, why?".
+ *
+ * <p>Exists because the only previous way to ask was {@code /calls/options},
+ * which THROWS when the institute has calling switched off. That is the right
+ * shape for the picker (it opens only after a deliberate click) but the wrong
+ * one for deciding whether to render a Call button at all: every learner
+ * side-view on every non-calling institute would fire a request that 510s,
+ * logging a server-side error and feeding the latency indicator a failure
+ * sample, purely to learn "no". This endpoint always answers 200.
+ *
+ * <p>Two independent gates, reported separately because the fixes differ and
+ * belong to different people:
+ * <ul>
+ *   <li>{@code enabled} — the INSTITUTE has a provider configured and switched
+ *       on. Off means nobody here can call; the UI shows no button at all,
+ *       since a learner-facing admin can do nothing about it.</li>
+ *   <li>{@code callerReady} — THIS person is set up to originate (an extension
+ *       for Airtel, a verified mobile for Exotel/Plivo). Not ready means the
+ *       button shows but is disabled, carrying {@code reason} as its tooltip —
+ *       an actionable "ask an admin for an extension", not a silent absence
+ *       that reads like a broken page.</li>
+ * </ul>
+ */
+@Data
+@Builder
+public class CallAvailabilityDTO {
+    /** Institute-level: a provider is configured AND enabled. */
+    private boolean enabled;
+    /** Caller-level: this user can originate. Always false when !enabled. */
+    private boolean callerReady;
+    /** Why the caller cannot dial — user-facing, null when they can. */
+    private String reason;
+    /** Active provider (EXOTEL / AIRTEL / …), null when not enabled. */
+    private String providerType;
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
@@ -7,13 +7,24 @@ import lombok.NoArgsConstructor;
  * Click-to-call request body. instituteId is required because
  * CustomUserDetails doesn't carry it — the frontend has it in local context
  * and passes it explicitly.
+ *
+ * <p>The call subject arrives one of two ways:
+ * <ul>
+ *   <li>{@code responseId} — a CRM lead (audience_response). The phone comes
+ *       off the lead row, falling back to the user's auth record.</li>
+ *   <li>{@code userId} alone — an enrolled learner with no lead row, called
+ *       from the LMS surfaces (students list / attendance / assessment
+ *       side-view). The phone comes from auth_service and the orchestrator
+ *       links a matching lead row when the learner happens to have one.</li>
+ * </ul>
+ * At least one of the two is required.
  */
 @Data
 @NoArgsConstructor
 public class ConnectCallRequestDTO {
     private String instituteId;
-    private String responseId;     // audience_response.id
-    private String userId;         // optional, for log/debug
+    private String responseId;     // audience_response.id — optional for learner calls
+    private String userId;         // the person being called when responseId is absent
 
     /**
      * Optional: the counsellor picked a specific provider number from the

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
@@ -19,4 +19,13 @@ public class ConnectCallResponseDTO {
      * that never advances.
      */
     private boolean realtimeEvents;
+    /**
+     * The audience_response the call was logged against, when there is one.
+     * Echoed back because a learner call sends no responseId but the
+     * orchestrator may still have linked an existing lead row — the UI needs
+     * that id to open the post-call disposition sheet (status + follow-up both
+     * key off it). Null for a learner with no lead row: the caller should skip
+     * disposition capture rather than send a blank id.
+     */
+    private String responseId;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
@@ -11,9 +11,12 @@ import vacademy.io.admin_core_service.features.telephony.spi.dto.OriginationPlan
 import vacademy.io.common.exceptions.VacademyException;
 
 /**
- * Airtel origination: no number pool. The counsellor's own VBC extension is the
- * first leg ({@code from}); the lead sees the counsellor's DID as caller-ID.
- * Both come from {@code telephony_counsellor_endpoint} (the extension map).
+ * Airtel origination: no number pool. The caller's own VBC extension is the
+ * first leg ({@code from}); the person called sees that caller's DID as
+ * caller-ID. Both come from {@code telephony_counsellor_endpoint} (the
+ * extension map), which holds a row for ANY platform user given an extension —
+ * counsellors and admins alike, so an admin can dial a learner from the LMS
+ * side-view the same way a counsellor dials a lead.
  */
 @Component
 public class AirtelOriginationResolver implements OutboundOriginationResolver {
@@ -31,9 +34,10 @@ public class AirtelOriginationResolver implements OutboundOriginationResolver {
                 .findByCounsellorUserIdAndProviderType(ctx.getCounsellorUserId(), ProviderType.AIRTEL)
                 .filter(e -> Boolean.TRUE.equals(e.getEnabled()))
                 .orElseThrow(() -> new VacademyException(
-                        "This counsellor has no Airtel extension mapped — add one in Calling settings."));
+                        "No Airtel extension is mapped to you — ask an admin to add one "
+                                + "under Settings → Calling."));
         if (ep.getExtension() == null || ep.getExtension().isBlank()) {
-            throw new VacademyException("This counsellor's Airtel extension is not set.");
+            throw new VacademyException("Your Airtel extension is not set.");
         }
         return OriginationPlan.builder()
                 .from(ep.getExtension())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
@@ -10,6 +10,8 @@ import vacademy.io.admin_core_service.features.telephony.spi.dto.OriginationCont
 import vacademy.io.admin_core_service.features.telephony.spi.dto.OriginationPlan;
 import vacademy.io.common.exceptions.VacademyException;
 
+import java.util.Optional;
+
 /**
  * Airtel origination: no number pool. The caller's own VBC extension is the
  * first leg ({@code from}); the person called sees that caller's DID as
@@ -28,16 +30,33 @@ public class AirtelOriginationResolver implements OutboundOriginationResolver {
         return ProviderType.AIRTEL;
     }
 
+    /** Same wording the dial-time failure uses, so the pre-flight message and the
+     *  error toast can never drift apart. */
+    private static final String NO_ENDPOINT =
+            "No Airtel extension is mapped to you — ask an admin to add one under Settings → Calling.";
+    private static final String NO_EXTENSION = "Your Airtel extension is not set.";
+
+    @Override
+    public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
+        if (callerUserId == null || callerUserId.isBlank()) return Optional.of(NO_ENDPOINT);
+        return endpointRepo
+                .findByCounsellorUserIdAndProviderType(callerUserId, ProviderType.AIRTEL)
+                .filter(e -> Boolean.TRUE.equals(e.getEnabled()))
+                .map(e -> (e.getExtension() == null || e.getExtension().isBlank())
+                        ? NO_EXTENSION
+                        : null)
+                .map(Optional::ofNullable)
+                .orElse(Optional.of(NO_ENDPOINT));
+    }
+
     @Override
     public OriginationPlan resolve(OriginationContext ctx) {
         TelephonyCounsellorEndpoint ep = endpointRepo
                 .findByCounsellorUserIdAndProviderType(ctx.getCounsellorUserId(), ProviderType.AIRTEL)
                 .filter(e -> Boolean.TRUE.equals(e.getEnabled()))
-                .orElseThrow(() -> new VacademyException(
-                        "No Airtel extension is mapped to you — ask an admin to add one "
-                                + "under Settings → Calling."));
+                .orElseThrow(() -> new VacademyException(NO_ENDPOINT));
         if (ep.getExtension() == null || ep.getExtension().isBlank()) {
-            throw new VacademyException("Your Airtel extension is not set.");
+            throw new VacademyException(NO_EXTENSION);
         }
         return OriginationPlan.builder()
                 .from(ep.getExtension())

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/exotel/ExotelOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/exotel/ExotelOriginationResolver.java
@@ -47,11 +47,21 @@ public class ExotelOriginationResolver implements OutboundOriginationResolver {
         return ProviderType.EXOTEL;
     }
 
+    /** Shared with the dial-time failure so the pre-flight and the toast match. */
+    private static final String NO_VERIFIED_MOBILE =
+            "Add a verified mobile number in your profile before placing calls";
+
+    @Override
+    public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
+        return userMobileResolver.findVerifiedMobile(callerUserId).isPresent()
+                ? Optional.empty()
+                : Optional.of(NO_VERIFIED_MOBILE);
+    }
+
     @Override
     public OriginationPlan resolve(OriginationContext ctx) {
         String counsellorPhone = userMobileResolver.findVerifiedMobile(ctx.getCounsellorUserId())
-                .orElseThrow(() -> new VacademyException(
-                        "Add a verified mobile number in your profile before placing calls"));
+                .orElseThrow(() -> new VacademyException(NO_VERIFIED_MOBILE));
 
         List<ProviderNumberView> views = ctx.getAvailable();
         if (views == null || views.isEmpty()) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/plivo/PlivoOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/plivo/PlivoOriginationResolver.java
@@ -12,6 +12,7 @@ import vacademy.io.common.exceptions.VacademyException;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Plivo origination for the v1 PSTN-bridge (counsellor-first) flow: the
@@ -42,11 +43,21 @@ public class PlivoOriginationResolver implements OutboundOriginationResolver {
         return ProviderType.PLIVO;
     }
 
+    /** Shared with the dial-time failure so the pre-flight and the toast match. */
+    private static final String NO_VERIFIED_MOBILE =
+            "Add a verified mobile number in your profile before placing calls";
+
+    @Override
+    public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
+        return userMobileResolver.findVerifiedMobile(callerUserId).isPresent()
+                ? Optional.empty()
+                : Optional.of(NO_VERIFIED_MOBILE);
+    }
+
     @Override
     public OriginationPlan resolve(OriginationContext ctx) {
         String counsellorPhone = userMobileResolver.findVerifiedMobile(ctx.getCounsellorUserId())
-                .orElseThrow(() -> new VacademyException(
-                        "Add a verified mobile number in your profile before placing calls"));
+                .orElseThrow(() -> new VacademyException(NO_VERIFIED_MOBILE));
 
         ProviderNumberView chosen = pickNumber(ctx);
         String callerId = chosen != null ? chosen.getPhoneNumber() : null;

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/spi/OutboundOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/spi/OutboundOriginationResolver.java
@@ -3,6 +3,8 @@ package vacademy.io.admin_core_service.features.telephony.spi;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.OriginationContext;
 import vacademy.io.admin_core_service.features.telephony.spi.dto.OriginationPlan;
 
+import java.util.Optional;
+
 /**
  * Decides the outbound origination (first-leg {@code from} + caller-ID +
  * provider-number) for a provider, so the core orchestration stops baking in
@@ -24,4 +26,27 @@ public interface OutboundOriginationResolver {
      * cannot be determined (no verified mobile, no number, no extension mapped).
      */
     OriginationPlan resolve(OriginationContext ctx);
+
+    /**
+     * Pre-flight: can THIS person originate a call at all, before we know who
+     * they are dialling? Returns the reason they cannot, or empty when ready.
+     *
+     * <p>Every provider needs something set up per-caller — Airtel/Vonage an
+     * extension, Exotel/Plivo a verified mobile on the profile — and until this
+     * existed the only way to discover it was to click Call and read the error
+     * toast. That is a bad trade for a click that may cost provider credits, and
+     * it was actively confusing for admins, whose extension the settings picker
+     * could not even create. The UI now asks first and shows the same sentence
+     * up front, on a disabled button.
+     *
+     * <p>Advisory only, and deliberately NOT a replacement for the checks inside
+     * {@link #resolve}: it runs against different inputs (no lead, no picked
+     * number) and its answer can go stale between the check and the dial.
+     * {@code resolve} stays the authority.
+     *
+     * <p>Default: ready. A provider that needs nothing per-caller says nothing.
+     */
+    default Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
+        return Optional.empty();
+    }
 }

--- a/frontend-admin-dashboard/src/components/shared/leads/call-picker-popover.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/call-picker-popover.tsx
@@ -6,7 +6,11 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
-import { fetchCallOptions, type NumberChoice } from './services/call-options';
+import {
+    fetchCallAvailability,
+    fetchCallOptions,
+    type NumberChoice,
+} from './services/call-options';
 
 /**
  * Runtime ExoPhone picker.
@@ -54,6 +58,25 @@ export function CallPickerPopover({
         staleTime: 30 * 1000,
     });
 
+    // Is THIS caller set up to originate? Without this the no-pool copy below
+    // promised "dials from the extension mapped to you" to people who had no
+    // extension mapped, and they only found out from an error toast after
+    // clicking Call now. Same cache key as the Call buttons, so this is normally
+    // already resolved by the time the popover opens.
+    const availabilityQuery = useQuery({
+        queryKey: ['telephony-availability', instituteId],
+        queryFn: () => fetchCallAvailability(instituteId),
+        enabled: open && !!instituteId && !disabled,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+    // Absent/failed answer must not block a dial that would otherwise work —
+    // the backend re-checks at dial time and owns the real verdict.
+    const callerNotReady = !!availabilityQuery.data && !availabilityQuery.data.callerReady;
+    const callerBlockedReason = callerNotReady
+        ? availabilityQuery.data?.reason ?? 'Your account is not set up to place calls yet'
+        : null;
+
     const numbers: NumberChoice[] = optionsQuery.data?.numbers ?? [];
     const recommendedId = optionsQuery.data?.recommendedNumberId ?? null;
     // No-pool providers (Airtel) dial from the counsellor's own extension —
@@ -81,6 +104,7 @@ export function CallPickerPopover({
     }, [open]);
 
     const handleConfirm = () => {
+        if (callerBlockedReason) return;
         // Pooled providers require a picked number; no-pool providers dial from
         // the counsellor's extension, so an empty preferredNumberId is correct.
         if (usesNumberPool && !selectedId) return;
@@ -122,7 +146,7 @@ export function CallPickerPopover({
                 </div>
 
                 <div className="max-h-72 overflow-y-auto px-2 py-2">
-                    {optionsQuery.isLoading && (
+                    {(optionsQuery.isLoading || availabilityQuery.isLoading) && (
                         <div className="space-y-2 px-2 py-1">
                             <Skeleton className="h-12 w-full" />
                             <Skeleton className="h-12 w-full" />
@@ -133,22 +157,40 @@ export function CallPickerPopover({
                             Could not load calling numbers. Try again.
                         </p>
                     )}
-                    {!optionsQuery.isLoading && !optionsQuery.isError && !usesNumberPool && (
-                        <div className="px-3 py-2.5">
-                            <p className="text-sm font-medium text-neutral-900">
-                                Calling from your extension
-                            </p>
-                            <p className="mt-1 text-xs text-neutral-500">
-                                {providerLabel
-                                    ? `This call dials through ${providerLabel} from the extension mapped to you.`
-                                    : 'This call dials from the extension mapped to you.'}{' '}
-                                The lead sees your configured caller ID.
-                            </p>
-                        </div>
-                    )}
+                    {!optionsQuery.isLoading &&
+                        !availabilityQuery.isLoading &&
+                        !optionsQuery.isError &&
+                        callerBlockedReason && (
+                            <div className="px-3 py-2.5">
+                                <p className="text-sm font-medium text-neutral-900">
+                                    You cannot place calls yet
+                                </p>
+                                <p className="mt-1 text-xs text-neutral-500">
+                                    {callerBlockedReason}
+                                </p>
+                            </div>
+                        )}
+                    {!optionsQuery.isLoading &&
+                        !availabilityQuery.isLoading &&
+                        !optionsQuery.isError &&
+                        !callerBlockedReason &&
+                        !usesNumberPool && (
+                            <div className="px-3 py-2.5">
+                                <p className="text-sm font-medium text-neutral-900">
+                                    Calling from your extension
+                                </p>
+                                <p className="mt-1 text-xs text-neutral-500">
+                                    {providerLabel
+                                        ? `This call dials through ${providerLabel} from the extension mapped to you.`
+                                        : 'This call dials from the extension mapped to you.'}{' '}
+                                    The lead sees your configured caller ID.
+                                </p>
+                            </div>
+                        )}
                     {usesNumberPool &&
                         !optionsQuery.isLoading &&
                         !optionsQuery.isError &&
+                        !callerBlockedReason &&
                         numbers.length === 0 && (
                             <p className="px-3 py-2 text-xs text-neutral-500">
                                 No calling numbers configured. Ask an admin to set one up under
@@ -156,6 +198,7 @@ export function CallPickerPopover({
                             </p>
                         )}
                     {usesNumberPool &&
+                        !callerBlockedReason &&
                         numbers.map((n) => {
                         const isRecommended = n.id === recommendedId;
                         const isSelected = n.id === selectedId;
@@ -214,7 +257,9 @@ export function CallPickerPopover({
                         onClick={handleConfirm}
                         disabled={
                             optionsQuery.isLoading ||
+                            availabilityQuery.isLoading ||
                             optionsQuery.isError ||
+                            !!callerBlockedReason ||
                             (usesNumberPool && (!selectedId || numbers.length === 0))
                         }
                         className="h-8"

--- a/frontend-admin-dashboard/src/components/shared/leads/services/call-options.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/services/call-options.ts
@@ -1,5 +1,27 @@
 import authenticatedAxiosInstance from '@/lib/auth/axiosInstance';
-import { TELEPHONY_CALL_OPTIONS } from '@/constants/urls';
+import { TELEPHONY_CALL_AVAILABILITY, TELEPHONY_CALL_OPTIONS } from '@/constants/urls';
+
+export interface CallAvailability {
+    /** The INSTITUTE has calling configured and switched on. */
+    enabled: boolean;
+    /** THIS user can originate (extension for Airtel, verified mobile for Exotel). */
+    callerReady: boolean;
+    /** Why they cannot — user-facing, null when they can. */
+    reason?: string | null;
+    providerType?: string | null;
+}
+
+/**
+ * GET /v1/telephony/calls/availability — always 200, so a page can ask "should I
+ * show a Call button" without firing a request that errors on every institute
+ * that does not call.
+ */
+export const fetchCallAvailability = async (instituteId: string): Promise<CallAvailability> => {
+    const { data } = await authenticatedAxiosInstance.get<CallAvailability>(
+        TELEPHONY_CALL_AVAILABILITY(instituteId)
+    );
+    return data;
+};
 
 export interface NumberChoice {
     id: string;

--- a/frontend-admin-dashboard/src/components/shared/leads/services/place-call.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/services/place-call.ts
@@ -3,7 +3,13 @@ import { TELEPHONY_CONNECT_CALL } from '@/constants/urls';
 
 export interface PlaceCallRequest {
     instituteId: string;
-    responseId: string;
+    /**
+     * audience_response id — present for CRM leads. Omitted when calling an
+     * enrolled learner from the LMS side-view, where there is no lead row; the
+     * backend then resolves the person (and their phone) from `userId` alone.
+     * At least one of the two is required.
+     */
+    responseId?: string;
     userId?: string;
     /**
      * Optional: id of the ExoPhone the counsellor explicitly picked at the
@@ -25,6 +31,13 @@ export interface PlaceCallResponse {
      * of a spinner that never advances. Absent → treat as true (legacy).
      */
     realtimeEvents?: boolean;
+    /**
+     * The lead row the call was filed under. Echoed back because a learner call
+     * sends no responseId, yet the backend links an existing lead row when the
+     * learner happens to have one — the disposition sheet needs that id (status
+     * change + follow-up both key off it). Absent → skip disposition capture.
+     */
+    responseId?: string | null;
 }
 
 /**

--- a/frontend-admin-dashboard/src/components/shared/leads/use-place-call.ts
+++ b/frontend-admin-dashboard/src/components/shared/leads/use-place-call.ts
@@ -112,8 +112,13 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
     const onSuccess = useCallback(
         (
             resp: PlaceCallResponse,
-            vars: { responseId: string; userId?: string; leadName?: string }
+            vars: { responseId?: string; userId?: string; leadName?: string }
         ) => {
+            // The lead row to file the disposition against: the one the caller
+            // knew, else the one the backend linked for a learner call. Neither
+            // exists for a learner with no lead row — that call skips the sheet
+            // rather than posting a status change against a blank target.
+            const dispositionResponseId = vars.responseId ?? resp.responseId ?? null;
             // Post-call providers (Airtel) emit no live progress feed — the call
             // outcome only exists once the provider exports its CDR (minutes after
             // hang-up) and our importer promotes the row. Don't fake a streaming
@@ -153,6 +158,7 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
                     durationSeconds?: number | null
                 ) => {
                     if (dispositionFired || !DISPOSITION_STATUSES.has(status)) return;
+                    if (!dispositionResponseId) return;
                     dispositionFired = true;
                     void import('./post-call-disposition-sheet')
                         .then((m) =>
@@ -162,7 +168,7 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
                                 durationSeconds: durationSeconds ?? null,
                                 leadUserId: vars.userId,
                                 leadName: vars.leadName,
-                                responseId: vars.responseId,
+                                responseId: dispositionResponseId,
                                 queryClient,
                             })
                         )
@@ -318,6 +324,7 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
                 durationSeconds?: number | null
             ) => {
                 if (dispositionFired || !DISPOSITION_STATUSES.has(status)) return;
+                if (!dispositionResponseId) return;
                 dispositionFired = true;
                 void import('./post-call-disposition-sheet')
                     .then((m) =>
@@ -327,7 +334,7 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
                             durationSeconds: durationSeconds ?? null,
                             leadUserId: vars.userId,
                             leadName: vars.leadName,
-                            responseId: vars.responseId,
+                            responseId: dispositionResponseId,
                             queryClient,
                         })
                     )
@@ -472,7 +479,9 @@ export function usePlaceCall({ invalidateKeys = [] }: UsePlaceCallOptions = {}) 
 
     return useMutation({
         mutationFn: (vars: {
-            responseId: string;
+            /** CRM lead row. Omit for a learner call — `userId` then identifies
+             *  the person and the backend resolves the rest. */
+            responseId?: string;
             userId?: string;
             preferredNumberId?: string;
             /** Lead's display name — shown on the post-call disposition sheet

--- a/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
+++ b/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from '@tanstack/react-query';
+import { Phone } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
+import { CallPickerPopover } from '@/components/shared/leads/call-picker-popover';
+import { usePlaceCall } from '@/components/shared/leads/use-place-call';
+import { fetchCallOptions } from '@/components/shared/leads/services/call-options';
+
+/**
+ * Click-to-call button for a person who is NOT (necessarily) a CRM lead —
+ * an enrolled learner in the students list, the attendance tracker, or an
+ * assessment's participants, all of which open the same student side-view.
+ *
+ * The lead surfaces call by `responseId` (audience_response). Learners have no
+ * such row, so this passes `userId` alone and the backend resolves the person,
+ * their phone, and — when the learner ALSO came through a form — the lead row to
+ * file the call under, so one person never ends up with two call histories.
+ *
+ * Same picker + live-status toast as the leads Call button: an accidental click
+ * costs a popover, not provider credits.
+ */
+interface ContactCallButtonProps {
+    /** The person being called (auth user id). */
+    userId?: string | null;
+    /**
+     * audience_response id, when this row IS a CRM lead. The student side-view is
+     * shared with the lead surfaces, and a lead is usually not enrolled — passing
+     * it makes the backend take the lead path (phone off the lead row) instead of
+     * the learner path, whose institute-enrolment check a lead would fail.
+     */
+    responseId?: string | null;
+    /** Their number — only used to decide whether calling is possible at all;
+     *  the backend re-resolves it so we never dial a stale local value. */
+    phone?: string | null;
+    /** Shown on the post-call disposition sheet when the call files onto a lead. */
+    name?: string | null;
+    className?: string;
+}
+
+/**
+ * Is calling usable for this institute right now? The options endpoint is the
+ * honest signal — it 4xx's unless a provider is configured AND enabled, which is
+ * exactly the condition under which a Call button would work. Cached per
+ * institute so the many rows/panels that mount this share one request, and a
+ * failure simply hides the button rather than showing one that always errors.
+ */
+function useTelephonyEnabled(instituteId: string): boolean {
+    const query = useQuery({
+        queryKey: ['telephony-enabled', instituteId],
+        queryFn: () => fetchCallOptions(instituteId),
+        enabled: !!instituteId,
+        staleTime: 10 * 60 * 1000,
+        retry: false,
+    });
+    return query.isSuccess;
+}
+
+export function ContactCallButton({
+    userId,
+    responseId,
+    phone,
+    name,
+    className,
+}: ContactCallButtonProps) {
+    const instituteId = getCurrentInstituteId() ?? '';
+    const telephonyEnabled = useTelephonyEnabled(instituteId);
+    const placeCall = usePlaceCall();
+
+    const hasPhone = !!phone && phone.trim() !== '' && phone.trim() !== '-';
+    if (!telephonyEnabled || (!userId && !responseId) || !hasPhone) return null;
+
+    const disabled = placeCall.isPending;
+
+    return (
+        <CallPickerPopover
+            leadUserId={userId}
+            disabled={disabled}
+            disabledReason={disabled ? 'A call is already being placed' : undefined}
+            onConfirm={(preferredNumberId) =>
+                placeCall.mutate({
+                    responseId: responseId ?? undefined,
+                    userId: userId ?? undefined,
+                    preferredNumberId: preferredNumberId || undefined,
+                    leadName: name ?? undefined,
+                })
+            }
+            trigger={
+                <button
+                    type="button"
+                    onClick={(e) => e.stopPropagation()}
+                    disabled={disabled}
+                    title="Call"
+                    aria-label="Call"
+                    className={cn(
+                        'inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',
+                        disabled
+                            ? 'cursor-not-allowed opacity-50'
+                            : 'hover:bg-success-50 hover:text-success-600',
+                        className
+                    )}
+                >
+                    <Phone weight="fill" className="size-3.5" />
+                </button>
+            }
+        />
+    );
+}

--- a/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
+++ b/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
@@ -4,7 +4,10 @@ import { cn } from '@/lib/utils';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { CallPickerPopover } from '@/components/shared/leads/call-picker-popover';
 import { usePlaceCall } from '@/components/shared/leads/use-place-call';
-import { fetchCallOptions } from '@/components/shared/leads/services/call-options';
+import {
+    fetchCallAvailability,
+    type CallAvailability,
+} from '@/components/shared/leads/services/call-options';
 
 /**
  * Click-to-call button for a person who is NOT (necessarily) a CRM lead —
@@ -38,21 +41,22 @@ interface ContactCallButtonProps {
 }
 
 /**
- * Is calling usable for this institute right now? The options endpoint is the
- * honest signal — it 4xx's unless a provider is configured AND enabled, which is
- * exactly the condition under which a Call button would work. Cached per
- * institute so the many rows/panels that mount this share one request, and a
- * failure simply hides the button rather than showing one that always errors.
+ * Two separate questions, two separate answers — see CallAvailabilityDTO.
+ *
+ * Cached per institute (not per row) so the many places that mount this button
+ * share one request. On failure we say "not enabled", which hides the button:
+ * if we cannot even ask, offering a call that would throw is worse than showing
+ * nothing.
  */
-function useTelephonyEnabled(instituteId: string): boolean {
+function useCallAvailability(instituteId: string): CallAvailability {
     const query = useQuery({
-        queryKey: ['telephony-enabled', instituteId],
-        queryFn: () => fetchCallOptions(instituteId),
+        queryKey: ['telephony-availability', instituteId],
+        queryFn: () => fetchCallAvailability(instituteId),
         enabled: !!instituteId,
-        staleTime: 10 * 60 * 1000,
+        staleTime: 5 * 60 * 1000,
         retry: false,
     });
-    return query.isSuccess;
+    return query.data ?? { enabled: false, callerReady: false };
 }
 
 export function ContactCallButton({
@@ -63,19 +67,30 @@ export function ContactCallButton({
     className,
 }: ContactCallButtonProps) {
     const instituteId = getCurrentInstituteId() ?? '';
-    const telephonyEnabled = useTelephonyEnabled(instituteId);
+    const availability = useCallAvailability(instituteId);
     const placeCall = usePlaceCall();
 
     const hasPhone = !!phone && phone.trim() !== '' && phone.trim() !== '-';
-    if (!telephonyEnabled || (!userId && !responseId) || !hasPhone) return null;
 
-    const disabled = placeCall.isPending;
+    // Institute-level off → render nothing. Whoever is looking at this learner
+    // cannot turn calling on from here, so a permanently dead button would just
+    // be clutter that reads like a bug.
+    if (!availability.enabled || (!userId && !responseId) || !hasPhone) return null;
+
+    // Caller-level not set up → keep the button but disable it and say why. This
+    // is the admin-without-an-extension case, and it IS actionable ("ask an admin
+    // to add one"), so hiding it would leave them with no idea calling exists.
+    const notReady = !availability.callerReady;
+    const disabled = notReady || placeCall.isPending;
+    const reason = notReady
+        ? availability.reason ?? 'Your account is not set up to place calls yet'
+        : undefined;
 
     return (
         <CallPickerPopover
             leadUserId={userId}
             disabled={disabled}
-            disabledReason={disabled ? 'A call is already being placed' : undefined}
+            disabledReason={reason ?? (disabled ? 'A call is already being placed' : undefined)}
             onConfirm={(preferredNumberId) =>
                 placeCall.mutate({
                     responseId: responseId ?? undefined,
@@ -89,7 +104,7 @@ export function ContactCallButton({
                     type="button"
                     onClick={(e) => e.stopPropagation()}
                     disabled={disabled}
-                    title="Call"
+                    title={reason ?? 'Call'}
                     aria-label="Call"
                     className={cn(
                         'inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -299,6 +299,11 @@ export const TELEPHONY_COUNSELLOR_ENDPOINTS = (instituteId: string) =>
     `${BASE_URL}/admin-core-service/v1/telephony/counsellor-endpoints/${instituteId}`;
 export const TELEPHONY_COUNSELLOR_ENDPOINT_BY_ID = (id: string) =>
     `${BASE_URL}/admin-core-service/v1/telephony/counsellor-endpoints/${encodeURIComponent(id)}`;
+// Who may be given an extension: this institute's counsellors AND admins.
+// Deliberately not the lead-counsellor picker — an extension is a phone-system
+// fact, so an admin who never touches the CRM still needs one to call a learner.
+export const TELEPHONY_ENDPOINT_ELIGIBLE_USERS = (instituteId: string) =>
+    `${BASE_URL}/admin-core-service/v1/telephony/counsellor-endpoints/${instituteId}/eligible-users`;
 export const TELEPHONY_NUMBERS = `${BASE_URL}/admin-core-service/v1/telephony/numbers`;
 export const TELEPHONY_NUMBER_BY_ID = (id: string) =>
     `${BASE_URL}/admin-core-service/v1/telephony/numbers/${id}`;

--- a/frontend-admin-dashboard/src/constants/urls.ts
+++ b/frontend-admin-dashboard/src/constants/urls.ts
@@ -214,6 +214,11 @@ export const TELEPHONY_AI_CALL_CAMPAIGN = (audienceId: string) =>
     `${BASE_URL}/admin-core-service/v1/telephony/ai-call/campaign/${audienceId}`;
 // Returns { numbers, recommendedNumberId, strategyKey } — drives the runtime
 // picker on the Call button when an institute has multiple ExoPhones.
+// "Can this person call, and if not why" — always 200, unlike CALL_OPTIONS which
+// throws when the institute has calling off. Used to decide whether a Call button
+// renders at all, on pages that are not about calling.
+export const TELEPHONY_CALL_AVAILABILITY = (instituteId: string) =>
+    `${BASE_URL}/admin-core-service/v1/telephony/calls/availability?instituteId=${encodeURIComponent(instituteId)}`;
 export const TELEPHONY_CALL_OPTIONS = (instituteId: string, userId?: string) =>
     `${BASE_URL}/admin-core-service/v1/telephony/calls/options?instituteId=${encodeURIComponent(instituteId)}${userId ? `&userId=${encodeURIComponent(userId)}` : ''}`;
 // userId + instituteId are both required — the backend rejects cross-institute lookups.

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/profile-ui.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/profile-ui.tsx
@@ -79,11 +79,16 @@ export const ProfileFieldRow = ({
     value,
     copied,
     onCopy,
+    action,
 }: {
     label: string;
     value: React.ReactNode;
     copied?: boolean;
     onCopy?: () => void;
+    /** Optional control rendered after the copy button — e.g. the click-to-call
+     *  button on the mobile row. Shown only when the row has a real value, so a
+     *  blank field never offers an action that cannot work. */
+    action?: React.ReactNode;
 }) => {
     const { t } = useTranslation('manageStudentsProfileUi');
     // A value counts as "empty" — rendered as an em-dash with NO copy icon — when
@@ -123,6 +128,7 @@ export const ProfileFieldRow = ({
                         )}
                     </button>
                 )}
+                {action && !isEmpty && <span className="shrink-0">{action}</span>}
             </dd>
         </div>
     );

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-overview/student-overview.tsx
@@ -25,6 +25,7 @@ import { getCustomFieldSettingsFromCache } from '@/services/custom-field-setting
 import type { FieldGroup } from '@/services/custom-field-settings';
 import { getPublicUrl } from '@/services/upload_file';
 import { ProfileSectionCard, ProfileFieldRow, ProfileEmpty } from '../profile-ui';
+import { ContactCallButton } from '@/components/shared/telephony/contact-call-button';
 import { EditStudentDetails } from './EditStudentDetails';
 import { EditLeadDetails } from './EditLeadDetails';
 import { StudentAttribution } from '../student-attribution/student-attribution';
@@ -211,6 +212,19 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
     // this keeps working in every locale.
     const COPYABLE_FIELD_KEYS = new Set<string>([OverviewFieldKey.MobileNo, OverviewFieldKey.EmailId]);
 
+    // Click-to-call sits on the learner's OWN mobile row only. The guardian rows
+    // are other people's numbers, and the backend dials the number on the
+    // subject's record — offering a button there would silently dial the wrong
+    // person. The button hides itself when the institute has no calling
+    // configured, so this costs nothing for institutes that don't call.
+    //
+    // This sidebar is shared: Manage Students, the attendance tracker and an
+    // assessment's participants all open it, and so do the lead surfaces. Leads
+    // carry a `_response_id` and are usually not enrolled, so pass it through —
+    // the backend then takes the lead path instead of the learner path.
+    const leadResponseId = (selectedStudent as unknown as Record<string, unknown> | null)
+        ?._response_id as string | undefined;
+
     // Enrolment-derived rows (Course / Level / Session) are intentionally hidden
     // from the Overview tab — they live on the Courses / enrolment surfaces.
     // Matched on the stable field keys so renamed/translated terms still filter.
@@ -284,6 +298,17 @@ export const StudentOverview = ({ isSubmissionTab }: { isSubmissionTab?: boolean
                                                               fieldRow.key
                                                           )
                                                     : undefined
+                                            }
+                                            action={
+                                                fieldRow.key === OverviewFieldKey.MobileNo &&
+                                                !fieldRow.isEmpty ? (
+                                                    <ContactCallButton
+                                                        userId={selectedStudent?.user_id}
+                                                        responseId={leadResponseId}
+                                                        phone={fieldRow.value}
+                                                        name={selectedStudent?.full_name}
+                                                    />
+                                                ) : undefined
                                             }
                                         />
                                     );

--- a/frontend-admin-dashboard/src/routes/settings/telephony/-components/telephony-counsellor-map-card.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/telephony/-components/telephony-counsellor-map-card.tsx
@@ -13,21 +13,27 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
-import { useLeadCounsellorOptions } from '@/hooks/use-lead-counsellor-options';
 import {
     fetchTelephonyConfig,
     fetchTelephonyProviders,
     fetchCounsellorEndpoints,
+    fetchEndpointEligibleUsers,
     upsertCounsellorEndpoint,
     deleteCounsellorEndpoint,
     type TelephonyCounsellorEndpoint,
+    type TelephonyEndpointUser,
 } from '../-services/telephony-admin';
 
 /**
- * Per-counsellor extension/DID mapping for providers without a number pool
- * (Airtel). Hidden for pooled providers (Exotel uses the Numbers card instead).
- * Pick a counsellor and enter the extension their provider gave them — outbound
- * calls dial from it, and inbound CDRs/recordings are attributed back through it.
+ * Per-user extension/DID mapping for providers without a number pool (Airtel).
+ * Hidden for pooled providers (Exotel uses the Numbers card instead). Pick a
+ * person and enter the extension their provider gave them — outbound calls dial
+ * from it, and inbound CDRs/recordings are attributed back through it.
+ *
+ * The picker offers counsellors AND admins. It used to offer only counsellors,
+ * so an admin had no extension and every call they placed failed at origination
+ * — including calls to learners from the LMS side-view, where there is no
+ * counsellor in the flow at all.
  */
 export function TelephonyCounsellorMapCard() {
     const instituteId = getCurrentInstituteId() ?? '';
@@ -51,15 +57,20 @@ export function TelephonyCounsellorMapCard() {
         provider.capabilities.includes('OUTBOUND_CALL') &&
         !provider.capabilities.includes('NUMBER_POOL');
 
-    // Routing CONFIG picker — assignable mode so an ADMIN who also holds the
-    // COUNSELLOR role can still map any counsellor, not just their hierarchy.
-    const { options: counsellors, isLoading: counsellorsLoading } = useLeadCounsellorOptions({
-        assignable: true,
+    // Phone-system roster, not a lead-routing one: counsellors + admins, never
+    // hierarchy-scoped. An admin mapping extensions must see everyone who can dial.
+    const eligibleUsersQuery = useQuery({
+        queryKey: ['telephony-endpoint-eligible-users', instituteId],
+        queryFn: () => fetchEndpointEligibleUsers(instituteId),
+        enabled: !!instituteId,
+        staleTime: 5 * 60 * 1000,
     });
-    const nameById = useMemo(
-        () => new Map(counsellors.map((c) => [c.id, c.full_name])),
-        [counsellors]
+    const eligibleUsers: TelephonyEndpointUser[] = useMemo(
+        () => eligibleUsersQuery.data ?? [],
+        [eligibleUsersQuery.data]
     );
+    const usersLoading = eligibleUsersQuery.isLoading;
+    const userById = useMemo(() => new Map(eligibleUsers.map((u) => [u.id, u])), [eligibleUsers]);
 
     const endpointsQuery = useQuery({
         queryKey: ['telephony-counsellor-endpoints', instituteId, providerType],
@@ -104,7 +115,7 @@ export function TelephonyCounsellorMapCard() {
         onError: () => toast.error('Failed to remove mapping'),
     });
 
-    // When a counsellor with an existing mapping is picked, pre-fill the form.
+    // When someone with an existing mapping is picked, pre-fill the form.
     const onPickCounsellor = (id: string) => {
         setCounsellorUserId(id);
         const existing = endpointsQuery.data?.find((e) => e.counsellorUserId === id);
@@ -115,11 +126,11 @@ export function TelephonyCounsellorMapCard() {
 
     const onSave = () => {
         if (!counsellorUserId) {
-            toast.error('Pick a counsellor');
+            toast.error('Pick a counsellor or admin');
             return;
         }
         if (!extension.trim()) {
-            toast.error('Enter the counsellor’s extension');
+            toast.error('Enter their extension');
             return;
         }
         saveMutation.mutate({
@@ -141,12 +152,11 @@ export function TelephonyCounsellorMapCard() {
             <div className="mb-4 flex items-center gap-2">
                 <IdentificationBadge className="size-5 text-primary-600" />
                 <div>
-                    <h2 className="text-base font-semibold text-neutral-900">
-                        Counsellor extensions
-                    </h2>
+                    <h2 className="text-base font-semibold text-neutral-900">User extensions</h2>
                     <p className="text-sm text-neutral-500">
-                        Map each counsellor to the extension {provider?.displayName} gave them.
-                        Calls dial from it, and recordings are matched back to the right person.
+                        Map each counsellor or admin to the extension {provider?.displayName} gave
+                        them. Calls dial from it, and recordings are matched back to the right
+                        person. An admin needs one too before they can call a learner.
                     </p>
                 </div>
             </div>
@@ -157,8 +167,10 @@ export function TelephonyCounsellorMapCard() {
                     {endpoints.map((e) => (
                         <div key={e.id} className="flex items-center justify-between px-3 py-2">
                             <div className="flex flex-col">
-                                <span className="text-sm font-medium text-neutral-900">
-                                    {nameById.get(e.counsellorUserId) ?? e.counsellorUserId}
+                                <span className="flex items-center gap-1.5 text-sm font-medium text-neutral-900">
+                                    {userById.get(e.counsellorUserId)?.fullName ??
+                                        e.counsellorUserId}
+                                    <RoleBadges roles={userById.get(e.counsellorUserId)?.roles} />
                                 </span>
                                 <span className="text-xs text-neutral-500">
                                     Ext {e.extension}
@@ -180,24 +192,27 @@ export function TelephonyCounsellorMapCard() {
                 </div>
             ) : (
                 <p className="mb-4 text-sm text-neutral-500">
-                    No counsellors mapped yet — add one below so they can place calls.
+                    Nobody mapped yet — add someone below so they can place calls.
                 </p>
             )}
 
             {/* Add / edit a mapping */}
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                 <div className="space-y-1.5">
-                    <Label>Counsellor</Label>
+                    <Label>Counsellor or admin</Label>
                     <Select value={counsellorUserId} onValueChange={onPickCounsellor}>
                         <SelectTrigger className="h-10">
                             <SelectValue
-                                placeholder={counsellorsLoading ? 'Loading…' : 'Select a counsellor'}
+                                placeholder={usersLoading ? 'Loading…' : 'Select a person'}
                             />
                         </SelectTrigger>
                         <SelectContent>
-                            {counsellors.map((c) => (
-                                <SelectItem key={c.id} value={c.id}>
-                                    {c.full_name}
+                            {eligibleUsers.map((u) => (
+                                <SelectItem key={u.id} value={u.id}>
+                                    <span className="flex items-center gap-1.5">
+                                        {u.fullName}
+                                        <RoleBadges roles={u.roles} />
+                                    </span>
                                 </SelectItem>
                             ))}
                         </SelectContent>
@@ -243,5 +258,30 @@ export function TelephonyCounsellorMapCard() {
                 </Button>
             </div>
         </div>
+    );
+}
+
+/**
+ * Role chips next to a name — the list mixes counsellors and admins, so whoever
+ * is mapping extensions can tell them apart at a glance. Only the two roles this
+ * picker selects on are shown; any other role a user holds is noise here.
+ */
+function RoleBadges({ roles }: { roles?: string[] | null }) {
+    if (!roles || roles.length === 0) return null;
+    const shown: string[] = [];
+    if (roles.includes('ADMIN')) shown.push('Admin');
+    if (roles.includes('COUNSELLOR') || roles.includes('COUNSELOR')) shown.push('Counsellor');
+    if (shown.length === 0) return null;
+    return (
+        <>
+            {shown.map((label) => (
+                <span
+                    key={label}
+                    className="rounded-full bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-600"
+                >
+                    {label}
+                </span>
+            ))}
+        </>
     );
 }

--- a/frontend-admin-dashboard/src/routes/settings/telephony/-services/telephony-admin.ts
+++ b/frontend-admin-dashboard/src/routes/settings/telephony/-services/telephony-admin.ts
@@ -4,6 +4,7 @@ import {
     TELEPHONY_PROVIDERS,
     TELEPHONY_COUNSELLOR_ENDPOINTS,
     TELEPHONY_COUNSELLOR_ENDPOINT_BY_ID,
+    TELEPHONY_ENDPOINT_ELIGIBLE_USERS,
     TELEPHONY_NUMBERS,
     TELEPHONY_NUMBER_BY_ID,
     TELEPHONY_NUMBER_ATTACH,
@@ -39,6 +40,15 @@ export interface TelephonyCounsellorEndpoint {
     providerUserId?: string | null;
     did?: string | null;
     enabled?: boolean | null;
+}
+
+/** A person eligible to hold a provider extension (counsellor or admin). */
+export interface TelephonyEndpointUser {
+    id: string;
+    fullName: string;
+    email?: string | null;
+    /** Institute roles, uppercased — e.g. ["ADMIN"], ["COUNSELLOR"]. */
+    roles?: string[] | null;
 }
 
 export interface TelephonyConfigView {
@@ -163,6 +173,21 @@ export const upsertCounsellorEndpoint = async (
         input
     );
     return data;
+};
+
+/**
+ * The people an admin may map an extension to: the institute's counsellors AND
+ * its admins. Replaces the lead-counsellor picker on this card — that list is
+ * COUNSELLOR-role only and hierarchy-scoped, so an admin could never be given an
+ * extension even though they need one to call a learner from the LMS side-view.
+ */
+export const fetchEndpointEligibleUsers = async (
+    instituteId: string
+): Promise<TelephonyEndpointUser[]> => {
+    const { data } = await authenticatedAxiosInstance.get<TelephonyEndpointUser[]>(
+        TELEPHONY_ENDPOINT_ELIGIBLE_USERS(instituteId)
+    );
+    return data ?? [];
 };
 
 export const deleteCounsellorEndpoint = async (id: string): Promise<void> => {


### PR DESCRIPTION
Two separate gaps blocked an admin from calling an LMS student.

Admins could not be given an extension. The DB was never the constraint: telephony_counsellor_endpoint holds any user id, and AirtelOriginationResolver just looks up the caller's. Only the settings picker was scoped, because it reused /lead-counsellor-options — a lead-ASSIGNMENT list, so COUNSELLOR-role only and hierarchy-scoped. An admin therefore had no extension and every call they placed died at origination. Adds a dedicated eligible-users endpoint returning the institute's counsellors AND admins; the card is now "User extensions" and badges each row by role. No migration: the column stays counsellor_user_id because the row is just "who dials from this extension".

Calls required a lead. /calls/connect took only a responseId (audience_response), which learners don't have, so the LMS surfaces had no way to dial at all. responseId is now optional and userId alone works. The learner path checks the person is enrolled in THIS institute before dialling — the phone lookup hits auth_service globally, so without that check a bare user id would let any calling-enabled institute reach any user on the platform. It also attaches the learner's newest lead row when they have one, so someone who came through a form and then enrolled keeps a single call history and timeline rather than two. The response echoes that id back so the UI knows whether the post-call disposition sheet applies; a learner with no lead row skips it instead of posting a status change against a blank target.

The button lands on the Mobile No. row of the side-view Overview. That one sidebar is what Manage Students, the attendance tracker and an assessment's participants all open, so all three get calling from a single mount. Guardian mobile rows deliberately get none — the backend dials the number on the subject's own record, so a button there would silently call the wrong person. The sidebar is shared with the lead surfaces too, hence the _response_id passthrough: a lead is usually not enrolled and would fail the learner check.

Verified: admin_core_service compiles clean from scratch on this branch. Frontend typecheck and eslint are clean for every touched file. Not yet exercised against a live Airtel account.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
