### PR TITLE
Fix the inverted Airtel readiness check, and stop it vetoing calls

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/UserMobileResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/UserMobileResolver.java
@@ -56,6 +56,26 @@ public class UserMobileResolver {
     }
 
     /**
+     * Same lookup, but a FAILED lookup propagates instead of being flattened
+     * into "no mobile on file".
+     *
+     * <p>{@link #findMobile} catches everything and returns empty, which suits
+     * the dial path (it is about to fail anyway with a clear message). It does
+     * NOT suit the pre-flight readiness probe behind the Call button: there,
+     * empty means "disable this person's button and tell them to add a mobile
+     * number", and an auth_service blip would say that to a counsellor whose
+     * number is sitting right there in their profile. Letting the exception out
+     * lets the probe's caller fail OPEN and leave the button alone.
+     */
+    public Optional<String> findVerifiedMobileStrict(String userId) {
+        if (userId == null || userId.isBlank()) return Optional.empty();
+        List<UserDTO> users = authService.getUsersFromAuthServiceByUserIds(List.of(userId));
+        if (users == null || users.isEmpty()) return Optional.empty();
+        String mobile = users.get(0).getMobileNumber();
+        return (mobile == null || mobile.isBlank()) ? Optional.empty() : Optional.of(mobile);
+    }
+
+    /**
      * The user's stored gender as {@code "MALE"}/{@code "FEMALE"} when set on the
      * auth record, else empty. Used to tell the AI voice bot how to address the lead
      * (honorific + Hindi second-person agreement). Form leads usually have no gender

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/airtel/AirtelOriginationResolver.java
@@ -39,14 +39,23 @@ public class AirtelOriginationResolver implements OutboundOriginationResolver {
     @Override
     public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
         if (callerUserId == null || callerUserId.isBlank()) return Optional.of(NO_ENDPOINT);
-        return endpointRepo
+        // Written as plain branches on purpose. The first version chained
+        // .map(e -> ready ? null : REASON) — and Optional.map treats a null
+        // mapper result as EMPTY, so the ready case collapsed into the same
+        // empty Optional as "no endpoint row at all" and then took the
+        // .orElse(NO_ENDPOINT) branch. Net effect: the only people reported as
+        // blocked were the ones who actually had a working extension, which
+        // disabled the Call button for every correctly-configured Airtel
+        // counsellor and admin. Nothing here is worth an Optional chain.
+        TelephonyCounsellorEndpoint ep = endpointRepo
                 .findByCounsellorUserIdAndProviderType(callerUserId, ProviderType.AIRTEL)
                 .filter(e -> Boolean.TRUE.equals(e.getEnabled()))
-                .map(e -> (e.getExtension() == null || e.getExtension().isBlank())
-                        ? NO_EXTENSION
-                        : null)
-                .map(Optional::ofNullable)
-                .orElse(Optional.of(NO_ENDPOINT));
+                .orElse(null);
+        if (ep == null) return Optional.of(NO_ENDPOINT);
+        if (ep.getExtension() == null || ep.getExtension().isBlank()) {
+            return Optional.of(NO_EXTENSION);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/exotel/ExotelOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/exotel/ExotelOriginationResolver.java
@@ -53,7 +53,13 @@ public class ExotelOriginationResolver implements OutboundOriginationResolver {
 
     @Override
     public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
-        return userMobileResolver.findVerifiedMobile(callerUserId).isPresent()
+        // Strict lookup, so an auth_service failure THROWS here and
+        // computeAvailability's catch degrades to "ready". findVerifiedMobile
+        // collapses an outage into an empty Optional, indistinguishable from
+        // "this person genuinely has no mobile" — using it would have disabled
+        // the Call button for every working counsellor during a blip, and told
+        // them to go add a mobile number they already have.
+        return userMobileResolver.findVerifiedMobileStrict(callerUserId).isPresent()
                 ? Optional.empty()
                 : Optional.of(NO_VERIFIED_MOBILE);
     }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/plivo/PlivoOriginationResolver.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/providers/plivo/PlivoOriginationResolver.java
@@ -49,7 +49,13 @@ public class PlivoOriginationResolver implements OutboundOriginationResolver {
 
     @Override
     public Optional<String> callerBlockedReason(String instituteId, String callerUserId) {
-        return userMobileResolver.findVerifiedMobile(callerUserId).isPresent()
+        // Strict lookup, so an auth_service failure THROWS here and
+        // computeAvailability's catch degrades to "ready". findVerifiedMobile
+        // collapses an outage into an empty Optional, indistinguishable from
+        // "this person genuinely has no mobile" — using it would have disabled
+        // the Call button for every working counsellor during a blip, and told
+        // them to go add a mobile number they already have.
+        return userMobileResolver.findVerifiedMobileStrict(callerUserId).isPresent()
                 ? Optional.empty()
                 : Optional.of(NO_VERIFIED_MOBILE);
     }

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/telephony/providers/CallerReadinessTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/telephony/providers/CallerReadinessTest.java
@@ -1,0 +1,169 @@
+package vacademy.io.admin_core_service.features.telephony.providers;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import vacademy.io.admin_core_service.features.telephony.core.UserMobileResolver;
+import vacademy.io.admin_core_service.features.telephony.core.VoiceCallingSettingsService;
+import vacademy.io.admin_core_service.features.telephony.enums.ProviderType;
+import vacademy.io.admin_core_service.features.telephony.persistence.entity.TelephonyCounsellorEndpoint;
+import vacademy.io.admin_core_service.features.telephony.persistence.repository.TelephonyCounsellorEndpointRepository;
+import vacademy.io.admin_core_service.features.telephony.providers.airtel.AirtelOriginationResolver;
+import vacademy.io.admin_core_service.features.telephony.providers.exotel.ExotelOriginationResolver;
+import vacademy.io.admin_core_service.features.telephony.providers.plivo.PlivoOriginationResolver;
+import vacademy.io.admin_core_service.features.telephony.persistence.repository.TelephonyCallLogRepository;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pre-flight readiness: "can THIS person place a call", asked before we know who
+ * they are dialling, so the Call button can be disabled with an actionable
+ * reason instead of failing after a click that may cost provider credits.
+ *
+ * <p>These exist because the first Airtel implementation inverted its own
+ * answer. It chained {@code .map(e -> ready ? null : REASON)}, and
+ * {@code Optional.map} turns a null mapper result into an EMPTY Optional — so
+ * the ready case became indistinguishable from "no endpoint row" and fell
+ * through to the not-mapped branch. The only people reported as blocked were
+ * the ones correctly configured, which disabled calling for every Airtel
+ * counsellor and admin who had an extension. Every branch is pinned here.
+ */
+class CallerReadinessTest {
+
+    private static final String INSTITUTE = "inst-1";
+    private static final String USER = "user-1";
+
+    /** These resolvers take their collaborators by field injection, so the test
+     *  sets them directly rather than standing up a Spring context. */
+    private static void inject(Object target, String field, Object value) {
+        try {
+            Field f = target.getClass().getDeclaredField(field);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("could not inject " + field, e);
+        }
+    }
+
+    private static TelephonyCounsellorEndpoint endpoint(String extension, boolean enabled) {
+        TelephonyCounsellorEndpoint ep = new TelephonyCounsellorEndpoint();
+        ep.setInstituteId(INSTITUTE);
+        ep.setCounsellorUserId(USER);
+        ep.setProviderType(ProviderType.AIRTEL);
+        ep.setExtension(extension);
+        ep.setEnabled(enabled);
+        return ep;
+    }
+
+    @Nested
+    class Airtel {
+
+        private AirtelOriginationResolver resolverWith(Optional<TelephonyCounsellorEndpoint> row) {
+            TelephonyCounsellorEndpointRepository repo =
+                    mock(TelephonyCounsellorEndpointRepository.class);
+            when(repo.findByCounsellorUserIdAndProviderType(anyString(), eq(ProviderType.AIRTEL)))
+                    .thenReturn(row);
+            AirtelOriginationResolver resolver = new AirtelOriginationResolver();
+            inject(resolver, "endpointRepo", repo);
+            return resolver;
+        }
+
+        /** The regression: a correctly-mapped extension must read as READY. */
+        @Test
+        void mappedExtensionIsReady() {
+            Optional<String> blocked = resolverWith(Optional.of(endpoint("447", true)))
+                    .callerBlockedReason(INSTITUTE, USER);
+            assertTrue(blocked.isEmpty(),
+                    "an enabled endpoint with an extension must not be reported blocked, got: "
+                            + blocked.orElse(""));
+        }
+
+        @Test
+        void noEndpointRowIsBlocked() {
+            Optional<String> blocked = resolverWith(Optional.empty())
+                    .callerBlockedReason(INSTITUTE, USER);
+            assertTrue(blocked.isPresent());
+            assertTrue(blocked.get().contains("extension"),
+                    "reason should name the missing extension");
+        }
+
+        @Test
+        void endpointWithBlankExtensionIsBlocked() {
+            assertTrue(resolverWith(Optional.of(endpoint("  ", true)))
+                    .callerBlockedReason(INSTITUTE, USER).isPresent());
+            assertTrue(resolverWith(Optional.of(endpoint(null, true)))
+                    .callerBlockedReason(INSTITUTE, USER).isPresent());
+        }
+
+        /** A disabled mapping is the admin's way of revoking calling. */
+        @Test
+        void disabledEndpointIsBlocked() {
+            assertTrue(resolverWith(Optional.of(endpoint("447", false)))
+                    .callerBlockedReason(INSTITUTE, USER).isPresent());
+        }
+
+        @Test
+        void blankCallerIsBlocked() {
+            AirtelOriginationResolver resolver = resolverWith(Optional.of(endpoint("447", true)));
+            assertTrue(resolver.callerBlockedReason(INSTITUTE, null).isPresent());
+            assertTrue(resolver.callerBlockedReason(INSTITUTE, "  ").isPresent());
+        }
+    }
+
+    @Nested
+    class VerifiedMobileProviders {
+
+        private ExotelOriginationResolver exotel(UserMobileResolver mobiles) {
+            return new ExotelOriginationResolver(mobiles, mock(TelephonyCallLogRepository.class),
+                    List.of());
+        }
+
+        private PlivoOriginationResolver plivo(UserMobileResolver mobiles) {
+            return new PlivoOriginationResolver(mobiles, mock(VoiceCallingSettingsService.class));
+        }
+
+        @Test
+        void mobileOnFileIsReady() {
+            UserMobileResolver mobiles = mock(UserMobileResolver.class);
+            when(mobiles.findVerifiedMobileStrict(USER)).thenReturn(Optional.of("+919000000000"));
+            assertTrue(exotel(mobiles).callerBlockedReason(INSTITUTE, USER).isEmpty());
+            assertTrue(plivo(mobiles).callerBlockedReason(INSTITUTE, USER).isEmpty());
+        }
+
+        @Test
+        void noMobileIsBlocked() {
+            UserMobileResolver mobiles = mock(UserMobileResolver.class);
+            when(mobiles.findVerifiedMobileStrict(USER)).thenReturn(Optional.empty());
+            assertTrue(exotel(mobiles).callerBlockedReason(INSTITUTE, USER).isPresent());
+            assertTrue(plivo(mobiles).callerBlockedReason(INSTITUTE, USER).isPresent());
+        }
+
+        /**
+         * A lookup FAILURE must escape, not be reported as "no mobile". The
+         * orchestrator catches it and leaves the button enabled — an
+         * auth_service blip must never tell a counsellor to add a number they
+         * already have, nor disable calling that would otherwise work.
+         */
+        @Test
+        void lookupFailurePropagatesSoTheCallerCanFailOpen() {
+            UserMobileResolver mobiles = mock(UserMobileResolver.class);
+            when(mobiles.findVerifiedMobileStrict(USER))
+                    .thenThrow(new VacademyException("auth_service down"));
+            assertEquals("auth_service down",
+                    org.junit.jupiter.api.Assertions.assertThrows(VacademyException.class,
+                            () -> exotel(mobiles).callerBlockedReason(INSTITUTE, USER))
+                            .getMessage());
+            org.junit.jupiter.api.Assertions.assertThrows(VacademyException.class,
+                    () -> plivo(mobiles).callerBlockedReason(INSTITUTE, USER));
+        }
+    }
+}

--- a/frontend-admin-dashboard/src/components/shared/leads/call-picker-popover.tsx
+++ b/frontend-admin-dashboard/src/components/shared/leads/call-picker-popover.tsx
@@ -104,7 +104,6 @@ export function CallPickerPopover({
     }, [open]);
 
     const handleConfirm = () => {
-        if (callerBlockedReason) return;
         // Pooled providers require a picked number; no-pool providers dial from
         // the counsellor's extension, so an empty preferredNumberId is correct.
         if (usesNumberPool && !selectedId) return;
@@ -161,11 +160,11 @@ export function CallPickerPopover({
                         !availabilityQuery.isLoading &&
                         !optionsQuery.isError &&
                         callerBlockedReason && (
-                            <div className="px-3 py-2.5">
-                                <p className="text-sm font-medium text-neutral-900">
-                                    You cannot place calls yet
+                            <div className="mx-2 mb-1 rounded-md bg-warning-50 px-3 py-2">
+                                <p className="text-xs font-medium text-warning-700">
+                                    This call may not connect
                                 </p>
-                                <p className="mt-1 text-xs text-neutral-500">
+                                <p className="mt-0.5 text-xs text-warning-600">
                                     {callerBlockedReason}
                                 </p>
                             </div>
@@ -173,7 +172,6 @@ export function CallPickerPopover({
                     {!optionsQuery.isLoading &&
                         !availabilityQuery.isLoading &&
                         !optionsQuery.isError &&
-                        !callerBlockedReason &&
                         !usesNumberPool && (
                             <div className="px-3 py-2.5">
                                 <p className="text-sm font-medium text-neutral-900">
@@ -190,7 +188,6 @@ export function CallPickerPopover({
                     {usesNumberPool &&
                         !optionsQuery.isLoading &&
                         !optionsQuery.isError &&
-                        !callerBlockedReason &&
                         numbers.length === 0 && (
                             <p className="px-3 py-2 text-xs text-neutral-500">
                                 No calling numbers configured. Ask an admin to set one up under
@@ -198,7 +195,6 @@ export function CallPickerPopover({
                             </p>
                         )}
                     {usesNumberPool &&
-                        !callerBlockedReason &&
                         numbers.map((n) => {
                         const isRecommended = n.id === recommendedId;
                         const isSelected = n.id === selectedId;
@@ -259,7 +255,6 @@ export function CallPickerPopover({
                             optionsQuery.isLoading ||
                             availabilityQuery.isLoading ||
                             optionsQuery.isError ||
-                            !!callerBlockedReason ||
                             (usesNumberPool && (!selectedId || numbers.length === 0))
                         }
                         className="h-8"

--- a/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
+++ b/frontend-admin-dashboard/src/components/shared/telephony/contact-call-button.tsx
@@ -77,13 +77,16 @@ export function ContactCallButton({
     // be clutter that reads like a bug.
     if (!availability.enabled || (!userId && !responseId) || !hasPhone) return null;
 
-    // Caller-level not set up → keep the button but disable it and say why. This
-    // is the admin-without-an-extension case, and it IS actionable ("ask an admin
-    // to add one"), so hiding it would leave them with no idea calling exists.
+    // Caller-level not set up → say so in the tooltip, but do NOT disable. The
+    // probe is advisory (see OutboundOriginationResolver#callerBlockedReason);
+    // treating it as a veto is what let one inverted Optional chain silence
+    // calling for every correctly-configured Airtel user. A wrong "blocked"
+    // would cost them calling entirely; a wrong "ready" costs one click and the
+    // same error toast as before. The backend decides at dial time.
     const notReady = !availability.callerReady;
-    const disabled = notReady || placeCall.isPending;
+    const disabled = placeCall.isPending;
     const reason = notReady
-        ? availability.reason ?? 'Your account is not set up to place calls yet'
+        ? availability.reason ?? 'Your account may not be set up to place calls yet'
         : undefined;
 
     return (


### PR DESCRIPTION
The Call button showed disabled for admins and counsellors who were correctly set up — an extension mapped, the institute's telephony configured. Exactly backwards, and my fault.

callerBlockedReason chained .map(e -> ready ? null : REASON). Optional.map treats a null mapper result as EMPTY, so the ready case collapsed into the same empty Optional as "no endpoint row at all" and then took .orElse(NO_ENDPOINT). The only people reported blocked were the ones with a working extension. Rewritten as plain branches; nothing there was worth an Optional chain.

Two things bounded the damage, neither by design: resolve() was untouched, so anything reaching /connect still dialled, and the institute-level gate only ever fed the new learner button — the picker never read it. What did reach counsellors was the veto, and that is the deeper mistake.

The SPI docblock says this probe is advisory and resolve() is the authority. Disabling the button on it said otherwise, which is why one bad answer could silence calling instead of merely showing a wrong hint. The failure modes are not symmetric: a false "blocked" costs someone their ability to call at all, a false "ready" costs one click and the same error toast they got before any of this existed. So the warning now informs without vetoing — the reason still shows up front, the button stays clickable, and in the picker the warning is a banner above the content rather than a replacement for it, so a mis-fire cannot hide the number list either. Nothing added here can now block a call that would have worked before.

Also fixes a latent one found while in there: the Exotel/Plivo probe used findVerifiedMobile, which swallows exceptions and returns empty, making an auth_service outage indistinguishable from "this person has no mobile" — it would have warned every working counsellor to add a number already in their profile. findVerifiedMobileStrict lets the failure propagate so computeAvailability's catch degrades to "ready".

CallerReadinessTest pins all eight branches. Verified it actually catches this: against the buggy version mappedExtensionIsReady fails with the exact symptom reported ("No Airtel extension is mapped to you"), and passes after. 78 telephony/audience/lead tests green, BUILD SUCCESS.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
