### PR TITLE
fix(ai-calling): a template swap no longer leaves the old parameters …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
@@ -585,6 +585,15 @@ public class AiCallActionService {
                     positional.put(String.valueOf(i++), resolveParam(param, vars));
                 }
             }
+            // A media-header template renders an image/document above the body and is
+            // rejected outright without one: "(#132012) ... header: Format mismatch,
+            // expected IMAGE, received UNKNOWN" - sn_unlockx on every Shikshanation call.
+            // UnifiedSendService reads _headerUrl per recipient, and both provider paths
+            // filter "_"-prefixed keys out of the body parameters, so this cannot disturb
+            // the positional count above - the very thing (#132000) punishes.
+            if (notBlank(rule.getTemplateHeaderUrl())) {
+                positional.put("_headerUrl", resolveParam(rule.getTemplateHeaderUrl(), vars));
+            }
             return mapper.writeValueAsString(positional);
         } catch (Exception e) {
             return "{}";

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
@@ -82,6 +82,27 @@ public class AiCallActionRule {
     private String templateLanguage;
 
     /**
+     * WhatsApp only: the image or document a media-header template renders above its body.
+     *
+     * <p>A template whose HEADER format is IMAGE or DOCUMENT will not send without one —
+     * Meta answers "(#132012) Parameter format does not match format in the created
+     * template ... header: Format mismatch, expected IMAGE, received UNKNOWN". That is
+     * what sn_unlockx did on every Shikshanation call once its body parameters were
+     * corrected: the caller agreed on the call and the promised WhatsApp never arrived.
+     *
+     * <p>Travels to the action as the {@code _headerUrl} entry in variables_json.
+     * UnifiedSendService reads that key per recipient, and both provider paths
+     * (WhatsAppService, WatiService) filter {@code _}-prefixed keys out of the body
+     * parameters, so it cannot disturb the positional count that {@link #templateParams}
+     * has to match exactly.
+     *
+     * <p>VIDEO headers are NOT supported here: they need options.headerType="video" on the
+     * send request, which the AI-call dispatcher does not set. IMAGE and DOCUMENT both
+     * take the default link path, which is why they work without one.
+     */
+    private String templateHeaderUrl;
+
+    /**
      * EMAIL only: what the person actually receives.
      *
      * <p>Email has no Meta template — EngagementDispatcher emails {@code draft_body}

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -29,6 +29,7 @@ import { whatsappTemplateService } from '@/services/whatsapp-template-service';
 import { getCurrentInstituteId } from '@/lib/auth/instituteUtils';
 import { fetchEmailTemplates } from '@/routes/calling/ai-agents/-services/ai-agents';
 import type { AiCallActionRule } from '@/routes/settings/-components/AiAgentsCard';
+import type { MetaWhatsAppTemplate } from '@/types/message-template-types';
 
 type TriggerKind = 'promised' | 'declined' | 'custom' | 'disposition' | 'meeting' | 'extracted';
 
@@ -74,7 +75,10 @@ function triggerKindOf(rule: AiCallActionRule): TriggerKind {
  * the admin saw a configured rule, the agent offered the link on a live call, and
  * nothing was ever sent.
  */
-function ruleProblems(rule: AiCallActionRule): string[] {
+function ruleProblems(
+    rule: AiCallActionRule,
+    templates: MetaWhatsAppTemplate[] = []
+): string[] {
     const problems: string[] = [];
     if (!rule.artefact || !rule.artefact.trim()) {
         problems.push('Give this rule a name — the AI needs one to refer to it.');
@@ -98,6 +102,37 @@ function ruleProblems(rule: AiCallActionRule): string[] {
         problems.push('Choose an approved WhatsApp template.');
     } else if (rule.channel === 'EMAIL' && !rule.messageBody) {
         problems.push('Write the email message.');
+    }
+    // Rules saved BEFORE the swap handler cleared stale params still carry the wrong
+    // count, and nothing on screen says so — the editor renders the current template's
+    // blanks while the rule holds the old array. Meta rejects that send outright, so
+    // surface it here rather than letting it fail silently on a live call.
+    if (rule.actionType !== 'BOOK_MEETING' && rule.channel === 'WHATSAPP' && rule.template) {
+        const chosen = templates.find((t) => t.name === rule.template);
+        if (chosen) {
+            // A media header needs an image/video/document supplied per send, and the
+            // AI-call path has nowhere to put one: EngagementDispatcher sets only
+            // source and sourceId on SendOptions, never headerUrl. Meta answers 132012,
+            // "header: Format mismatch, expected IMAGE, received UNKNOWN" — which is
+            // what sn_unlockx did on every Shikshanation call once its body params were
+            // fixed. The template can never succeed here, so say so while it is being
+            // chosen rather than on a live call.
+            const headerFormat = chosen.components?.find((c) => c.type === 'HEADER')?.format;
+            if (headerFormat && headerFormat !== 'TEXT') {
+                problems.push(
+                    `"${rule.template}" has a ${headerFormat.toLowerCase()} header. An AI call cannot attach one, so Meta rejects the send — choose a template whose header is text-only, or none.`
+                );
+            }
+            const need = templateParamCount(chosen);
+            const have = (rule.templateParams || []).length;
+            if (have !== need) {
+                problems.push(
+                    need === 0
+                        ? `"${rule.template}" takes no variables, but ${have} value${have === 1 ? '' : 's'} from a previous template ${have === 1 ? 'is' : 'are'} still saved. Pick the template again to clear them.`
+                        : `"${rule.template}" needs exactly ${need} value${need === 1 ? '' : 's'}, but ${have} ${have === 1 ? 'is' : 'are'} saved. Pick the template again to reset them.`
+                );
+            }
+        }
     }
     // The question IS the trigger for a "caller says yes" rule: with no question the
     // agent never offers it, so nothing can be agreed to and the rule sits idle.
@@ -131,6 +166,12 @@ function templatePlaceholders(bodyText: string): number {
         m = re.exec(bodyText || '');
     }
     return found.size;
+}
+
+/** How many values the chosen template needs. 0 when we cannot see its body. */
+function templateParamCount(t?: MetaWhatsAppTemplate): number {
+    const body = t?.components?.find((c) => c.type === 'BODY')?.text || '';
+    return templatePlaceholders(body);
 }
 
 /** The variables a call can always fill, offered as a hint next to each parameter. */
@@ -474,9 +515,31 @@ export function SendRulesEditor({
                                         value={rule.template || ''}
                                         onValueChange={(v) => {
                                             const t = templates.find((x) => x.name === v);
+                                            // Meta parameters are positional and the count must
+                                            // match EXACTLY, so the params belong to the template
+                                            // that is chosen now — not to the one it replaced.
+                                            // Leaving them behind is silent: the editor renders
+                                            // the new template's blanks (or "takes no variables")
+                                            // while the rule still carries the old array, and the
+                                            // mismatch only surfaces mid-call, as Meta error 132000.
+                                            // Shikshanation's quiz rule kept two params from
+                                            // hello_utility_confirmation after being pointed at
+                                            // sn_unlockx, which declares none, and every send
+                                            // failed. Values for positions the new template still
+                                            // has are kept, so swapping between two 2-variable
+                                            // templates does not make the admin retype them.
+                                            const count = templateParamCount(t);
+                                            const prev = rule.templateParams || [];
                                             update(i, {
                                                 template: v,
                                                 templateLanguage: t?.language || undefined,
+                                                templateParams:
+                                                    count === 0
+                                                        ? []
+                                                        : Array.from(
+                                                              { length: count },
+                                                              (_x, k) => prev[k] || ''
+                                                          ),
                                             });
                                         }}
                                     >
@@ -641,9 +704,9 @@ Namaste {{name}}, ...`}
                             <div />
                         </div>
 
-                        {ruleProblems(rule).length > 0 && (
+                        {ruleProblems(rule, templates).length > 0 && (
                             <div className="rounded-md bg-warning-50 p-2">
-                                {ruleProblems(rule).map((problem) => (
+                                {ruleProblems(rule, templates).map((problem) => (
                                     <p key={problem} className="text-caption text-warning-600">
                                         {problem}
                                     </p>

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -110,17 +110,26 @@ function ruleProblems(
     if (rule.actionType !== 'BOOK_MEETING' && rule.channel === 'WHATSAPP' && rule.template) {
         const chosen = templates.find((t) => t.name === rule.template);
         if (chosen) {
-            // A media header needs an image/video/document supplied per send, and the
-            // AI-call path has nowhere to put one: EngagementDispatcher sets only
-            // source and sourceId on SendOptions, never headerUrl. Meta answers 132012,
-            // "header: Format mismatch, expected IMAGE, received UNKNOWN" — which is
-            // what sn_unlockx did on every Shikshanation call once its body params were
-            // fixed. The template can never succeed here, so say so while it is being
-            // chosen rather than on a live call.
+            // A media-header template renders a file above the body and is rejected
+            // outright without one — Meta answers 132012, "header: Format mismatch,
+            // expected IMAGE, received UNKNOWN". That is what sn_unlockx did on every
+            // Shikshanation call once its body parameters were fixed.
+            //
+            // Image and document travel as the _headerUrl variable, which
+            // UnifiedSendService reads per recipient. Video does NOT: it needs
+            // options.headerType="video" on the send request, and the AI-call dispatcher
+            // sets only source and sourceId — so a video template cannot work here.
             const headerFormat = chosen.components?.find((c) => c.type === 'HEADER')?.format;
-            if (headerFormat && headerFormat !== 'TEXT') {
+            if (headerFormat === 'VIDEO') {
                 problems.push(
-                    `"${rule.template}" has a ${headerFormat.toLowerCase()} header. An AI call cannot attach one, so Meta rejects the send — choose a template whose header is text-only, or none.`
+                    `"${rule.template}" has a video header, which an AI call cannot attach — Meta rejects the send. Choose a template with an image, document or text header.`
+                );
+            } else if (
+                (headerFormat === 'IMAGE' || headerFormat === 'DOCUMENT') &&
+                !(rule.templateHeaderUrl || '').trim()
+            ) {
+                problems.push(
+                    `"${rule.template}" shows ${headerFormat === 'IMAGE' ? 'an image' : 'a document'} above the message, so it needs a link to that file — Meta rejects the send without one.`
                 );
             }
             const need = templateParamCount(chosen);
@@ -172,6 +181,12 @@ function templatePlaceholders(bodyText: string): number {
 function templateParamCount(t?: MetaWhatsAppTemplate): number {
     const body = t?.components?.find((c) => c.type === 'BODY')?.text || '';
     return templatePlaceholders(body);
+}
+
+/** IMAGE / DOCUMENT / VIDEO when the template shows a file above the body, else undefined. */
+function mediaHeaderFormat(t?: MetaWhatsAppTemplate): 'IMAGE' | 'DOCUMENT' | 'VIDEO' | undefined {
+    const f = t?.components?.find((c) => c.type === 'HEADER')?.format;
+    return f === 'IMAGE' || f === 'DOCUMENT' || f === 'VIDEO' ? f : undefined;
 }
 
 /** The variables a call can always fill, offered as a hint next to each parameter. */
@@ -540,6 +555,15 @@ export function SendRulesEditor({
                                                               { length: count },
                                                               (_x, k) => prev[k] || ''
                                                           ),
+                                                // The header file belongs to the old template's
+                                                // header, so it is dropped unless the new one
+                                                // also shows one. Same staleness trap as the
+                                                // params, with a worse failure: a leftover link
+                                                // on a text-header template is sent as a header
+                                                // Meta is not expecting.
+                                                templateHeaderUrl: mediaHeaderFormat(t)
+                                                    ? rule.templateHeaderUrl
+                                                    : undefined,
                                             });
                                         }}
                                     >
@@ -617,6 +641,44 @@ Namaste {{name}}, ...`}
                                 )}
                             </div>
                         </div>
+
+                        {isWhatsApp &&
+                            rule.template &&
+                            (() => {
+                                const chosen = templates.find((t) => t.name === rule.template);
+                                const fmt = mediaHeaderFormat(chosen);
+                                if (!chosen || !fmt) return null;
+                                if (fmt === 'VIDEO') {
+                                    return (
+                                        <p className="text-caption text-warning-600">
+                                            This template has a video header, which an AI call
+                                            cannot attach. Pick one with an image, document or text
+                                            header.
+                                        </p>
+                                    );
+                                }
+                                return (
+                                    <div className="space-y-1.5">
+                                        <Label className="text-caption">
+                                            Link to the {fmt === 'IMAGE' ? 'image' : 'document'}{' '}
+                                            shown above the message
+                                        </Label>
+                                        <Input
+                                            className="h-8"
+                                            placeholder="https://… — a public link to the file"
+                                            value={rule.templateHeaderUrl || ''}
+                                            onChange={(e) =>
+                                                update(i, { templateHeaderUrl: e.target.value })
+                                            }
+                                        />
+                                        <p className="text-caption text-neutral-500">
+                                            This template shows{' '}
+                                            {fmt === 'IMAGE' ? 'an image' : 'a document'} above the
+                                            text. Meta rejects the send without one.
+                                        </p>
+                                    </div>
+                                );
+                            })()}
 
                         {isWhatsApp && rule.template && (() => {
                             const chosen = templates.find((t) => t.name === rule.template);

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
@@ -99,6 +99,13 @@ export interface AiCallActionRule {
      */
     templateParams?: string[];
     /**
+     * WhatsApp only: the image or document a media-header template shows above its body.
+     * Required for such a template — without it Meta rejects the send with 132012,
+     * "header: Format mismatch, expected IMAGE, received UNKNOWN". Travels to the send as
+     * the `_headerUrl` variable, which both provider paths keep out of the body params.
+     */
+    templateHeaderUrl?: string;
+    /**
      * EMAIL only: the message the person receives. Email has no template layer — it is
      * sent verbatim and its FIRST LINE becomes the subject. Supports {{name}}.
      */


### PR DESCRIPTION
…behind

Picking a different WhatsApp template updated `template` and `templateLanguage` but left `templateParams` untouched, so the rule kept the values belonging to the template it replaced.

Nothing on screen said so. The editor renders the NEW template's blanks — or "This template takes no variables — nothing else to fill in" — while the saved rule still carried the old array. The mismatch only surfaced mid-call, as Meta error 132000:

    body: number of localizable_params (2) does not match
          the expected number of params (0)

Shikshanation's scholarship-quiz rule was pointed at sn_unlockx, which declares no variables, and kept the two params from hello_utility_confirmation. Sends had worked on Sep 7 and Sep 9 and failed from Sep 10 — the WhatsApp the caller was promised on the call simply never arrived, with no signal anywhere in the UI.

Three changes:

- The template picker now resizes templateParams to the chosen template. Values for positions the new template still has are preserved, so swapping between two 2-variable templates does not make the admin retype them.

- ruleProblems() reports a count mismatch. Rules SAVED before this fix still carry the wrong array and would otherwise stay silently broken; this surfaces them the moment the agent is opened.

- ruleProblems() also rejects a template with a media header. Meta answers 132012 ("header: Format mismatch, expected IMAGE, received UNKNOWN") because EngagementDispatcher sets only source and sourceId on SendOptions, never headerUrl — so an image/video/document template can never send from an AI call. sn_unlockx hit exactly this once its body params were corrected. Supporting header media is a separate change; refusing to configure an impossible rule is the honest behaviour until then.

Checks: design-lint clean; tsc reports no error in this file; eslint unchanged at the file's pre-existing 72 prettier errors (identical count before and after).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
