### PR TITLE
fix(workflow): stop AI-drafted triggers referencing context keys the …

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/controller/WorkflowAiCatalogController.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import vacademy.io.admin_core_service.features.workflow.service.TriggerContextKeyRegistry;
 
 /**
  * AI-grade grounding schema for the workflow drafter (see WORKFLOW_AI_ASSIST_DESIGN.md).
@@ -31,10 +33,12 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WorkflowAiCatalogController {
 
+    private final TriggerContextKeyRegistry triggerContextKeyRegistry;
+
     @GetMapping
     public ResponseEntity<Map<String, Object>> getAiCatalog() {
         Map<String, Object> out = new LinkedHashMap<>();
-        out.put("version", "2026-07-31");
+        out.put("version", "2026-09-11");
         out.put("workflowJsonShape", workflowJsonShape());
         out.put("generationRules", generationRules());
         out.put("nodeTypes", nodeTypes());
@@ -82,6 +86,14 @@ public class WorkflowAiCatalogController {
                 "ROUTER", "In the enum + FE palette but has NO handler — a workflow containing it cannot execute that node.",
                 "SEND_PUSH_NOTIFICATION", "Stub — logs and returns status 'dispatched' without sending. Do not use."));
         out.put("commonTriggers", commonTriggers());
+        // Every #ctx key each event puts on the seed context, from the same registry the
+        // validator enforces. Inlined because the model cannot follow the URLs under
+        // `references` — audited failure: the drafter invented #ctx['lead'] for
+        // AUDIENCE_LEAD_SUBMISSION and the trigger silently never ran.
+        out.put("triggerContextKeys", triggerContextKeys());
+        out.put("engineContextKeys", "Present on every event run in addition to triggerContextKeys: "
+                + String.join(", ", TriggerContextKeyRegistry.ENGINE_KEYS)
+                + ". Only triggerId, eventName, eventId exist while the idempotency key is evaluated.");
         out.put("references", m(
                 "allTriggerEvents", "/admin-core-service/v1/workflow/catalog/trigger-events",
                 "leadContextVariables", "/admin-core-service/v1/workflow/catalog/trigger-context-variables",
@@ -127,7 +139,8 @@ public class WorkflowAiCatalogController {
             "SEND_EMAIL / SEND_WHATSAPP 'on' must resolve to a List. Wrap a single object as a SpEL list literal: \"{#ctx['user']}\".",
             "Recipient and templateVars field names must exist in the source query's output item fields. Casing differs per query (snake_case vs camelCase) — copy from readQueries[].itemFields.",
             "Trigger scoping is by event_id only; event_applied_type is metadata and does NOT scope. Set event_id to a real institute-owned entity, or null for 'all'.",
-            "Idempotency: set trigger.idempotency_generation_setting. Per-person flows (enrollment/lead drips) need CUSTOM_EXPRESSION including the person, e.g. {\"strategy\":\"CUSTOM_EXPRESSION\",\"customExpression\":\"'wf_' + #ctx['triggerId'] + '_' + #ctx['eventId'] + '_' + #ctx['user']['id']\"}. EVENT_BASED is ONLY for periodic-scan emitters (LIVE_SESSION_START/END, MEMBERSHIP_EXPIRY) — its key has no person in it, so on an enrollment event it would let only the first learner ever enter. Omitted = UUID = no dedup (event retries double-fire).",
+            "Idempotency: set trigger.idempotency_generation_setting. Per-person flows (enrollment/lead drips) need CUSTOM_EXPRESSION including the person, e.g. {\"strategy\":\"CUSTOM_EXPRESSION\",\"customExpression\":\"'wf_' + #ctx['triggerId'] + '_' + #ctx['eventId'] + '_' + #ctx['user']['id']\"}. The person key MUST be one the event actually emits (see triggerContextKeys): #ctx['user']['id'] only where 'user' is listed; otherwise the id key that IS listed (#ctx['userId'], #ctx['responseId'], #ctx['leadId'], #ctx['userPlanId']). A key that is not there makes the SpEL throw and the trigger is skipped with NO execution row. EVENT_BASED is ONLY for periodic-scan emitters (LIVE_SESSION_START/END, MEMBERSHIP_EXPIRY) — its key has no person in it, so on an enrollment event it would let only the first learner ever enter. Omitted = UUID = no dedup (event retries double-fire).",
+            "Trigger context keys are a closed list: only reference #ctx['<key>'] values listed for the event in triggerContextKeys / commonTriggers[].producedContextKeys, in engineContextKeys, or produced by an upstream node in this graph. Never invent a key such as 'lead' or 'student' — a missing key yields null (or throws when indexed), and a send node's 'on' of \"{#ctx['missing']}\" sends nothing.",
             "Mutating prebuilt keys (see mutatingQueryKeys) are allowed ONLY when the goal explicitly asks to create/modify data (e.g. 'create the live sessions every morning'). They are skipped in Test Run (dryRun gate), but ALWAYS warn in rationale that the workflow writes real data when active. Never use them for read/reporting goals.",
             "Never use ROUTER (no handler) or SEND_PUSH_NOTIFICATION (stub). See avoidNodeTypes.",
             "DELAY config is nested: config.delay.{value,unit} or config.delay.{until:NEXT_DAY_OF_WEEK,dayOfWeek,time,timezone}. Never flat delayValue/delayUnit (executes as 0-delay).",
@@ -278,30 +291,47 @@ public class WorkflowAiCatalogController {
         return q;
     }
 
+    /**
+     * producedContextKeys come from {@link TriggerContextKeyRegistry} — the same list the
+     * validator enforces — so this text can no longer drift from what the emitters set. The
+     * notes carry what a bare key list cannot: types, which key is the person, and traps.
+     */
     private List<Map<String, Object>> commonTriggers() {
         List<Map<String, Object>> t = new ArrayList<>();
         t.add(trigger("AUDIENCE_LEAD_SUBMISSION", "AUDIENCE", "audienceId (or null=all)",
-                "lead, customFields, respondentEmailRequests, adminEmailRequests, instituteName, campaignName",
-                "Fires once per form submission with that single lead's data."));
+                keysOf("AUDIENCE_LEAD_SUBMISSION"),
+                "Fires once per form submission with that single lead's data. The person is #ctx['user'] (UserDTO: id, fullName, email, mobileNumber) — there is NO 'lead' key. Send node on = \"{#ctx['user']}\"; idempotency person = #ctx['user']['id'], or #ctx['responseId'] for once-per-submission. customFields is a Map keyed by the form's field labels."));
         t.add(trigger("LEARNER_BATCH_ENROLLMENT", "PACKAGE_SESSION", "packageSessionId (or null=all)",
-                "user (UserDTO), packageSessionIds, packageId, subOrg",
-                null));
+                keysOf("LEARNER_BATCH_ENROLLMENT"),
+                "Person = #ctx['user'] (UserDTO). packageSessionIds is a SINGLE id string despite the plural name. packageName is the course name."));
         t.add(trigger("LIVE_SESSION_CREATE", "LIVE_SESSION", "liveSessionId (or null=all)",
-                "liveSession (title, startTime, defaultMeetLink...), createdBy, instituteId",
-                "No student emails in context — add a QUERY to fetch recipients."));
+                keysOf("LIVE_SESSION_CREATE"),
+                "liveSession has title, startTime, defaultMeetLink...; createdBy is the admin's user id. No student emails in context — add a QUERY to fetch recipients."));
         t.add(trigger("ABANDONED_CART", "ENROLL_INVITE", "enrollInviteId (or null=all)",
-                "user, userPlanId, packageSessionId, packageId",
-                null));
+                keysOf("ABANDONED_CART"),
+                "'user' is present only when the account could be resolved — use #ctx['userId'] as the idempotency person, not #ctx['user']['id']."));
         t.add(trigger("PAYMENT_FAILED", "ENROLL_INVITE", "enrollInviteId (or null=all)",
-                "paymentLog, user, userPlanId, packageSessionIds, enrollInviteId",
-                null));
+                keysOf("PAYMENT_FAILED"),
+                "The main (first-payment) emitter sets NO 'user' — only userId. 'user' and 'renewal' appear on the renewal-charge emitter. Idempotency person = #ctx['userId'] (or #ctx['userPlanId'])."));
         t.add(trigger("MEMBERSHIP_EXPIRY", "USER_PLAN", "null (institute-wide, daily 09:00 cron)",
-                "expiring plan context",
-                "Emitted by a daily scheduler; use EVENT_BASED idempotency."));
+                keysOf("MEMBERSHIP_EXPIRY"),
+                "Emitted by a daily scheduler, once per expiring plan; ids only (no 'user' object) — QUERY for the learner if a name/email is needed. Use EVENT_BASED idempotency."));
         t.add(trigger("LEAD_ASSIGNED_TO_COUNSELOR", "AUDIENCE", "audienceId or poolId",
-                "see /catalog/trigger-context-variables (leadName, counselorEmail, tat, ...)",
-                null));
+                keysOf("LEAD_ASSIGNED_TO_COUNSELOR"),
+                "Flat lead keys (leadName, leadEmail, leadMobile, counselorEmail...) — no 'user' object. Idempotency person = #ctx['leadId']."));
         return t;
+    }
+
+    private String keysOf(String event) {
+        Set<String> keys = triggerContextKeyRegistry.emittedKeys(event);
+        return keys == null ? "(not catalogued)" : String.join(", ", keys);
+    }
+
+    /** event → comma-joined emitted keys, for every event the registry knows. */
+    private Map<String, Object> triggerContextKeys() {
+        Map<String, Object> out = new LinkedHashMap<>();
+        triggerContextKeyRegistry.allKnown().forEach((event, keys) -> out.put(event, String.join(", ", keys)));
+        return out;
     }
 
     // ---- small builders --------------------------------------------------

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/TriggerContextKeyRegistry.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/TriggerContextKeyRegistry.java
@@ -1,0 +1,122 @@
+package vacademy.io.admin_core_service.features.workflow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import vacademy.io.admin_core_service.features.workflow.controller.WorkflowCatalogController;
+import vacademy.io.admin_core_service.features.workflow.enums.WorkflowTriggerEvent;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Which top-level {@code #ctx[...]} keys each trigger event actually puts on the seed context.
+ *
+ * <p>Exists because the AI drafter and admins can only reference keys they are told about, and a
+ * key that is NOT there fails in the worst possible way: a CUSTOM_EXPRESSION idempotency key such
+ * as {@code #ctx['lead']['id']} throws inside SpEL, and {@code WorkflowTriggerService} then skips
+ * the trigger — no execution row, nothing in the Executions tab. (Audited 2026-09-11: the AI
+ * catalog advertised a {@code lead} key for AUDIENCE_LEAD_SUBMISSION that no emitter sets.)</p>
+ *
+ * <p>The audited events below were read off their emitters — the file is named next to each so
+ * the list can be re-checked when an emitter changes. Lead-SLA and assessment events delegate to
+ * {@link WorkflowCatalogController#getTriggerContextVariables()}, which is already the admin-facing
+ * token list for those events. Events not covered return {@link Optional#empty()} and are not
+ * validated — an unknown event must never produce a false error.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class TriggerContextKeyRegistry {
+
+    private final WorkflowCatalogController workflowCatalogController;
+
+    /** Matches the first-level key of a {@code #ctx['key']} reference. */
+    private static final Pattern CTX_KEY = Pattern.compile("#ctx\\['([^']+)'\\]");
+
+    /**
+     * Keys {@code WorkflowTriggerService} stamps on every seed context before the engine runs.
+     * Note that only {@code triggerId}, {@code eventName} and {@code eventId} exist at idempotency
+     * key time (see {@code CustomExpressionKeyGenerator}); the rest are added just after.
+     */
+    public static final Set<String> ENGINE_KEYS = Set.of(
+            "triggerId", "eventName", "eventId", "instituteId", "triggerEvents", "executionId",
+            "eventAppliedType", "isGlobalTrigger", "triggerTime");
+
+    /** Keys available while the CUSTOM_EXPRESSION idempotency key is being evaluated. */
+    public static final Set<String> IDEMPOTENCY_TIME_ENGINE_KEYS = Set.of("triggerId", "eventName", "eventId");
+
+    private static final Map<String, Set<String>> AUDITED = new LinkedHashMap<>();
+
+    static {
+        // AudienceService: submitLead (~L1289), submitLeadV2 (~L1803), form-provider webhook (~L5001).
+        // The person is `user` (UserDTO) on all three paths. There is NO `lead` key. userId /
+        // leadUserId / phone / parentMobile are set by the first two paths only.
+        AUDITED.put(WorkflowTriggerEvent.AUDIENCE_LEAD_SUBMISSION.name(), Set.of(
+                "user", "userId", "leadUserId", "phone", "parentMobile", "responseId", "audience", "audienceId",
+                "instituteId", "instituteName", "campaignName", "customFields", "submissionTime",
+                "sendRespondentEmail", "respondentEmailRequests", "adminEmailRequests", "formProvider"));
+        // StudentRegistrationManager ~L1200. `packageSessionIds` is a single id string despite the name.
+        AUDITED.put(WorkflowTriggerEvent.LEARNER_BATCH_ENROLLMENT.name(), Set.of(
+                "user", "packageSessionIds", "subOrg", "packageId", "packageName", "lmsEditExistingUser"));
+        // Step1Service ~L85 / LiveSessionWorkflowAsyncHelper ~L55.
+        AUDITED.put(WorkflowTriggerEvent.LIVE_SESSION_CREATE.name(), Set.of(
+                "liveSession", "createdBy"));
+        // LearnerEnrollmentEntryService ~L170. `user` only when the account could be resolved.
+        AUDITED.put(WorkflowTriggerEvent.ABANDONED_CART.name(), Set.of(
+                "userId", "userPlanId", "packageSessionId", "packageSessionIds", "packageId", "packageName", "user"));
+        // PaymentLogService ~L1815 (no `user`) + RenewalPaymentService.emitRenewalEvent (adds renewal, user when resolvable).
+        AUDITED.put(WorkflowTriggerEvent.PAYMENT_FAILED.name(), Set.of(
+                "paymentLog", "userId", "userPlanId", "amount", "vendor", "enrollInviteId", "packageSessionIds",
+                "renewal", "user"));
+        // PackageSessionScheduler ~L165. No `user`.
+        AUDITED.put(WorkflowTriggerEvent.MEMBERSHIP_EXPIRY.name(), Set.of(
+                "userPlanId", "userId", "paymentPlanId", "enrollInviteId", "endDate", "daysToExpiry"));
+    }
+
+    /**
+     * Keys emitted by {@code eventName}, plus {@link #ENGINE_KEYS}. Empty when the event is not
+     * catalogued — callers must treat that as "unknown", not "none".
+     */
+    public Optional<Set<String>> knownKeys(String eventName) {
+        if (eventName == null) return Optional.empty();
+        Set<String> emitted = emittedKeys(eventName);
+        if (emitted == null) return Optional.empty();
+        Set<String> all = new LinkedHashSet<>(emitted);
+        all.addAll(ENGINE_KEYS);
+        return Optional.of(all);
+    }
+
+    /** Only the emitter's own keys (no engine keys), for display in the AI catalog. Null when unknown. */
+    public Set<String> emittedKeys(String eventName) {
+        Set<String> audited = AUDITED.get(eventName);
+        if (audited != null) return audited;
+        List<Map<String, String>> vars = catalogVars().get(eventName);
+        if (vars == null) return null;
+        Set<String> keys = new LinkedHashSet<>();
+        for (Map<String, String> v : vars) keys.add(v.get("key"));
+        return keys;
+    }
+
+    /** Every event this registry knows, in a stable order (audited first, then catalog events). */
+    public Map<String, Set<String>> allKnown() {
+        Map<String, Set<String>> out = new LinkedHashMap<>(AUDITED);
+        for (String event : catalogVars().keySet()) {
+            out.computeIfAbsent(event, this::emittedKeys);
+        }
+        return out;
+    }
+
+    /** First-level {@code #ctx['key']} references in a SpEL expression, in order of appearance. */
+    public static Set<String> referencedCtxKeys(String expression) {
+        Set<String> keys = new LinkedHashSet<>();
+        if (expression == null) return keys;
+        Matcher m = CTX_KEY.matcher(expression);
+        while (m.find()) keys.add(m.group(1));
+        return keys;
+    }
+
+    private Map<String, List<Map<String, String>>> catalogVars() {
+        Map<String, List<Map<String, String>>> body = workflowCatalogController.getTriggerContextVariables().getBody();
+        return body == null ? Map.of() : body;
+    }
+}

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowTriggerService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowTriggerService.java
@@ -137,9 +137,13 @@ public class WorkflowTriggerService {
                         count, triggers.size(), trigger.getId(), trigger.getTriggerEventName(),
                         trigger.getWorkflow().getId());
 
+                // Declared outside the try so the failure path below marks the SAME execution.
+                // Re-generating the key there is wrong for non-deterministic strategies (UUID,
+                // the default): the new key matches no row, markAsFailed finds nothing, and the
+                // execution is left PROCESSING forever.
+                String idempotencyKey = null;
                 try {
                     // Generate idempotency key based on trigger's configuration
-                    String idempotencyKey;
                     try {
                         idempotencyKey = idempotencyStrategyFactory.generateKey(
                                 trigger, eventName, eventId, contextData);
@@ -152,6 +156,7 @@ public class WorkflowTriggerService {
                                 .withTag("trigger.event", eventName)
                                 .withTag("institute.id", instituteId)
                                 .send();
+                        recordKeyGenerationFailure(trigger, eventName, eventId, instituteId, contextData, e);
                         continue; // Skip this trigger
                     }
 
@@ -212,11 +217,11 @@ public class WorkflowTriggerService {
                     log.error("Error executing workflowId='{}' for triggerId='{}'",
                             trigger.getWorkflow().getId(), trigger.getId(), ex);
 
-                    // Mark as failed
+                    // Mark as failed — on the key that created the execution, never a fresh one.
                     try {
-                        String idempotencyKey = idempotencyStrategyFactory.generateKey(
-                                trigger, eventName, eventId, contextData);
-                        idempotencyService.markAsFailed(idempotencyKey, ex.getMessage());
+                        if (idempotencyKey != null) {
+                            idempotencyService.markAsFailed(idempotencyKey, ex.getMessage());
+                        }
                     } catch (Exception e) {
                         log.error("Failed to mark execution as failed", e);
                     }
@@ -259,6 +264,45 @@ public class WorkflowTriggerService {
      * UI tab; it is never a reason not to run the automation. The worst outcome of a failure
      * is one run missing from one tab.</p>
      */
+    /**
+     * A trigger whose idempotency expression cannot be evaluated (typically a CUSTOM_EXPRESSION
+     * naming a context key the event never emits, e.g. {@code #ctx['lead']['id']}) used to be
+     * skipped with nothing but a log line — the workflow showed zero executions and the admin had
+     * no way to see why. Record a FAILED execution instead so it shows up in the Executions tab
+     * and on the learner's Workflows tab with the real cause. Best-effort: this must never throw
+     * back into the emitter.
+     */
+    private void recordKeyGenerationFailure(WorkflowTrigger trigger, String eventName, String eventId,
+            String instituteId, Map<String, Object> contextData, Exception cause) {
+        try {
+            String surrogateKey = "idempotency_error_" + java.util.UUID.randomUUID();
+            vacademy.io.admin_core_service.features.workflow.entity.WorkflowExecution execution =
+                    idempotencyService.markAsProcessingForTrigger(
+                            surrogateKey, trigger.getWorkflow().getId(), trigger.getId());
+            Map<String, Object> seedContext = new HashMap<>(
+                    Optional.ofNullable(contextData).orElse(new HashMap<>()));
+            seedContext.put("triggerEvents", eventName);
+            seedContext.put("triggerId", trigger.getId());
+            seedContext.put("instituteId", instituteId);
+            seedContext.put("executionId", execution.getId());
+            seedContext.put("eventId", eventId);
+            recordRunSubject(execution.getId(), seedContext);
+            Throwable root = cause;
+            while (root.getCause() != null && root.getCause() != root) {
+                root = root.getCause();
+            }
+            String message = "Idempotency key could not be generated from the trigger's "
+                    + "idempotency_generation_setting — the workflow did not run. "
+                    + "Check that every #ctx[...] key in the expression is emitted by " + eventName
+                    + ". Cause: " + root.getMessage();
+            idempotencyService.markAsFailed(surrogateKey, message.length() > 2000 ? message.substring(0, 2000) : message);
+            log.warn("Recorded FAILED execution {} for trigger {} (idempotency key generation failed)",
+                    execution.getId(), trigger.getId());
+        } catch (Exception e) {
+            log.error("Could not record idempotency-failure execution for trigger {}", trigger.getId(), e);
+        }
+    }
+
     private void recordRunSubject(String executionId, Map<String, Object> seedContext) {
         try {
             idempotencyService.recordSubjectAndContext(

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowValidationService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowValidationService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import vacademy.io.admin_core_service.features.workflow.dto.IdempotencySettings;
 import vacademy.io.admin_core_service.features.workflow.dto.WorkflowBuilderDTO;
+import vacademy.io.admin_core_service.features.workflow.enums.IdempotencyStrategy;
 import vacademy.io.admin_core_service.features.workflow.service.idempotency.IdempotencyStrategyFactory;
 
 import java.util.*;
@@ -18,6 +19,16 @@ public class WorkflowValidationService {
 
     private final ObjectMapper objectMapper;
     private final IdempotencyStrategyFactory idempotencyStrategyFactory;
+    private final TriggerContextKeyRegistry triggerContextKeyRegistry;
+
+    /**
+     * Node types that only consume the context. A workflow made solely of these (plus the
+     * TRIGGER) has no node that could add a key, so every {@code #ctx['x']} a send node reads
+     * must come from the trigger event itself.
+     */
+    private static final Set<String> NON_PRODUCING_NODE_TYPES = Set.of(
+            "TRIGGER", "SEND_EMAIL", "SEND_WHATSAPP", "COMBOT", "SEND_PUSH_NOTIFICATION",
+            "DELAY", "CONDITION", "SET_LEAD_STATUS");
 
     @lombok.Data
     @lombok.AllArgsConstructor
@@ -121,7 +132,87 @@ public class WorkflowValidationService {
             validateTriggerIdempotency(dto.getTrigger().getIdempotencyGenerationSetting(), errors);
         }
 
+        if ("EVENT_DRIVEN".equalsIgnoreCase(dto.getWorkflowType()) && dto.getTrigger() != null) {
+            validateTriggerContextKeys(dto, errors);
+        }
+
         return errors;
+    }
+
+    /**
+     * A {@code #ctx['key']} that the trigger event never emits is the one mistake the engine
+     * cannot surface: in a CUSTOM_EXPRESSION idempotency key it throws inside SpEL and
+     * {@code WorkflowTriggerService} skips the trigger before any execution row exists; in a send
+     * node's {@code on} it yields {@code [null]} and the node sends nothing. Both were shipped by
+     * the AI drafter on 2026-09-11 ({@code #ctx['lead']} on AUDIENCE_LEAD_SUBMISSION). Checked
+     * only for events {@link TriggerContextKeyRegistry} knows — an uncatalogued event is skipped.
+     */
+    private void validateTriggerContextKeys(WorkflowBuilderDTO dto, List<ValidationError> errors) {
+        String event = dto.getTrigger().getTriggerEventName();
+        Set<String> emitted = triggerContextKeyRegistry.emittedKeys(event);
+        if (emitted == null) {
+            return;
+        }
+
+        // Idempotency expression: evaluated against the raw emitter context + triggerId/eventName/eventId,
+        // before any node runs — nothing upstream can supply a missing key, so this is an ERROR.
+        String customExpression = customIdempotencyExpression(dto.getTrigger().getIdempotencyGenerationSetting());
+        if (customExpression != null) {
+            Set<String> allowed = new LinkedHashSet<>(emitted);
+            allowed.addAll(TriggerContextKeyRegistry.IDEMPOTENCY_TIME_ENGINE_KEYS);
+            List<String> unknown = TriggerContextKeyRegistry.referencedCtxKeys(customExpression).stream()
+                    .filter(k -> !allowed.contains(k))
+                    .toList();
+            if (!unknown.isEmpty()) {
+                errors.add(new ValidationError(null, "trigger.idempotency_generation_setting",
+                        "customExpression references #ctx" + unknown + " but " + event
+                                + " never puts " + (unknown.size() == 1 ? "that key" : "those keys")
+                                + " on the context — the expression would throw and the trigger would be skipped"
+                                + " with no execution. Keys available here: " + String.join(", ", allowed),
+                        "ERROR"));
+            }
+        }
+
+        // Send-node 'on': only checkable when no node in the graph can add context keys.
+        boolean anyProducer = dto.getNodes().stream()
+                .map(WorkflowBuilderDTO.NodeDTO::getNodeType)
+                .anyMatch(t -> t == null || !NON_PRODUCING_NODE_TYPES.contains(t.toUpperCase()));
+        if (anyProducer) {
+            return;
+        }
+        Set<String> allowedOnKeys = new LinkedHashSet<>(emitted);
+        allowedOnKeys.addAll(TriggerContextKeyRegistry.ENGINE_KEYS);
+        allowedOnKeys.add("item"); // forEach iteration variable
+        for (WorkflowBuilderDTO.NodeDTO node : dto.getNodes()) {
+            if (!(node.getConfig() instanceof Map<?, ?> config)) continue;
+            Object on = config.get("on");
+            if (!(on instanceof String onExpr) || onExpr.isBlank()) continue;
+            List<String> unknown = TriggerContextKeyRegistry.referencedCtxKeys(onExpr).stream()
+                    .filter(k -> !allowedOnKeys.contains(k))
+                    .toList();
+            if (!unknown.isEmpty()) {
+                errors.add(new ValidationError(node.getId(), "config.on",
+                        "'on' references #ctx" + unknown + " but " + event + " does not emit "
+                                + (unknown.size() == 1 ? "that key" : "those keys")
+                                + " and no upstream node produces it — the node would have no recipients."
+                                + " Keys available here: " + String.join(", ", allowedOnKeys),
+                        "WARNING"));
+            }
+        }
+    }
+
+    /** The customExpression of a CUSTOM_EXPRESSION idempotency setting (object or JSON string), else null. */
+    private String customIdempotencyExpression(Object provided) {
+        if (provided == null) return null;
+        try {
+            String json = provided instanceof String s ? s : objectMapper.writeValueAsString(provided);
+            if (json.isBlank() || "null".equals(json)) return null;
+            IdempotencySettings settings = objectMapper.readValue(json, IdempotencySettings.class);
+            if (settings.getStrategy() != IdempotencyStrategy.CUSTOM_EXPRESSION) return null;
+            return settings.getCustomExpression();
+        } catch (Exception e) {
+            return null; // malformed settings are reported by validateTriggerIdempotency
+        }
     }
 
     /**

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowValidationServiceTriggerContextKeysTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/workflow/service/WorkflowValidationServiceTriggerContextKeysTest.java
@@ -1,0 +1,130 @@
+package vacademy.io.admin_core_service.features.workflow.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vacademy.io.admin_core_service.features.workflow.controller.WorkflowCatalogController;
+import vacademy.io.admin_core_service.features.workflow.dto.WorkflowBuilderDTO;
+import vacademy.io.admin_core_service.features.workflow.service.idempotency.IdempotencyStrategyFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the 2026-09-11 failure: the AI drafter emitted {@code #ctx['lead']} for an
+ * AUDIENCE_LEAD_SUBMISSION workflow (idempotency expression + SEND_WHATSAPP 'on'), the key
+ * generator threw, and the trigger was skipped with no execution row.
+ */
+class WorkflowValidationServiceTriggerContextKeysTest {
+
+    private WorkflowValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper om = new ObjectMapper();
+        service = new WorkflowValidationService(
+                om,
+                new IdempotencyStrategyFactory(List.of(), om),
+                new TriggerContextKeyRegistry(new WorkflowCatalogController()));
+    }
+
+    private static WorkflowBuilderDTO eventWorkflow(String event, String idempotencyExpr, String onExpr) {
+        WorkflowBuilderDTO.NodeDTO trigger = WorkflowBuilderDTO.NodeDTO.builder()
+                .id("t1").name("Trigger").nodeType("TRIGGER").isStartNode(true)
+                .config(Map.of("routing", List.of(Map.of("type", "goto", "targetNodeId", "s1"))))
+                .build();
+        WorkflowBuilderDTO.NodeDTO send = WorkflowBuilderDTO.NodeDTO.builder()
+                .id("s1").name("Send").nodeType("SEND_WHATSAPP").isStartNode(false)
+                .config(Map.of("on", onExpr, "templateName", "yoga_leads",
+                        "routing", List.of(Map.of("type", "end"))))
+                .build();
+        WorkflowBuilderDTO.EdgeDTO edge = WorkflowBuilderDTO.EdgeDTO.builder()
+                .id("e1").sourceNodeId("t1").targetNodeId("s1").build();
+        WorkflowBuilderDTO.TriggerDTO triggerDTO = WorkflowBuilderDTO.TriggerDTO.builder()
+                .triggerEventName(event)
+                .eventAppliedType("AUDIENCE")
+                .idempotencyGenerationSetting(idempotencyExpr == null ? null
+                        : Map.of("strategy", "CUSTOM_EXPRESSION", "customExpression", idempotencyExpr))
+                .build();
+        return WorkflowBuilderDTO.builder()
+                .name("wf").workflowType("EVENT_DRIVEN")
+                .nodes(List.of(trigger, send)).edges(List.of(edge))
+                .trigger(triggerDTO)
+                .build();
+    }
+
+    @Test
+    @DisplayName("#ctx['lead'] in the idempotency expression is an ERROR naming the real keys")
+    void unknownIdempotencyKeyIsError() {
+        var errors = service.validate(eventWorkflow("AUDIENCE_LEAD_SUBMISSION",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['lead']['id']", "{#ctx['user']}"));
+
+        var idem = errors.stream()
+                .filter(e -> "trigger.idempotency_generation_setting".equals(e.getField()))
+                .toList();
+        assertEquals(1, idem.size(), () -> "expected one idempotency error, got " + errors);
+        assertEquals("ERROR", idem.get(0).getSeverity());
+        assertTrue(idem.get(0).getMessage().contains("[lead]"), idem.get(0).getMessage());
+        assertTrue(idem.get(0).getMessage().contains("responseId"), idem.get(0).getMessage());
+        assertTrue(idem.get(0).getMessage().contains("user"), idem.get(0).getMessage());
+    }
+
+    @Test
+    @DisplayName("'on' = {#ctx['lead']} with no producing node upstream is a WARNING on the node")
+    void unknownOnKeyIsWarning() {
+        var errors = service.validate(eventWorkflow("AUDIENCE_LEAD_SUBMISSION",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['responseId']", "{#ctx['lead']}"));
+
+        var on = errors.stream().filter(e -> "config.on".equals(e.getField())).toList();
+        assertEquals(1, on.size(), () -> "expected one 'on' warning, got " + errors);
+        assertEquals("WARNING", on.get(0).getSeverity());
+        assertEquals("s1", on.get(0).getNodeId());
+        assertTrue(errors.stream().noneMatch(e -> "trigger.idempotency_generation_setting".equals(e.getField())));
+    }
+
+    @Test
+    @DisplayName("Keys the event really emits (user, responseId, triggerId) pass clean")
+    void knownKeysPass() {
+        var errors = service.validate(eventWorkflow("AUDIENCE_LEAD_SUBMISSION",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['user']['id']", "{#ctx['user']}"));
+        assertTrue(errors.isEmpty(), () -> "expected no errors, got " + errors);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_FAILED main path has no 'user' — #ctx['user']['id'] idempotency is flagged")
+    void paymentFailedUserKeyIsFlaggedButUserIdPasses() {
+        // 'user' IS in the union (renewal emitter sets it) so it passes the closed-list check; the
+        // catalog note steers the drafter to userId. What must be flagged is a wholly absent key.
+        var flagged = service.validate(eventWorkflow("PAYMENT_FAILED",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['student']['id']", "{#ctx['user']}"));
+        assertTrue(flagged.stream().anyMatch(e -> "ERROR".equals(e.getSeverity())
+                && e.getMessage().contains("[student]")), flagged::toString);
+
+        var ok = service.validate(eventWorkflow("PAYMENT_FAILED",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['userId']", "{#ctx['user']}"));
+        assertTrue(ok.stream().noneMatch(e -> "trigger.idempotency_generation_setting".equals(e.getField())), ok::toString);
+    }
+
+    @Test
+    @DisplayName("An event the registry does not know is never validated (no false errors)")
+    void unknownEventIsSkipped() {
+        var errors = service.validate(eventWorkflow("COURSE_CREATED",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['whatever']['id']", "{#ctx['whatever']}"));
+        assertTrue(errors.isEmpty(), () -> "expected no errors for an uncatalogued event, got " + errors);
+    }
+
+    @Test
+    @DisplayName("Lead-SLA events resolve their keys from the admin catalog (leadId known, lead unknown)")
+    void leadEventsUseCatalogKeys() {
+        var ok = service.validate(eventWorkflow("LEAD_ASSIGNED_TO_COUNSELOR",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['leadId']", "{#ctx['leadMobile']}"));
+        assertTrue(ok.stream().noneMatch(e -> "ERROR".equals(e.getSeverity())), ok::toString);
+
+        var bad = service.validate(eventWorkflow("LEAD_ASSIGNED_TO_COUNSELOR",
+                "'wf_' + #ctx['triggerId'] + '_' + #ctx['lead']['id']", "{#ctx['leadMobile']}"));
+        assertTrue(bad.stream().anyMatch(e -> "ERROR".equals(e.getSeverity())), bad::toString);
+    }
+}


### PR DESCRIPTION
…event never emits

An AI-drafted AUDIENCE_LEAD_SUBMISSION -> SEND_WHATSAPP workflow (0be9ec89, 2026-09-11) never ran: the drafter used #ctx['lead'] in both the CUSTOM_EXPRESSION idempotency key and the send node's 'on'. No emitter sets a 'lead' key (the person is #ctx['user']), so the SpEL threw inside CustomExpressionKeyGenerator and WorkflowTriggerService skipped the trigger with only a log line - zero execution rows, nothing in the UI.

Root cause was the AI catalog itself: commonTriggers advertised "lead" as the first context key for that event, and the idempotency rule's only example indexed #ctx['user']['id'], so the model merged the two. The same drift existed for PAYMENT_FAILED / MEMBERSHIP_EXPIRY / ABANDONED_CART, which advertised 'user' where the main emitters set only userId.

- TriggerContextKeyRegistry: one audited list of the keys each event puts on the seed context (emitters cited per entry); lead-SLA and assessment events reuse the admin catalog's trigger-context-variables map. Unknown events return empty.
- WorkflowAiCatalogController: producedContextKeys now come from the registry, the full per-event key map is inlined as triggerContextKeys (the model cannot follow the reference URLs), per-trigger notes name the person key, and a new rule makes trigger context keys a closed list.
- WorkflowValidationService: an unknown #ctx key in a CUSTOM_EXPRESSION idempotency expression is an ERROR (nothing can supply it - it is evaluated before any node); an unknown key in a send node's 'on' is a WARNING when no upstream node could produce it. Both feed the drafter's repair loop; the ERROR also blocks a manual publish of the same mistake.
- WorkflowTriggerService: an idempotency-key failure now records a FAILED execution with the cause instead of silently skipping, and the outer failure path marks the execution by the key that created it rather than re-generating one (the default UUID strategy would never find the row, leaving it PROCESSING).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
