### PR TITLE
fix(ai-calling): stop the classifier inventing dispositions on near-s…

### DIFF
--- a/voice_bot_service/app/config.py
+++ b/voice_bot_service/app/config.py
@@ -542,6 +542,17 @@ class Settings:
     report_require_conversation: bool = field(
         default_factory=lambda: _env("REPORT_REQUIRE_CONVERSATION", "true").lower() == "true")
 
+    # Stricter sibling of the above: refuse a substantive disposition when the caller
+    # DID speak but said nothing beyond a greeting or a bare "yes"/"haan". A one-word
+    # "Hello." satisfied report_require_conversation, reached the classifier, and came
+    # back as a Demo_Booked with an invented name, member count and meeting time
+    # (institute 3716991c, 2026-09-09 — 13 such calls got a decisive label).
+    # Negations are exempt, so a bare "no" still classifies and still stops the retry.
+    # Separate kill-switch: this gate is newer and strictly stricter than the
+    # caller-turn test, so it can be reverted without disabling that one.
+    report_require_substance: bool = field(
+        default_factory=lambda: _env("REPORT_REQUIRE_SUBSTANCE", "true").lower() == "true")
+
     # Hard per-call ceiling when the agent config doesn't set maxCallMinutes —
     # bounds telephony + STT/LLM/TTS spend on a runaway conversation.
     max_call_minutes_default: float = 10.0

--- a/voice_bot_service/app/report.py
+++ b/voice_bot_service/app/report.py
@@ -34,9 +34,32 @@ logger = logging.getLogger(__name__)
 
 _ANALYSIS_TIMEOUT = httpx.Timeout(20.0, connect=5.0)
 
+# The "I cannot judge this call" label. Every degraded path already wrote this
+# string; it is named here because it now has a THIRD job beyond the sentinel and
+# the heuristic fallback: it is offered to the model as an explicit, legal answer
+# (see _analyze), so a thin transcript has somewhere to go other than a guess.
+#
+# It is deliberately the same label admin_core's classifier routes to RETRY. An
+# unjudgeable call should be re-dialled, never closed.
+_INSUFFICIENT = "Incomplete"
+
 
 def _transcript_text(transcript: List[Dict[str, str]]) -> str:
     return "\n".join(f"{t['role']}: {t['text']}" for t in transcript if t.get("text"))
+
+
+def _now_stamp(now: dt.datetime) -> str:
+    """"Wednesday, 9 September 2026, 4:00 PM" — the un-padded day and hour the
+    analyser is given to resolve "tomorrow 3pm" against.
+
+    Assembled by hand rather than with strftime("%A, %-d %B %Y, %-I:%M %p"): the
+    `%-d` / `%-I` no-padding modifiers are a glibc extension and raise
+    ValueError("Invalid format string") on Windows, which made _analyze — and so
+    every prompt assertion about it — impossible to unit-test off the container.
+    Output is byte-identical to the glibc format on Linux.
+    """
+    return (f"{now.strftime('%A')}, {now.day} {now.strftime('%B')} {now.year}, "
+            f"{now.hour % 12 or 12}:{now.strftime('%M')} {now.strftime('%p')}")
 
 
 def _llm_target(s):
@@ -67,8 +90,21 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
     s = get_settings()
     agent = outcome.context.get("agent") or {}
     dispositions = agent.get("dispositions") or [
-        "Interested", "Likely_Interested", "Callback", "Not_Interested", "Incomplete",
+        "Interested", "Likely_Interested", "Callback", "Not_Interested", _INSUFFICIENT,
     ]
+    # The model MUST have a legal way to say "the transcript does not support any of
+    # these". Most agent vocabularies are pure outcome labels (Demo_Booked, Not_
+    # Interested, Wrong_Person, …) with no such option, so the model was being asked
+    # to pick an outcome for a call that had none — and it obliged, inventing the
+    # conversation that would justify its pick. Observed on institute 3716991c
+    # (2026-09-09): 13 of 31 near-silent calls got a decisive label, one of them a
+    # Demo_Booked with a fabricated name, member count, platform and meeting time
+    # from a transcript whose only caller turn was "Hello."
+    #
+    # Appended, never substituted: the admin's own vocabulary is untouched, and the
+    # membership check below already treats this label as valid on every agent.
+    if _INSUFFICIENT not in dispositions:
+        dispositions = [*dispositions, _INSUFFICIENT]
     questions = agent.get("extractionQuestions") or []
     transcript = _transcript_text(outcome.transcript)
     if not transcript.strip():
@@ -86,7 +122,7 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
         now = dt.datetime.now(ZoneInfo(tzname))
     except Exception:
         tzname, now = "Asia/Kolkata", dt.datetime.now(ZoneInfo("Asia/Kolkata"))
-    now_stamp = now.strftime("%A, %-d %B %Y, %-I:%M %p")
+    now_stamp = _now_stamp(now)
     now_offset = now.strftime("%z")
     now_offset = f"{now_offset[:3]}:{now_offset[3:]}" if now_offset else "+05:30"
 
@@ -125,9 +161,34 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
 
     prompt = (
         "You analyse a phone call transcript between an assistant and a caller.\n"
+        # Evidence discipline. Without this the model was handed a bare list of labels
+        # with no definitions and no requirement to show its work, so on a transcript
+        # of "Hello." it picked a plausible-sounding outcome and then wrote the
+        # supporting facts to match — including the meetingRequested/meetingDatetimeIso
+        # pair that _drop_unevidenced_booking cross-checks, defeating that guard from
+        # inside the same JSON response.
+        "EVIDENCE RULES — these override every other instruction below:\n"
+        "1. Judge ONLY what the transcript literally contains. Never infer, complete or "
+        "imagine a turn that is not there. A transcript often ends mid-sentence because "
+        "the caller hung up — that is not a conversation for you to finish on their "
+        "behalf.\n"
+        f"2. If the transcript does not clearly support any other label, answer "
+        f"\"{_INSUFFICIENT}\". A greeting, a silence, or a bare 'yes'/'haan'/'ok' with no "
+        "further content is NOT evidence of interest, identity, refusal or a booking. "
+        f"\"{_INSUFFICIENT}\" is a CORRECT and expected answer on a short or one-sided "
+        "call — always prefer it to a guess.\n"
+        "3. Never state a name, phone number, platform, member count, price, place or "
+        "time the caller did not actually say. In extractedQa use null for every "
+        "question the caller did not answer; do not fill one in from what a business "
+        "like theirs would probably say.\n"
+        "4. A booking/demo/meeting/callback label requires BOTH that the caller agreed "
+        "AND that a specific day or time was spoken on the call. If no time was agreed, "
+        "the label is not a booking, meetingRequested is false and meetingDatetimeIso "
+        "is null.\n"
         f"RIGHT NOW it is {now_stamp} ({tzname}, UTC offset {now_offset}). Use this to resolve any "
         "relative day the caller mentioned into an exact date.\n"
-        f"Return STRICT JSON with keys: disposition (one of {dispositions}), "
+        f"Return STRICT JSON with keys: disposition (exactly one of {dispositions} — "
+        f"\"{_INSUFFICIENT}\" whenever the evidence is thin), "
         "summary (2-3 sentences), leadRating (integer 1-10 interest score or null), "
         "extractedQa (object: question -> answer, only what was actually said"
         + (f"; questions of interest: {questions}" if questions else "")
@@ -167,15 +228,64 @@ async def _analyze(outcome: CallOutcome) -> Dict[str, Any]:
             content = resp.json()["choices"][0]["message"].get("content") or ""
         match = re.search(r"\{.*\}", content, re.DOTALL)
         parsed = json.loads(match.group(0)) if match else {}
-        if parsed.get("disposition") not in dispositions:
-            parsed["disposition"] = "Incomplete"
+        _coerce_disposition(parsed, dispositions, outcome.corr)
         return parsed
     except Exception:
         logger.exception("analysis failed corr=%s — degrading to heuristic", outcome.corr)
-        return {"disposition": "Incomplete",
+        return {"disposition": _INSUFFICIENT,
                 "summary": "Automatic analysis unavailable; see transcript.",
                 "leadRating": None, "extractedQa": {}, "callbackRequested": False,
                 "callbackTimeText": None, **_NO_SENDS}
+
+
+def _norm_label(s: Any) -> str:
+    """Alphanumerics only, casefolded — so "Demo_Booked", "demo booked" and
+    "DemoBooked" are one label. Separator and case drift is the model restyling a
+    label we gave it, not choosing a different one."""
+    return "".join(ch for ch in str(s).casefold() if ch.isalnum())
+
+
+def _coerce_disposition(parsed: Dict[str, Any], dispositions: List[str], corr: str) -> None:
+    """Force the model's label into the agent's vocabulary, recovering near-misses.
+
+    The membership check this replaces was exact-match, and a label that missed was
+    overwritten with the sentinel and then FORGOTTEN — no log, no field, nothing.
+    That silently destroyed real judgements: in the 2026-09-09 audit of institute
+    3716991c, five substantive conversations (one 230s call where the prospect spelled
+    out that he tracks attendance and payments by hand — a textbook qualified lead)
+    all landed on Incomplete and were routed to retry instead of to a human, and the
+    label the model had actually chosen was unrecoverable after the fact.
+
+    Two changes. Case/separator drift is now RECOVERED rather than discarded, and a
+    label that genuinely is not in the vocabulary is logged and preserved on
+    `dispositionRawLabel` so the next occurrence is diagnosable from the report
+    instead of requiring a transcript read.
+
+    Still coerces rather than trusting an unknown label: admin_core keys retry,
+    assignment and lead status off this string, so a label it has no rule for must
+    not reach it. The sentinel routes to retry, which is the recoverable direction.
+    """
+    label = parsed.get("disposition")
+    raw = str(label).strip() if label is not None else ""
+    if raw in dispositions:
+        return
+
+    target = _norm_label(raw)
+    if target:
+        for d in dispositions:
+            if _norm_label(d) == target:
+                if d != raw:
+                    logger.info("report: disposition %r normalised to %r corr=%s", raw, d, corr)
+                parsed["disposition"] = d
+                return
+
+    if raw:
+        parsed["dispositionRawLabel"] = raw
+        logger.warning(
+            "report: disposition %r is not in this agent's vocabulary %s — coercing to "
+            "%s (lead goes to retry, not closed) corr=%s",
+            raw, dispositions, _INSUFFICIENT, corr)
+    parsed["disposition"] = _INSUFFICIENT
 
 
 # Disposition labels that assert a MEETING WAS SECURED. Substring match on a
@@ -206,28 +316,42 @@ def _drop_unevidenced_booking(analysis: Dict[str, Any], corr: str) -> None:
     and if the agent carries a booking_page_id admin_core's auto-book will
     create a real calendar entry off it.
 
-    Only fires on a DIRECT self-contradiction: a booking-shaped label with
-    meetingRequested false AND no resolved datetime. An agent whose vocabulary
-    has a softer label ("Demo_Requested") is untouched as long as the model
-    supplied evidence for it. Degrades to Incomplete, which routes the lead to
-    retry rather than closing it — the same fallback _analyze already uses when
-    it cannot judge a call at all.
+    A booking-shaped label now requires BOTH halves of the evidence: the caller
+    agreed (meetingRequested) AND a concrete time was resolved
+    (meetingDatetimeIso). The first cut of this guard early-returned on EITHER
+    signal, so half-evidence was enough to keep the label — and prod call
+    0519330a (2026-09-09, institute 3716991c) walked straight through it:
+    24 seconds, the caller's entire contribution was "Hello / Okay / Yes / Yeah /
+    Yes", the model returned meetingRequested=true with meetingDatetimeIso=None,
+    and the lead was stamped Demo_Booked. A demo with no time is not a booking,
+    whatever the model asserts about the caller's enthusiasm.
+
+    An agent whose vocabulary has a softer label ("Demo_Requested") is untouched:
+    the hints below only match labels that CLAIM a secured slot. Degrades to
+    Incomplete, which routes the lead to retry rather than closing it — the same
+    fallback _analyze already uses when it cannot judge a call at all.
     """
     try:
         label = str(analysis.get("disposition") or "")
-        norm = "".join(ch for ch in label.casefold() if ch.isalnum())
+        norm = _norm_label(label)
         if not norm or not any(h in norm for h in _BOOKING_LABEL_HINTS):
             return
-        if analysis.get("meetingRequested"):
-            return
-        if str(analysis.get("meetingDatetimeIso") or "").strip():
+        agreed = bool(analysis.get("meetingRequested"))
+        when = str(analysis.get("meetingDatetimeIso") or "").strip()
+        if agreed and when:
             return
         logger.warning(
             "report: disposition %r claims a booking but the analyser reported "
-            "meetingRequested=%s and no meeting time — degrading to Incomplete "
-            "corr=%s", label, analysis.get("meetingRequested"), corr)
-        analysis["disposition"] = "Incomplete"
+            "meetingRequested=%s and meeting time %r — degrading to %s corr=%s",
+            label, analysis.get("meetingRequested"), when or None, _INSUFFICIENT, corr)
+        analysis["disposition"] = _INSUFFICIENT
         analysis["dispositionDowngradedFrom"] = label
+        # A label we just refused must not leave its own evidence standing —
+        # admin_core auto-books off meetingRequested + meetingDatetimeIso
+        # independently of the disposition, so leaving them would create the very
+        # calendar entry this guard exists to prevent.
+        analysis["meetingRequested"] = False
+        analysis["meetingDatetimeIso"] = None
     except Exception:
         # Never cost the report: an unexpected shape here must leave the
         # analysis exactly as the model returned it.
@@ -426,6 +550,58 @@ def _is_conversation(outcome: CallOutcome) -> bool:
     return len(_caller_turns(outcome)) >= 1
 
 
+# Caller words that carry NO classifiable content on their own: greetings, openers,
+# backchannel and forms of address. Bare AFFIRMATIONS count as contentless too and
+# are reused from _AFFIRMATIVE_WORDS above rather than duplicated — "yes" in answer
+# to "do you have two minutes?" says nothing about interest, identity or a booking.
+#
+# NEGATIONS are deliberately ABSENT from both sets, so a caller whose only word was
+# "no" / "nahi" / "नहीं" still reaches the classifier. That is the case
+# _is_conversation's docstring protects: forcing a refusal to Incomplete flips a STOP
+# into retry and re-dials someone who already said no. Thin evidence of a refusal is
+# still evidence, and honouring it errs toward not calling back.
+#
+# WHOLE WORDS after stripping punctuation, per the "ha" / "kaun bol raha hai" trap
+# documented on _AFFIRMATIVE_WORDS.
+_GREETING_WORDS = frozenset({
+    "hello", "helo", "hallo", "hi", "hey", "namaste", "namaskar", "salaam", "sat",
+    "sriakal", "sir", "madam", "maam", "mam", "ji", "hmm", "hm", "mm", "mmm", "uh",
+    "um", "uhh", "huh", "eh", "aa", "haa", "speaking", "who", "kaun", "kon", "boliye",
+    "bolo", "bol", "kahiye", "hn",
+    "हेलो", "हैलो", "नमस्ते", "नमस्कार", "सर", "मैडम", "जी", "कौन", "बोलिए", "बोलो",
+    "कहिए", "हम्म", "हूँ", "हूं",
+})
+
+
+def _has_substance(outcome: CallOutcome) -> bool:
+    """Did the caller contribute anything a disposition could actually rest on?
+
+    _is_conversation asks whether the caller spoke AT ALL; this asks whether what
+    they said carries meaning. The gap between those two questions is where the
+    fabrications lived: a bare "Hello." is one caller turn, so it passed that gate,
+    reached the classifier, and the classifier — asked to pick an outcome label for a
+    call that had no outcome — invented one along with the conversation that would
+    justify it.
+
+    Measured on institute 3716991c, 2026-09-09: 31 of 77 calls had the caller
+    contributing three words or fewer, and 13 of those were stamped with a decisive
+    disposition. Call ee49966e is the limit case — 8 seconds, caller said only
+    "Hello.", the bot's own opening line still mid-sentence, and the report claimed a
+    named prospect had agreed to a demo at a specific time, ran 50 members on Zoom and
+    distributed links by hand. Every one of those facts was generated, and the
+    fabricated meetingRequested/meetingDatetimeIso pair also walked it past
+    _drop_unevidenced_booking.
+
+    A call failing this test is NOT a judgement that the lead is uninterested — it is
+    a refusal to guess. It routes to Incomplete and therefore to retry, which is what
+    should happen to someone who picked up and never got a word in.
+    """
+    words = [w.strip(_WORD_STRIP) for w in
+             " ".join(_caller_turns(outcome)).casefold().split()]
+    return any(w and w not in _GREETING_WORDS and w not in _AFFIRMATIVE_WORDS
+               for w in words)
+
+
 def _status(outcome: CallOutcome) -> str:
     # The lead answered (the WS only opens on answer); "completed" iff they
     # actually spoke — a dead-air pickup classifies as no-answer downstream.
@@ -615,15 +791,32 @@ async def _ladder_tts_cache(outcome: CallOutcome, diag_blob) -> None:
 async def build_and_post_report(outcome: CallOutcome, call_uuid: Optional[str]) -> bool:
     ctx = outcome.context
     # Never let the classifier judge a call the caller never took part in — see
-    # _is_conversation. Skipping _analyze also saves the LLM round trip on the
-    # 17% of dials that are answering machines.
-    if get_settings().report_require_conversation and not _is_conversation(outcome):
-        logger.info("report: no two-sided conversation corr=%s (%d caller turns) — "
-                    "forcing Incomplete, skipping analysis",
-                    outcome.corr, len(_caller_turns(outcome)))
+    # _is_conversation — nor one where their only words were a greeting or a bare
+    # "yes" — see _has_substance. Skipping _analyze also saves the LLM round trip on
+    # the 17% of dials that are answering machines.
+    #
+    # Two independent kill-switches because the gates carry different risk: the
+    # caller-turn test has been live for months, the substance floor is newer and
+    # strictly stricter. REPORT_REQUIRE_SUBSTANCE=false reverts only the new gate.
+    s = get_settings()
+    no_turn = s.report_require_conversation and not _is_conversation(outcome)
+    no_substance = s.report_require_substance and not _has_substance(outcome)
+    if no_turn or no_substance:
+        # Distinct summaries on purpose: these two reasons are told apart by
+        # fingerprinting ai_summary when auditing a batch, and collapsing them would
+        # hide which gate is carrying the volume.
+        if no_turn:
+            reason = "no caller turn captured"
+            summary = "No two-sided conversation took place (no caller turn captured)."
+        else:
+            reason = "caller said nothing beyond a greeting or bare acknowledgement"
+            summary = ("No substantive conversation took place (caller said nothing "
+                       "beyond a greeting or bare acknowledgement).")
+        logger.info("report: %s corr=%s (%d caller turns) — forcing %s, skipping analysis",
+                    reason, outcome.corr, len(_caller_turns(outcome)), _INSUFFICIENT)
         analysis = {
-            "disposition": "Incomplete",
-            "summary": "No two-sided conversation took place (no caller turn captured).",
+            "disposition": _INSUFFICIENT,
+            "summary": summary,
             "leadRating": None, "extractedQa": {}, "callbackRequested": False,
             "callbackTimeText": None, "meetingRequested": False,
             "meetingDatetimeIso": None, "meetingDatetimeText": None, "meetingType": None,
@@ -647,6 +840,13 @@ async def build_and_post_report(outcome: CallOutcome, call_uuid: Optional[str]) 
             outcome.connected_at, tz=dt.timezone.utc
         ).isoformat().replace("+00:00", "Z"),
         "disposition": analysis.get("disposition"),
+        # Diagnosis only. Set when a guard overrode the model (dispositionRawLabel = a
+        # label outside the agent's vocabulary, dispositionDowngradedFrom = a booking
+        # claim we refused). admin_core's parser reads named keys and ignores the rest,
+        # so these ride along in raw_payload and answer "what did the model actually
+        # say before we overruled it?" without a schema change or a transcript read.
+        "dispositionRawLabel": analysis.get("dispositionRawLabel"),
+        "dispositionDowngradedFrom": analysis.get("dispositionDowngradedFrom"),
         "leadRating": analysis.get("leadRating"),
         "summary": analysis.get("summary"),
         "extractedQa": analysis.get("extractedQa") or {},

--- a/voice_bot_service/tests/test_call_behavior.py
+++ b/voice_bot_service/tests/test_call_behavior.py
@@ -2873,3 +2873,190 @@ async def test_a_yes_over_a_statement_still_carries_on():
     cues = _cue_texts(rec)
     assert any("carry on" in c for c in cues), cues
     assert not any("their ANSWER" in c for c in cues), cues
+
+
+# ── Disposition fidelity: institute 3716991c, 2026-09-09 (77-call audit) ──────
+#
+# The classifier was inventing conversations. On a transcript whose only caller
+# turn was "Hello." it returned Demo_Booked plus the facts that would justify it —
+# a name, a member count, a platform and a meeting time, none of them spoken — and
+# because it fabricated meetingRequested + meetingDatetimeIso in the same response
+# it also walked past _drop_unevidenced_booking. 13 of 31 near-silent calls got a
+# decisive label; of 5 Demo_Booked, 1 was pure fabrication and 1 had no agreed time.
+
+
+def test_has_substance_rejects_greeting_only_but_keeps_refusals():
+    # ee49966e: 8s, the entire caller contribution, stamped Demo_Booked.
+    assert rpt._has_substance(_ConvOutcome([
+        {"role": "assistant", "text": "Hi, is this Shweta? Aarushi from Vacademy — we"},
+        {"role": "user", "text": "Hello."}])) is False
+    # 0519330a: 24s of pure acknowledgement, stamped Demo_Booked with no agreed time.
+    assert rpt._has_substance(_ConvOutcome([
+        {"role": "user", "text": "Hello."}, {"role": "user", "text": "Okay."},
+        {"role": "user", "text": "Yes."}, {"role": "user", "text": "Yeah."},
+        {"role": "user", "text": "Yes."}])) is False
+    # Hinglish/Devanagari equivalents, with the danda Sarvam appends to every final.
+    assert rpt._has_substance(_ConvOutcome([
+        {"role": "user", "text": "हेलो।"}, {"role": "user", "text": "हाँ जी।"}])) is False
+    assert rpt._has_substance(_ConvOutcome([{"role": "user", "text": "kaun?"}])) is False
+
+    # CRITICAL, mirrors _is_conversation's own guarantee: a REFUSAL is thin evidence
+    # but it is still evidence. Negations are in neither filler set, so a bare "no"
+    # still classifies — otherwise a terminal refusal becomes a retry and we re-dial
+    # someone who already said stop.
+    assert rpt._has_substance(_ConvOutcome([{"role": "user", "text": "no"}])) is True
+    assert rpt._has_substance(_ConvOutcome([{"role": "user", "text": "nahi."}])) is True
+    assert rpt._has_substance(_ConvOutcome([{"role": "user", "text": "नहीं।"}])) is True
+    # Anything with real content passes, including one substantive word among fillers.
+    assert rpt._has_substance(_ConvOutcome([
+        {"role": "user", "text": "Hello."},
+        {"role": "user", "text": "Hybrid."}])) is True
+    # Synthetic bracketed cues are not caller words at all (via _caller_turns).
+    assert rpt._has_substance(_ConvOutcome([
+        {"role": "user", "text": "[unclear sound from the caller]"}])) is False
+
+
+@pytest.mark.asyncio
+async def test_greeting_only_call_never_reaches_the_classifier(monkeypatch):
+    """The ee49966e end-to-end: a fabricated Demo_Booked must not be postable."""
+    analysed = []
+
+    async def spy_analyze(o):
+        analysed.append(1)
+        return {"disposition": "Demo_Booked", "meetingRequested": True,
+                "meetingDatetimeIso": "2026-09-10T16:00:00+05:30", "leadRating": 7}
+
+    posted = {}
+
+    async def capture(inst, tok, payload):
+        posted.update(payload)
+        return True
+
+    monkeypatch.setattr(rpt, "_analyze", spy_analyze)
+    monkeypatch.setattr(rpt.admin_core, "post_report", capture)
+    o = _ConvOutcome([
+        {"role": "assistant", "text": "Hi, is this Shweta? Aarushi from Vacademy — we"},
+        {"role": "user", "text": "Hello."}])
+    assert await rpt.build_and_post_report(o, "cu") is True
+    assert analysed == [], "the classifier judged a call with only a greeting"
+    assert posted["disposition"] == "Incomplete"
+    # The caller DID speak, so this is a connect — status must stay honest even
+    # though we refuse to judge the call.
+    assert posted["status"] == "completed"
+    # No meeting evidence may survive: admin_core auto-books off these two fields
+    # independently of the disposition.
+    assert posted["meetingRequested"] is False
+    assert posted["meetingDatetimeIso"] is None
+    assert "substantive" in posted["summary"], posted["summary"]
+
+
+def test_booking_label_requires_both_agreement_and_a_time():
+    # 0519330a: half the evidence was enough to keep the label under the first cut
+    # of this guard, because it early-returned on EITHER signal.
+    a = {"disposition": "Demo_Booked", "meetingRequested": True,
+         "meetingDatetimeIso": None}
+    rpt._drop_unevidenced_booking(a, "c")
+    assert a["disposition"] == "Incomplete"
+    assert a["dispositionDowngradedFrom"] == "Demo_Booked"
+    assert a["meetingRequested"] is False and a["meetingDatetimeIso"] is None
+
+    # 775ac5ac (2026-08-14), the original incident: neither signal.
+    b2 = {"disposition": "Demo_Booked", "meetingRequested": False,
+          "meetingDatetimeIso": ""}
+    rpt._drop_unevidenced_booking(b2, "c")
+    assert b2["disposition"] == "Incomplete"
+
+    # A time with no agreement is equally not a booking.
+    c2 = {"disposition": "Counselling_Scheduled", "meetingRequested": False,
+          "meetingDatetimeIso": "2026-09-11T15:00:00+05:30"}
+    rpt._drop_unevidenced_booking(c2, "c")
+    assert c2["disposition"] == "Incomplete"
+
+
+def test_fully_evidenced_booking_and_soft_labels_survive():
+    # d0b5d7a8: 152s, 34 caller words, a real agreed slot. Must be untouched.
+    ok = {"disposition": "Demo_Booked", "meetingRequested": True,
+          "meetingDatetimeIso": "2026-09-11T15:00:00+05:30"}
+    rpt._drop_unevidenced_booking(ok, "c")
+    assert ok["disposition"] == "Demo_Booked"
+    assert "dispositionDowngradedFrom" not in ok
+    assert ok["meetingRequested"] is True
+
+    # Labels that do not CLAIM a secured slot are out of scope for this guard,
+    # however thin their evidence — "callback" must not trip the "book" hint.
+    for label in ("Interested_Callback", "Not_Interested", "Wrong_Person",
+                  "Overview_Sent", "Language_Barrier"):
+        a = {"disposition": label, "meetingRequested": False, "meetingDatetimeIso": None}
+        rpt._drop_unevidenced_booking(a, "c")
+        assert a["disposition"] == label, label
+
+
+def test_out_of_vocabulary_label_is_recovered_or_preserved():
+    vocab = ["Demo_Booked", "Interested_Callback", "Not_Interested", "Incomplete"]
+
+    # Case/separator drift is the model restyling OUR label — recover it silently
+    # instead of throwing the judgement away.
+    for spelled in ("demo_booked", "Demo Booked", "DemoBooked", "  demo booked  "):
+        p = {"disposition": spelled}
+        rpt._coerce_disposition(p, vocab, "c")
+        assert p["disposition"] == "Demo_Booked", spelled
+        assert "dispositionRawLabel" not in p
+
+    # A genuinely unknown label is still coerced (admin_core keys retry and lead
+    # status off this string) but is no longer FORGOTTEN — that silent overwrite is
+    # why 5 real conversations became Incomplete with no way to see what was meant.
+    p = {"disposition": "Very_Warm_Lead"}
+    rpt._coerce_disposition(p, vocab, "c")
+    assert p["disposition"] == "Incomplete"
+    assert p["dispositionRawLabel"] == "Very_Warm_Lead"
+
+    # A missing/blank label leaves no raw field to report.
+    for empty in ({}, {"disposition": None}, {"disposition": "  "}):
+        rpt._coerce_disposition(empty, vocab, "c")
+        assert empty["disposition"] == "Incomplete"
+        assert "dispositionRawLabel" not in empty
+
+
+@pytest.mark.asyncio
+async def test_classifier_is_always_offered_an_insufficient_option(monkeypatch):
+    """The root cause: agent vocabularies are pure outcome labels, so the model had
+    no legal way to say "this call had no outcome" — and invented one instead."""
+    sent = []
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"choices": [{"message": {"content": '{"disposition": "Incomplete"}'}}]}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, headers=None, json=None):
+            sent.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(rpt.httpx, "AsyncClient", lambda *a, **k: _Client())
+
+    o = _ConvOutcome([{"role": "user", "text": "we run hybrid yoga classes"}])
+    # The audited agent's vocabulary — no "Incomplete" anywhere in it.
+    o.context = {"agent": {"dispositions": ["Demo_Booked", "Interested_Callback",
+                                            "Overview_Sent", "Not_Interested",
+                                            "Wrong_Person", "Language_Barrier",
+                                            "Incomplete_Call"]},
+                 "instituteId": "i"}
+    out = await rpt._analyze(o)
+    assert out["disposition"] == "Incomplete"
+    prompt = sent[0]["messages"][0]["content"]
+    assert "Incomplete" in prompt, "no insufficient-evidence option was offered"
+    assert "EVIDENCE RULES" in prompt
+    # The admin's own labels must still all be on offer.
+    for label in ("Demo_Booked", "Wrong_Person", "Incomplete_Call"):
+        assert label in prompt, label
+    # And the anti-fabrication instructions the audit turned on.
+    assert "did not actually say" in prompt


### PR DESCRIPTION
…ilent calls

Auditing 104 AI calls for institute 3716991c (8-10 Sep) found the end-of-call classifier fabricating outcomes. Call ee49966e: 8 seconds, the caller's entire contribution was "Hello.", the bot's own opening line still mid-sentence — and the report came back Demo_Booked with meetingRequested=true, a resolved meeting time, leadRating 7, and an extractedQa naming a member count, a platform and a distribution method. None of it was said. 13 of 31 near-silent calls received a decisive label this way.

Both existing guards were defeated. _is_conversation only asked whether the caller spoke AT ALL, so a bare "Hello." passed it and reached the classifier. _drop_unevidenced_booking cross-checks the disposition against meetingRequested/meetingDatetimeIso, but the model fabricated both halves in the same JSON response, so the check passed by construction — it fired zero times across the whole batch while five Demo_Booked were written.

Root cause: agent vocabularies are pure outcome labels (Demo_Booked, Not_Interested, Wrong_Person, ...) with no "cannot tell" option, so the model was asked to pick an outcome for a call that had none, and it invented the conversation that would justify its pick.

Four changes to voice_bot_service/app/report.py:

- _has_substance: a new gate asking whether the caller said anything MEANINGFUL, not merely anything. Reuses the existing _AFFIRMATIVE_WORDS/_WORD_STRIP whole-word machinery. Negations are deliberately in neither filler set, so a bare "no"/"nahi" still classifies — otherwise a terminal refusal becomes a retry and we re-dial someone who said stop. New REPORT_REQUIRE_SUBSTANCE kill-switch, separate from REPORT_REQUIRE_CONVERSATION so the newer, stricter gate can be reverted alone.

- _drop_unevidenced_booking now requires BOTH agreement and a resolved time. It early-returned on EITHER signal before, which is how 0519330a kept Demo_Booked with meetingDatetimeIso=null. It also clears the meeting evidence it refuses: admin_core auto-books off those two fields independently of the disposition, so leaving them would create the calendar entry this guard exists to prevent.

- _analyze always offers "Incomplete" as a legal answer (appended, never substituting the admin's vocabulary) and the prompt now carries EVIDENCE RULES forbidding inferred turns, invented facts and unevidenced bookings.

- _coerce_disposition replaces a bare exact-match check that overwrote a missed label and then FORGOT it. Case/separator drift is now recovered; a genuinely unknown label still coerces to the sentinel (admin_core keys retry and lead status off this string) but is logged and preserved on dispositionRawLabel, so the next occurrence is diagnosable without reading a transcript.

Also made _now_stamp portable: strftime's %-d/%-I are a glibc extension that raises on Windows, which made _analyze — and every prompt assertion about it — impossible to unit-test off the container. Output is byte-identical on Linux.

Replayed against all 104 stored calls: 27 dispositions change, Demo_Booked 6 -> 3. The three survivors are 152s+ conversations with 34-131 caller words and real agreed times. All 11 longest gated calls were checked turn by turn and are correct rejections ("Yes, who?" and "जी बोलिए।" had both been stamped Interested_Callback). Expect Incomplete to become the majority label (~57%) — that is the honest shape of a campaign where 31% of dials produced no caller turn and another 24% only a greeting; retries are bounded at maxRetries=3 with exhausted leads handed to a human.

Six new tests, each encoding a real call from the audit (ee49966e, 0519330a, d0b5d7a8, plus the 2026-08-14 775ac5ac incident). Suite: 385 passed, 8 failed — the 8 being this box's documented environmental baseline.

Not addressed here: 14 answered-but-silent calls are still stamped no-answer, which under-counts connects. That spans admin_core's mapStatus/CallStatus/ CallSearchService and changes retry semantics, so it needs its own pass.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
