### PR TITLE
Let a struck-through price survive HTML sanitising

### DIFF
--- a/ai_service/app/routers/page_builder.py
+++ b/ai_service/app/routers/page_builder.py
@@ -97,13 +97,19 @@ def _sanitize_html(value: str) -> str:
 # structural/text tags only, class-based styling via a separate scrubbed CSS
 # blob, images only from vetted URLs, no scripts/iframes/svg/forms/media.
 
+# del/ins/strike: a struck-through original price is the commonest thing a
+# marketing section needs and <del> is what authors write for it. nh3 keeps a
+# disallowed tag's CHILDREN, so omitting it turned "<del>₹1,599</del>" into
+# bare "₹1,599" and left the matching `del { … }` CSS rule dead — a silent
+# no-op that reads as "the edit did not save". No scripting surface; their
+# "cite" attribute stays disallowed (it is a URL).
 _CUSTOM_HTML_TAGS = {
     "a", "article", "aside", "b", "blockquote", "br", "button", "caption",
-    "cite", "code", "dd", "div", "dl", "dt", "em", "figcaption", "figure",
-    "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
-    "li", "mark", "nav", "ol", "p", "pre", "s", "section", "small", "span",
-    "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
-    "time", "tr", "u", "ul",
+    "cite", "code", "dd", "del", "div", "dl", "dt", "em", "figcaption",
+    "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr",
+    "i", "img", "ins", "li", "mark", "nav", "ol", "p", "pre", "s", "section",
+    "small", "span", "strike", "strong", "sub", "sup", "table", "tbody", "td",
+    "tfoot", "th", "thead", "time", "tr", "u", "ul",
 }
 _CUSTOM_HTML_ATTRS = {
     "*": {"class", "id", "style", "title", "role", "aria-label", "aria-hidden"},

--- a/ai_service/app/services/html_page_import.py
+++ b/ai_service/app/services/html_page_import.py
@@ -33,13 +33,16 @@ _SVG_TAGS = {
     "clipPath", "linearGradient", "radialGradient", "stop", "pattern", "filter",
     "feGaussianBlur", "feOffset", "feBlend", "feColorMatrix",
 }
+# del/ins/strike: see the note on _CUSTOM_HTML_TAGS in routers/page_builder.py
+# — nh3 keeps a disallowed tag's children, so a missing <del> silently degrades
+# a struck price to plain text and kills the `del { … }` rule that styles it.
 PAGE_HTML_TAGS = {
     "a", "article", "aside", "b", "blockquote", "br", "button", "caption",
-    "cite", "code", "dd", "div", "dl", "dt", "em", "figcaption", "figure",
-    "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
-    "li", "main", "mark", "nav", "ol", "p", "pre", "s", "section", "small",
-    "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-    "thead", "time", "tr", "u", "ul",
+    "cite", "code", "dd", "del", "div", "dl", "dt", "em", "figcaption",
+    "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr",
+    "i", "img", "ins", "li", "main", "mark", "nav", "ol", "p", "pre", "s",
+    "section", "small", "span", "strike", "strong", "sub", "sup", "table",
+    "tbody", "td", "tfoot", "th", "thead", "time", "tr", "u", "ul",
 } | _SVG_TAGS
 
 _SVG_ATTRS = {

--- a/frontend-admin-dashboard/src/routes/manage-pages/-utils/catalogue-html.ts
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-utils/catalogue-html.ts
@@ -20,14 +20,24 @@
  */
 import DOMPurify from 'dompurify';
 
-/** Structural/text tags only — no script/style/iframe/svg/media/form inputs. */
+/** Structural/text tags only — no script/style/iframe/svg/media/form inputs.
+ *
+ *  del/ins/strike are here for one reason: a struck-through original price is
+ *  the single most common thing a marketing page needs, and `<del>` is what
+ *  every author (human or AI) writes for it. Leaving it out did not fail
+ *  loudly — DOMPurify keeps the CHILDREN of a disallowed tag, so
+ *  `<del>₹1,599</del>` rendered as bare `₹1,599`, and the `.price del { … }`
+ *  rule in the same blob matched nothing. The page looked like it had simply
+ *  ignored the edit, so it got "fixed" by hand over and over. They are
+ *  presentational text-level elements with no scripting surface; their `cite`
+ *  attribute is deliberately NOT allowed (it is a URL). */
 const ALLOWED_TAGS = [
     'a', 'article', 'aside', 'b', 'blockquote', 'br', 'button', 'caption',
-    'cite', 'code', 'dd', 'div', 'dl', 'dt', 'em', 'figcaption', 'figure',
-    'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'i', 'img',
-    'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section', 'small', 'span',
-    'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead',
-    'time', 'tr', 'u', 'ul',
+    'cite', 'code', 'dd', 'del', 'div', 'dl', 'dt', 'em', 'figcaption',
+    'figure', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr',
+    'i', 'img', 'ins', 'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section',
+    'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'time', 'tr', 'u', 'ul',
 ];
 
 const ALLOWED_ATTR = [

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-utils/catalogue-html.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-utils/catalogue-html.ts
@@ -20,14 +20,24 @@
  */
 import DOMPurify from 'dompurify';
 
-/** Structural/text tags only — no script/style/iframe/svg/media/form inputs. */
+/** Structural/text tags only — no script/style/iframe/svg/media/form inputs.
+ *
+ *  del/ins/strike are here for one reason: a struck-through original price is
+ *  the single most common thing a marketing page needs, and `<del>` is what
+ *  every author (human or AI) writes for it. Leaving it out did not fail
+ *  loudly — DOMPurify keeps the CHILDREN of a disallowed tag, so
+ *  `<del>₹1,599</del>` rendered as bare `₹1,599`, and the `.price del { … }`
+ *  rule in the same blob matched nothing. The page looked like it had simply
+ *  ignored the edit, so it got "fixed" by hand over and over. They are
+ *  presentational text-level elements with no scripting surface; their `cite`
+ *  attribute is deliberately NOT allowed (it is a URL). */
 const ALLOWED_TAGS = [
     'a', 'article', 'aside', 'b', 'blockquote', 'br', 'button', 'caption',
-    'cite', 'code', 'dd', 'div', 'dl', 'dt', 'em', 'figcaption', 'figure',
-    'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'i', 'img',
-    'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section', 'small', 'span',
-    'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead',
-    'time', 'tr', 'u', 'ul',
+    'cite', 'code', 'dd', 'del', 'div', 'dl', 'dt', 'em', 'figcaption',
+    'figure', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr',
+    'i', 'img', 'ins', 'li', 'mark', 'nav', 'ol', 'p', 'pre', 's', 'section',
+    'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'time', 'tr', 'u', 'ul',
 ];
 
 const ALLOWED_ATTR = [


### PR DESCRIPTION
A marketing section's commonest need is an old price with a line through it, and every author - human or AI - writes that as <del>. All four sanitiser allowlists omitted it.

It did not fail loudly, which is why it kept coming back. Both nh3 and DOMPurify keep the CHILDREN of a disallowed tag, so <del>Rs 1,599</del> came through as bare "Rs 1,599" and the matching `del { ... }` rule in the same blob then matched nothing. The page simply looked as though it had ignored the edit, so it was re-done by hand instead of being reported.

Adds del, ins and strike to the four allowlists that have to agree:
  ai_service/app/routers/page_builder.py        (nh3)
  ai_service/app/services/html_page_import.py   (nh3)
  frontend-admin-dashboard .../catalogue-html.ts        (DOMPurify)
  frontend-learner-dashboard-app .../catalogue-html.ts  (DOMPurify)

These are presentational text-level elements with no scripting surface. Their `cite` attribute stays disallowed, because it is a URL.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
