### PR TITLE
feat(catalogue): mount a catalogue at a white-label domain's root + fix header active state

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingResolveResponse.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingResolveResponse.java
@@ -51,4 +51,6 @@ public class DomainRoutingResolveResponse {
     private Integer logoHeightPx;
     private Boolean stackNameBelowLogo;
     private NamingOverridesDto namingOverrides;
+    /** Catalogue served at this host's root (clean URLs). Null = classic /<tag> routing. */
+    private String rootCatalogueTag;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingUpsertRequest.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/dto/DomainRoutingUpsertRequest.java
@@ -53,4 +53,11 @@ public class DomainRoutingUpsertRequest {
     @JsonProperty("isPrimary")
     @JsonAlias({ "is_primary", "primary" })
     private Boolean primary;
+
+    /**
+     * Catalogue tag to mount at this host's root (see
+     * InstituteDomainRouting#rootCatalogueTag). Absent/null on update means
+     * "leave it alone"; send an empty string to clear it.
+     */
+    private String rootCatalogueTag;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/entity/InstituteDomainRouting.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/entity/InstituteDomainRouting.java
@@ -142,4 +142,15 @@ public class InstituteDomainRouting {
      */
     @Column(name = "is_primary", nullable = false)
     private boolean primary;
+
+    /**
+     * Tag of the course catalogue that answers on this host's ROOT. When set,
+     * the learner app renders that catalogue at <code>/</code> and its pages at
+     * <code>/&lt;page-route&gt;</code>, and forwards the legacy
+     * <code>/&lt;tag&gt;/...</code> URLs to the clean ones. Null keeps the
+     * classic behaviour where <code>/</code> redirects to {@link #redirect}.
+     * Only meaningful for LEARNER rows.
+     */
+    @Column(name = "root_catalogue_tag")
+    private String rootCatalogueTag;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingAdminService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingAdminService.java
@@ -145,6 +145,7 @@ public class DomainRoutingAdminService {
                                 .logoHeightPx(request.getLogoHeightPx())
                                 .stackNameBelowLogo(request.getStackNameBelowLogo())
                                 .applyNamingSetting(Boolean.TRUE.equals(request.getApplyNamingSetting()))
+                                .rootCatalogueTag(normalizeRootTag(request.getRootCatalogueTag()))
                                 .primary(Boolean.TRUE.equals(request.getPrimary()))
                                 .build();
                 return repository.save(entity);
@@ -235,6 +236,11 @@ public class DomainRoutingAdminService {
                         if (request.getPrimary() != null) {
                                 existing.setPrimary(request.getPrimary());
                         }
+                        // Same contract as primary: absent means untouched, so a caller that
+                        // predates the field cannot silently un-mount a root catalogue.
+                        if (request.getRootCatalogueTag() != null) {
+                                existing.setRootCatalogueTag(normalizeRootTag(request.getRootCatalogueTag()));
+                        }
                         return repository.save(existing);
                 });
         }
@@ -250,5 +256,12 @@ public class DomainRoutingAdminService {
                         throw new IllegalArgumentException(
                                         "All fields domain, subdomain, role, instituteId are required");
                 }
+        }
+
+        /** Trim, strip any leading slash, and turn blank into null (= not mounted). */
+        private static String normalizeRootTag(String raw) {
+                if (raw == null) return null;
+                String t = raw.trim().replaceFirst("^/+", "");
+                return t.isEmpty() ? null : t;
         }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/domain_routing/service/DomainRoutingService.java
@@ -123,7 +123,8 @@ public class DomainRoutingService {
                 .hideInstituteName(mapping.getHideInstituteName())
                 .logoWidthPx(mapping.getLogoWidthPx())
                 .logoHeightPx(mapping.getLogoHeightPx())
-                .stackNameBelowLogo(mapping.getStackNameBelowLogo());
+                .stackNameBelowLogo(mapping.getStackNameBelowLogo())
+                .rootCatalogueTag(mapping.getRootCatalogueTag());
 
         if (institute != null) {
             responseBuilder.instituteId(institute.getId())

--- a/admin_core_service/src/main/resources/db/migration/V503__domain_routing_root_catalogue_tag.sql
+++ b/admin_core_service/src/main/resources/db/migration/V503__domain_routing_root_catalogue_tag.sql
@@ -1,0 +1,6 @@
+-- A white-label domain can mount ONE course catalogue at its root, so the
+-- marketing site answers on https://example.com/ and /about instead of
+-- /<tag> and /<tag>/about. Null = today's behaviour (the root redirects to
+-- `redirect`, and every catalogue keeps its /<tag> prefix).
+ALTER TABLE institute_domain_routing
+    ADD COLUMN IF NOT EXISTS root_catalogue_tag VARCHAR(255);

--- a/frontend-learner-dashboard-app/src/routeTree.gen.ts
+++ b/frontend-learner-dashboard-app/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as VerifyIndexRouteImport } from './routes/verify/index'
 import { Route as UserProfileIndexRouteImport } from './routes/user-profile/index'
 import { Route as TryIndexRouteImport } from './routes/try/index'
@@ -120,6 +121,11 @@ import { Route as AdmissionPaymentInstituteIdApplicantIdPaymentOptionIdIndexRout
 import { Route as StudyLibraryCoursesCourseDetailsSubjectsModulesChaptersIndexRouteImport } from './routes/study-library/courses/course-details/subjects/modules/chapters/index'
 import { Route as StudyLibraryCoursesCourseDetailsSubjectsModulesChaptersSlidesIndexRouteImport } from './routes/study-library/courses/course-details/subjects/modules/chapters/slides/index'
 
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const VerifyIndexRoute = VerifyIndexRouteImport.update({
   id: '/verify/',
   path: '/verify/',
@@ -722,6 +728,7 @@ const StudyLibraryCoursesCourseDetailsSubjectsModulesChaptersSlidesIndexRoute =
   )
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
   '/$tagName/$pageSlug': typeof TagNamePageSlugRoute
   '/assignment/$slideId': typeof AssignmentSlideIdRoute
   '/parent/documents': typeof ParentDocumentsRouteWithChildren
@@ -834,6 +841,7 @@ export interface FileRoutesByFullPath {
   '/study-library/courses/course-details/subjects/modules/chapters/slides': typeof StudyLibraryCoursesCourseDetailsSubjectsModulesChaptersSlidesIndexRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/$tagName/$pageSlug': typeof TagNamePageSlugRoute
   '/assignment/$slideId': typeof AssignmentSlideIdRoute
   '/sub-org-registration/payment-result': typeof SubOrgRegistrationPaymentResultRoute
@@ -945,6 +953,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/$tagName/$pageSlug': typeof TagNamePageSlugRoute
   '/assignment/$slideId': typeof AssignmentSlideIdRoute
   '/parent/documents': typeof ParentDocumentsRouteWithChildren
@@ -1059,6 +1068,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/$tagName/$pageSlug'
     | '/assignment/$slideId'
     | '/parent/documents'
@@ -1171,6 +1181,7 @@ export interface FileRouteTypes {
     | '/study-library/courses/course-details/subjects/modules/chapters/slides'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
     | '/$tagName/$pageSlug'
     | '/assignment/$slideId'
     | '/sub-org-registration/payment-result'
@@ -1281,6 +1292,7 @@ export interface FileRouteTypes {
     | '/study-library/courses/course-details/subjects/modules/chapters/slides'
   id:
     | '__root__'
+    | '/'
     | '/$tagName/$pageSlug'
     | '/assignment/$slideId'
     | '/parent/documents'
@@ -1394,6 +1406,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   TagNamePageSlugRoute: typeof TagNamePageSlugRoute
   AssignmentSlideIdRoute: typeof AssignmentSlideIdRoute
   ParentDocumentsRoute: typeof ParentDocumentsRouteWithChildren
@@ -1499,6 +1512,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/verify/': {
       id: '/verify/'
       path: '/verify'
@@ -2314,6 +2334,7 @@ const ParentChildChildIdRouteWithChildren =
   ParentChildChildIdRoute._addFileChildren(ParentChildChildIdRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   TagNamePageSlugRoute: TagNamePageSlugRoute,
   AssignmentSlideIdRoute: AssignmentSlideIdRoute,
   ParentDocumentsRoute: ParentDocumentsRouteWithChildren,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/-components/CourseDetailsPage.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/-components/CourseDetailsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useTranslation } from "react-i18next";
 import { withArabicFallback } from "@/utils/branding";
 import { BASE_URL, GET_PRODUCT_PAGE_BY_CODE } from "@/constants/urls";
@@ -474,7 +475,7 @@ export const CourseDetailsPage: React.FC<CourseDetailsPageProps> = ({
   useEffect(() => {
     if (!customCoursePageRoute) return;
     navigate({
-      to: `/${tagName}/${customCoursePageRoute}`,
+      to: `${RouteMatcher.basePath(tagName)}/${customCoursePageRoute}`,
       search: { enrollInviteId, packageSessionId, bannerImage, level },
       replace: true,
     });
@@ -1108,7 +1109,7 @@ export const CourseDetailsPage: React.FC<CourseDetailsPageProps> = ({
             })}
           </p>
           <button
-            onClick={() => navigate({ to: `/${tagName}` })}
+            onClick={() => navigate({ to: RouteMatcher.pagePath(tagName) })}
             className="px-4 py-2 bg-primary-500 text-white rounded-catalogue-sm hover:bg-primary-400 transition-colors"
           >
             {t("courseDetails.backToCatalog")}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/$courseId/index.tsx
@@ -1,4 +1,6 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect, Navigate } from "@tanstack/react-router";
+import { RouteMatcher } from "../-services/route-matcher";
+import { CatalogueTagContext } from "../-components/CatalogueTagContext";
 import { CourseDetailsPage } from "./-components/CourseDetailsPage";
 import { CourseSubPage } from "../-components/CourseSubPage";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
@@ -75,6 +77,12 @@ function RouteComponent() {
     return <DashboardLoader />;
   }
 
+  // "/new/<x>" on a host where `new` is mounted at the root → "/<x>", search
+  // params included (enrol links carry ?enrollInviteId=…).
+  if (RouteMatcher.isRootMounted(resolvedTagName)) {
+    return <Navigate to={`/${resolvedCourseId}` as never} search={true} replace />;
+  }
+
   // Check if courseId looks like a course ID (numeric or UUID)
   const isNumeric = /^\d+$/.test(resolvedCourseId);
   const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(resolvedCourseId);
@@ -88,7 +96,11 @@ function RouteComponent() {
       return <DashboardLoader />;
     }
     // If no institute ID after loading, pass empty string (subpage will handle it)
-    return <CourseSubPage tagName={resolvedTagName} page={resolvedCourseId} instituteId={domainRouting.instituteId || ''} instituteThemeCode={domainRouting.instituteThemeCode} />;
+    return (
+      <CatalogueTagContext.Provider value={resolvedTagName}>
+        <CourseSubPage tagName={resolvedTagName} page={resolvedCourseId} instituteId={domainRouting.instituteId || ''} instituteThemeCode={domainRouting.instituteThemeCode} />
+      </CatalogueTagContext.Provider>
+    );
   }
 
   // Show loading while domain routing is resolving
@@ -127,6 +139,7 @@ function RouteComponent() {
 
 
   return (
+    <CatalogueTagContext.Provider value={resolvedTagName}>
     <CourseDetailsPage
       courseId={resolvedCourseId}
       tagName={resolvedTagName}
@@ -140,5 +153,6 @@ function RouteComponent() {
       available_slots={available_slots}
       productPageCode={productPageCode}
     />
+    </CatalogueTagContext.Provider>
   );
 }

--- a/frontend-learner-dashboard-app/src/routes/$tagName/$pageSlug.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/$pageSlug.tsx
@@ -2,7 +2,9 @@
  * Handles custom catalogue pages, e.g. /vacademy/about-us, /vacademy/contact.
  * The page route slug is matched against the catalogue config's pages[].route field.
  */
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { RouteMatcher } from "./-services/route-matcher";
+import { CatalogueTagContext } from "./-components/CatalogueTagContext";
 import { CourseCataloguePage } from "./-components/CourseCataloguePage";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
@@ -55,12 +57,19 @@ function RouteComponent() {
 
   if (!domainRouting.instituteId) return <RootNotFoundComponent />;
 
+  // "/new/about" on a host where `new` is mounted at the root → "/about".
+  if (RouteMatcher.isRootMounted(resolvedTagName)) {
+    return <Navigate to={`/${resolvedPageSlug}` as never} search={true} replace />;
+  }
+
   return (
-    <CourseCataloguePage
-      tagName={resolvedTagName}
-      instituteId={domainRouting.instituteId}
-      instituteThemeCode={domainRouting.instituteThemeCode}
-      pageSlug={resolvedPageSlug}
-    />
+    <CatalogueTagContext.Provider value={resolvedTagName}>
+      <CourseCataloguePage
+        tagName={resolvedTagName}
+        instituteId={domainRouting.instituteId}
+        instituteThemeCode={domainRouting.instituteThemeCode}
+        pageSlug={resolvedPageSlug}
+      />
+    </CatalogueTagContext.Provider>
   );
 }

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/CatalogueLink.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/CatalogueLink.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useNavigate, useParams } from '@tanstack/react-router';
+import { RouteMatcher } from '../-services/route-matcher';
+import { useCatalogueTag } from './CatalogueTagContext';
 
 interface CatalogueLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     /** The route value — can be a page slug ("about-us"), "homepage", full URL, or #anchor */
@@ -17,7 +19,8 @@ interface CatalogueLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElemen
 export const CatalogueLink: React.FC<CatalogueLinkProps> = ({ to, children, target, className, style, ...rest }) => {
     const navigate = useNavigate();
     const params = useParams({ strict: false }) as { tagName?: string };
-    const tagName = params.tagName || '';
+    // Context first: on a root-mounted host the param is a page route, not the tag.
+    const tagName = useCatalogueTag(params.tagName || '');
 
     if (!to || to === '#') {
         return <span className={className} style={style} {...rest}>{children}</span>;
@@ -53,10 +56,16 @@ export const CatalogueLink: React.FC<CatalogueLinkProps> = ({ to, children, targ
         );
     }
 
-    // Internal route (possibly with anchor)
-    const normalizedRoute = routePart.toLowerCase().replace(/^\//, '').replace(/\/$/, '').trim();
-    const isHome = normalizedRoute === 'home' || normalizedRoute === 'homepage' || normalizedRoute === '' || normalizedRoute === '/';
-    const fullPath = isHome ? `/${tagName}` : `/${tagName}/${normalizedRoute}`;
+    // Internal route (possibly with anchor). A page route may arrive as
+    // "/new/contact" (authored as an absolute site path) — strip the tag so a
+    // root-mounted host does not emit "/new/contact" for a page that lives at
+    // "/contact"; RouteMatcher.pagePath() then applies whichever prefix the
+    // host actually uses.
+    const escapedTag = tagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const strippedRoute = tagName
+        ? routePart.replace(new RegExp(`^/?${escapedTag}(?=/|$)`, 'i'), '')
+        : routePart;
+    const fullPath = RouteMatcher.pagePath(tagName, strippedRoute);
     const fullHref = fullPath + hashPart;
 
     const handleClick = (e: React.MouseEvent) => {

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/CatalogueTagContext.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/CatalogueTagContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+/**
+ * The catalogue tag the current page tree belongs to.
+ *
+ * Components used to read it from the router params, which stops being true
+ * the moment a catalogue is mounted at the host's root: on "/about" the
+ * `$tagName` param is "about" (a page route, not a catalogue), and on "/"
+ * there is no param at all. The route components know the real tag — they
+ * resolved it — so they provide it here and link builders read it from here
+ * first, falling back to the param for the classic "/<tag>/..." layout.
+ */
+export const CatalogueTagContext = createContext<string | null>(null);
+
+export const useCatalogueTag = (fallback?: string): string =>
+  useContext(CatalogueTagContext) ?? fallback ?? "";

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/CourseCataloguePage.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/CourseCataloguePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { RouteMatcher } from "../-services/route-matcher";
 import { useTranslation } from "react-i18next";
 import { withArabicFallback } from "@/utils/branding";
 import { Capacitor } from "@capacitor/core";
@@ -109,7 +110,9 @@ export const CourseCataloguePage: React.FC<CourseCataloguePageProps> = ({
         setIsLoading(true);
         console.log("[CourseCataloguePage] Fetching catalogue data for:", { instituteId, tagName });
 
-        const data = await CourseCatalogueService.getCourseCatalogueByTag(instituteId, tagName);
+        // Memoised: on a root-mounted host the route already fetched this
+        // catalogue to classify the URL, so this is normally a cache hit.
+        const data = await CourseCatalogueService.getCourseCatalogueByTagMemo(instituteId, tagName);
 
         console.log("[CourseCataloguePage] Successfully fetched catalogue data");
         setCatalogueData(data);
@@ -707,7 +710,7 @@ export const CourseCataloguePage: React.FC<CourseCataloguePageProps> = ({
           legacyGetStartedVisible={!(catalogueData?.globalSettings?.courseCatalogeType?.enabled ?? false)}
           onLogin={handleIntroLogin}
           onLegacyGetStarted={() => setShowLeadCollection(true)}
-          onNavigate={(route) => navigate({ to: `/${tagName}/${route.replace(/^\//, '')}` })}
+          onNavigate={(route) => navigate({ to: RouteMatcher.pagePath(tagName, route) })}
           nativePad={isAndroid || isIOS}
         />
       )}

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/CourseSubPage.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/CourseSubPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { RouteMatcher } from "../-services/route-matcher";
 import { useTranslation } from "react-i18next";
 import { withArabicFallback } from "@/utils/branding";
 import { useNavigate } from "@tanstack/react-router";
@@ -321,7 +322,7 @@ export const CourseSubPage: React.FC<CourseSubPageProps> = ({
             {t("courseSubPage.pageNotFoundDetail", { page })}
           </p>
           <button
-            onClick={() => navigate({ to: `/${tagName}` })}
+            onClick={() => navigate({ to: RouteMatcher.pagePath(tagName) })}
             className="px-4 py-2 bg-primary-600 text-white rounded-catalogue-sm hover:bg-primary-700"
           >
             {t("courseSubPage.goBackToCatalogue")}
@@ -490,7 +491,7 @@ export const CourseSubPage: React.FC<CourseSubPageProps> = ({
               console.log("[CourseSubPage] Lead collection is disabled, not showing modal");
             }
           }}
-          onNavigate={(route) => navigate({ to: `/${tagName}/${route.replace(/^\//, '')}` })}
+          onNavigate={(route) => navigate({ to: RouteMatcher.pagePath(tagName, route) })}
         />
       )}
     </div>

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/RootMountedSegment.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/RootMountedSegment.tsx
@@ -1,0 +1,115 @@
+import React, { lazy, Suspense, useEffect, useState } from "react";
+import { useSearch } from "@tanstack/react-router";
+import { DashboardLoader } from "@/components/core/dashboard-loader";
+import { CourseCatalogueService } from "../-services/course-catalogue-service";
+import { RouteMatcher } from "../-services/route-matcher";
+import { CatalogueTagContext } from "./CatalogueTagContext";
+import type { CourseCatalogueData } from "../-types/course-catalogue-types";
+
+const CourseCataloguePage = lazy(() =>
+  import("./CourseCataloguePage").then((m) => ({ default: m.CourseCataloguePage })),
+);
+const CourseDetailsPage = lazy(() =>
+  import("../$courseId/-components/CourseDetailsPage").then((m) => ({
+    default: m.CourseDetailsPage,
+  })),
+);
+
+const looksLikeCourseId = (segment: string) =>
+  /^\d+$/.test(segment) ||
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(segment);
+
+/**
+ * Decides what a single URL segment means on a host whose root is a catalogue.
+ *
+ * With `new` mounted at the root, "/about" no longer says which catalogue it
+ * belongs to — the `$tagName` route sees "about" as a tag. Three readings are
+ * possible and they are checked in this order:
+ *
+ *   1. a page of the root catalogue      → render that page  ("/about")
+ *   2. a course/book id                  → course details    ("/<uuid>")
+ *   3. neither                           → `fallback`: the segment really is
+ *      another catalogue's tag on the same host ("/CourseCollections"), which
+ *      keeps its classic "/<tag>/..." routing untouched.
+ *
+ * Only reading 1 needs data — the root catalogue's page list — and it comes
+ * through the memoised fetch, so the page that then renders reuses the same
+ * request instead of downloading the catalogue twice.
+ */
+export const RootMountedSegment: React.FC<{
+  rootTag: string;
+  segment: string;
+  instituteId: string;
+  instituteThemeCode?: string | null;
+  fallback: React.ReactNode;
+}> = ({ rootTag, segment, instituteId, instituteThemeCode, fallback }) => {
+  // The `/$tagName/` route validates no search params, so read them loosely —
+  // a root-mounted course link carries the same ?enrollInviteId=… the tagged
+  // one does.
+  const search = useSearch({ strict: false }) as Record<string, string | undefined>;
+  const [verdict, setVerdict] = useState<"loading" | "page" | "course" | "other">(
+    looksLikeCourseId(segment) ? "course" : "loading",
+  );
+
+  useEffect(() => {
+    if (looksLikeCourseId(segment)) {
+      setVerdict("course");
+      return;
+    }
+    let cancelled = false;
+    setVerdict("loading");
+    CourseCatalogueService.getCourseCatalogueByTagMemo(instituteId, rootTag)
+      .then((data: CourseCatalogueData) => {
+        if (cancelled) return;
+        const wanted = RouteMatcher.normalizeRoute(segment);
+        const isPage = (data.pages || []).some(
+          (p) =>
+            RouteMatcher.normalizeRoute(p.route || "") === wanted ||
+            RouteMatcher.normalizeRoute(p.id || "") === wanted,
+        );
+        setVerdict(isPage ? "page" : "other");
+      })
+      .catch(() => {
+        // If the root catalogue cannot be read, behave exactly as before the
+        // feature existed rather than blanking a URL that used to work.
+        if (!cancelled) setVerdict("other");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [instituteId, rootTag, segment]);
+
+  if (verdict === "loading") return <DashboardLoader />;
+  if (verdict === "other") return <>{fallback}</>;
+
+  return (
+    <CatalogueTagContext.Provider value={rootTag}>
+      <Suspense fallback={<DashboardLoader />}>
+        {verdict === "course" ? (
+          <CourseDetailsPage
+            courseId={segment}
+            tagName={rootTag}
+            instituteId={instituteId}
+            instituteThemeCode={instituteThemeCode}
+            enrollInviteId={search.enrollInviteId}
+            packageSessionId={search.packageSessionId}
+            bannerImage={search.bannerImage}
+            level={search.level}
+            price={search.price}
+            available_slots={
+              search.available_slots !== undefined ? Number(search.available_slots) : undefined
+            }
+            productPageCode={search.productPageCode}
+          />
+        ) : (
+          <CourseCataloguePage
+            tagName={rootTag}
+            instituteId={instituteId}
+            instituteThemeCode={instituteThemeCode}
+            pageSlug={segment}
+          />
+        )}
+      </Suspense>
+    </CatalogueTagContext.Provider>
+  );
+};

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BookCatalogueComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useNavigate, useLocation } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
@@ -492,7 +493,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
     if (book.available_slots !== undefined) searchParams.set("available_slots", book.available_slots.toString());
 
     navigate({
-      to: `/${tagName}/${book.id}`,
+      to: `${RouteMatcher.basePath(tagName)}/${book.id}`,
       search: searchParams.toString() ? Object.fromEntries(searchParams) : {},
     });
   };
@@ -836,7 +837,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                                       {/* Go to Cart button */}
                                       <Button
                                         className="h-7 px-2 bg-primary-400 hover:bg-primary-500 text-white text-caption font-semibold rounded-catalogue-md shadow-md flex items-center gap-1 flex-shrink-0 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
-                                        onClick={() => navigate({ to: `/${tagName}/cart` })}
+                                        onClick={() => navigate({ to: `${RouteMatcher.basePath(tagName)}/cart` })}
                                       >
                                         <ShoppingBag className="h-3 w-3" />
                                         {t("bookCatalogue.cart")}
@@ -863,7 +864,7 @@ export const BookCatalogueComponent: React.FC<BookCatalogueProps> = ({
                                     </Button>
                                     <Button
                                       className="h-8 px-2 bg-primary-400 hover:bg-primary-500 text-white text-caption font-semibold rounded-catalogue-md shadow-md flex items-center gap-1 flex-shrink-0 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
-                                      onClick={() => navigate({ to: `/${tagName}/cart` })}
+                                      onClick={() => navigate({ to: `${RouteMatcher.basePath(tagName)}/cart` })}
                                     >
                                       <ShoppingBag className="h-3 w-3" />
                                       Cart

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BuyRentSectionComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/BuyRentSectionComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useNavigate, useLocation } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ShoppingBag, BookOpen, ArrowRight, X } from "@phosphor-icons/react";
@@ -38,7 +39,7 @@ export const BuyRentSectionComponent: React.FC<BuyRentSectionProps> = ({
         detail: { levelFilter: levelFilterValue } 
       }));
     }
-    navigate({ to: `/${currentTagName}` as any });
+    navigate({ to: RouteMatcher.pagePath(currentTagName) as any });
   };
 
   const handleRentClick = () => setShowRentConfirmation(true);

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseCatalogComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseCatalogComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import {
@@ -1152,7 +1153,7 @@ export const CourseCatalogComponent: React.FC<CourseCatalogComponentProps> = ({
     }
 
     navigate({
-      to: `/${tagName}/${customPageRoute ?? course.id}`,
+      to: `${RouteMatcher.basePath(tagName)}/${customPageRoute ?? course.id}`,
       search: searchParams.toString()
         ? {
             enrollInviteId: course.enrollInviteId,
@@ -1801,7 +1802,7 @@ export const CourseCatalogComponent: React.FC<CourseCatalogComponentProps> = ({
       {/* Floating Cart Button - Fixed at bottom right */}
       {/* {cartButtonConfig?.enabled && <div className="fixed bottom-14 right-3 z-50">
         <Button
-          onClick={() => navigate({ to: `/${tagName}/cart` })}
+          onClick={() => navigate({ to: `${RouteMatcher.basePath(tagName)}/cart` })}
           className="h-12 w-12 rounded-full bg-primary hover:bg-primary-700 text-white shadow-lg flex items-center justify-center relative"
           size="sm"
         >

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseRecommendationsComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseRecommendationsComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { CourseRecommendationsProps } from "../../-types/course-catalogue-types";
@@ -102,7 +103,7 @@ export const CourseRecommendationsComponent: React.FC<CourseRecommendationsCompo
   }, [instituteId, limit]);
 
   const handleCourseClick = (courseId: string) => {
-    navigate({ to: `/${tagName}/${courseId}` });
+    navigate({ to: `${RouteMatcher.basePath(tagName)}/${courseId}` });
   };
 
   if (isLoading) {

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/CourseShowcaseComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { RouteMatcher } from "../../-services/route-matcher";
 import axios from "axios";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
@@ -225,7 +226,7 @@ export const CourseShowcaseComponent: React.FC<CourseShowcaseProps> = ({
 
     const openCourse = (c: ShowcaseCourse) =>
         navigate({
-            to: `/${tagName}/${c.id}`,
+            to: `${RouteMatcher.basePath(tagName ?? "")}/${c.id}`,
             search: {
                 enrollInviteId: c.enrollInviteId,
                 packageSessionId: c.packageSessionId,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/FooterComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/FooterComponent.tsx
@@ -51,7 +51,7 @@ export const FooterComponent: React.FC<FooterProps & {
 
     const normalizedRoute = RouteMatcher.normalizeRoute(route);
     if (normalizedRoute === 'home' || normalizedRoute === '') {
-      navigate({ to: `/${tagName}` });
+      navigate({ to: RouteMatcher.pagePath(tagName) });
       return;
     }
 

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HeaderComponent.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HeaderComponent.tsx
@@ -109,6 +109,16 @@ export const HeaderComponent: React.FC<HeaderProps & {
     // mobile menu, or the "is there anything to show?" checks that gate them.
     const visibleNavigation = navigation.filter((item) => item?.enabled !== false);
 
+    // The catalogue this header belongs to. The prop is authoritative — the
+    // route resolved it — and the first path segment was only ever a fallback
+    // for the default "home". On a root-mounted host that segment is a PAGE
+    // ("/about"), so reading it as the tag would send every Home click to
+    // "/about" and the cart to "/about/cart".
+    const effectiveTagName =
+      tagName && tagName !== 'home'
+        ? tagName
+        : (location.pathname.split('/').filter(Boolean)[0] || tagName);
+
     // Filter out "Sign Up" auth links when signup is disabled at the institute level.
     const visibleAuthLinks = signupEnabled
       ? authLinks
@@ -271,12 +281,10 @@ export const HeaderComponent: React.FC<HeaderProps & {
     // either: Courses was the only nav item that could ever look active.
     const isActiveRoute = (route: string) => {
       if (RouteMatcher.isExternalLink(route)) return false;
-      const pathSegments = location.pathname.split('/').filter(Boolean);
-      // Read the page slug as "whatever follows the tag", not as a fixed index,
-      // so a catalogue ever mounted without its tag segment still resolves.
-      const tagIndex = pathSegments.indexOf(tagName);
+      // "Whatever follows the catalogue base": the segment after "/<tag>", or
+      // the first segment when this catalogue is mounted at the host's root.
       const currentRoute = RouteMatcher.normalizeRoute(
-        pathSegments[tagIndex >= 0 ? tagIndex + 1 : 1] || ''
+        RouteMatcher.segmentsAfterBase(location.pathname, effectiveTagName)[0] || ''
       );
       const target = RouteMatcher.normalizeRoute(route || '');
       const targetIsHome = target === '' || target === 'home';
@@ -319,20 +327,12 @@ export const HeaderComponent: React.FC<HeaderProps & {
       const normalizedRoute = RouteMatcher.normalizeRoute(route);
 
       if (normalizedRoute === 'home' || normalizedRoute === '' || route === '/') {
-        const currentPath = location.pathname;
-        const pathSegments = currentPath.split('/').filter(Boolean);
-        const currentTagName = pathSegments[0] || tagName;
-
-        navigate({ to: `/${currentTagName}` });
+        navigate({ to: RouteMatcher.pagePath(effectiveTagName) });
         return;
       }
 
       if (normalizedRoute === 'courses') {
-        const currentPath = location.pathname;
-        const pathSegments = currentPath.split('/').filter(Boolean);
-        const currentTagName = pathSegments[0] || tagName;
-
-        navigate({ to: `/${currentTagName}` });
+        navigate({ to: RouteMatcher.pagePath(effectiveTagName) });
         return;
       }
 
@@ -374,7 +374,9 @@ export const HeaderComponent: React.FC<HeaderProps & {
       let hideCart = false;
 
       const currentPath = location.pathname.toLowerCase();
-      const pathSegments = location.pathname.split('/').filter(Boolean);
+      // Segments after the catalogue base, so "/new/<id>" and a root-mounted
+      // "/<id>" both read as a course-details page.
+      const afterBase = RouteMatcher.segmentsAfterBase(location.pathname, effectiveTagName);
 
       // Hide on cart page
       if (currentPath.includes('/cart')) {
@@ -382,9 +384,9 @@ export const HeaderComponent: React.FC<HeaderProps & {
         hideCart = true;
       }
 
-      // Hide on book/course details page (pattern: /$tagName/$courseId)
-      if (pathSegments.length >= 2) {
-        const potentialCourseId = pathSegments[1];
+      // Hide on book/course details page (pattern: <base>/$courseId)
+      if (afterBase.length >= 1) {
+        const potentialCourseId = afterBase[0];
         const isNumeric = /^\d+$/.test(potentialCourseId);
         const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(potentialCourseId);
         if (isNumeric || isUUID) {
@@ -396,7 +398,7 @@ export const HeaderComponent: React.FC<HeaderProps & {
       // Check if current page has buyRentSection component
       // Hide search but KEEP cart visible on plan page
       if (catalogueData?.pages) {
-        const pageRoute = pathSegments.slice(1).join('/') || '';
+        const pageRoute = afterBase.join('/') || '';
         for (const page of catalogueData.pages) {
           const pageRouteLower = (page.route || '').toLowerCase();
           const pageIdLower = (page.id || '').toLowerCase();
@@ -597,10 +599,7 @@ export const HeaderComponent: React.FC<HeaderProps & {
                   {!hideCart && (
                   <button
                     onClick={() => {
-                      const currentPath = location.pathname;
-                      const pathSegments = currentPath.split('/').filter(Boolean);
-                      const currentTagName = pathSegments[0] || tagName;
-                      navigate({ to: `/${currentTagName}/cart` });
+                      navigate({ to: `${RouteMatcher.basePath(effectiveTagName)}/cart` });
                     }}
                     className="relative p-2 rounded-catalogue-sm text-catalogue-text-secondary hover:text-catalogue-text-primary hover:bg-catalogue-interactive-hover transition-colors duration-200"
                     aria-label={t("header.shoppingCart")}
@@ -821,10 +820,7 @@ export const HeaderComponent: React.FC<HeaderProps & {
                             // Set genre filter in sessionStorage
                             sessionStorage.setItem('genreFilter', genre.toLowerCase());
                             // Navigate to homepage with genre filter
-                            const currentPath = location.pathname;
-                            const pathSegments = currentPath.split('/').filter(Boolean);
-                            const currentTagName = pathSegments[0] || tagName;
-                            navigate({ to: `/${currentTagName}` });
+                            navigate({ to: RouteMatcher.pagePath(effectiveTagName) });
                           }}
                           className="group w-full text-left px-6 py-3 text-sm font-medium text-catalogue-text-secondary hover:text-catalogue-text-primary hover:bg-catalogue-bg-subtle border-b border-catalogue-border-subtle last:border-b-0 transition-all duration-200 ease-in-out transform hover:translate-x-1"
                         >

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HtmlPageSection.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-components/components/HtmlPageSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { RouteMatcher } from "../../-services/route-matcher";
 import { useNavigate } from '@tanstack/react-router';
 import { renderHtmlPage, type HtmlAction } from '../../-utils/catalogue-html';
 
@@ -39,7 +40,7 @@ export const HtmlPageSection = ({
                     // Routes are page slugs within THIS site; '' is the home
                     // page. Going through the router keeps it a client-side
                     // navigation and keeps the tag scope.
-                    navigate({ to: action.route ? `/${tagName}/${action.route}` : `/${tagName}` });
+                    navigate({ to: RouteMatcher.pagePath(tagName, action.route) });
                     break;
                 case 'lead-form':
                     window.dispatchEvent(
@@ -49,7 +50,7 @@ export const HtmlPageSection = ({
                     );
                     break;
                 case 'enrol':
-                    if (action.courseId) navigate({ to: `/${tagName}/course/${action.courseId}` });
+                    if (action.courseId) navigate({ to: `${RouteMatcher.basePath(tagName)}/course/${action.courseId}` });
                     break;
                 case 'link':
                     window.open(action.href, '_blank', 'noopener,noreferrer');

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-services/course-catalogue-service.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-services/course-catalogue-service.ts
@@ -367,6 +367,33 @@ export class CourseCatalogueService {
     }
   }
 
+  /**
+   * In-flight + short-lived cache in front of getCourseCatalogueByTag.
+   *
+   * A root-mounted host has to look at the root catalogue's page list before
+   * it can tell whether "/about" is one of its pages or a second catalogue's
+   * tag — and the page component then fetches the same catalogue to render it.
+   * Sharing the promise turns that into one request. The TTL is deliberately
+   * short (an editor publishing sees the change on the next navigation) and the
+   * cache is per tab, so it never masks a Publish for longer than a reload.
+   */
+  private static readonly memo = new Map<string, { at: number; promise: Promise<CourseCatalogueData> }>();
+  private static readonly MEMO_TTL_MS = 30_000;
+
+  static getCourseCatalogueByTagMemo(
+    instituteId: string,
+    tagName: string
+  ): Promise<CourseCatalogueData> {
+    const key = `${instituteId}::${tagName}`;
+    const hit = this.memo.get(key);
+    if (hit && Date.now() - hit.at < this.MEMO_TTL_MS) return hit.promise;
+    const promise = this.getCourseCatalogueByTag(instituteId, tagName);
+    this.memo.set(key, { at: Date.now(), promise });
+    // A failed fetch must not be served from cache for 30s.
+    promise.catch(() => { if (this.memo.get(key)?.promise === promise) this.memo.delete(key); });
+    return promise;
+  }
+
   static async getCourseCatalogueByTag(
     instituteId: string,
     tagName: string

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.ts
@@ -1,4 +1,5 @@
 import { CourseCatalogueData, Page } from "../-types/course-catalogue-types";
+import { getCachedRootCatalogueTag } from "@/services/domain-routing";
 
 /**
  * Route matcher utility for handling dynamic page routing
@@ -23,6 +24,56 @@ export class RouteMatcher {
       .replace(/\/$/, "") // Remove trailing slash
       .replace(/^homepage$/, "home") // Map homepage to home
       .trim();
+  }
+
+  /**
+   * True when `tagName` is the catalogue mounted at this host's ROOT — see
+   * `institute_domain_routing.root_catalogue_tag`. A root-mounted catalogue
+   * answers on "/" and "/<page>" with no tag segment, so every URL the site
+   * builds for itself has to drop the "/<tag>" prefix. Any other catalogue on
+   * the same host (a second tag) keeps classic routing untouched.
+   */
+  static isRootMounted(tagName: string | undefined | null): boolean {
+    const root = getCachedRootCatalogueTag();
+    if (!root || !tagName) return false;
+    return this.normalizeRoute(root) === this.normalizeRoute(tagName);
+  }
+
+  /** "/<tag>" for a classic catalogue, "" for the root-mounted one. */
+  static basePath(tagName: string): string {
+    if (!tagName || this.isRootMounted(tagName)) return "";
+    return `/${tagName}`;
+  }
+
+  /**
+   * The ONE place that turns (tag, page-route) into a path. Home collapses to
+   * the base ("/" when root-mounted); everything else is "<base>/<route>".
+   */
+  static pagePath(tagName: string, route?: string | null): string {
+    const base = this.basePath(tagName);
+    // Trim slashes but keep the author's casing: the page component matches
+    // `page.route === pageSlug` exactly, so lowercasing here would turn a
+    // route like "Toddler-Reset" into a link to a page that reports not found.
+    const clean = (route || "").trim().replace(/^\/+/, "").replace(/\/+$/, "");
+    if (this.normalizeRoute(clean) === "home" || clean === "") return base || "/";
+    return `${base}/${clean}`;
+  }
+
+  /**
+   * Path segments AFTER the catalogue base: ["about"] for both "/new/about"
+   * and, when `new` is root-mounted, "/about". Callers that need "which page
+   * am I on" read this instead of counting segments themselves.
+   */
+  static segmentsAfterBase(pathname: string, tagName: string): string[] {
+    const segs = pathname.split("/").filter(Boolean);
+    if (this.isRootMounted(tagName)) {
+      // A legacy "/<tag>/..." URL on a root-mounted host still means the same page.
+      return segs[0] && this.normalizeRoute(segs[0]) === this.normalizeRoute(tagName)
+        ? segs.slice(1)
+        : segs;
+    }
+    const idx = segs.indexOf(tagName);
+    return idx >= 0 ? segs.slice(idx + 1) : segs.slice(1);
   }
 
   /**
@@ -85,16 +136,9 @@ export class RouteMatcher {
       return routeId;
     }
 
-    // Build the route with tagName prefix
-    const normalizedId = this.normalizeRoute(routeId);
-    
-    // Special case for home/homepage - just return /$tagName
-    if (normalizedId === "home") {
-      return `/${tagName}`;
-    }
-
-    // For other pages, return /$tagName/$routeId
-    return `/${tagName}/${normalizedId}`;
+    // "/<tag>/<route>" — or "/<route>" when this catalogue is mounted at the
+    // host's root. pagePath() owns that rule so no caller re-derives it.
+    return this.pagePath(tagName, routeId);
   }
 
   /**
@@ -126,12 +170,7 @@ export class RouteMatcher {
       const matchedPage = this.findMatchingPage(item.route, catalogueData.pages);
 
       if (matchedPage) {
-        // Route should be /$tagName or /$tagName/routeId
-        const normalizedRoute = this.normalizeRoute(item.route);
-        const finalRoute =
-          normalizedRoute === "home" || normalizedRoute === ""
-            ? `/${tagName}`
-            : `/${tagName}/${normalizedRoute}`;
+        const finalRoute = this.pagePath(tagName, item.route);
 
         return {
           label: item.label,

--- a/frontend-learner-dashboard-app/src/routes/$tagName/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/index.tsx
@@ -1,5 +1,9 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect, Navigate } from "@tanstack/react-router";
 import { useDomainRouting } from "@/hooks/use-domain-routing";
+import { getCachedRootCatalogueTag } from "@/services/domain-routing";
+import { RouteMatcher } from "./-services/route-matcher";
+import { CatalogueTagContext } from "./-components/CatalogueTagContext";
+import { RootMountedSegment } from "./-components/RootMountedSegment";
 import { DashboardLoader } from "@/components/core/dashboard-loader";
 import RootNotFoundComponent from "@/components/core/default-not-found";
 import { useEffect, useState, lazy, Suspense } from "react";
@@ -121,13 +125,38 @@ function RouteComponent() {
   //   instituteThemeCode: domainRouting.instituteThemeCode,
   // });
 
-  return (
-    <Suspense fallback={<DashboardLoader />}>
-      <CourseCataloguePage
-        tagName={resolvedTagName}
+  const classic = (
+    <CatalogueTagContext.Provider value={resolvedTagName}>
+      <Suspense fallback={<DashboardLoader />}>
+        <CourseCataloguePage
+          tagName={resolvedTagName}
+          instituteId={domainRouting.instituteId}
+          instituteThemeCode={domainRouting.instituteThemeCode}
+        />
+      </Suspense>
+    </CatalogueTagContext.Provider>
+  );
+
+  // Root-mounted host (institute_domain_routing.root_catalogue_tag): the
+  // catalogue answers on "/" so a URL that still carries its tag is a legacy
+  // link — forward it to the clean address. Any other single segment is
+  // read as a page or course of the root catalogue first, and only then as a
+  // second catalogue's tag.
+  const rootTag = getCachedRootCatalogueTag();
+  if (rootTag) {
+    if (RouteMatcher.isRootMounted(resolvedTagName)) {
+      return <Navigate to="/" replace />;
+    }
+    return (
+      <RootMountedSegment
+        rootTag={rootTag}
+        segment={resolvedTagName}
         instituteId={domainRouting.instituteId}
         instituteThemeCode={domainRouting.instituteThemeCode}
+        fallback={classic}
       />
-    </Suspense>
-  );
+    );
+  }
+
+  return classic;
 }

--- a/frontend-learner-dashboard-app/src/routes/__root.tsx
+++ b/frontend-learner-dashboard-app/src/routes/__root.tsx
@@ -973,6 +973,13 @@ export const Route = createRootRouteWithContext<{
         );
 
         if (domainRoutingResult) {
+          // A host with a root-mounted catalogue serves it right here at "/"
+          // (routes/index.tsx) — bouncing to "/<tag>" is exactly what that
+          // flag exists to stop. resolveDomainRouting has already cached the
+          // tag for the route component and every link builder.
+          if ((domainRoutingResult.rootCatalogueTag || "").trim()) {
+            return;
+          }
           // API returned valid institute data, use the redirect field from API response
           const redirectPath = domainRoutingResult.redirect || "/courses";
           throw redirect({ to: redirectPath as never });

--- a/frontend-learner-dashboard-app/src/routes/index.tsx
+++ b/frontend-learner-dashboard-app/src/routes/index.tsx
@@ -1,0 +1,77 @@
+import { createFileRoute, Navigate, redirect } from "@tanstack/react-router";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { DashboardLoader } from "@/components/core/dashboard-loader";
+import RootNotFoundComponent from "@/components/core/default-not-found";
+import { useDomainRouting } from "@/hooks/use-domain-routing";
+import { getCachedRootCatalogueTag } from "@/services/domain-routing";
+import { shouldHidePaidPurchaseUI } from "@/utils/ios-iap-compliance";
+import { hasActiveLearnerSession } from "@/lib/auth/sessionUtility";
+import { CatalogueTagContext } from "./$tagName/-components/CatalogueTagContext";
+
+const CourseCataloguePage = lazy(() =>
+  import("./$tagName/-components/CourseCataloguePage").then((m) => ({
+    default: m.CourseCataloguePage,
+  })),
+);
+
+/**
+ * The site root.
+ *
+ * Historically "/" never rendered anything: `__root`'s beforeLoad always
+ * redirected it — to the dashboard when signed in, otherwise to the domain's
+ * `redirect` (a catalogue at "/<tag>", or /login). That is still what happens
+ * for every host EXCEPT one whose routing row names a `root_catalogue_tag`:
+ * there `__root` lets "/" through and this route renders that catalogue's home
+ * page, so a white-label marketing site answers on the bare domain instead of
+ * bouncing visitors to "/new".
+ */
+export const Route = createFileRoute("/")({
+  // Same reader-mode gate as /$tagName: the catalogue is a marketplace surface.
+  beforeLoad: async () => {
+    if (shouldHidePaidPurchaseUI()) {
+      throw redirect({
+        to: (await hasActiveLearnerSession()) ? "/dashboard" : "/login",
+      });
+    }
+  },
+  component: RootCatalogueRoute,
+});
+
+function RootCatalogueRoute() {
+  const domainRouting = useDomainRouting();
+  const [hasRetried, setHasRetried] = useState(false);
+
+  useEffect(() => {
+    if (!domainRouting.isLoading && !domainRouting.instituteId && !hasRetried) {
+      setHasRetried(true);
+      domainRouting.resolveRouting();
+    }
+  }, [domainRouting.isLoading, domainRouting.instituteId, hasRetried, domainRouting]);
+
+  if (domainRouting.isLoading || (!domainRouting.instituteId && !hasRetried)) {
+    return <DashboardLoader />;
+  }
+
+  const rootTag = getCachedRootCatalogueTag();
+
+  // Reached "/" without a root catalogue — __root would normally have
+  // redirected, so this is a resolve that failed or a host that lost its
+  // flag mid-session. Fall back to what the old code did.
+  if (!rootTag) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!domainRouting.instituteId) return <RootNotFoundComponent />;
+
+  return (
+    <CatalogueTagContext.Provider value={rootTag}>
+      <Suspense fallback={<DashboardLoader />}>
+        <CourseCataloguePage
+          tagName={rootTag}
+          instituteId={domainRouting.instituteId}
+          instituteThemeCode={domainRouting.instituteThemeCode}
+        />
+      </Suspense>
+    </CatalogueTagContext.Provider>
+  );
+}

--- a/frontend-learner-dashboard-app/src/services/domain-routing.ts
+++ b/frontend-learner-dashboard-app/src/services/domain-routing.ts
@@ -56,6 +56,10 @@ export interface DomainRoutingResponse {
   // Minimal naming overrides surfaced pre-login so screens like the login page
   // can honor institute-specific terminology before the full settings payload
   // is fetched post-login.
+  // Tag of the catalogue mounted at this host's ROOT: when set, the site
+  // answers on "/" and "/<page>" instead of "/<tag>" and "/<tag>/<page>".
+  // Absent/null = classic tagged routing. See RouteMatcher.basePath().
+  rootCatalogueTag?: string | null;
   namingOverrides?: {
     course?: string | null;
     coursePlural?: string | null;
@@ -101,6 +105,48 @@ export interface CachedInstituteBranding {
 const BRANDING_CACHE_KEY = "InstituteBranding";
 const PREFERRED_COUNTRIES_CACHE_KEY = "InstitutePreferredCountries";
 const PHONE_COUNTRY_GEO_MODE_CACHE_KEY = "InstitutePhoneCountryGeoMode";
+const ROOT_CATALOGUE_TAG_CACHE_KEY = "InstituteRootCatalogueTag";
+
+let cachedRootCatalogueTagMemory: string | null | undefined;
+
+/**
+ * Catalogue tag mounted at this host's root, or null. Synchronous on purpose:
+ * link builders (RouteMatcher, CatalogueLink, the header) run during render
+ * and cannot await the resolve. Written on EVERY resolve — including a null
+ * — so un-mounting a catalogue server-side takes effect on the next load
+ * rather than lingering in localStorage.
+ */
+export const getCachedRootCatalogueTag = (): string | null => {
+  if (cachedRootCatalogueTagMemory !== undefined) {
+    return cachedRootCatalogueTagMemory;
+  }
+  try {
+    if (typeof window !== "undefined" && window.localStorage) {
+      const stored = window.localStorage.getItem(ROOT_CATALOGUE_TAG_CACHE_KEY);
+      cachedRootCatalogueTagMemory = stored && stored.trim() ? stored.trim() : null;
+      return cachedRootCatalogueTagMemory;
+    }
+  } catch {
+    // storage blocked — fall through to "not mounted"
+  }
+  cachedRootCatalogueTagMemory = null;
+  return null;
+};
+
+export const setCachedRootCatalogueTag = (tag: string | null | undefined) => {
+  const clean = (tag ?? "").trim().replace(/^\/+/, "");
+  cachedRootCatalogueTagMemory = clean || null;
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return;
+    if (clean) {
+      window.localStorage.setItem(ROOT_CATALOGUE_TAG_CACHE_KEY, clean);
+    } else {
+      window.localStorage.removeItem(ROOT_CATALOGUE_TAG_CACHE_KEY);
+    }
+  } catch (error) {
+    console.warn("[Domain Routing] Failed to persist root catalogue tag:", error);
+  }
+};
 let cachedBrandingMemory: CachedInstituteBranding | null = null;
 let cachedPreferredCountriesMemory: string[] | null = null;
 let cachedPhoneCountryGeoModeMemory: PhoneCountryGeoMode | null = null;
@@ -515,6 +561,9 @@ export const resolveDomainRouting = async (
     // which institute this page belongs to.
     setCachedPreferredCountries(data.commaSeparatedPreferredCountry ?? null);
     setCachedPhoneCountryGeoMode(data.phoneCountryGeoMode ?? null);
+    // Same reasoning: the root-mount flag must follow the resolve, whichever
+    // caller made it, or a cold load of "/" cannot know to render the site.
+    setCachedRootCatalogueTag(data.rootCatalogueTag ?? null);
 
     // Successfully resolved domain routing
     return data;


### PR DESCRIPTION
## Why

`the7cs.co.in` now serves the 7Cs catalogue, but every visitor sees the address bar flip to `/new` — every catalogue lives at `/<tag>` and `__root` redirects `/` to the routing row's `redirect`. That rewrite is client-side, so nothing at DNS / Cloudflare / page-editor level can remove it. Same shape on every white-label site (edzumo lands on `/new-landing-page/home`, readonrent on `/collections/buy-rent`).

While measuring this, the header's active-nav highlight turned out to be label-driven and broken on multi-page sites.

## What

**1. Root-mounted catalogue — opt-in per domain, no change for anyone else**

- `institute_domain_routing.root_catalogue_tag` (V503, nullable) → `DomainRoutingResolveResponse.rootCatalogueTag`; upsert carries it, absent = untouched (same contract as `primary`)
- `routes/index.tsx` renders the root catalogue at `/`; `__root` returns instead of redirecting when the flag is present
- `RootMountedSegment`: `/about` is read as a page of the root catalogue → then a course id → then **another catalogue's tag** (so `/CourseCollections/...` on the same host keeps classic routing)
- legacy `/new` and `/new/<page>` forward to `/` and `/<page>`, search params kept
- `RouteMatcher.basePath/pagePath/segmentsAfterBase` are now the only place the `/<tag>` prefix is decided; the 20 inline `` `/${tagName}/…` `` builders go through them
- `CatalogueTagContext` carries the real tag to `CatalogueLink` (on `/about` the `$tagName` param is the page)
- the flag is cached on every resolve (null overwrites) so link builders read it synchronously

**2. Header active state**

`isActiveRoute` forced "Courses" active on `/<tagName>` and suppressed "Home", and its fallback compared `/new/about` to `about` with `startsWith` (never matches). Now matched on the segment after the catalogue base; `""`/`home` both mean the home page.

## Verified (local build → production backend)

| Scenario | Result |
|---|---|
| 7Cs **with** flag: `/`, `/about`, `/books-copy` | clean URLs, correct nav item highlighted |
| `/new` → `/`, `/new/about` → `/about` | legacy links forward |
| header clicks, hero anchor, authored `/new/contact` link | clean URLs / scrolls / forwards to `/contact` |
| `/CourseCollections`, `/CourseCollections/toddler-reset` (2nd catalogue, same host) | untouched |
| 7Cs **without** flag | identical to today |
| **Shiksha Nation** (5 tags, no flag): `/`, `/course-collect`, `/course-collections`, `/book-store` | all render, card links keep `/course-collect/<id>?enrollInviteId=…` |

admin-core compiles; design-lint 0 errors; tsc adds no errors on touched lines (the ~660 pre-existing ones are untouched).

## Rollout

Needs both admin-core (migration) and learner deploys. Activation is one row update: `root_catalogue_tag = 'new'` on the two `the7cs.co.in` routing rows. Leave `7cs.vacademy.io` classic unless asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)