### PR TITLE
fix(catalogue): allow <del>/<ins>/<strike> in custom HTML

### DIFF
--- a/ai_service/app/routers/page_builder.py
+++ b/ai_service/app/routers/page_builder.py
@@ -97,13 +97,19 @@ def _sanitize_html(value: str) -> str:
 # structural/text tags only, class-based styling via a separate scrubbed CSS
 # blob, images only from vetted URLs, no scripts/iframes/svg/forms/media.
 
+# del/ins/strike: a struck-through original price is the commonest thing a
+# marketing section needs and <del> is what authors write for it. nh3 keeps a
+# disallowed tag's CHILDREN, so omitting it turned "<del>₹1,599</del>" into
+# bare "₹1,599" and left the matching `del { … }` CSS rule dead — a silent
+# no-op that reads as "the edit did not save". No scripting surface; their
+# "cite" attribute stays disallowed (it is a URL).
 _CUSTOM_HTML_TAGS = {
     "a", "article", "aside", "b", "blockquote", "br", "button", "caption",
-    "cite", "code", "dd", "div", "dl", "dt", "em", "figcaption", "figure",
-    "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
-    "li", "mark", "nav", "ol", "p", "pre", "s", "section", "small", "span",
-    "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
-    "time", "tr", "u", "ul",
+    "cite", "code", "dd", "del", "div", "dl", "dt", "em", "figcaption",
+    "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr",
+    "i", "img", "ins", "li", "mark", "nav", "ol", "p", "pre", "s", "section",
+    "small", "span", "strike", "strong", "sub", "sup", "table", "tbody", "td",
+    "tfoot", "th", "thead", "time", "tr", "u", "ul",
 }
 _CUSTOM_HTML_ATTRS = {
     "*": {"class", "id", "style", "title", "role", "aria-label", "aria-hidden"},

--- a/ai_service/app/services/html_page_import.py
+++ b/ai_service/app/services/html_page_import.py
@@ -33,13 +33,16 @@ _SVG_TAGS = {
     "clipPath", "linearGradient", "radialGradient", "stop", "pattern", "filter",
     "feGaussianBlur", "feOffset", "feBlend", "feColorMatrix",
 }
+# del/ins/strike: see the note on _CUSTOM_HTML_TAGS in routers/page_builder.py
+# — nh3 keeps a disallowed tag's children, so a missing <del> silently degrades
+# a struck price to plain text and kills the `del { … }` rule that styles it.
 PAGE_HTML_TAGS = {
     "a", "article", "aside", "b", "blockquote", "br", "button", "caption",
-    "cite", "code", "dd", "div", "dl", "dt", "em", "figcaption", "figure",
-    "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
-    "li", "main", "mark", "nav", "ol", "p", "pre", "s", "section", "small",
-    "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-    "thead", "time", "tr", "u", "ul",
+    "cite", "code", "dd", "del", "div", "dl", "dt", "em", "figcaption",
+    "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr",
+    "i", "img", "ins", "li", "main", "mark", "nav", "ol", "p", "pre", "s",
+    "section", "small", "span", "strike", "strong", "sub", "sup", "table",
+    "tbody", "td", "tfoot", "th", "thead", "time", "tr", "u", "ul",
 } | _SVG_TAGS
 
 _SVG_ATTRS = {

--- a/frontend-admin-dashboard/src/routes/manage-pages/-utils/catalogue-html.ts
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-utils/catalogue-html.ts
@@ -20,14 +20,24 @@
  */
 import DOMPurify from 'dompurify';
 
-/** Structural/text tags only — no script/style/iframe/svg/media/form inputs. */
+/** Structural/text tags only — no script/style/iframe/svg/media/form inputs.
+ *
+ *  del/ins/strike are here for one reason: a struck-through original price is
+ *  the single most common thing a marketing page needs, and `<del>` is what
+ *  every author (human or AI) writes for it. Leaving it out did not fail
+ *  loudly — DOMPurify keeps the CHILDREN of a disallowed tag, so
+ *  `<del>₹1,599</del>` rendered as bare `₹1,599`, and the `.price del { … }`
+ *  rule in the same blob matched nothing. The page looked like it had simply
+ *  ignored the edit, so it got "fixed" by hand over and over. They are
+ *  presentational text-level elements with no scripting surface; their `cite`
+ *  attribute is deliberately NOT allowed (it is a URL). */
 const ALLOWED_TAGS = [
     'a', 'article', 'aside', 'b', 'blockquote', 'br', 'button', 'caption',
-    'cite', 'code', 'dd', 'div', 'dl', 'dt', 'em', 'figcaption', 'figure',
-    'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'i', 'img',
-    'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section', 'small', 'span',
-    'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead',
-    'time', 'tr', 'u', 'ul',
+    'cite', 'code', 'dd', 'del', 'div', 'dl', 'dt', 'em', 'figcaption',
+    'figure', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr',
+    'i', 'img', 'ins', 'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section',
+    'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'time', 'tr', 'u', 'ul',
 ];
 
 const ALLOWED_ATTR = [

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-utils/catalogue-html.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-utils/catalogue-html.ts
@@ -20,14 +20,24 @@
  */
 import DOMPurify from 'dompurify';
 
-/** Structural/text tags only — no script/style/iframe/svg/media/form inputs. */
+/** Structural/text tags only — no script/style/iframe/svg/media/form inputs.
+ *
+ *  del/ins/strike are here for one reason: a struck-through original price is
+ *  the single most common thing a marketing page needs, and `<del>` is what
+ *  every author (human or AI) writes for it. Leaving it out did not fail
+ *  loudly — DOMPurify keeps the CHILDREN of a disallowed tag, so
+ *  `<del>₹1,599</del>` rendered as bare `₹1,599`, and the `.price del { … }`
+ *  rule in the same blob matched nothing. The page looked like it had simply
+ *  ignored the edit, so it got "fixed" by hand over and over. They are
+ *  presentational text-level elements with no scripting surface; their `cite`
+ *  attribute is deliberately NOT allowed (it is a URL). */
 const ALLOWED_TAGS = [
     'a', 'article', 'aside', 'b', 'blockquote', 'br', 'button', 'caption',
-    'cite', 'code', 'dd', 'div', 'dl', 'dt', 'em', 'figcaption', 'figure',
-    'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'i', 'img',
-    'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section', 'small', 'span',
-    'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead',
-    'time', 'tr', 'u', 'ul',
+    'cite', 'code', 'dd', 'del', 'div', 'dl', 'dt', 'em', 'figcaption',
+    'figure', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr',
+    'i', 'img', 'ins', 'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section',
+    'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'time', 'tr', 'u', 'ul',
 ];
 
 const ALLOWED_ATTR = [


### PR DESCRIPTION
## The bug

A struck-through original price is the commonest thing a marketing page needs, and `<del>` is what every author — human or AI — writes for it. None of the four allowlists that govern catalogue custom HTML included it.

**The failure mode is what makes this worth fixing.** Both DOMPurify and nh3 drop a disallowed tag but **keep its children**, so `<del>₹1,599</del>` rendered as bare `₹1,599` — no error, no warning — and the `.price-value del { … }` rule sitting in the same CSS blob then matched nothing, losing the muted colour and smaller size along with the strike.

To an admin that reads as *"the backend reverted my edit"*. The7Cs `toddler-reset` page was duly hand-patched six times across three days with `position:absolute` white bars and inline `text-decoration: line-through !important` — both of which *do* survive, since `style` is allowlisted.

## The fix

`del`, `ins` and `strike` added to all four allowlists:

| file | symbol |
|---|---|
| `frontend-learner-dashboard-app/src/routes/$tagName/-utils/catalogue-html.ts` | `ALLOWED_TAGS` |
| `frontend-admin-dashboard/src/routes/manage-pages/-utils/catalogue-html.ts` | `ALLOWED_TAGS` (byte-identical copy) |
| `ai_service/app/routers/page_builder.py` | `_CUSTOM_HTML_TAGS` — htmlBlock sections |
| `ai_service/app/services/html_page_import.py` | `PAGE_HTML_TAGS` — whole-page import |

## Security note

These are presentational text-level elements with no scripting surface. Their `cite` attribute is **deliberately not** allowlisted, because it is a URL and every URL attribute here is vetted. Nothing else in either allowlist changed — `script`, `iframe`, `form`, `style` tags and the URL/CSS scrubbing are untouched.

## Verification

- Ran the **real** DOMPurify config headless against both tag lists:

  | input | before | after |
  |---|---|---|
  | `<del>₹1,599</del>` | `₹1,599` (tag gone) | `<del>₹1,599</del>` |
  | `<strike>` / `<ins>` | stripped | preserved |
  | `<script>` / `<iframe>` | blocked | blocked |

- `node scripts/check-style-engine-sync.mjs` → `style-engine sync: clean ✓` (the two `catalogue-html.ts` copies hash to the same blob)
- Both Python modules parse, and each tag set evaluates to the expected membership.

## Related

The7Cs `toddler-reset` page has already been switched to `<s>` in prod as a no-deploy workaround (`<s>` was the one strike tag already allowlisted). Once this ships, the natural `<del>` markup works too — including the second live copy of that page at `/new-landing-page/toddler`, which still carries the original `<del>` and renders unstruck today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
