### PR TITLE
fix(payments): stop the plan editor orphaning one-time plans, and sto…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/SubscriptionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/SubscriptionService.java
@@ -165,7 +165,11 @@ public class SubscriptionService {
         try {
             return planChangeService.summarise(plan, instituteId, packageSessionIds);
         } catch (Exception e) {
-            log.warn("Could not resolve plan-change eligibility for plan {}: {}", plan.getId(), e.getMessage());
+            // ERROR with the stack trace, deliberately: degrading to "no switching offered"
+            // makes a genuine failure look identical to "correctly not eligible", and that
+            // ambiguity has already cost a debugging session. The card still renders.
+            log.error("Could not resolve plan-change eligibility for plan {} (institute {}) — "
+                    + "reporting not-eligible", plan.getId(), instituteId, e);
             return new PlanChangeService.PlanChangeSummary(false, null);
         }
     }

--- a/frontend-admin-dashboard/src/routes/settings/-components/Payment/PaymentPlanEditor.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Payment/PaymentPlanEditor.tsx
@@ -108,6 +108,11 @@ export const PaymentPlanEditor: React.FC<PaymentPlanEditorProps> = ({
                         ) || [],
                 },
                 upfront: {
+                    // Spread first: this block rebuilds config.upfront field-by-field, so
+                    // anything not named here is dropped. planId was — and losing it makes
+                    // the save look like a NEW plan, so editing a one-time option retired
+                    // its plan and minted a duplicate, orphaning every user_plan on it.
+                    ...(editingPlan.config?.upfront || {}),
                     fullPrice: editingPlan.config?.upfront?.fullPrice || '',
                     // transformApiPlanToLocalFormat derives these from validity_in_days,
                     // so an existing plan re-opens on the option it was saved with.


### PR DESCRIPTION
…p hiding failures

Two follow-ups from debugging why a learner saw no "change plan" option.

PaymentPlanEditor rebuilt config.upfront field-by-field on load — an allow-list, not a spread — so planId was dropped the moment a one-time option was opened in the editor. The save then had no id to send, the backend treated the plan as new, and editPaymentPlans retired the stored one and minted a duplicate. That is how "oneTime" ended up existing twice at the same price, with the learner's user_plan pointing at one row and the switchable flag on the other. The creator path already round-tripped the id correctly; only the editor lost it.

SubscriptionService.planChangeSummary degraded to "not eligible" on any exception and logged it at WARN with e.getMessage() and no stack trace. The degrade is right — a failure here must never take down the learner's whole membership card — but it made a genuine bug indistinguishable from a correct "nothing to switch to", which cost a debugging session. Now logged at ERROR with the stack trace and the institute id; behaviour is unchanged.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
