### PR TITLE
fix(settings): show built-in tab names in Display Settings

### DIFF
--- a/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
+++ b/frontend-admin-dashboard/src/components/common/layout-container/sidebar/utils.ts
@@ -164,13 +164,34 @@ export const resolveLocalizedTerm = (
 // seeded, which predates i18n and is therefore always English.
 let useSystemDefaultsFlag = false;
 
+/** `sidebar:aiLecturePlanning` -> `Ai Lecture Planning`. Last-resort only. */
+const humanizeSidebarKey = (key: string): string => {
+    const leaf = key.slice(key.indexOf(':') + 1);
+    const spaced = leaf
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/[._-]+/g, ' ')
+        .trim();
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
 // English is always loaded (it is the fallbackLng), so forcing it here never
 // yields a raw key even when another language is active.
-const sidebarT = (key: string, options?: Record<string, unknown>): string =>
-    i18next.t(key, {
+//
+// The fallback below is not decoration. i18next.t() returns `undefined` until
+// init() has run and the bare key until the namespace is seeded, and these
+// labels feed BOTH the nav and the Tab Name / Label boxes in Display Settings —
+// which is how an editor full of blank name fields next to filled-in routes
+// shipped. A nameless sidebar entry is never the right answer, so degrade to a
+// readable form of the key rather than to nothing.
+const sidebarT = (key: string, options?: Record<string, unknown>): string => {
+    const value = i18next.t(key, {
         ...(options ?? {}),
         ...(useSystemDefaultsFlag ? { lng: DEFAULT_LOCALE } : {}),
-    }) as string;
+    }) as string | undefined;
+    const leaf = key.slice(key.indexOf(':') + 1);
+    if (!value || value === key || value === leaf) return humanizeSidebarKey(key);
+    return value;
+};
 
 export const withSystemDefaults = <T>(fn: () => T): T => {
     const prev = useSystemDefaultsFlag;

--- a/frontend-admin-dashboard/src/components/common/layout-container/top-navbar.tsx/navbar.tsx
+++ b/frontend-admin-dashboard/src/components/common/layout-container/top-navbar.tsx/navbar.tsx
@@ -64,8 +64,8 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { PagedResponse, SystemAlertItem } from '@/services/notifications/system-alerts';
-import { DEFAULT_ADMIN_DISPLAY_SETTINGS } from '@/constants/display-settings/admin-defaults';
-import { DEFAULT_TEACHER_DISPLAY_SETTINGS } from '@/constants/display-settings/teacher-defaults';
+import { getDefaultAdminDisplaySettings } from '@/constants/display-settings/admin-defaults';
+import { getDefaultTeacherDisplaySettings } from '@/constants/display-settings/teacher-defaults';
 import { MyButton } from '@/components/design-system/button';
 import { ClearAllAlertsButton } from '@/components/common/notifications/ClearAllAlertsButton';
 import { DismissAlertButton } from '@/components/common/notifications/DismissAlertButton';
@@ -132,9 +132,17 @@ export function Navbar({ showMobileBackButton }: { showMobileBackButton?: boolea
     const isAdminRoleForDS = roles.includes('ADMIN');
     const roleKeyForDS = getActiveRoleDisplaySettingsKey();
     const cachedDS = getDisplaySettingsFromCache(roleKeyForDS);
-    const defaultDS = isAdminRoleForDS
-        ? DEFAULT_ADMIN_DISPLAY_SETTINGS
-        : DEFAULT_TEACHER_DISPLAY_SETTINGS;
+    // Only the permission flags and `ui` are read from this fallback, and neither
+    // depends on the sidebar labels the getters resolve through i18n — so the
+    // role is the whole dependency. Memoized because the navbar is always
+    // mounted and building the defaults walks every sidebar entry.
+    const defaultDS = useMemo(
+        () =>
+            isAdminRoleForDS
+                ? getDefaultAdminDisplaySettings()
+                : getDefaultTeacherDisplaySettings(),
+        [isAdminRoleForDS]
+    );
     const effectiveDS = cachedDS || defaultDS;
     const canViewProfile = effectiveDS.permissions.canViewProfileDetails;
     const canEditProfile = effectiveDS.permissions.canEditProfileDetails;

--- a/frontend-admin-dashboard/src/constants/display-settings/admin-defaults.ts
+++ b/frontend-admin-dashboard/src/constants/display-settings/admin-defaults.ts
@@ -1,4 +1,4 @@
-import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
+import { getSidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 import type { SidebarItemsType } from '@/types/layout-container/layout-container-types';
 import type {
     DisplaySettingsData,
@@ -37,10 +37,21 @@ const OPT_IN_TAB_IDS = new Set<string>([
     // one deliberate switch is the gate, not eight.
 ]);
 
+// NOTE: built-in tabs are deliberately seeded WITHOUT a `label`.
+//
+// mySidebar treats a saved label as a user customization unless it still matches
+// the built-in name, and then renders it verbatim forever. Seeding the name that
+// i18n/naming-settings resolve to TODAY would therefore freeze it: an institute
+// that saves while the UI is in French, or before renaming "Course" to
+// "Program", would keep the old wording in the nav after the switch. Leaving the
+// label unset keeps every built-in tab on the live, translated name.
+//
+// Display Settings shows these names by falling back to the sidebar entry for
+// display only (see AdminDisplaySettings), which is what fills the Tab Name
+// boxes without writing anything into the saved config.
 function mapSidebarToConfig(menu: SidebarItemsType[]): SidebarTabConfig[] {
     return menu.map((item, index) => ({
         id: item.id,
-        label: item.title,
         route: item.to,
         order: index + 1,
         visible:
@@ -52,7 +63,6 @@ function mapSidebarToConfig(menu: SidebarItemsType[]): SidebarTabConfig[] {
                 const id = sub.subItemId || sub.subItem || `${item.id}-${subIndex + 1}`;
                 return {
                     id,
-                    label: sub.subItem,
                     route: sub.subItemLink || '#',
                     order: subIndex + 1,
                     visible: !SUB_ITEMS_HIDDEN_BY_DEFAULT.has(id),
@@ -128,8 +138,11 @@ function defaultDashboardWidgetsAdmin(): DashboardWidgetConfig[] {
     return ids.map((id, idx) => ({ id, order: idx + 1, visible: !defaultOff.has(id) }));
 }
 
-export const DEFAULT_ADMIN_DISPLAY_SETTINGS: DisplaySettingsData = {
-    sidebar: mapSidebarToConfig(SidebarItemsData),
+// Everything except `sidebar`, which is built per call below rather than here:
+// anything read off the sidebar entries at module-evaluation time predates
+// i18next.init() (src/index.tsx imports the route tree before ./i18n), and this
+// file is in the route graph.
+const ADMIN_DEFAULTS_BASE: Omit<DisplaySettingsData, 'sidebar'> = {
     dashboard: {
         widgets: defaultDashboardWidgetsAdmin(),
     },
@@ -328,3 +341,17 @@ export const DEFAULT_ADMIN_DISPLAY_SETTINGS: DisplaySettingsData = {
     leadsFilterCustomFields: [],
     postLoginRedirectRoute: '/dashboard',
 };
+
+/**
+ * Default admin display settings.
+ *
+ * Call this rather than caching the result at module scope — the sidebar entries
+ * it reads resolve through i18n and the institute's naming settings, neither of
+ * which exists while modules are still being evaluated.
+ */
+export function getDefaultAdminDisplaySettings(): DisplaySettingsData {
+    return {
+        ...ADMIN_DEFAULTS_BASE,
+        sidebar: mapSidebarToConfig(getSidebarItemsData()),
+    };
+}

--- a/frontend-admin-dashboard/src/constants/display-settings/sidebar-defaults-labels.test.ts
+++ b/frontend-admin-dashboard/src/constants/display-settings/sidebar-defaults-labels.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Built-in sidebar tabs must be seeded WITHOUT a `label`.
+ *
+ * mySidebar treats a saved label as a deliberate user customization unless it
+ * still matches the built-in name, and then renders it verbatim forever
+ * (`title: isSeededTitle ? item.title : cfg.label`). A default that seeds the
+ * name i18n resolves to today would therefore freeze the nav: an institute that
+ * saves its display settings while the UI is in French, or before renaming
+ * "Course" to "Program", would keep the stale wording afterwards.
+ *
+ * Display Settings fills its Tab Name / Label boxes by falling back to the live
+ * sidebar entry instead — display only, nothing written to the saved config.
+ * See sidebar-tab-names.test.tsx for that half.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import i18next from 'i18next';
+import sidebarEn from '../../../public/locales/en/sidebar.json';
+import { getDefaultAdminDisplaySettings } from './admin-defaults';
+import { getDefaultTeacherDisplaySettings } from './teacher-defaults';
+
+beforeAll(async () => {
+    await i18next.init({
+        lng: 'en',
+        fallbackLng: 'en',
+        ns: ['sidebar'],
+        resources: { en: { sidebar: sidebarEn } },
+        interpolation: { escapeValue: false },
+    });
+});
+
+const labelled = (sidebar: ReturnType<typeof getDefaultAdminDisplaySettings>['sidebar']) => [
+    ...sidebar.filter((tab) => tab.label !== undefined).map((tab) => tab.id),
+    ...sidebar.flatMap((tab) =>
+        (tab.subTabs || [])
+            .filter((sub) => sub.label !== undefined)
+            .map((sub) => `${tab.id}/${sub.id}`)
+    ),
+];
+
+describe('default sidebar config', () => {
+    it('seeds no label on any built-in admin tab or sub-tab', () => {
+        const { sidebar } = getDefaultAdminDisplaySettings();
+        expect(sidebar.length).toBeGreaterThan(0);
+        expect(sidebar.some((tab) => (tab.subTabs || []).length > 0)).toBe(true);
+        expect(labelled(sidebar)).toEqual([]);
+    });
+
+    it('seeds no label on any built-in teacher tab or sub-tab', () => {
+        const { sidebar } = getDefaultTeacherDisplaySettings();
+        expect(sidebar.length).toBeGreaterThan(0);
+        expect(labelled(sidebar)).toEqual([]);
+    });
+
+    it('still seeds the routes and ordering the nav needs', () => {
+        const { sidebar } = getDefaultAdminDisplaySettings();
+        const contacts = sidebar.find((tab) => tab.id === 'manage-contacts');
+        expect(contacts?.order).toBeGreaterThan(0);
+        expect(contacts?.subTabs?.map((sub) => sub.route)).toContain('/manage-contacts');
+    });
+});

--- a/frontend-admin-dashboard/src/constants/display-settings/teacher-defaults.ts
+++ b/frontend-admin-dashboard/src/constants/display-settings/teacher-defaults.ts
@@ -1,4 +1,4 @@
-import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
+import { getSidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 import type { SidebarItemsType } from '@/types/layout-container/layout-container-types';
 import type {
     DisplaySettingsData,
@@ -7,12 +7,15 @@ import type {
 } from '@/types/display-settings';
 import { DEFAULT_ASSESSMENT_ACTION_SETTINGS } from '@/types/display-settings';
 
+// Built-in tabs are seeded WITHOUT a `label` — see the note on
+// mapSidebarToConfig in admin-defaults.ts. A seeded name would be read back as a
+// user customization and freeze the nav at whatever wording was current when the
+// config was saved.
 function mapSidebarToTeacherConfig(menu: SidebarItemsType[]): SidebarTabConfig[] {
     return menu
         .filter((item) => item.id !== 'settings') // settings tab must be hidden for teacher
         .map((item, index) => ({
             id: item.id,
-            label: item.title,
             route: item.to,
             order: index + 1,
             // By default, show everything except tabs which are inherently admin-only filtered elsewhere;
@@ -40,7 +43,6 @@ function mapSidebarToTeacherConfig(menu: SidebarItemsType[]): SidebarTabConfig[]
                     const subId = sub.subItemId || sub.subItem || `${item.id}-${subIndex + 1}`;
                     return {
                         id: subId,
-                        label: sub.subItem,
                         route: sub.subItemLink || '#',
                         order: subIndex + 1,
                         // Sub-org teams + manage-institute-suborgs + notification hub
@@ -128,8 +130,9 @@ function defaultDashboardWidgetsTeacher(): DashboardWidgetConfig[] {
     }));
 }
 
-export const DEFAULT_TEACHER_DISPLAY_SETTINGS: DisplaySettingsData = {
-    sidebar: mapSidebarToTeacherConfig(SidebarItemsData),
+// Everything except `sidebar`, which is built per call below — see the matching
+// note in admin-defaults.ts.
+const TEACHER_DEFAULTS_BASE: Omit<DisplaySettingsData, 'sidebar'> = {
     dashboard: {
         widgets: defaultDashboardWidgetsTeacher(),
     },
@@ -326,3 +329,14 @@ export const DEFAULT_TEACHER_DISPLAY_SETTINGS: DisplaySettingsData = {
     leadsFilterCustomFields: [],
     postLoginRedirectRoute: '/dashboard',
 };
+
+/**
+ * Default teacher display settings. See getDefaultAdminDisplaySettings() for why
+ * this must not be cached at module scope.
+ */
+export function getDefaultTeacherDisplaySettings(): DisplaySettingsData {
+    return {
+        ...TEACHER_DEFAULTS_BASE,
+        sidebar: mapSidebarToTeacherConfig(getSidebarItemsData()),
+    };
+}

--- a/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/AdminDisplaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/AdminDisplaySettings.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { RoleDisplayPanelProps } from './panel-props';
 import { applyRoleConstraints } from '@/lib/display-settings/role-constraints';
 import { useTranslation } from 'react-i18next';
+import { useNamingSettingsVersion } from '@/hooks/useNamingSettingsVersion';
 import { UnsavedChangesBar } from '@/components/common/unsaved-changes-bar';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
+import { getSidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -31,7 +32,7 @@ import {
     type LearnerManagementSettings,
 } from '@/types/display-settings';
 import { getDisplaySettingsWithFallback, saveDisplaySettings } from '@/services/display-settings';
-import { DEFAULT_ADMIN_DISPLAY_SETTINGS } from '@/constants/display-settings/admin-defaults';
+import { getDefaultAdminDisplaySettings } from '@/constants/display-settings/admin-defaults';
 import {
     DEFAULT_HIDDEN_COURSE_DETAILS_TABS,
     OFFLINE_GATED_COURSE_DETAILS_TABS,
@@ -106,6 +107,22 @@ const LEARNER_MANAGEMENT_DEFAULTS: LearnerManagementSettings = {
 
 export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanelProps = {}) {
     const { t } = useTranslation('settingsAdminDisplay');
+    // Built-in tab names come from getSidebarItemsData(), which resolves them
+    // through the i18next singleton and through the institute's naming settings.
+    // Neither is available while modules are being evaluated, so this has to be
+    // read during render — a value captured at module scope is simply blank, and
+    // that is what left every Tab Name / Label box in this editor empty.
+    //
+    // `ready` flips when the sidebar catalog lands and `namingVersion` bumps on a
+    // rename or a language switch; between them the memo can never hold on to
+    // stale labels, and the lookup stays off the per-keystroke render path (it
+    // re-reads localStorage once per built-in entry).
+    const { ready: sidebarCatalogReady } = useTranslation('sidebar');
+    const namingVersion = useNamingSettingsVersion();
+    const sidebarItems = useMemo(
+        () => getSidebarItemsData(),
+        [sidebarCatalogReady, namingVersion]
+    );
 
     const ADMIN_DISPLAY_SECTIONS: SettingsSectionGroup[] = [
         {
@@ -426,7 +443,7 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
             // Get tabs in the active category, sorted by order
             const categoryTabs = prev.sidebar
                 .filter((t) => {
-                    const baseItem = SidebarItemsData.find((i) => i.id === t.id);
+                    const baseItem = sidebarItems.find((i) => i.id === t.id);
                     const cat = baseItem?.category || t.category || 'CRM';
                     return cat === activeCategory;
                 })
@@ -517,7 +534,7 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                         buttonType="secondary"
                         scale="small"
                         onClick={() => {
-                            setSettings(DEFAULT_ADMIN_DISPLAY_SETTINGS);
+                            setSettings(getDefaultAdminDisplaySettings());
                             setHasChanges(true);
                         }}
                     >
@@ -1655,13 +1672,15 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                         {(() => {
                             const categoryTabs = settings.sidebar
                                 .filter((tab) => {
-                                    const baseItem = SidebarItemsData.find((i) => i.id === tab.id);
+                                    const baseItem = sidebarItems.find((i) => i.id === tab.id);
                                     const cat = baseItem?.category || tab.category || 'CRM';
                                     return cat === activeCategory;
                                 })
                                 .sort((a, b) => a.order - b.order);
 
-                            return categoryTabs.map((tab, tabIdx) => (
+                            return categoryTabs.map((tab, tabIdx) => {
+                                const baseItem = sidebarItems.find((i) => i.id === tab.id);
+                                return (
                                 <div key={tab.id} className="mb-3 rounded border p-3">
                                     <div className="flex items-start gap-3">
                                         {/* Move up/down buttons */}
@@ -1696,7 +1715,7 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                                                 <div className="col-span-2">
                                                     <Label>{t('sidebarTabs.tabName')}</Label>
                                                     <Input
-                                                        value={tab.label || ''}
+                                                        value={tab.label || baseItem?.title || ''}
                                                         onChange={(e) =>
                                                             updateSettings((prev) => ({
                                                                 ...prev,
@@ -1799,7 +1818,12 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                                                         .slice()
                                                         .sort((a, b) => a.order - b.order);
 
-                                                    return sortedSubs.map((sub, subIdx) => (
+                                                    return sortedSubs.map((sub, subIdx) => {
+                                                    const baseSub = baseItem?.subItems?.find(
+                                                        (i) =>
+                                                            (i.subItemId || i.subItem) === sub.id
+                                                    );
+                                                    return (
                                                         <div
                                                             key={sub.id}
                                                             className="flex items-center gap-3 rounded border p-2"
@@ -1837,7 +1861,11 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                                                             <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-4 md:items-center">
                                                                 <div className="col-span-2">
                                                                     <Input
-                                                                        value={sub.label || ''}
+                                                                        value={
+                                                                            sub.label ||
+                                                                            baseSub?.subItem ||
+                                                                            ''
+                                                                        }
                                                                         placeholder={t('common.label')}
                                                                         onChange={(e) =>
                                                                             updateSettings((prev) => ({
@@ -1994,13 +2022,15 @@ export default function AdminDisplaySettings({ onDirtyChange }: RoleDisplayPanel
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    ));
+                                                    );
+                                                    });
                                                 })()}
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                            ));
+                            );
+                            });
                         })()}
                     </Tabs>
                     <div className="pt-2">

--- a/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/CustomRoleDisplaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/CustomRoleDisplaySettings.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { RoleDisplayPanelProps } from './panel-props';
 import { applyRoleConstraints } from '@/lib/display-settings/role-constraints';
 import { useTranslation } from 'react-i18next';
+import { useNamingSettingsVersion } from '@/hooks/useNamingSettingsVersion';
 import type { TFunction } from 'i18next';
 import { UnsavedChangesBar } from '@/components/common/unsaved-changes-bar';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
+import { getSidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -27,7 +28,7 @@ import { ListCustomFieldControlsCard } from './ListCustomFieldControlsCard';
 import { StudentManagementActionsCard } from './StudentManagementActionsCard';
 import { AssessmentActionsCard } from './AssessmentActionsCard';
 import { TeamRoleVisibilityCard } from './TeamRoleVisibilityCard';
-import { DEFAULT_TEACHER_DISPLAY_SETTINGS } from '@/constants/display-settings/teacher-defaults';
+import { getDefaultTeacherDisplaySettings } from '@/constants/display-settings/teacher-defaults';
 import {
     DEFAULT_HIDDEN_COURSE_DETAILS_TABS,
     OFFLINE_GATED_COURSE_DETAILS_TABS,
@@ -271,6 +272,22 @@ export default function CustomRoleDisplaySettings({
     roleName?: string;
 }) {
     const { t } = useTranslation('settingsCustomRoleDisplay');
+    // Built-in tab names come from getSidebarItemsData(), which resolves them
+    // through the i18next singleton and through the institute's naming settings.
+    // Neither is available while modules are being evaluated, so this has to be
+    // read during render — a value captured at module scope is simply blank, and
+    // that is what left every Tab Name / Label box in this editor empty.
+    //
+    // `ready` flips when the sidebar catalog lands and `namingVersion` bumps on a
+    // rename or a language switch; between them the memo can never hold on to
+    // stale labels, and the lookup stays off the per-keystroke render path (it
+    // re-reads localStorage once per built-in entry).
+    const { ready: sidebarCatalogReady } = useTranslation('sidebar');
+    const namingVersion = useNamingSettingsVersion();
+    const sidebarItems = useMemo(
+        () => getSidebarItemsData(),
+        [sidebarCatalogReady, namingVersion]
+    );
     const [settings, setSettings] = useState<DisplaySettingsData | null>(null);
     const [isSaving, setIsSaving] = useState(false);
     const [hasChanges, setHasChanges] = useState(false);
@@ -450,7 +467,7 @@ export default function CustomRoleDisplaySettings({
         updateSettings((prev) => {
             const categoryTabs = prev.sidebar
                 .filter((t) => {
-                    const baseItem = SidebarItemsData.find((i) => i.id === t.id);
+                    const baseItem = sidebarItems.find((i) => i.id === t.id);
                     const cat = baseItem?.category || t.category || 'CRM';
                     return cat === activeCategory;
                 })
@@ -543,7 +560,7 @@ export default function CustomRoleDisplaySettings({
                     <MyButton
                         buttonType="secondary"
                         scale="small"
-                        onClick={() => setSettings(DEFAULT_TEACHER_DISPLAY_SETTINGS)}
+                        onClick={() => setSettings(getDefaultTeacherDisplaySettings())}
                     >
                         {t('common.resetToDefaults')}
                     </MyButton>
@@ -1646,13 +1663,15 @@ export default function CustomRoleDisplaySettings({
                         {(() => {
                             const categoryTabs = settings.sidebar
                                 .filter((tab) => {
-                                    const baseItem = SidebarItemsData.find((i) => i.id === tab.id);
+                                    const baseItem = sidebarItems.find((i) => i.id === tab.id);
                                     const cat = baseItem?.category || tab.category || 'CRM';
                                     return cat === activeCategory;
                                 })
                                 .sort((a, b) => a.order - b.order);
 
-                            return categoryTabs.map((tab, tabIdx) => (
+                            return categoryTabs.map((tab, tabIdx) => {
+                                const baseItem = sidebarItems.find((i) => i.id === tab.id);
+                                return (
                                 <div key={tab.id} className="mb-3 rounded border p-3">
                                     <div className="flex items-start gap-3">
                                         <div className="flex flex-col items-center gap-1 pt-6">
@@ -1684,7 +1703,7 @@ export default function CustomRoleDisplaySettings({
                                                 <div className="col-span-2">
                                                     <Label>{t('common.tabName')}</Label>
                                                     <Input
-                                                        value={tab.label || ''}
+                                                        value={tab.label || baseItem?.title || ''}
                                                         onChange={(e) =>
                                                             updateSettings((prev) => ({
                                                                 ...prev,
@@ -1786,7 +1805,12 @@ export default function CustomRoleDisplaySettings({
                                                         .slice()
                                                         .sort((a, b) => a.order - b.order);
 
-                                                    return sortedSubs.map((sub, subIdx) => (
+                                                    return sortedSubs.map((sub, subIdx) => {
+                                                    const baseSub = baseItem?.subItems?.find(
+                                                        (i) =>
+                                                            (i.subItemId || i.subItem) === sub.id
+                                                    );
+                                                    return (
                                                         <div
                                                             key={sub.id}
                                                             className="flex items-center gap-3 rounded border p-2"
@@ -1821,7 +1845,11 @@ export default function CustomRoleDisplaySettings({
                                                             <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-4 md:items-center">
                                                                 <div className="col-span-2">
                                                                     <Input
-                                                                        value={sub.label || ''}
+                                                                        value={
+                                                                            sub.label ||
+                                                                            baseSub?.subItem ||
+                                                                            ''
+                                                                        }
                                                                         placeholder={t('common.labelPlaceholder')}
                                                                         onChange={(e) =>
                                                                             updateSettings((prev) => ({
@@ -1978,13 +2006,15 @@ export default function CustomRoleDisplaySettings({
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    ));
+                                                    );
+                                                    });
                                                 })()}
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                            ));
+                            );
+                            });
                         })()}
                     </Tabs>
                     <div className="pt-2">

--- a/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/TeacherDisplaySettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/TeacherDisplaySettings.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { RoleDisplayPanelProps } from './panel-props';
 import { applyRoleConstraints } from '@/lib/display-settings/role-constraints';
 import { useTranslation } from 'react-i18next';
+import { useNamingSettingsVersion } from '@/hooks/useNamingSettingsVersion';
 import type { TFunction } from 'i18next';
 import { UnsavedChangesBar } from '@/components/common/unsaved-changes-bar';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
+import { getSidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -27,7 +28,7 @@ import { ListCustomFieldControlsCard } from './ListCustomFieldControlsCard';
 import { StudentManagementActionsCard } from './StudentManagementActionsCard';
 import { AssessmentActionsCard } from './AssessmentActionsCard';
 import { TeamRoleVisibilityCard } from './TeamRoleVisibilityCard';
-import { DEFAULT_TEACHER_DISPLAY_SETTINGS } from '@/constants/display-settings/teacher-defaults';
+import { getDefaultTeacherDisplaySettings } from '@/constants/display-settings/teacher-defaults';
 import {
     DEFAULT_HIDDEN_COURSE_DETAILS_TABS,
     OFFLINE_GATED_COURSE_DETAILS_TABS,
@@ -269,6 +270,22 @@ function getLearnerManagementOptions(
 
 export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPanelProps = {}) {
     const { t } = useTranslation('settingsTeacherDisplay');
+    // Built-in tab names come from getSidebarItemsData(), which resolves them
+    // through the i18next singleton and through the institute's naming settings.
+    // Neither is available while modules are being evaluated, so this has to be
+    // read during render — a value captured at module scope is simply blank, and
+    // that is what left every Tab Name / Label box in this editor empty.
+    //
+    // `ready` flips when the sidebar catalog lands and `namingVersion` bumps on a
+    // rename or a language switch; between them the memo can never hold on to
+    // stale labels, and the lookup stays off the per-keystroke render path (it
+    // re-reads localStorage once per built-in entry).
+    const { ready: sidebarCatalogReady } = useTranslation('sidebar');
+    const namingVersion = useNamingSettingsVersion();
+    const sidebarItems = useMemo(
+        () => getSidebarItemsData(),
+        [sidebarCatalogReady, namingVersion]
+    );
     const TEACHER_DISPLAY_SECTIONS = getTeacherDisplaySections(t);
     const STUDENT_SIDE_VIEW_OPTIONS = getStudentSideViewOptions(t);
     const LEARNER_MANAGEMENT_OPTIONS = getLearnerManagementOptions(t);
@@ -444,7 +461,7 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
         updateSettings((prev) => {
             const categoryTabs = prev.sidebar
                 .filter((t) => {
-                    const baseItem = SidebarItemsData.find((i) => i.id === t.id);
+                    const baseItem = sidebarItems.find((i) => i.id === t.id);
                     const cat = baseItem?.category || t.category || 'CRM';
                     return cat === activeCategory;
                 })
@@ -532,7 +549,7 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                     <MyButton
                         buttonType="secondary"
                         scale="small"
-                        onClick={() => setSettings(DEFAULT_TEACHER_DISPLAY_SETTINGS)}
+                        onClick={() => setSettings(getDefaultTeacherDisplaySettings())}
                     >
                         {t('resetToDefaults')}
                     </MyButton>
@@ -1647,13 +1664,15 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                         {(() => {
                             const categoryTabs = settings.sidebar
                                 .filter((tab) => {
-                                    const baseItem = SidebarItemsData.find((i) => i.id === tab.id);
+                                    const baseItem = sidebarItems.find((i) => i.id === tab.id);
                                     const cat = baseItem?.category || tab.category || 'CRM';
                                     return cat === activeCategory;
                                 })
                                 .sort((a, b) => a.order - b.order);
 
-                            return categoryTabs.map((tab, tabIdx) => (
+                            return categoryTabs.map((tab, tabIdx) => {
+                                const baseItem = sidebarItems.find((i) => i.id === tab.id);
+                                return (
                                 <div key={tab.id} className="mb-3 rounded border p-3">
                                     <div className="flex items-start gap-3">
                                         {/* Move up/down buttons */}
@@ -1688,7 +1707,7 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                                                 <div className="col-span-2">
                                                     <Label>{t('cards.sidebarTabs.tabName')}</Label>
                                                     <Input
-                                                        value={tab.label || ''}
+                                                        value={tab.label || baseItem?.title || ''}
                                                         onChange={(e) =>
                                                             updateSettings((prev) => ({
                                                                 ...prev,
@@ -1790,7 +1809,12 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                                                         .slice()
                                                         .sort((a, b) => a.order - b.order);
 
-                                                    return sortedSubs.map((sub, subIdx) => (
+                                                    return sortedSubs.map((sub, subIdx) => {
+                                                    const baseSub = baseItem?.subItems?.find(
+                                                        (i) =>
+                                                            (i.subItemId || i.subItem) === sub.id
+                                                    );
+                                                    return (
                                                         <div
                                                             key={sub.id}
                                                             className="flex items-center gap-3 rounded border p-2"
@@ -1828,7 +1852,11 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                                                             <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-4 md:items-center">
                                                                 <div className="col-span-2">
                                                                     <Input
-                                                                        value={sub.label || ''}
+                                                                        value={
+                                                                            sub.label ||
+                                                                            baseSub?.subItem ||
+                                                                            ''
+                                                                        }
                                                                         placeholder={t('cards.sidebarTabs.labelPlaceholder')}
                                                                         onChange={(e) =>
                                                                             updateSettings((prev) => ({
@@ -1985,13 +2013,15 @@ export default function TeacherDisplaySettings({ onDirtyChange }: RoleDisplayPan
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    ));
+                                                    );
+                                                    });
                                                 })()}
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                            ));
+                            );
+                            });
                         })()}
                     </Tabs>
                     <div className="pt-2">

--- a/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/sidebar-tab-names.test.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/RoleDisplay/sidebar-tab-names.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Display Settings → Sidebar Tabs used to render a column of empty "Tab Name" and
+ * "Label" boxes next to correctly-filled routes: the built-in names resolve
+ * through i18next, and they were being read at module-evaluation time, before
+ * i18next had been initialised, so every one of them was `undefined`.
+ *
+ * A saved institute config stores ids, routes, order and visibility but no
+ * labels for built-in tabs — that is what `savedSettings` below reproduces — so
+ * the names have to come from the sidebar catalog at render time.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import sidebarEn from '../../../../../public/locales/en/sidebar.json';
+import type { DisplaySettingsData } from '@/types/display-settings';
+
+const savedSettings: DisplaySettingsData = {
+    sidebar: [
+        {
+            id: 'manage-contacts',
+            route: '/manage-contacts',
+            order: 1,
+            visible: true,
+            subTabs: [
+                { id: 'all-contacts', route: '/manage-contacts', order: 1, visible: true },
+                { id: 'user-tags-main', route: '/user-tags/institute', order: 2, visible: true },
+            ],
+        },
+        {
+            id: 'admissions',
+            route: '',
+            order: 2,
+            visible: false,
+            subTabs: [
+                {
+                    id: 'admission-dashboard',
+                    route: '/admissions/dashboard',
+                    order: 1,
+                    visible: true,
+                },
+            ],
+        },
+    ],
+    dashboard: { widgets: [] },
+    permissions: {
+        canViewInstituteDetails: false,
+        canEditInstituteDetails: false,
+        canViewProfileDetails: false,
+        canEditProfileDetails: false,
+    },
+    postLoginRedirectRoute: '/dashboard',
+};
+
+vi.mock('@/services/display-settings', () => ({
+    getDisplaySettingsWithFallback: vi.fn(async () => savedSettings),
+    saveDisplaySettings: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/routes/settings/-hooks/use-offline-access-enabled', () => ({
+    useOfflineAccessEnabled: () => false,
+}));
+
+// Needs a live TanStack router to install its navigation blocker; the save bar
+// is not what this test is about.
+vi.mock('@/components/common/unsaved-changes-bar', () => ({
+    useUnsavedChangesGuard: () => undefined,
+    UnsavedChangesBar: () => null,
+}));
+
+// Imported at module scope, while i18next is still uninitialised — the same
+// order production uses, and the one that produced the blank boxes.
+import AdminDisplaySettings from './AdminDisplaySettings';
+
+beforeAll(async () => {
+    await i18next.use(initReactI18next).init({
+        lng: 'en',
+        fallbackLng: 'en',
+        ns: ['sidebar', 'settingsAdminDisplay'],
+        defaultNS: 'settingsAdminDisplay',
+        resources: { en: { sidebar: sidebarEn, settingsAdminDisplay: {} } },
+        interpolation: { escapeValue: false },
+        react: { useSuspense: false },
+    });
+});
+
+const renderEditor = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <AdminDisplaySettings />
+        </QueryClientProvider>
+    );
+};
+
+/** Every text box in the editor, by the value the user would see in it. */
+const textBoxValues = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('input'))
+        .map((el) => el.value)
+        .filter(Boolean);
+
+describe('Display Settings · Sidebar Tabs', () => {
+    it('shows the built-in name for a tab saved without a label', async () => {
+        renderEditor();
+        expect(await screen.findByDisplayValue(sidebarEn.manageContacts)).toBeInTheDocument();
+    });
+
+    it('shows built-in names for sub-tabs saved without labels', async () => {
+        renderEditor();
+        await screen.findByDisplayValue(sidebarEn.manageContacts);
+        expect(screen.getByDisplayValue(sidebarEn.allContacts)).toBeInTheDocument();
+    });
+
+    it('leaves no name box blank while its route is filled in', async () => {
+        const { container } = renderEditor();
+        await screen.findByDisplayValue(sidebarEn.manageContacts);
+
+        const values = textBoxValues(container);
+        // The saved routes are all present...
+        expect(values).toContain('/manage-contacts');
+        expect(values).toContain('/user-tags/institute');
+        // ...and so is a real name for each of them, which is what was missing.
+        expect(values).toContain(sidebarEn.manageContacts);
+        expect(values).toContain(sidebarEn.userTags);
+    });
+});

--- a/frontend-admin-dashboard/src/services/display-settings.ts
+++ b/frontend-admin-dashboard/src/services/display-settings.ts
@@ -9,8 +9,8 @@ import {
     type DisplaySettingsData,
 } from '@/types/display-settings';
 import { StorageKey } from '@/constants/storage/storage';
-import { DEFAULT_ADMIN_DISPLAY_SETTINGS } from '@/constants/display-settings/admin-defaults';
-import { DEFAULT_TEACHER_DISPLAY_SETTINGS } from '@/constants/display-settings/teacher-defaults';
+import { getDefaultAdminDisplaySettings } from '@/constants/display-settings/admin-defaults';
+import { getDefaultTeacherDisplaySettings } from '@/constants/display-settings/teacher-defaults';
 import { SidebarItemsData } from '@/components/common/layout-container/sidebar/utils';
 
 import type { SidebarCategory } from '@/types/layout-container/layout-container-types';
@@ -252,9 +252,9 @@ function getLocalStorageKey(role: RoleKey, instituteId?: string | null): string 
 }
 
 function getDefaults(role: RoleKey): DisplaySettingsData {
-    if (role === ADMIN_DISPLAY_SETTINGS_KEY) return DEFAULT_ADMIN_DISPLAY_SETTINGS;
+    if (role === ADMIN_DISPLAY_SETTINGS_KEY) return getDefaultAdminDisplaySettings();
     // Both teacher and custom role can use teacher defaults as baseline
-    return DEFAULT_TEACHER_DISPLAY_SETTINGS;
+    return getDefaultTeacherDisplaySettings();
 }
 
 function mergeArrayById<T extends { id: string }>(


### PR DESCRIPTION
Settings > Display Settings > Sidebar Tabs rendered a column of blank "Tab Name" and "Label" boxes beside correctly-filled Routes.

sidebar/utils.ts exports SidebarItemsData as a module-scope snapshot, and every title in it resolves through i18next.t(). That snapshot is taken while modules are still being evaluated - index.tsx imports the route tree before ./i18n - and i18next.t() returns undefined before init(), not the raw key. All 37 tab titles and 101 sub-tab labels were therefore undefined, and the editor seeds its boxes from exactly that. Routes are plain strings, which is why only the names were blank.

The nav was unaffected because mySidebar already falls back to the live item title when a saved label is absent; the editor had no such fallback.

- Display Settings now falls back to the live sidebar entry for display, so the boxes show the current translated name.
- The three RoleDisplay editors read getSidebarItemsData() during render, memoized on the sidebar catalog's readiness and the naming-settings version, instead of the deprecated snapshot.
- Defaults are built per call (getDefaultAdminDisplaySettings / getDefaultTeacherDisplaySettings) rather than at module scope.
- Built-in tabs stay deliberately label-less in those defaults. mySidebar reads a saved label as a user customization and then renders it verbatim, so seeding today's wording would freeze the nav for any institute that later switches language or renames a term.
- sidebarT() degrades to a readable form of the key instead of to nothing.

Persisted config and nav output are unchanged; only the editor's display and the module-evaluation timing differ.

Tests: sidebar-tab-names.test.tsx renders the editor from a saved config that has routes but no labels (fails 3/3 without the fallback); sidebar-defaults-labels.test.ts locks in that defaults seed no labels.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
