### PR TITLE
fix(ai-calling): tell Meta the header is an image, not a document

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/engagement/service/EngagementDispatcher.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/engagement/service/EngagementDispatcher.java
@@ -191,6 +191,18 @@ public class EngagementDispatcher {
                     "WhatsApp needs a Meta-approved template. Send this on email/in-app, or wait for "
                     + "template approval. (The AI draft is a preview of intent, not a sendable WhatsApp message.)");
         }
+        Map<String, String> variables = parseVariables(action.getVariablesJson());
+        // A media header is only rendered as an IMAGE if headerType is literally "image".
+        // WhatsAppService.buildHeaderConfig decides with
+        //     "image".equalsIgnoreCase(headerType) ? "image" : "document"
+        // so a null type silently becomes a document — and attaches filename "file.pdf".
+        // Meta then compares that against the template's declared header and rejects the
+        // whole send: "(#132012) header: Format mismatch, expected IMAGE, received
+        // DOCUMENT". The URL was travelling correctly; only its type was missing.
+        // Carried per-action in variables_json rather than as a column: it belongs to the
+        // template the rule chose, and "_"-prefixed keys are filtered out of the body
+        // parameters by both provider paths, so it cannot disturb the positional count.
+        String headerType = variables.get("_headerType");
         UnifiedSendRequest req = UnifiedSendRequest.builder()
                 .instituteId(action.getInstituteId())
                 .channel("WHATSAPP")
@@ -203,11 +215,14 @@ public class EngagementDispatcher {
                         .phone(subject.getPhone())
                         .userId(subject.getUserId())
                         .name(subject.getName())
-                        .variables(parseVariables(action.getVariablesJson()))
+                        .variables(variables)
                         .build()))
                 .options(UnifiedSendRequest.SendOptions.builder()
                         .source(SOURCE)
                         .sourceId(action.getId())
+                        // Null for a text-header or headerless template, which is what
+                        // UnifiedSendService expects when there is no media to attach.
+                        .headerType(headerType != null && !headerType.isBlank() ? headerType : null)
                         .build())
                 .build();
         requireAccepted(notificationService.sendUnified(req), "whatsapp");

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/AiCallActionService.java
@@ -593,6 +593,17 @@ public class AiCallActionService {
             // the positional count above - the very thing (#132000) punishes.
             if (notBlank(rule.getTemplateHeaderUrl())) {
                 positional.put("_headerUrl", resolveParam(rule.getTemplateHeaderUrl(), vars));
+                // The URL alone is not enough. WhatsAppService.buildHeaderConfig resolves
+                // the kind with "image".equalsIgnoreCase(headerType) ? "image" : "document",
+                // so an absent type makes every media header a DOCUMENT (with a made-up
+                // "file.pdf" filename) and Meta answers "(#132012) header: Format mismatch,
+                // expected IMAGE, received DOCUMENT". Default to image: that is what a
+                // header template overwhelmingly is, and it is the value that fails LOUDLY
+                // rather than silently mis-typing an image as a document.
+                String headerType = notBlank(rule.getTemplateHeaderType())
+                        ? rule.getTemplateHeaderType().trim().toLowerCase(Locale.ROOT)
+                        : "image";
+                positional.put("_headerType", headerType);
             }
             return mapper.writeValueAsString(positional);
         } catch (Exception e) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/AiCallActionRule.java
@@ -103,6 +103,20 @@ public class AiCallActionRule {
     private String templateHeaderUrl;
 
     /**
+     * "image" or "document" — which kind of file {@link #templateHeaderUrl} points at.
+     *
+     * <p>Derived by the editor from the chosen template's HEADER format, never typed by an
+     * admin. It exists because the type is not inferable downstream:
+     * WhatsAppService.buildHeaderConfig decides with
+     * {@code "image".equalsIgnoreCase(headerType) ? "image" : "document"}, so a missing
+     * type silently becomes a document — filename and all — and Meta rejects the send with
+     * "(#132012) header: Format mismatch, expected IMAGE, received DOCUMENT".
+     *
+     * <p>Travels as {@code _headerType} in variables_json, next to {@code _headerUrl}.
+     */
+    private String templateHeaderType;
+
+    /**
      * EMAIL only: what the person actually receives.
      *
      * <p>Email has no Meta template — EngagementDispatcher emails {@code draft_body}

--- a/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
+++ b/frontend-admin-dashboard/src/routes/calling/ai-agents/-components/send-rules-editor.tsx
@@ -564,6 +564,17 @@ export function SendRulesEditor({
                                                 templateHeaderUrl: mediaHeaderFormat(t)
                                                     ? rule.templateHeaderUrl
                                                     : undefined,
+                                                // Derived, never typed. The send has to say
+                                                // whether the file is an image or a document —
+                                                // WhatsAppService treats anything that is not
+                                                // literally "image" as a document — and the
+                                                // template already declares which it is.
+                                                templateHeaderType:
+                                                    mediaHeaderFormat(t) === 'IMAGE'
+                                                        ? 'image'
+                                                        : mediaHeaderFormat(t) === 'DOCUMENT'
+                                                          ? 'document'
+                                                          : undefined,
                                             });
                                         }}
                                     >

--- a/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/AiAgentsCard.tsx
@@ -106,6 +106,13 @@ export interface AiCallActionRule {
      */
     templateHeaderUrl?: string;
     /**
+     * Which kind of file `templateHeaderUrl` points at. Derived from the chosen template,
+     * never typed. The send must say so explicitly — WhatsAppService treats anything that
+     * is not literally "image" as a document, so an absent type makes Meta reject an image
+     * template with 132012, "expected IMAGE, received DOCUMENT".
+     */
+    templateHeaderType?: 'image' | 'document';
+    /**
      * EMAIL only: the message the person receives. Email has no template layer — it is
      * sent verbatim and its FIRST LINE becomes the subject. Supports {{name}}.
      */


### PR DESCRIPTION
Supplying templateHeaderUrl moved sn_unlockx from one 132012 to another:

    header: Format mismatch, expected IMAGE, received UNKNOWN     (no URL)
    header: Format mismatch, expected IMAGE, received DOCUMENT    (URL, no type)

The URL was travelling correctly. What was missing is the TYPE, and nothing downstream can infer it. WhatsAppService.buildHeaderConfig decides with

    String type = "image".equalsIgnoreCase(headerType) ? "image" : "document";

so a null headerType is not "unset" — it is an explicit document, and the code then attaches a fabricated filename "file.pdf" to prove it. EngagementDispatcher set only source and sourceId on SendOptions, so every media header an AI call ever sent went out as a document.

I claimed the null branch was the image path when I added templateHeaderUrl. It is not; it is the not-video branch. This is the line that actually decides.

The type is carried per-action in variables_json as _headerType, beside _headerUrl, and read back by the dispatcher onto SendOptions.headerType. No new column, and "_"-prefixed keys are filtered out of the body parameters by both provider paths, so it cannot disturb the positional count that 132000 punishes. The editor derives image/document from the chosen template's HEADER format — there is nothing new for an admin to fill in.

AiCallActionService defaults to "image" when a rule has a URL but no type. That is deliberate: rules saved before this field existed (the Shikshanation quiz rule among them) already carry a URL, and an image header is what a media template overwhelmingly is. Those rules start working without being re-saved.

Chain verified hop by hop against the source this time, not inferred:
  - parseVariables is a plain Jackson map read, so _headerType survives it
  - SendOptions is @Builder with a headerType field
  - UnifiedSendService reads options.getHeaderType() and passes it positionally as argument 8 of sendWhatsappMessagesDetailed — signature matches call site
  - that forwards to sendViaCombotProvider (COMBOT/META is the live provider, per the notification-service logs) and on into buildHeaderConfig

Checks: admin_core_service compiles with no errors; tsc reports none in either frontend file; design-lint clean; eslint unchanged (send-rules-editor keeps its pre-existing count, AiAgentsCard stays at 10).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
