### PR TITLE
feat(copy-check): enforce marking in code, draw with a real pen, fix …

### DIFF
--- a/ai_service/app/services/copy_check/annotator.py
+++ b/ai_service/app/services/copy_check/annotator.py
@@ -19,6 +19,7 @@ a different dpi than the map claims, or if pages differ in size.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import os
@@ -99,6 +100,16 @@ _ADVANCE_SLACK = 1.12
 # heavy on the pull, light on the push - and no two instances of a letter come
 # out identical. Set COPY_CHECK_PEN_STROKES=0 to go back to the font.
 _PEN_STROKES = os.getenv("COPY_CHECK_PEN_STROKES", "1") != "0"
+# hand_render: the marking guide's own pen. Text in a handwriting face with
+# per-glyph jitter, ticks and crosses as wobbly Bezier strokes, the total in
+# a hand-thrown loop - drawn on a transparent raster layer and composited
+# over the page, so the student's copy underneath is never touched. Every
+# placement decision and every paper-boundary test above still applies; only
+# the ink changes. COPY_CHECK_HAND_RENDER=0 reverts to the vector pen.
+_HAND_RENDER = os.getenv("COPY_CHECK_HAND_RENDER", "1") != "0"
+_PEN: list = [None]            # one hand_render.Pen per copy, seeded from it
+_LINE_H: list = [None]         # the current page's typical row height, in points
+_PEN_SCALE = 4.0               # raster px per PDF point on the overlay layers
 _JOINED_FACES = ("snell", "savoye", "chancery", "brush", "zapfino", "roundhand")
 _HW_FONTNAME = "hwnote"
 # x-height/em of the print hand every size in this module was tuned against.
@@ -114,6 +125,10 @@ _HW_FONTSIZE = 12.5
 # correct. The final point is missing." is 46 characters on its own. Capping at
 # 46 truncated exactly the notes that explain why a mark was lost. Praise stays
 # short because the model writes it short, not because this forces it.
+# Slack allowed when testing a mark against the paper boundary, in points.
+# Matches the tolerance the row-span test has always used; the mask is
+# measured at 40dpi so a cell is ~1.8pt and sub-cell overshoot is noise.
+_PAPER_TOL = 1.0
 _MAX_NOTE_CHARS = 110
 # Below this the mark is not trustworthy enough to release unreviewed.
 _REVIEW_CONFIDENCE = 0.60
@@ -372,6 +387,8 @@ _INK_MAP: list = [None]
 # through the marker's own note ("Bu[X]yer m[X]st be insolv[X]nt") is worse
 # than one on the student's words.
 _PLACED: list = [None]
+# Per-row paper boundary for the page being drawn (see _paper_rows).
+_PAPER: list = [None]
 # Where the added marking strip begins, when there is one. A note belongs
 # there by preference: it is blank paper beside the answer, which is exactly
 # where a teacher writes when the notebook gives them the room.
@@ -398,6 +415,37 @@ def _ink(colour, rng, x: float = None, y: float = None):
     return (max(0.0, min(1.0, r * k)),
             max(0.0, min(1.0, g * k * rng.uniform(0.97, 1.03))),
             max(0.0, min(1.0, b * k * rng.uniform(0.94, 1.02))))
+
+
+def _point_on_paper(x: float, y: float) -> bool:
+    """Is this exact point physically on the student's notebook page?
+
+    The last line of defence for the marking guide's first rule. Placement
+    decides WHERE a mark goes, but eighteen call sites draw strokes and any one
+    of them can run past the sheet - on a copy photographed on a bedsheet that
+    put 98% of the ink on the bedsheet. Checking here means no primitive can
+    write off the paper whatever the caller intended.
+    """
+    paper = _PAPER[0]
+    if not paper:
+        return True
+    r = int(y / paper["sy"])
+    if r < 0 or r >= paper["rows"]:
+        return False
+    mask = paper.get("mask")
+    if mask is not None:
+        # Test the paper itself. The row span is one horizontal interval, so on
+        # a sheet photographed at an angle it reaches past the corners and over
+        # the bedsheet beside them; the mask does not.
+        sx, sy = paper["sx"], paper["sy"]
+        for dx, dy in ((0.0, 0.0), (-_PAPER_TOL, 0.0), (_PAPER_TOL, 0.0),
+                       (0.0, -_PAPER_TOL), (0.0, _PAPER_TOL)):
+            cc, rr = int((x + dx) / sx), int((y + dy) / sy)
+            if 0 <= rr < paper["rows"] and 0 <= cc < paper["cols"] and mask[rr, cc]:
+                return True                    # within 1pt of paper, as before
+        return False
+    hi = paper["hi"][r]
+    return hi > 0 and (paper["lo"][r] - 1.0) <= x <= (hi + 1.0)
 
 
 def _clip_point(x: float, y: float) -> tuple:
@@ -491,6 +539,139 @@ def _cursive_text(page: Any, origin: Any, text: str, fontname: str, size: float,
         x += _text_width(token, fontname, wsize, font)
 
 
+def _pen_for(pdf_bytes: bytes) -> Any:
+    """The copy's pen: one hand for the whole script, seeded from the file."""
+    if not _HAND_RENDER:
+        return None
+    try:
+        from . import hand_render
+        seed = int.from_bytes(hashlib.blake2b(pdf_bytes[:1 << 20], digest_size=8).digest(), "big")
+        return hand_render.Pen(seed)
+    except Exception:
+        logger.debug("hand_render unavailable; using the vector pen", exc_info=True)
+        return None
+
+
+def _composite_layer(page: Any, layer: Any, ox_px: float, oy_px: float) -> Optional[Any]:
+    """Crop a drawn RGBA layer to its ink and place it on the page.
+
+    (ox_px, oy_px) is where the layer's top-left sits, in page pixels at
+    _PEN_SCALE. Returns the rect covered in points, or None if the ink would
+    leave the paper - the caller then falls back to the vector pen, whose
+    per-stroke gate can still draw the part that fits.
+    """
+    import io
+    import fitz
+
+    bbox = layer.getbbox()
+    if not bbox:
+        return None
+    x0, y0, x1, y1 = bbox
+    S = _PEN_SCALE
+    rect = fitz.Rect((ox_px + x0) / S, (oy_px + y0) / S, (ox_px + x1) / S, (oy_px + y1) / S)
+    if not _on_paper(_PAPER[0], rect):
+        return None
+    if _CLIP[0] is not None and not _CLIP[0].contains(rect):
+        return None
+    buf = io.BytesIO()
+    layer.crop(bbox).save(buf, format="PNG")
+    page.insert_image(rect, stream=buf.getvalue(), overlay=True)
+    return rect
+
+
+def _pen_text_overlay(page: Any, origin: Any, text: str, size: float,
+                      max_x: Optional[float] = None) -> Optional[Any]:
+    """Write `text` with the copy's pen, baseline-left at `origin` (points)."""
+    pen = _PEN[0]
+    if pen is None or not text:
+        return None
+    try:
+        from PIL import Image, ImageFont
+        S = _PEN_SCALE
+        # Kalam carries a small x-height, so at the size the placement ladder
+        # chose for the old face it reads a shade too small beside the
+        # student's hand. The guide asks for notes ~1.1x the line height.
+        px = max(6, int(round(size * S * 1.18)))
+        font = ImageFont.truetype(pen.font_path, px)
+        # Shrink until the line fits before the limit the caller set; the
+        # caller has already wrapped, so this rarely runs more than once.
+        for _ in range(6):
+            est_pt = font.getlength(text) * 1.12 / S
+            if max_x is None or origin.x + est_pt <= max_x or px <= 8:
+                break
+            px = int(px * 0.92)
+            font = ImageFont.truetype(pen.font_path, px)
+        est_w = int(font.getlength(text) * 1.3) + 4 * px
+        est_h = 4 * px
+        layer = Image.new("RGBA", (est_w, est_h), (0, 0, 0, 0))
+        # Pen.text takes the TOP-left of the text (PIL's convention), not the
+        # baseline its docstring names. Placing the baseline there put every
+        # score and note one text-height below its row. The font's ascent is
+        # the distance from top to baseline; draw that much higher.
+        ascent = font.getmetrics()[0]
+        ax, ay = 2 * px, int(2.4 * px)          # baseline-left inside the layer
+        pen.text(layer, (ax, ay - ascent), text, px)
+        return _composite_layer(page, layer, origin.x * S - ax, origin.y * S - ay)
+    except Exception:
+        logger.debug("hand_render text failed; using the vector pen", exc_info=True)
+        return None
+
+
+def _pen_mark_overlay(page: Any, style: str, cx: float, cy: float, size: float) -> Optional[Any]:
+    """A tick or cross with the copy's pen. (cx, cy) is the top-left of the
+    size x size box the vector pen would have used."""
+    pen = _PEN[0]
+    if pen is None:
+        return None
+    try:
+        from PIL import Image
+        S = _PEN_SCALE
+        h = size * S
+        layer = Image.new("RGBA", (int(h * 4), int(h * 4)), (0, 0, 0, 0))
+        if style == "tick":
+            # vertex sits low-left in the box, the tail climbs to the right
+            pen.tick(layer, (h * 1.4, h * 2.6), h * 0.95)
+        else:
+            pen.cross(layer, (h * 2.0, h * 2.0), h * 0.85)
+        # layer (h*1.4, h*2.6) / (h*2, h*2) correspond to the box's own
+        # anchor points; map the layer origin so they coincide.
+        if style == "tick":
+            ox = cx * S + h * 0.30 - h * 1.4
+            oy = cy * S + h * 0.85 - h * 2.6
+        else:
+            ox = cx * S + h * 0.5 - h * 2.0
+            oy = cy * S + h * 0.5 - h * 2.0
+        return _composite_layer(page, layer, ox, oy)
+    except Exception:
+        logger.debug("hand_render mark failed; using the vector pen", exc_info=True)
+        return None
+
+
+def _pen_total_overlay(page: Any, centre: Any, text: str, size: float) -> Optional[Any]:
+    """The circled total with the copy's pen; `size` is the digit height in points."""
+    pen = _PEN[0]
+    if pen is None:
+        return None
+    try:
+        from PIL import Image, ImageFont
+        S = _PEN_SCALE
+        px = int(round(size * S))
+        font = ImageFont.truetype(pen.font_path, px)
+        w = font.getlength(text)
+        layer = Image.new("RGBA", (int(w * 2.2) + 6 * px, 6 * px), (0, 0, 0, 0))
+        ax, ay = int(w * 0.6) + 3 * px, int(2.2 * px)      # top-left of the digits
+        pen.circled_total(layer, (ax, ay), text, px)
+        # Pen draws from the top-left; the digits' centre is about half an
+        # ascent below that. Put it at `centre`.
+        ascent = font.getmetrics()[0]
+        ox = centre.x * S - (ax + w * 0.5)
+        oy = centre.y * S - (ay + ascent * 0.5)
+        return _composite_layer(page, layer, ox, oy)
+    except Exception:
+        logger.debug("hand_render total failed; using the vector pen", exc_info=True)
+        return None
+
+
 def _pen_text(page: Any, origin: Any, text: str, size: float, colour, rng,
               slant: float = 0.0, max_x: Optional[float] = None,
               rise: Optional[float] = None, tilt: Optional[float] = None) -> None:
@@ -504,6 +685,9 @@ def _pen_text(page: Any, origin: Any, text: str, size: float, colour, rng,
     """
     import fitz
     from . import penfont
+
+    if _PEN[0] is not None and _pen_text_overlay(page, origin, text, size, max_x) is not None:
+        return
 
     # A joined hand, when one is installed. penfont draws each letter as
     # separate strokes on a unit box, so nothing ever connects and every
@@ -592,6 +776,9 @@ def _hand_text(page: Any, origin: Any, text: str, fontname: str, size: float,
     climb = math.tan(math.radians(rise))
     for ch in text:
         w = _text_width(ch, fontname, size, font)
+        if ch != " " and not _point_on_paper(x, origin.y + drift):
+            x += w
+            continue
         if ch == " ":
             x += w * rng.uniform(1.0, _ADVANCE_SLACK)
             continue
@@ -695,6 +882,8 @@ def _hand_line(page: Any, p0: Any, p1: Any, colour, width: float, rng,
     for i in range(n):
         a = fitz.Point(*_clip_point(pts[i].x, pts[i].y))
         b = fitz.Point(*_clip_point(pts[i + 1].x, pts[i + 1].y))
+        if not (_point_on_paper(a.x, a.y) and _point_on_paper(b.x, b.y)):
+            continue                     # a pen cannot reach past the paper
         t = (i + 0.5) / n
         taper = min(1.0, min(t, 1.0 - t) / 0.18)
         dx, dy = b.x - a.x, b.y - a.y
@@ -748,6 +937,9 @@ def _draw_tick_or_cross(page, style, cx, cy, size, colour, rng, rect,
     """The tick / cross gesture, shared by both anchor positions."""
     import fitz
     import math
+
+    if _PEN[0] is not None and _pen_mark_overlay(page, style, cx, cy, size) is not None:
+        return
 
     if style == "tick":
         # Drawn as a real pen tick: a short down-stroke into a long, higher
@@ -892,8 +1084,14 @@ def _draw_mark(page: Any, rect: Any, style: str, bounds: Any = None,
     # Start at the first letter, stop at the last. Critics found underlines
     # beginning "left of the pink margin rule in blank paper" and trailing past
     # the final word - a pen starts and stops where the words do.
-    ink_a = max(_INK_SPAN[0][0] if _INK_SPAN[0] else rect.x0, rect.x0)
-    ink_b = min(_INK_SPAN[0][1] if _INK_SPAN[0] else rect.x1, rect.x1)
+    # Where the words actually are. The layout's own span is preferred; when
+    # it carries none (a scanned copy reached the renderer with no ink_x0/x1
+    # on any row) measure the page itself. Without this the span was the ROW
+    # BOX, which is pinned to the sheet edges - and every underline ran the
+    # full width of the page, which the marking guide forbids outright.
+    ink_span = _INK_SPAN[0] or _row_ink_span(_INK_MAP[0], rect)
+    ink_a = max(ink_span[0] if ink_span else rect.x0, rect.x0)
+    ink_b = min(ink_span[1] if ink_span else rect.x1, rect.x1)
     if ink_b - ink_a < 30.0:
         ink_a, ink_b = rect.x0, rect.x1
     span = max(ink_b - ink_a, 40.0)
@@ -1067,27 +1265,82 @@ def _draw_mark(page: Any, rect: Any, style: str, bounds: Any = None,
                               default=cx) + rng.uniform(6.0, 14.0)
                 cx = shifted if shifted + size <= sheet_x1 - 12.0 else None
             if cx is not None:
-                _draw_tick_or_cross(page, style, cx, cy, size, colour, rng,
-                                    rect, line_x0, line_x1)
-                return
-        left_x = rect.x0 - size - 3
-        if left_x >= sheet_x0:
-            cx = left_x
-        elif rect.x0 > sheet_x0 + 6:
-            cx = sheet_x0
-        else:
-            cx = min(rect.x1 + 4, sheet_x1 - size)
+                box = fitz.Rect(cx - 4, cy - 4, cx + size + 4, cy + size + 4)
+                if _on_paper(_PAPER[0], box):
+                    logger.debug("TICKPLACE site=right style=%s cx=%.1f cy=%.1f size=%.1f "
+                                 "own=%s end_x=%.1f sheet=(%.1f,%.1f) rect=%s",
+                                 style, cx, cy, size, own, end_x, sheet_x0, sheet_x1, rect)
+                    _draw_tick_or_cross(page, style, cx, cy, size, colour, rng,
+                                        rect, line_x0, line_x1)
+                    return
+                logger.debug("tick would fall off the paper; trying the margin")
+        # Fallback placement. Prefer just past the row's MEASURED ink: a tick
+        # belongs beside the words it approves. The row BOX is no guide here -
+        # the layout pins it to the sheet edge on most rows, so the right-hand
+        # test above fails and this fallback used to drop straight to the
+        # sheet's left edge. Measured on one copy that parked 17 of 49 marks
+        # in a single column on the printed margin rule, where a tick renders
+        # as a 3pt vertical bar - the clearest possible tell that no teacher
+        # held the pen, and the MCQ answers beside it got nothing at all.
+        ink_end = own[1] if own else (_INK_SPAN[0][1] if _INK_SPAN[0] else None)
+        cx = None
+        if ink_end is not None and ink_end + 6.0 + size <= sheet_x1 - 12.0:
+            cx = ink_end + rng.uniform(6.0, 14.0)
+        if cx is None:
+            left_x = rect.x0 - size - 3
+            if left_x >= sheet_x0:
+                cx = left_x
+            elif rect.x0 > sheet_x0 + 6:
+                cx = sheet_x0
+            else:
+                cx = min(rect.x1 + 4, sheet_x1 - size)
         cx = max(sheet_x0 + 2.0, min(cx, sheet_x1 - size - 12.0))
         cy = rect.y0 + (rect.height - size) / 2.0
 
+        # A mark is never drawn narrower than its own gesture. When the chosen
+        # spot is not wholly on the paper the strokes are gated away one
+        # segment at a time and what survives is a 2-4pt vertical sliver
+        # against the printed margin rule - measured at 17 of 49 marks on one
+        # copy, with the MCQ answers beside them left unticked. Try the places
+        # a marker would actually use, and if none of them fits, write nothing
+        # here rather than leave a bar.
+        box = fitz.Rect(cx, cy, cx + size, cy + size)
+        if not _on_paper(_PAPER[0], box):
+            spots = []
+            if ink_end is not None:
+                spots.append(ink_end + 6.0)          # just after the words
+            spots.append(rect.x0 - size - 3.0)       # before the first word
+            spots.append(sheet_x1 - size - 12.0)     # the right margin
+            placed = False
+            for trial in spots:
+                trial = max(sheet_x0 + 2.0, min(trial, sheet_x1 - size - 12.0))
+                probe = fitz.Rect(trial, cy, trial + size, cy + size)
+                if _on_paper(_PAPER[0], probe):
+                    cx, placed = trial, True
+                    break
+            if not placed:
+                logger.debug("no room for a whole %s on row %s; skipped rather "
+                             "than drawing a sliver", style, rect)
+                return
+
+        logger.debug("TICKPLACE site=fallback style=%s cx=%.1f cy=%.1f size=%.1f "
+                     "own=%s ink_end=%s sheet=(%.1f,%.1f) rect=%s",
+                     style, cx, cy, size, own, ink_end, sheet_x0, sheet_x1, rect)
         _draw_tick_or_cross(page, style, cx, cy, size, colour, rng, rect,
                             line_x0, line_x1)
         return
 
     # margin_note / region_note / anything unrecognised: underline the span so
-    # the note in the margin has something to point at.
-    _hand_line(page, fitz.Point(line_x0, rect.y1 + 1),
-               fitz.Point(line_x1, rect.y1 + 1), colour, 1.0, rng)
+    # the note in the margin has something to point at - but only a SHORT one.
+    # The marking guide forbids a rule across a whole line, and on a scanned
+    # copy the printed ruling is read as ink, so the measured span can run
+    # the full width of the sheet. A pointer that long is a full-width line by
+    # another name: measured at five per copy. Beyond a third of the sheet, a
+    # comment sits under its row well enough with no pointer at all.
+    sheet_w = (bounds.width if bounds else page.rect.width)
+    if (line_x1 - line_x0) <= sheet_w * 0.34:
+        _hand_line(page, fitz.Point(line_x0, rect.y1 + 1),
+                   fitz.Point(line_x1, rect.y1 + 1), colour, 1.0, rng)
 
 
 def _note_rect(slot, width: float, height: float):
@@ -1131,6 +1384,11 @@ def _free_slot(candidates, occupied, width: float, height: float, page: Any,
         # consecutive lines of the answer.
         if imap is not None and _ink_under(imap, box) > 0.02:
             continue
+        # The paper is the only canvas. A slot that runs off the sheet onto a
+        # bedsheet, a desk or the scanner's white ground is not somewhere a
+        # teacher's pen could have reached.
+        if not _on_paper(_PAPER[0], box):
+            continue
         return x, y_top
     return None
 
@@ -1166,7 +1424,32 @@ def _ink_map(page: Any, sheet: Any) -> Optional[dict]:
         # Per-row background: page 7 of the copy is a dark scan whose median
         # sits below any fixed threshold, which collapsed it to solid ink.
         bg = np.median(band, axis=1, keepdims=True)
-        return {"ink": band < (bg - 45.0), "sx": sx, "sy": sy, "x0": x0}
+        ink = band < (bg - 45.0)
+        # The notebook's own printed ruling is dark too, and on a scan it
+        # reads as ink running edge to edge on every ruled row. Then nothing
+        # downstream can find a blank band or the end of a line: comments
+        # reported "no free band" on every page, ticks were pushed off the
+        # right and parked in the left margin, and a pointer underline ran
+        # the full width of the sheet. A rule is 1-3px tall at this
+        # resolution; the pen is not. A vertical opening keeps only ink at
+        # least a few pixels tall, which drops every rule however it wanders
+        # and keeps the handwriting.
+        try:
+            import cv2
+            kh = max(3, int(round(pix.height / 1170.0 * 4)))
+            ink = cv2.morphologyEx(ink.astype(np.uint8), cv2.MORPH_OPEN,
+                                   np.ones((kh, 1), np.uint8)).astype(bool)
+        except Exception:
+            logger.debug("ruling not removed from the ink map", exc_info=True)
+        # Vertical lines are not writing either: the printed margin rule, and
+        # on a phone scan the dark strip where the page edge meets the
+        # scanner's shadow. That strip read as ink on EVERY row, so each
+        # row's writing appeared to run to the sheet edge, every right-margin
+        # score was pushed off the paper, and every note reported no room.
+        # A column inked down more than 40% of the page is a line, not text.
+        col_cov = ink.mean(axis=0)
+        ink[:, col_cov > 0.40] = False
+        return {"ink": ink, "sx": sx, "sy": sy, "x0": x0}
     except Exception:
         logger.debug("could not measure the ink map", exc_info=True)
         return None
@@ -1193,9 +1476,263 @@ def _row_ink_span(imap: Optional[dict], rect: Any) -> Optional[tuple]:
         if cols.size == 0:
             return None
         sx, off = imap["sx"], imap["x0"]
-        return ((off + int(cols.min())) * sx, (off + int(cols.max())) * sx)
+        # Two pixels of ink at the page edge are not where the line ends. On a
+        # phone scan the printed rule curls where it meets the edge, leaving a
+        # 2pt speck on every row; taking cols.max() then said every line ran
+        # to x=570 and pushed every right-margin score off the paper. Walk the
+        # runs and drop a narrow run that sits far from its nearest neighbour.
+        runs: list[list[int]] = []
+        for c in cols.tolist():
+            if runs and c - runs[-1][1] <= 3:
+                runs[-1][1] = c
+            else:
+                runs.append([c, c])
+        min_w = max(3.0, 5.0 / sx)              # narrower than ~5pt
+        far = 40.0 / sx                          # further than ~40pt away
+        keep = []
+        for i, (a, b) in enumerate(runs):
+            narrow = (b - a + 1) < min_w
+            prev_gap = a - runs[i - 1][1] if i > 0 else float("inf")
+            next_gap = runs[i + 1][0] - b if i + 1 < len(runs) else float("inf")
+            if narrow and min(prev_gap, next_gap) > far:
+                continue
+            keep.append((a, b))
+        if not keep:
+            keep = [(runs[0][0], runs[-1][1])]
+        return ((off + keep[0][0]) * sx, (off + keep[-1][1]) * sx)
     except Exception:
         return None
+
+
+def _paper_quad(rgb: Any) -> Any:
+    """Boolean mask of the notebook paper in a page raster. True = paper.
+
+    Replaces a brightness-and-largest-blob rule that was measured admitting
+    only 14% of the students' OWN handwriting - on three pages of thirteen it
+    admitted nothing at all, so those pages came back unmarked. Two kinds of
+    picture, detected rather than assumed:
+
+      PHOTO  a phone photograph of an open notebook on a bedsheet. Paper is
+             bright AND achromatic; the bedsheet, the cartoon blanket and the
+             hand holding the page are all strongly coloured, so score by
+             lightness minus chroma rather than lightness alone - that is what
+             the old rule got wrong, because a lit patch of blanket outscored
+             a shadowed half of the page. Then fit a convex quadrilateral to
+             the blob and FILL it: an open spread is two quads hinged at the
+             gutter, not one, so a single 4-gon either clips a leaf or swallows
+             a wedge of bedsheet.
+
+      SCAN   a sheet pasted on a white PDF canvas. The sheet's own background
+             is the same pure white as the canvas, so brightness cannot outline
+             it - keeping the non-white pixels returned the handwriting only,
+             which is exactly why the scanned copy came back nearly blank. Take
+             the extent of its content instead.
+
+    The mask must be the whole sheet - gutter, fingers, blank rows between
+    lines - because a blank row with no paper admits no mark on that row.
+    """
+    import numpy as np
+    import cv2
+
+    a = np.clip(np.asarray(rgb), 0, 255).astype(np.uint8)
+    H, W = a.shape[:2]
+
+    # Everything that is not the flat white PDF canvas.
+    v_all = a.mean(axis=2)
+    s_all = a.max(axis=2).astype(int) - a.min(axis=2).astype(int)
+    nw = ~((v_all > 250) & (s_all < 8))
+    ys = np.nonzero(nw.any(axis=1))[0]
+    xs = np.nonzero(nw.any(axis=0))[0]
+    if not ys.size or not xs.size:
+        return np.zeros((H, W), bool)
+    y0, y1, x0, x1 = ys[0], ys[-1] + 1, xs[0], xs[-1] + 1
+    sub = a[y0:y1, x0:x1]
+    if sub.size == 0:
+        return np.zeros((H, W), bool)
+
+    h, w = sub.shape[:2]
+    v = sub.mean(axis=2)
+    s = sub.max(axis=2).astype(int) - sub.min(axis=2).astype(int)
+    out = np.zeros((H, W), bool)
+
+    if float(((v > 250) & (s < 8)).mean()) > 0.35:
+        # SCAN: the sheet is the extent of its own content.
+        #
+        # Restricted to ACHROMATIC content. A scan is grey ruling and blue or
+        # black ink on white, all low-saturation, so this costs nothing here -
+        # but it is what stops the branch handing back the whole frame if a
+        # brightly lit photograph is ever misrouted into it. Taking every
+        # non-white pixel would make a patterned bedsheet part of the sheet
+        # and switch the boundary rule off altogether, silently.
+        content = (v < 250) & (s < 60)
+        # By COVERAGE, never by any(). One stray pixel decides a bounding box:
+        # a single pale anti-aliasing pixel where the sheet meets the
+        # background - measured at RGB(238,180,217), just inside the
+        # achromatic test - stretched this box to the whole frame and made the
+        # bedsheet paper. The same trap caught the "Scanned with ... Scanner"
+        # caption in _photo_bounds. Take the first and last row and column
+        # that carry real content, then fill everything between them, so the
+        # blank paper between two written lines is still paper.
+        rows_ok = np.nonzero(content.mean(axis=1) > 0.01)[0]
+        cols_ok = np.nonzero(content.mean(axis=0) > 0.01)[0]
+        m = np.zeros((h, w), bool)
+        if rows_ok.size and cols_ok.size:
+            m[rows_ok[0]:rows_ok[-1] + 1, cols_ok[0]:cols_ok[-1] + 1] = True
+        out[y0:y1, x0:x1] = m
+        return out
+
+    # PHOTO: paperness = bright and achromatic.
+    lab = cv2.cvtColor(sub, cv2.COLOR_RGB2LAB)
+    L = lab[:, :, 0].astype(np.float32)
+    A = lab[:, :, 1].astype(np.float32) - 128.0
+    B = lab[:, :, 2].astype(np.float32) - 128.0
+    chroma = np.sqrt(A * A + B * B)
+    score = np.clip(L - 2.0 * chroma, -60.0, 255.0)
+    rng = max(1e-6, float(score.max() - score.min()))
+    score = ((score - score.min()) / rng * 255.0).astype(np.uint8)
+
+    thr, _ = cv2.threshold(score, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    # Loosen Otsu: paper in shadow is dim, and losing it costs a whole leaf.
+    bw = (score >= max(1.0, thr - 10)).astype(np.uint8)
+    k = max(3, int(round(min(h, w) * 0.012)) | 1)
+    se = np.ones((k, k), np.uint8)
+    bw = cv2.morphologyEx(bw, cv2.MORPH_CLOSE, se)
+    bw = cv2.morphologyEx(bw, cv2.MORPH_OPEN, se)
+
+    nlab, lbl, stats, _ = cv2.connectedComponentsWithStats(bw, 8)
+    if nlab <= 1:
+        return out
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    big = int(np.argmax(areas)) + 1
+    keep = (lbl == big)
+    for i in range(1, nlab):        # the far leaf of a spread, a lit corner
+        if i != big and stats[i, cv2.CC_STAT_AREA] > 0.08 * areas.max():
+            keep |= (lbl == i)
+
+    def quad(points: Any) -> Any:
+        hull = cv2.convexHull(points)
+        peri = cv2.arcLength(hull, True)
+        for f in np.linspace(0.005, 0.15, 60):
+            ap = cv2.approxPolyDP(hull, f * peri, True)
+            if len(ap) <= 4:
+                if len(ap) == 4:
+                    return ap.reshape(-1, 2).astype(np.int32)
+                break
+        return cv2.boxPoints(cv2.minAreaRect(hull)).astype(np.int32)
+
+    def fill(poly: Any) -> Any:
+        o = np.zeros((h, w), np.uint8)
+        cv2.fillConvexPoly(o, poly, 1)
+        return o
+
+    yy, xx = np.nonzero(keep)
+    if xx.size < 50:
+        return out
+    pts = np.stack([xx, yy], 1).astype(np.int32).reshape(-1, 1, 2)
+    total = float(keep.sum())
+
+    def merit(f: Any) -> float:
+        return float((f & keep).sum() - 0.35 * (f & ~keep).sum()) / total
+
+    best_fill = fill(quad(pts))
+    best = merit(best_fill.astype(bool))
+    # Sweep the gutter: two quads beat one whenever the picture is a spread.
+    for c in np.linspace(0.12 * w, 0.88 * w, 35):
+        left = pts[pts[:, 0, 0] < c].reshape(-1, 1, 2)
+        right = pts[pts[:, 0, 0] >= c].reshape(-1, 1, 2)
+        if len(left) < 80 or len(right) < 80:
+            continue
+        f = fill(quad(left)) | fill(quad(right))
+        m = merit(f.astype(bool))
+        if m > best:
+            best, best_fill = m, f
+
+    grown = best_fill.astype(bool) | keep
+    d = max(1, int(round(6 * min(h, w) / 264.0)))
+    grown = cv2.dilate(grown.astype(np.uint8),
+                       np.ones((2 * d + 1, 2 * d + 1), np.uint8)).astype(bool)
+
+    # A page that runs off the picture is cut by the frame, not by its edge.
+    snap = int(round(0.03 * max(h, w)))
+    if snap > 0:
+        for r in range(h):
+            c = np.nonzero(grown[r])[0]
+            if not c.size:
+                continue
+            if c[-1] >= w - 1 - snap:
+                grown[r, c[-1]:] = True
+            if c[0] <= snap:
+                grown[r, :c[0]] = True
+        for c in np.nonzero(grown.any(axis=0))[0]:
+            rr = np.nonzero(grown[:, c])[0]
+            if rr[0] <= snap:
+                grown[:rr[0], c] = True
+            if rr[-1] >= h - 1 - snap:
+                grown[rr[-1]:, c] = True
+
+    out[y0:y1, x0:x1] = grown
+    return out
+
+
+def _paper_rows(page: Any) -> Optional[dict]:
+    """The notebook page's own boundary for this page.
+
+    Returns the paper MASK plus, for callers that still want them, the
+    per-raster-row spans. The mask is what the gate should test: a span is one
+    horizontal interval per row, which cannot describe a page photographed at
+    an angle - at the top and bottom of a tilted sheet the interval reaches
+    past the corners and over the bedsheet beside them.
+    """
+    try:
+        import numpy as np
+
+        pix = page.get_pixmap(dpi=40)
+        a = np.frombuffer(pix.samples, np.uint8).reshape(
+            pix.height, pix.width, pix.n)[:, :, :3].astype(int)
+        H, W = a.shape[:2]
+        mask = _paper_quad(a)
+        if not mask.any():
+            return None
+
+        sx, sy = page.rect.width / W, page.rect.height / H
+        lo = np.full(H, -1.0); hi = np.full(H, -1.0)
+        for r in range(H):
+            cols = np.nonzero(mask[r])[0]
+            if cols.size:
+                lo[r], hi[r] = cols.min() * sx, (cols.max() + 1) * sx
+        if not (hi > 0).any():
+            return None
+        return {"lo": lo, "hi": hi, "sy": sy, "sx": sx,
+                "rows": H, "cols": W, "mask": mask}
+    except Exception:
+        logger.debug("could not measure the paper boundary", exc_info=True)
+        return None
+def _on_paper(paper: Optional[dict], box: Any) -> bool:
+    """True only if every row the box covers is paper for its full width."""
+    if not paper:
+        return True
+    lo, hi, sy = paper["lo"], paper["hi"], paper["sy"]
+    r0 = max(0, min(paper["rows"] - 1, int(box.y0 / sy)))
+    r1 = max(r0 + 1, min(paper["rows"], int(box.y1 / sy) + 1))
+    mask = paper.get("mask")
+    if mask is not None:
+        # The same 1pt slack the span test below allows. The mask is measured
+        # at 40dpi, so one cell is ~1.8pt: without slack a row box pinned 0.3pt
+        # past the sheet edge - a third of one cell, and far less than the
+        # width of the pen - is called off-paper, which rejected nine of the
+        # twenty-four lines on one scanned page.
+        sx, sy = paper["sx"], paper["sy"]
+        r0 = max(0, min(paper["rows"] - 1, int((box.y0 + _PAPER_TOL) / sy)))
+        r1 = max(r0 + 1, min(paper["rows"], int((box.y1 - _PAPER_TOL) / sy) + 1))
+        c0 = max(0, min(paper["cols"] - 1, int((box.x0 + _PAPER_TOL) / sx)))
+        c1 = max(c0 + 1, min(paper["cols"], int((box.x1 - _PAPER_TOL) / sx) + 1))
+        return bool(mask[r0:r1, c0:c1].all())
+    for r in range(r0, r1):
+        if hi[r] <= 0:
+            return False                       # no paper at all on this row
+        if box.x0 < lo[r] - 1.0 or box.x1 > hi[r] + 1.0:
+            return False
+    return True
 
 
 def _photo_bounds(page: Any) -> Optional[Any]:
@@ -1233,6 +1770,19 @@ def _photo_bounds(page: Any) -> Optional[Any]:
         rows = np.nonzero(row_cov > 0.5)[0]
         cols = np.nonzero(col_cov > 0.5)[0]
         if rows.size == 0 or cols.size == 0:
+            return None
+        # A page is never a sliver. On a SCAN the sheet is the same white as
+        # the canvas, so the only column more than half non-white is the
+        # printed pink margin rule - and this returned a 3pt-wide "photograph"
+        # at x=84. Intersected with the sheet, that gave every mark on the
+        # page a zero-width home: 17 of 49 ticks were clamped onto the rule and
+        # rendered as vertical bars, while the MCQ answers beside them got
+        # nothing. The validation above was on photographs only. When the
+        # bound is narrower than a quarter of the frame it has found a rule,
+        # not a page; say so and let the caller fall back to the ink box.
+        if (cols.max() + 1 - cols.min()) < 0.25 * pix.width:
+            logger.debug("photo bound %.0f-%.0fpx is a rule, not a page; ignoring",
+                         float(cols.min()), float(cols.max()))
             return None
         sx, sy = page.rect.width / pix.width, page.rect.height / pix.height
         return fitz.Rect(float(cols.min()) * sx, float(rows.min()) * sy,
@@ -1389,8 +1939,8 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
     scale = _pen_scale(_handwriting_fontfile())
     obstacles = list(occupied or [])
 
-    def wrap(size: float, max_w: float) -> list:
-        words, lines, cur = note.split(), [], ""
+    def wrap(size: float, max_w: float, text: Optional[str] = None) -> list:
+        words, lines, cur = (note if text is None else text).split(), [], ""
         for w in words:
             trial = (cur + " " + w).strip()
             if _text_width(trial, fontname, size, measure_font) * _ADVANCE_SLACK <= max_w:
@@ -1414,6 +1964,15 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
     ideal = max(11.0 * scale, min(base_size, 15.0 * scale))
     floor = 9.0 * scale
     attempt = 0
+    # The ladder above keeps a remark whole and keeps it near its answer, and
+    # refuses a placement that would cost either. That is right until refusing
+    # means writing nothing: a comment that never reaches the page takes the
+    # reason for the deduction with it, and the student is left holding a mark
+    # with no explanation - measured here as a 90-character note silently
+    # dropped while 428pt of blank paper sat below it. So when the ladder is
+    # exhausted, drop both conditions - one short line, anywhere blank on the
+    # sheet - and give up only if the page truly has no room.
+    desperate = False
     while True:
         size = max(floor, ideal - attempt * 0.75)
         # Widening the column is cheaper than shrinking the hand: it costs
@@ -1437,7 +1996,7 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
         # Fewer lines as the search gets desperate: a gap two lines tall is
         # far commoner than one three lines tall, and a one-line note that is
         # actually on the page beats a three-line note that is not.
-        cap = 3 if attempt < 2 else (2 if attempt < 5 else 1)
+        cap = 1 if desperate else (3 if attempt < 2 else (2 if attempt < 5 else 1))
         wrapped_all = wrap(size, max_w)
         # Taking the first `cap` lines and discarding the rest is how
         # "s.18: partner is agent of the firm" reached the page as
@@ -1449,19 +2008,25 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
             kept = " ".join(wrapped_all[:cap]).rstrip(" ,;:-")
             while " " in kept and kept.rsplit(" ", 1)[-1].lower() in _DANGLING:
                 kept = kept.rsplit(" ", 1)[0].rstrip(" ,;:-")
-            if len(kept) < len(note) * 0.55:
+            if len(kept) < len(note) * 0.55 and not desperate:
                 attempt += 1
                 if attempt > 8:
-                    logger.debug("nowhere to write a whole remark near %s", rect)
-                    return None
+                    logger.debug("nowhere to write a whole remark near %s"
+                                 " - shortening it instead of dropping it", rect)
+                    desperate, attempt = True, 0
                 continue
-            lines = wrap(size, max_w)[:cap]
+            # Re-wrap the SHORTENED remark rather than slicing the full one:
+            # slicing is what turned "s.18: partner is agent of the firm" into
+            # "s.18 partner is".
+            lines = wrap(size, max_w, kept)[:cap]
         else:
             lines = wrapped_all
         if not lines:
             attempt += 1
             if attempt > 8:
-                return None
+                if desperate:
+                    return None
+                desperate, attempt = True, 0
             continue
         widest = max(_text_width(l, fontname, size, measure_font) for l in lines)
         # Reserve what will actually be drawn. The block reaches a `lift` above
@@ -1475,7 +2040,10 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
         # either gets refused or lands on the answer. Short lines still climb
         # steeply; long ones flatten, exactly as a hand does.
         band_lift = min(widest * math.tan(math.radians(climb)), size * 0.6)
-        line_h = size * 1.3 + band_lift
+        # The pen's Kalam is ~1.9 sizes tall from ascender to descender; the
+        # vector face this ladder was tuned for was 1.3. Reserve what will be
+        # inked, or the band search clears a strip the note then overruns.
+        line_h = size * (1.9 if _PEN[0] is not None else 1.3) + band_lift
         height = line_h * len(lines) + 4.0 + band_lift
         # Prefer what the page itself says is written over what the layout
         # map guessed; fall back to the boxes when no map was measured.
@@ -1497,11 +2065,16 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
         # ended up with "Riskraiehddes fadmerobbilipbeitySPBskeasivpedge".
         blockers = list(measured_bands or obstacles) + list(_PLACED[0] or [])
         band = _free_band(sheet, blockers, height, rect.y1, floor_y=floor_y,
-                          max_dist=sheet.height * 0.30)
+                          max_dist=None if desperate else sheet.height * 0.30)
         if band is not None:
             break
         attempt += 1
         if size <= floor and attempt > 6:
+            if not desperate:
+                # Near the answer is a preference. On the page at all is not.
+                logger.debug("no free band near %s - searching the whole sheet", rect)
+                desperate, attempt = True, 0
+                continue
             logger.debug("no free band on page for pen note near %s", rect)
             return None
 
@@ -1530,7 +2103,11 @@ def _write_in_free_band(page: Any, rect: Any, note: str, occupied: Optional[list
                   rise=math.degrees(math.atan(band_lift / max(widest, 1.0))),
                   tilt=note_tilt)
     # Recorded exactly as reserved: anchor minus the lift, for the full height.
-    return _note_rect((x0, y0 - band_lift), width, height)
+    placed_box = _note_rect((x0, y0 - band_lift), width, height)
+    if not _on_paper(_PAPER[0], placed_box):
+        logger.debug("free band lies off the paper; leaving the note out")
+        return None
+    return placed_box
 
 
 def _strip_note(page: Any, rect: Any, note: str, occupied: Optional[list],
@@ -1596,6 +2173,167 @@ def _strip_note(page: Any, rect: Any, note: str, occupied: Optional[list],
     return None
 
 
+def _pen_text_width(text: str, size: float) -> float:
+    """Width in points of `text` as the copy's pen will write it."""
+    pen = _PEN[0]
+    if pen is not None:
+        try:
+            from PIL import ImageFont
+            px = max(6, int(round(size * _PEN_SCALE * 1.18)))
+            return ImageFont.truetype(pen.font_path, px).getlength(text) * 1.08 / _PEN_SCALE
+        except Exception:
+            pass
+    return 0.55 * size * max(1, len(text))
+
+
+def _place_by_contract(page: Any, rect: Any, style: str, note: str, position: Optional[str],
+                       sheet: Any, occupied: Optional[list]) -> Optional[Any]:
+    """Write `note` where the marking guide's placement says, or return None.
+
+    The renderer contract, in points:
+      right_margin  x = sheet right edge - 7% of the page width, level with the row
+      left_margin   right-aligned just before the row's first ink
+      below_line    x = row's first ink, one line below, wrapped at the right margin
+      right_of_line just past the row's last ink, level with it
+    enforce.py guarantees every score is right_margin on the answer's last row
+    and every deduction note is below_line; the free-space search that placed
+    them before put scores in whichever margin had room, which on one copy was
+    the left one for every question. A spot the contract names is used only
+    if it is on the paper and clear of the student's writing; otherwise the
+    caller falls back to the search, so nothing is dropped for being tidy.
+    """
+    import fitz
+
+    from .validator import VALID_POSITIONS
+
+    if not note or position not in VALID_POSITIONS:
+        return None
+    sheet = sheet or page.rect
+    page_w = page.rect.width
+    # Size from the PAGE's line height, never the target row's: a merged
+    # "Q16. Ans. (c)" row was twice as tall as its neighbours, and the note
+    # hung on it came out twice the size of the note two lines above and
+    # wrapped onto a second line. One hand writes at one size.
+    h = _LINE_H[0] or max(rect.height, 12.0)
+    own = _row_ink_span(_INK_MAP[0], rect)
+    ink_a = own[0] if own else rect.x0
+    ink_b = own[1] if own else min(rect.x1, ink_a + 0.6 * sheet.width)
+    is_score = style in ("score", "total")
+    size = max(11.0, min(24.0, h * (1.4 if is_score else 1.1)))
+    base_y = rect.y0 + rect.height * 0.5 + size * 0.35
+    notes = list(_PLACED[0] or [])
+
+    def clear(box: Any) -> bool:
+        why = None
+        if not _on_paper(_PAPER[0], box):
+            why = "off paper"
+        elif _CLIP[0] is not None and not _CLIP[0].contains(box):
+            why = f"outside clip {_CLIP[0]}"
+        elif _ink_under(_INK_MAP[0], box) > 0.03:
+            why = f"ink under {_ink_under(_INK_MAP[0], box):.2f}"
+        elif any(box.intersects(n) for n in notes):
+            why = "collides with a placed note"
+        if why:
+            logger.debug("CONTRACT %s %r at %s refused: %s", position, note[:20], box, why)
+            return False
+        return True
+
+    lines: list[tuple[str, float, float]] = []      # (text, x0, baseline)
+    if position in ("right_margin_same_line", "right_of_line"):
+        width = _pen_text_width(note, size)
+        if position == "right_margin_same_line":
+            x0 = sheet.x1 - page_w * 0.07 - width
+        else:
+            x0 = ink_b + 6.0
+        # Keep clear of the row's writing - but only when that writing was
+        # actually measured. The layout's row box is pinned to the sheet edge
+        # on merged rows, and trusting it pushed scores off the paper.
+        if own:
+            x0 = max(x0, ink_b + 6.0)
+        if x0 + width > sheet.x1 - 3.0:
+            size = max(10.0, size * (sheet.x1 - 3.0 - x0) / max(width, 1.0))
+            width = _pen_text_width(note, size)
+        lines = [(note, x0, base_y)]
+    elif position == "left_margin_same_line":
+        width = _pen_text_width(note, size)
+        x0 = max(sheet.x0 + 3.0, ink_a - 6.0 - width)
+        if x0 + width > ink_a - 3.0:
+            size = max(9.0, size * (ink_a - 3.0 - x0) / max(width, 1.0))
+            width = _pen_text_width(note, size)
+        lines = [(note, x0, base_y)]
+    elif position == "below_line_left":
+        size = max(10.0, min(20.0, h * 1.1))
+        # Fit the note to the GAP under the row, not to the row. A 20pt note
+        # dropped into a 20pt gap fills it edge to edge and the pen's own
+        # wobble lands on the next line - "Wrong option. Correct: (c)" was
+        # written across the student's Q3. Measure the gap from the page's
+        # ink; if there is not room for a legible line, say so and let the
+        # caller find another spot.
+        gap = None
+        try:
+            bands = _ink_bands(_INK_MAP[0], sheet) or []
+            below = [b.y0 for b in bands if b.y0 > rect.y1 + 2.0 and b.width > sheet.width * 0.15]
+            if below:
+                gap = min(below) - rect.y1
+        except Exception:
+            gap = None
+        # Geometry, not statistics: the note's inked footprint runs from
+        # ~1.05 sizes above its baseline to ~0.45 below (Kalam, 1.18x, with
+        # wobble). Every line of it must end above the next line of writing.
+        # The ink-fraction test let a note graze the ascenders of the row
+        # below because ascenders are sparse; a teacher's eye does not.
+        # Measured on the pen itself: Kalam inks ~0.95 sizes above the
+        # baseline and up to ~0.95 below (deep descenders plus the pen's own
+        # jitter) - a footprint 1.9x the nominal size, not the 1.5x of a
+        # print face.
+        if gap is not None:
+            if gap < 14.0:
+                return None
+            size = max(9.0, min(size, (gap - 3.0) / 1.9))
+        x0 = max(sheet.x0 + 6.0, ink_a)
+        max_w = (sheet.x1 - page_w * 0.05) - x0
+        words, cur, wrapped = note.split(), "", []
+        for w in words:
+            trial = (cur + " " + w).strip()
+            if _pen_text_width(trial, size) <= max_w or not cur:
+                cur = trial
+            else:
+                wrapped.append(cur); cur = w
+        if cur:
+            wrapped.append(cur)
+        wrapped = wrapped[:2]
+        if gap is not None and len(wrapped) > 1 and gap < size * 1.9 * 2 + 3.0:
+            wrapped = wrapped[:1]          # one line is all that fits
+        y = rect.y1 + 2.0 + size * 0.95    # top of the ink just under the row
+        if gap is not None and y + size * 0.95 > rect.y1 + gap - 1.0:
+            return None
+        for i, t in enumerate(wrapped):
+            lines.append((t, x0, y + i * size * 1.5))
+    else:
+        return None
+
+    boxes = []
+    for t, x0, by in lines:
+        w = _pen_text_width(t, size)
+        # the pen writes Kalam at 1.18x the nominal size with a little
+        # baseline wobble; test the footprint that is actually inked
+        # Digits have no descenders: a score's ink is ~0.85 above the
+        # baseline to ~0.35 below. Reserving a full text footprint for it
+        # made every score two rows tall and "collide" with its neighbour.
+        up, down = (0.85, 0.35) if is_score else (1.0, 1.0)
+        boxes.append(fitz.Rect(x0 - 1.0, by - size * up, x0 + w + 1.0, by + size * down))
+    if not boxes or not all(clear(b) for b in boxes):
+        return None
+    rng = _hand_rng("contract", style, note[:24], round(rect.y0, 1))
+    for t, x0, by in lines:
+        _pen_text(page, fitz.Point(x0, by), t, size, _NOTE_TEXT, rng,
+                  slant=rng.uniform(-3.0, 3.0), max_x=sheet.x1 - 2.0)
+    placed = boxes[0]
+    for b in boxes[1:]:
+        placed = placed | b
+    return placed
+
+
 def _place_note(page: Any, rect: Any, style: str, note: str,
                 occupied: Optional[list] = None, sheet: Any = None) -> None:
     """Write the pen note somewhere it can actually be read.
@@ -1657,7 +2395,11 @@ def _place_note(page: Any, rect: Any, style: str, note: str,
     # Sized against the student's own writing. The row band is taller than the
     # letters in it (roughly 2x), so a note at ~1.0 of the band lands near the
     # 1.2-1.8x of the HANDWRITING the marking guide asks for.
-    base_size = max(13.0, min(26.0, rect.height * 1.0)) * scale
+    # ...but against the PAGE's line height when that is known, never the one
+    # row this note happens to hang on: a merged two-line row made one note
+    # twice the size of its neighbours, wrapped over two lines.
+    row_h = _LINE_H[0] if _LINE_H[0] else rect.height
+    base_size = max(13.0, min(26.0, row_h * 1.0)) * scale
     occupied = occupied or []
     # The marked row itself is not an obstacle for a note that sits beside it.
     obstacles = [o for o in occupied if not o.intersects(rect) or o != rect]
@@ -1885,8 +2627,8 @@ def _place_note(page: Any, rect: Any, style: str, note: str,
     # ink to `obstacles` did not reach it - and this is the path that was
     # laying comments straight across the student's paragraph. Check the
     # writing here as well as the comments already placed.
-    if _ink_under(_INK_MAP[0], box) > 0.02:
-        logger.debug("column slot sits on the student's writing; using blank paper")
+    if _ink_under(_INK_MAP[0], box) > 0.02 or not _on_paper(_PAPER[0], box):
+        logger.debug("column slot is on the writing or off the paper; using blank paper")
         return _write_in_free_band(page, rect, note, occupied, sheet,
                                    fontname, base_size, measure_font)
     for other in (_PLACED[0] or []):
@@ -1994,6 +2736,37 @@ def _draw_score_badge(page: Any, centre: Any, awarded: float, out_of: Optional[f
     while size > radius * 0.46 and _text_width(inline, badge_font, size, badge_measure) > radius * 1.55:
         size -= 0.5
     centred(inline, centre.y + radius * 0.30, size)
+
+
+def _draw_grand_total(page: Any, centre: Any, awarded: float, out_of: float,
+                      line_h: float) -> None:
+    """The copy's total, the way the marking guide asks for it.
+
+    "awarded/max", large, with a hand-thrown loop round it, below the Page No
+    box on page one. Unlike the per-question badge this ALWAYS shows the
+    denominator and ALWAYS carries a ring: the guide is explicit, and a bare
+    "24" in the corner of a 30-mark paper read as a page number.
+
+    The ring is sized to the digits, not the digits to the ring: fitting text
+    into a fixed circle shrank "24/30" to 16pt inside a 50pt loop, and the
+    loop, not the mark, was what the eye landed on.
+    """
+    import fitz
+
+    text = _latin1(f"{_fmt_marks(awarded)}/{_fmt_marks(out_of)}")
+    if _PEN[0] is not None and _pen_total_overlay(page, centre, text, line_h * 1.45) is not None:
+        return
+    font, measure = _digit_pen(page)
+    rng = _hand_rng("grand-total", round(centre.x, 1), round(centre.y, 1), text)
+    size = line_h * 1.45                          # digits ~1.5 lines tall
+    width = _text_width(text, font, size, measure)
+    rx = width / 2.0 + size * 0.42
+    ry = size * 0.80                              # overall ~2.3 lines tall
+    _hand_oval(page, fitz.Rect(centre.x - rx, centre.y - ry, centre.x + rx, centre.y + ry),
+               _WRONG, 1.9, rng)
+    _hand_text(page, fitz.Point(centre.x - width / 2.0, centre.y + size * 0.34),
+               text, font, size, _WRONG, rng, font=measure,
+               slant=rng.uniform(-3.0, 3.0))
 
 
 def page_id_for(order: Optional[dict], page_no: int) -> Optional[str]:
@@ -2267,6 +3040,7 @@ def build_annotated_pdf(
     _INK_MAP[0] = None
     _PLACED[0] = None
     _ROW_SLOPE[0] = 0.0
+    _PEN[0] = _pen_for(pdf_bytes)
 
     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
 
@@ -2413,9 +3187,11 @@ def build_annotated_pdf(
     # Measured once per page, before a single mark is drawn: our own ink would
     # otherwise widen every span we then try to avoid.
     ink_maps: dict[str, Any] = {}
+    paper_rows: dict[str, Any] = {}
     for pid, page_no in (order or {}).items():
         if 0 <= page_no < doc.page_count:
             ink_maps[pid] = _ink_map(doc[page_no], paper.get(pid))
+            paper_rows[pid] = _paper_rows(doc[page_no])
 
     drawn = 0
     # question_number -> (page_no, y) of its lowest annotation, so the circled
@@ -2440,6 +3216,19 @@ def build_annotated_pdf(
                  "brace": 3, "underline": 4, "feedback": 5, "margin_note": 5,
                  "region_note": 5, "tick": 6}
     ordered: list = []
+    total_override: list = [None]      # a 'total' annotation, if enforce.py sent one
+    # A page's typical line height: the median of its row boxes, in points.
+    # Notes and scores are sized from this so one page is written in one hand.
+    line_h_by_page: dict[str, float] = {}
+    for lp in layout_map.get("pages") or []:
+        pid_ = lp.get("page_id"); wh_ = dims.get(pid_); pn_ = order.get(pid_)
+        if not wh_ or pn_ is None or pn_ >= doc.page_count:
+            continue
+        sy_ = content.get(pn_, doc[pn_].rect).height / wh_[1]
+        hs_ = sorted(float(l["box"][3]) * sy_ for l in (lp.get("lines") or [])
+                     if l.get("box") and len(l["box"]) == 4 and float(l["box"][3]) > 0)
+        if hs_:
+            line_h_by_page[pid_] = max(10.0, min(30.0, hs_[len(hs_) // 2]))
     for verdict in verdicts:
         for ann in verdict.get("annotations") or []:
             ordered.append((verdict, ann))
@@ -2466,6 +3255,17 @@ def build_annotated_pdf(
             sy = crect.height / layout_wh[1]
             x, y, w, h = (float(v) for v in target["box"])
             rect = fitz.Rect(x * sx, y * sy, (x + w) * sx, (y + h) * sy)
+            # A mark is never drawn narrower than 0.8x the row height. Some
+            # rows are slivers - a label-only row like "Q15", or a stray OCR
+            # box - and a tick sized to one renders as a vertical bar sitting
+            # against the printed margin rule, which is the single clearest
+            # tell that no teacher held the pen. Widen about the centre and
+            # keep it inside the page content.
+            min_w = rect.height * 0.8
+            if 0 < rect.width < min_w:
+                grow = (min_w - rect.width) / 2.0
+                rect = fitz.Rect(max(crect.x0, rect.x0 - grow), rect.y0,
+                                 min(crect.x1, rect.x1 + grow), rect.y1)
 
             _CLIP[0] = paper.get(page_id)
             _SHADE[0] = shade_by_page.get(page_id)
@@ -2478,6 +3278,8 @@ def build_annotated_pdf(
             # of every page, so it reported no free space anywhere. Measure it.
             _INK_MAP[0] = ink_maps.get(page_id)
             _PLACED[0] = occupied.setdefault(page_id + ":notes", [])
+            _PAPER[0] = paper_rows.get(page_id)
+            _LINE_H[0] = line_h_by_page.get(page_id)
             _MARGIN_X[0] = (content.get(page_no, page.rect).x1
                             if margin_ratio > 0.0 else None)
             measured = _row_ink_span(_INK_MAP[0], rect)
@@ -2491,6 +3293,12 @@ def build_annotated_pdf(
                 rect = fitz.Rect(rect.x0, rect.y0, rect.x1,
                                  max(rect.y1, float(ink_bottom) * sy))
             style = (ann.get("style") or "margin_note").strip().lower()
+            if style == "total":
+                # enforce.py's grand total: drawn once, below the Page No box,
+                # by the block after this loop - never as a row annotation.
+                if ann.get("text"):
+                    total_override[0] = str(ann["text"])
+                continue
             if style in ("underline", "strike", "strikethrough"):
                 # Band the y so two row ids on the same visual line collapse.
                 key = (page_no, round(rect.y0 / 9.0))
@@ -2526,7 +3334,12 @@ def build_annotated_pdf(
             if note:
                 page_boxes = occupied.setdefault(page_id, [])
                 sheet_r = paper.get(page_id)
-                placed = _place_note(page, rect, style, note, page_boxes, sheet_r)
+                # The guide's placement first; the free-space search only when
+                # that spot is off the paper or on the student's writing.
+                placed = _place_by_contract(page, rect, style, note,
+                                            ann.get("position"), sheet_r, page_boxes)
+                if placed is None:
+                    placed = _place_note(page, rect, style, note, page_boxes, sheet_r)
 
             _draw_mark(page, rect, style, paper.get(page_id),
                        has_note=placed is not None)
@@ -2559,6 +3372,14 @@ def build_annotated_pdf(
         import fitz
         total = sum(float(v.get("marks_awarded") or 0) for v in verdicts)
         out_of = sum(float(v.get("max_marks") or 0) for v in verdicts)
+        if total_override[0] and "/" in total_override[0]:
+            # enforce.py computes the total against the PAPER's maximum, not
+            # the sum of the questions that happened to be graded.
+            try:
+                a_txt, m_txt = total_override[0].split("/", 1)
+                total, out_of = float(a_txt), float(m_txt)
+            except ValueError:
+                pass
         first = doc[0]
         # Inside the SHEET's top-right corner, not the PDF page's. Hard-coding
         # page.width - 46 put the most prominent mark on the whole script -
@@ -2567,12 +3388,36 @@ def build_annotated_pdf(
         first_id = next((pid for pid, idx in order.items() if idx == 0), None)
         sheet0 = paper.get(first_id)
         _CLIP[0] = sheet0
+        _PAPER[0] = paper_rows.get(first_id)
+        # The marking guide's total: "awarded/max", hand-circled, about 2.3x
+        # the line height, just below the Page No box. The earlier badge sat
+        # 34pt from the sheet edge with a 22pt ring, so on a scan the ring and
+        # the "/30" fell past the paper and were gated away, leaving a bare
+        # "24" - the most prominent mark on the script, and it read as a
+        # page number. Size it from the page's own rows and keep the whole
+        # thing inside the sheet.
+        line_h = 22.0
+        try:
+            lp0 = next((p for p in layout_map.get("pages") or []
+                        if p.get("page_id") == first_id), None)
+            if lp0 and lp0.get("lines"):
+                wh0 = dims.get(first_id)
+                pr0 = content.get(0, first.rect)
+                sy0 = pr0.height / wh0[1] if wh0 else 1.0
+                hs = sorted(float(l["box"][3]) * sy0 for l in lp0["lines"]
+                            if l.get("box") and len(l["box"]) == 4 and float(l["box"][3]) > 0)
+                if hs:
+                    line_h = max(14.0, min(40.0, hs[len(hs) // 2]))
+        except Exception:
+            logger.debug("could not size the total from the rows", exc_info=True)
+        # Half-width of the ring, to keep the whole mark inside the sheet.
+        half_w = line_h * 1.45 * 0.62 * 2.6
         if sheet0 is not None:
-            bx = sheet0.x1 - 34.0
-            by = sheet0.y0 + 34.0
+            bx = sheet0.x1 - half_w - 14.0
+            by = sheet0.y0 + 62.0 + line_h * 1.2    # below the Page No / Date box
         else:
-            bx, by = first.rect.width - 46, 52
-        _draw_score_badge(first, fitz.Point(bx, by), total, out_of, radius=22.0)
+            bx, by = first.rect.width - half_w - 24.0, 62.0 + line_h * 1.2
+        _draw_grand_total(first, fitz.Point(bx, by), total, out_of, line_h)
 
     _CLIP[0] = None
     if append_summary:

--- a/ai_service/app/services/copy_check/enforce.py
+++ b/ai_service/app/services/copy_check/enforce.py
@@ -1,0 +1,304 @@
+"""enforce.py — makes copy-check behaviour correct regardless of what the model returns.
+
+Run this between the grader and the renderer:
+
+    fixed = enforce(results, layout_map, questions, paper_max=36)
+    render(fixed.annotations)          # + fixed.total, fixed.report
+
+A prompt can ask the model for exactly one score per question; it cannot guarantee it.
+This module guarantees it. For every graded question it:
+
+  1. Resolves every annotation to a REAL row id. If `target` does not exist, it finds the row
+     whose text best matches `anchor_text` (fuzzy). If that fails, the annotation is dropped
+     and logged - never drawn "somewhere".
+  2. Forces exactly ONE score per attempted/cancelled question: text "x/max", placement
+     right_margin, on the LAST row of the answer. Extra scores removed; missing score added.
+  3. Forces ONE deduction note if awarded < max (from the model's note, else from
+     criteria_breakdown reason, else from feedback). Placement below_line on the last row,
+     left_margin only if that row is the last on its page.
+  4. Removes praise on MCQ/short answers and on any partial answer; keeps at most one note
+     otherwise.
+  5. Cancelled attempt -> 0/max + "Attempt cancelled by student."
+  6. Moves any score placed left_margin / below_line to right_margin.
+  7. Computes the grand total from marks_awarded and the PAPER max (not the sum of graded
+     questions), and emits the `total` annotation for page 1.
+  8. Returns a report listing everything it changed and every question that ended with no ink,
+     so the pipeline can fail loudly instead of shipping a half-checked copy.
+
+Inputs
+  results:    list of grader outputs, one per question, each with question_id/paper_label,
+              marks_awarded, annotations[], answer_rows[], criteria_breakdown[], feedback.
+  layout_map: {"pages":[{"page_id":"p1","lines":[{"line_id":"p1_r1","text":"..."}, ...]}]}
+  questions:  list of {"question_id":..., "paper_label":..., "max_marks":..., "question_type":...}
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+SHORT_TYPES = {"MCQ", "ONE_WORD", "SHORT_ANSWER", "FILL_BLANK", "TRUE_FALSE"}
+PRAISE = re.compile(r"^(good|well|excellent|nice|correct|very good|well done|well explained|option correct)[.! ]*$", re.I)
+
+
+@dataclass
+class Result:
+    annotations: list[dict[str, Any]]
+    total: dict[str, Any] | None
+    report: list[str] = field(default_factory=list)
+    unmarked: list[str] = field(default_factory=list)
+
+
+def _rows(layout_map: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for page in layout_map.get("pages") or []:
+        lines = page.get("lines") or []
+        for i, line in enumerate(lines):
+            out[str(line.get("line_id"))] = {
+                "page_id": str(page.get("page_id")),
+                "text": (line.get("text") or "").strip(),
+                "last_on_page": i == len(lines) - 1,
+                "index": i,
+            }
+    return out
+
+
+def _resolve(target: str | None, anchor: str | None, page_hint: str | None,
+             rows: dict[str, dict[str, Any]], report: list[str], tag: str) -> str | None:
+    if target and target in rows:
+        return target
+    if not anchor:
+        report.append(f"{tag}: dropped - bad target {target!r} and no anchor_text")
+        return None
+    cands = [(rid, r) for rid, r in rows.items() if not page_hint or r["page_id"] == page_hint] or list(rows.items())
+    best, best_score = None, 0.0
+    a = anchor.lower()
+    for rid, r in cands:
+        t = r["text"].lower()
+        if not t:
+            continue
+        s = difflib.SequenceMatcher(None, a, t).ratio()
+        if a in t or t in a:
+            s = max(s, 0.9)
+        if s > best_score:
+            best, best_score = rid, s
+    if best and best_score >= 0.55:
+        report.append(f"{tag}: target {target!r} not found, re-anchored to {best} ({best_score:.2f})")
+        return best
+    report.append(f"{tag}: dropped - no row matches anchor {anchor!r}")
+    return None
+
+
+def _fmt(x: float) -> str:
+    return f"{x:g}"
+
+
+def enforce(results: list[dict[str, Any]], layout_map: dict[str, Any],
+            questions: list[dict[str, Any]], paper_max: float | None = None,
+            first_page_id: str | None = None) -> Result:
+    rows = _rows(layout_map)
+    qmeta = {str(q.get("question_id")): q for q in questions}
+    qmeta.update({str(q.get("paper_label")): q for q in questions if q.get("paper_label")})
+    out: list[dict[str, Any]] = []
+    report: list[str] = []
+    unmarked: list[str] = []
+    awarded_sum = 0.0
+    seen_praise = 0
+
+    for res in results:
+        qid = str(res.get("paper_label") or res.get("question_id"))
+        q = qmeta.get(qid, {})
+        qtype = str(q.get("question_type") or res.get("question_type") or "").upper()
+        mx = float(q.get("max_marks") or res.get("max_marks") or 0)
+        awarded = float(res.get("marks_awarded") or 0)
+        key = str(q.get("correct_answer") or "").strip().lower()
+        if qtype in SHORT_TYPES and key and res.get("extracted_answer"):
+            # The option the student CHOSE, read strictly: a bracketed letter
+            # "(b)", "Ans (B)", or the answer being a bare letter. A
+            # startswith() test on a one-letter key matched the "A" of
+            # "(A) is false but (R) is true" against key "a" and gave a wrong
+            # assertion-reason answer full marks.
+            ext = str(res["extracted_answer"]).strip()
+            m_opt = (re.search(r"(?:ans\.?|answer|option)\s*[:\-]?\s*\(?\s*([a-dA-D])\s*\)?(?![a-z])", ext, re.I)
+                     or re.fullmatch(r"\s*(?:[Qq]\s*\d+\.?\s*)?\(?([a-dA-D])\)?\.?\s*", ext)
+                     or (len(ext) <= 20 and re.search(r"\(([a-dA-D])\)\s*\.?\s*$", ext)))
+            chosen = m_opt.group(1).lower() if m_opt else None
+            keyn = re.sub(r"[^a-z0-9]", "", key)
+            if chosen and keyn and chosen == keyn:
+                if awarded < mx:
+                    report.append(f"Q{qid}: MCQ matches key but grader gave {awarded}/{mx} - overriding to full")
+                awarded = mx
+        awarded = round(awarded * 2) / 2                      # 0.5 steps
+        awarded = max(0.0, min(mx, awarded))
+        awarded_sum += awarded
+        cancelled = str(res.get("verdict") or "").lower() == "cancelled"
+        attempted = bool(res.get("extracted_answer")) or bool(res.get("annotations")) or cancelled
+        tag = f"Q{qid}"
+
+        if not attempted:
+            report.append(f"{tag}: unattempted, no ink")
+            continue
+
+        # ---- resolve every annotation to a real row
+        anns: list[dict[str, Any]] = []
+        for a in res.get("annotations") or []:
+            rid = _resolve(a.get("target"), a.get("anchor_text"), a.get("page_id"), rows, report, tag)
+            if not rid:
+                continue
+            b = dict(a)
+            b["target"], b["page_id"], b["q"] = rid, rows[rid]["page_id"], qid
+            anns.append(b)
+
+        # ---- last row of the answer
+        ar = res.get("answer_rows") or []
+        last = ar[-1] if ar and ar[-1] in rows else None
+        if not last and anns:
+            last = max((a["target"] for a in anns), key=lambda r: (rows[r]["page_id"], rows[r]["index"]))
+        if not last and ar:
+            last = _resolve(ar[-1], res.get("extracted_answer", "")[-60:], None, rows, report, tag + ".last")
+        if not last:
+            unmarked.append(qid)
+            report.append(f"{tag}: NO ROW FOUND - question will be unmarked")
+            continue
+
+        # ---- praise rules
+        kept: list[dict[str, Any]] = []
+        for a in anns:
+            txt = (a.get("text") or "").strip()
+            if a.get("style") in ("margin_note", "region_note") and PRAISE.match(txt):
+                if qtype in SHORT_TYPES or awarded < mx or seen_praise >= 1:
+                    report.append(f"{tag}: removed praise {txt!r}")
+                    continue
+                seen_praise += 1
+            kept.append(a)
+        anns = kept
+
+        # ---- exactly one score, right margin, last row
+        anns = [a for a in anns if a.get("style") != "score"]
+        anns.append({"style": "score", "q": qid, "target": last, "page_id": rows[last]["page_id"],
+                     "placement": "right_margin", "text": f"{_fmt(awarded)}/{_fmt(mx)}",
+                     "anchor_text": rows[last]["text"]})
+
+        # ---- deduction note
+        if cancelled:
+            anns = [a for a in anns if a.get("style") not in ("margin_note",)]
+            anns.append({"style": "margin_note", "q": qid, "target": last, "page_id": rows[last]["page_id"],
+                         "placement": "left_margin" if rows[last]["last_on_page"] else "below_line",
+                         "text": "Attempt cancelled by student.", "anchor_text": rows[last]["text"]})
+        elif awarded < mx:
+            notes = [a for a in anns if a.get("style") == "margin_note" and (a.get("text") or "").strip()]
+            if notes:
+                note = notes[0]
+                anns = [a for a in anns if a is note or a.get("style") != "margin_note"]
+            else:
+                reason = ""
+                for c in res.get("criteria_breakdown") or []:
+                    if float(c.get("marks") or 0) < float(c.get("max_marks") or 1e9) and c.get("reason"):
+                        reason = c["reason"]
+                        break
+                reason = reason or (res.get("feedback") or "Marks deducted: answer incomplete.")
+                reason = re.sub(r"\b\d+(\.\d+)?\s*marks?\b.*?(because|as|since)\s*", "", reason, flags=re.I)
+                reason = reason.strip()[:90] if qtype in SHORT_TYPES else reason.strip().split(". ")[0][:90]
+                report.append(f"{tag}: deduction note missing, synthesised from feedback")
+                note = {"style": "margin_note", "q": qid, "text": reason, "anchor_text": rows[last]["text"]}
+                anns.append(note)
+            note["target"], note["page_id"] = last, rows[last]["page_id"]
+            note["placement"] = "left_margin" if rows[last]["last_on_page"] else "below_line"
+        else:
+            # Full marks: only praise survives - plus the one note the guide
+            # requires on a second attempt, which is not praise and must stay.
+            anns = [a for a in anns if not (a.get("style") == "margin_note"
+                                            and not PRAISE.match((a.get("text") or "").strip())
+                                            and not (a.get("text") or "").startswith("Answered twice"))]
+
+        # ---- MCQ / short: guarantee a tick or cross on the answer row
+        if qtype in SHORT_TYPES and not any(a.get("style") in ("tick", "cross") for a in anns):
+            anns.append({"style": "tick" if awarded >= mx else "cross", "q": qid, "target": last,
+                         "page_id": rows[last]["page_id"], "placement": "right_of_line",
+                         "text": None, "anchor_text": rows[last]["text"]})
+            report.append(f"{tag}: added missing tick/cross")
+
+        # ---- tick budget
+        ticks = [a for a in anns if a.get("style") == "tick"]
+        if len(ticks) > 4:
+            for a in ticks[4:]:
+                anns.remove(a)
+            report.append(f"{tag}: trimmed ticks to 4")
+
+        out.extend(anns)
+
+    # ---- student labels no paper question claimed
+    claimed: set[str] = set()
+    for res in results:
+        for rng in (res.get("answer_rows"), res.get("answer_rows_duplicate")):
+            if rng and len(rng) == 2 and rng[0] in rows and rng[1] in rows:
+                p0, i0 = rows[rng[0]]["page_id"], rows[rng[0]]["index"]
+                p1, i1 = rows[rng[1]]["page_id"], rows[rng[1]]["index"]
+                for rid, m in rows.items():
+                    if (m["page_id"], m["index"]) >= (p0, i0) and (m["page_id"], m["index"]) <= (p1, i1):
+                        claimed.add(rid)
+    # A label row ("Q4.") whose answer starts on the very next row is claimed
+    # by that answer even when the grader's answer_rows began at the "Ans."
+    # line: without this, three correctly graded questions were reported as
+    # "not in the paper" alongside the six that really were.
+    by_pos = {(m["page_id"], m["index"]): rid for rid, m in rows.items()}
+    def _claimed(rid: str) -> bool:
+        if rid in claimed:
+            return True
+        m = rows[rid]
+        nxt = by_pos.get((m["page_id"], m["index"] + 1))
+        return bool(nxt and nxt in claimed)
+    def _scribbled_after(rid: str) -> bool:
+        m = rows[rid]
+        nxt = by_pos.get((m["page_id"], m["index"] + 1))
+        return bool(nxt and re.search(r"crossed|scribbl|~~", rows[nxt]["text"], re.I))
+    orphan = [f"{rid} {m['text'][:30]!r}" for rid, m in rows.items()
+              if not _claimed(rid) and not _scribbled_after(rid)
+              and re.match(r"^\s*[QqO0]\s*\.?\s*\d+", m["text"])]
+    if orphan:
+        report.append("STUDENT ANSWERS NOT IN THE PAPER (question paper incomplete?): " + "; ".join(orphan))
+
+    # ---- grand total on page 1
+    total = None
+    if rows:
+        pid = first_page_id or (layout_map.get("pages") or [{}])[0].get("page_id")
+        first_row = next((r for r, m in rows.items() if m["page_id"] == pid), None)
+        mx_total = paper_max if paper_max is not None else sum(float(q.get("max_marks") or 0) for q in questions)
+        if paper_max is None:
+            report.append("paper_max not supplied - total max computed from the question list")
+        total = {"style": "total", "q": "total", "target": first_row, "page_id": pid,
+                 "placement": "right_margin", "text": f"{_fmt(awarded_sum)}/{_fmt(mx_total)}"}
+    if unmarked:
+        report.append(f"UNMARKED QUESTIONS: {', '.join(unmarked)} - do not ship this copy")
+    return Result(out, total, report, unmarked)
+
+
+# ------------------------------------------------------------------ self-test
+if __name__ == "__main__":
+    layout = {"pages": [
+        {"page_id": "p1", "lines": [{"line_id": "p1_r1", "text": "Q1"}, {"line_id": "p1_r2", "text": "Ans (b)"},
+                                    {"line_id": "p1_r3", "text": "Q2"}, {"line_id": "p1_r4", "text": "Ans (c)"}]},
+        {"page_id": "p2", "lines": [{"line_id": "p2_r1", "text": "Q4 first law the incident ray"},
+                                    {"line_id": "p2_r2", "text": "all lie in the same plane"}]}]}
+    qs = [{"question_id": "1", "max_marks": 1, "question_type": "MCQ"},
+          {"question_id": "2", "max_marks": 1, "question_type": "MCQ"},
+          {"question_id": "4", "max_marks": 2, "question_type": "LONG_ANSWER"}]
+    res = [
+        # old-prompt style MCQ: praise, no score, wrong target
+        {"question_id": "1", "marks_awarded": 1, "extracted_answer": "(b)", "answer_rows": ["p1_r2", "p1_r2"],
+         "annotations": [{"style": "margin_note", "target": "p1_r9", "anchor_text": "Ans (b)", "text": "Well", "placement": "below_line"}]},
+        # nothing at all
+        {"question_id": "2", "marks_awarded": 0, "extracted_answer": "(c)", "answer_rows": ["p1_r4", "p1_r4"], "annotations": [],
+         "feedback": "Wrong option. Correct option: (a)."},
+        # score in left margin, deduction, no note
+        {"question_id": "4", "marks_awarded": 1.5, "extracted_answer": "first law ... same plane",
+         "answer_rows": ["p2_r1", "p2_r2"],
+         "annotations": [{"style": "score", "target": "p2_r1", "anchor_text": "Q4 first law", "text": "1.5/2", "placement": "left_margin"}],
+         "criteria_breakdown": [{"criteria_name": "Second law", "marks": 0.5, "max_marks": 1, "reason": "0.5 marks deducted because angle of reflection not stated"}]},
+    ]
+    r = enforce(res, layout, qs, paper_max=36)
+    for a in r.annotations:
+        print(a["q"], a["style"], a["target"], a["placement"], a.get("text"))
+    print("TOTAL", r.total["text"])
+    print("\n".join(r.report))

--- a/ai_service/app/services/copy_check/enforce_bridge.py
+++ b/ai_service/app/services/copy_check/enforce_bridge.py
@@ -1,0 +1,208 @@
+"""Run enforce.py over this pipeline's verdicts, in place.
+
+enforce() takes the grader's outputs as a flat list and returns a flat list of
+annotations keyed by `q`; this pipeline carries one verdict dict per question
+and renders from each verdict's own `annotations`. The bridge converts on the
+way in and writes the enforced annotations back on the way out, so the
+orchestrator, the renderer and every test keep the shape they already use.
+
+    verdicts, total, report, unmarked = apply_enforcement(verdicts, layout_map)
+
+Placement names: enforce emits the marking guide's names (right_margin,
+below_line, ...); the validator's canonical field is `position` in the older
+vocabulary. Both are written so either reader works.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .enforce import SHORT_TYPES, enforce
+from .validator import VALID_POSITIONS, _POSITION_ALIASES
+
+logger = logging.getLogger(__name__)
+
+
+_LABEL = re.compile(r"^\s*[QqO0]\s*\.?\s*(\d{1,2})\b")
+_OPTION = re.compile(r"\(\s*([a-dA-D])\s*\)")
+
+
+def _mcq_attempts(rows_in_order, paper_num, labels):
+    """Every place in the copy where a labelled MCQ attempt sits, in page order.
+
+    An attempt is a row whose label is one of `labels`, with the option letter
+    on that row or the next one. Returns [(row_id_of_answer, option)].
+    """
+    out = []
+    for i, (rid, page_id, text) in enumerate(rows_in_order):
+        m = _LABEL.match(text)
+        if not m or int(m.group(1)) not in labels:
+            continue
+        cand = [(rid, text)]
+        if i + 1 < len(rows_in_order) and rows_in_order[i + 1][1] == page_id:
+            cand.append((rows_in_order[i + 1][0], rows_in_order[i + 1][2]))
+        for arid, atext in cand:
+            after = atext[m.end():] if arid == rid else atext
+            if re.search(r"crossed|scribbl|~~", after, re.I):
+                break
+            om = _OPTION.search(after)
+            if om:
+                out.append((arid, om.group(1).lower()))
+                break
+    return out
+
+
+def first_attempt_mcqs(verdicts, layout_map, meta):
+    """Grade MCQs that carry a key deterministically, taking the FIRST attempt.
+
+    A per-question grader cannot honour "if the same question is answered
+    twice, grade the first attempt": when the second attempt carries the
+    paper's own label it matches by label every time - three from-scratch
+    runs graded Sagar's page-5 "(d)" and named (b) as correct while his
+    page-1 "(b)" went unclaimed. With the key this is arithmetic: find every
+    labelled attempt in page order, grade the first against the key, note
+    the rest "Answered twice - first attempt taken." The student's labels may
+    be offset from the paper's (physics numbered 1-7 here); the offset is
+    read off the sibling questions the grader DID place.
+    """
+    rows_in_order = []
+    for page in layout_map.get("pages") or []:
+        for line in page.get("lines") or []:
+            rows_in_order.append((str(line.get("line_id")), str(page.get("page_id")),
+                                  (line.get("text") or "").strip()))
+    by_label = {str(m.get("paper_label")): m for m in meta}
+    report = []
+    for v in verdicts:
+        m = by_label.get(str(v.get("label")))
+        key = str((m or {}).get("correct_answer") or v.get("correct_answer") or "").strip().lower()
+        qtype = str((m or {}).get("question_type") or v.get("question_type") or "").upper()
+        if not key or qtype not in SHORT_TYPES:
+            continue
+        mp = _LABEL.match(str(v.get("label") or ""))
+        if not mp:
+            continue
+        paper_num = int(mp.group(1))
+        # The number the STUDENT wrote for this question: the label the grader
+        # was given (the caller maps paper -> student numbering, e.g. a paper
+        # whose sections are rotated on the students' copies), plus whatever
+        # label the grader itself reported. Never an inferred offset: with
+        # rotated sections the offsets {-14, 0, +14} all appear at once, and
+        # paper Q1 and paper Q15 would each claim the other's answer.
+        labels = set()
+        for cand in (v.get("student_number"), v.get("student_label")):
+            mc = _LABEL.match(str(cand or ""))
+            if mc:
+                labels.add(int(mc.group(1)))
+        if not labels:
+            labels = {paper_num}
+        attempts = _mcq_attempts(rows_in_order, paper_num, labels)
+        if not attempts:
+            continue
+        first_row, first_opt = attempts[0]
+        mx = float(v.get("max_marks") or 1)
+        awarded = mx if first_opt == key else 0.0
+        page_of = {rid: pg for rid, pg, _ in rows_in_order}
+        text_of = {rid: t for rid, _, t in rows_in_order}
+        anns = [
+            {"style": "tick" if awarded else "cross", "target": first_row, "page_id": page_of[first_row],
+             "anchor_text": text_of[first_row], "placement": "right_of_line", "text": None},
+            {"style": "score", "target": first_row, "page_id": page_of[first_row],
+             "anchor_text": text_of[first_row], "placement": "right_margin",
+             "text": f"{awarded:g}/{mx:g}"},
+        ]
+        if not awarded:
+            anns.append({"style": "margin_note", "target": first_row, "page_id": page_of[first_row],
+                         "anchor_text": text_of[first_row], "placement": "below_line",
+                         "text": f"Wrong option. Correct: ({key})"})
+        for rid, _opt in attempts[1:]:
+            anns.append({"style": "margin_note", "target": rid, "page_id": page_of[rid],
+                         "anchor_text": text_of[rid], "placement": "below_line",
+                         "text": "Answered twice - first attempt taken."})
+        changed = (abs(float(v.get("marks_awarded") or 0) - awarded) > 0.01
+                   or (v.get("answer_rows") or [None])[-1] != first_row)
+        v["marks_awarded"] = awarded
+        v["verdict"] = "correct" if awarded else "wrong"
+        v["answer_rows"] = [first_row, first_row]
+        v["answer_rows_duplicate"] = [attempts[1][0], attempts[-1][0]] if len(attempts) > 1 else None
+        v["extracted_answer"] = f"({first_opt})"
+        v["annotations"] = anns
+        if changed or len(attempts) > 1:
+            report.append(f"Q{paper_num}: MCQ graded by key - first attempt {first_row} ({first_opt}) "
+                          f"{'=' if awarded else '!='} key ({key}) -> {awarded:g}/{mx:g}"
+                          + (f"; {len(attempts)-1} later attempt(s) noted" if len(attempts) > 1 else ""))
+    return report
+
+
+def _question_meta(verdicts: list[dict[str, Any]],
+                   questions: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """What enforce needs to know per question. Prefer the caller's list;
+    otherwise derive it from the verdicts, treating a 1-mark question as
+    short-answer, which is the regime the grading prompt itself uses."""
+    if questions:
+        out = []
+        for q in questions:
+            out.append({
+                "question_id": q.get("question_id"),
+                "paper_label": q.get("paper_label") or q.get("label"),
+                "max_marks": q.get("max_marks"),
+                "question_type": q.get("question_type"),
+                # enforce.py overrides a mis-graded MCQ only when a key exists
+                "correct_answer": q.get("correct_answer"),
+            })
+        return out
+    out = []
+    for v in verdicts:
+        mx = float(v.get("max_marks") or 0)
+        out.append({
+            "question_id": v.get("question_id"),
+            "paper_label": v.get("label") or v.get("paper_label"),
+            "max_marks": mx,
+            "question_type": v.get("question_type") or ("MCQ" if mx <= 1 else "LONG_ANSWER"),
+            "correct_answer": v.get("correct_answer"),
+        })
+    return out
+
+
+def apply_enforcement(verdicts: list[dict[str, Any]], layout_map: dict[str, Any],
+                      questions: list[dict[str, Any]] | None = None,
+                      paper_max: float | None = None,
+                      ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, list[str], list[str]]:
+    meta = _question_meta(verdicts, questions)
+    results = []
+    for v in verdicts:
+        r = dict(v)
+        r["paper_label"] = v.get("label") or v.get("paper_label") or v.get("question_id")
+        results.append(r)
+
+    pre_report = first_attempt_mcqs(verdicts, layout_map, meta)
+    results = []
+    for v in verdicts:
+        r = dict(v)
+        r["paper_label"] = v.get("label") or v.get("paper_label") or v.get("question_id")
+        results.append(r)
+    fixed = enforce(results, layout_map, meta, paper_max=paper_max)
+    fixed.report[:0] = pre_report
+
+    by_q: dict[str, list[dict[str, Any]]] = {}
+    for a in fixed.annotations:
+        b = dict(a)
+        placement = b.get("placement")
+        b["position"] = _POSITION_ALIASES.get(placement, placement) if placement in VALID_POSITIONS else None
+        by_q.setdefault(str(b.get("q")), []).append(b)
+
+    for v in verdicts:
+        key = str(v.get("label") or v.get("paper_label") or v.get("question_id"))
+        v["annotations"] = by_q.get(key, [])
+        v["enforced"] = True
+
+    if fixed.total and verdicts:
+        t = dict(fixed.total)
+        t["position"] = "right_margin_same_line"
+        verdicts[0].setdefault("annotations", []).append(t)
+
+    for line in fixed.report:
+        logger.info("enforce: %s", line)
+    if fixed.unmarked:
+        logger.error("enforce: UNMARKED QUESTIONS %s - copy must not ship", fixed.unmarked)
+    return verdicts, fixed.total, fixed.report, fixed.unmarked

--- a/ai_service/app/services/copy_check/hand_render.py
+++ b/ai_service/app/services/copy_check/hand_render.py
@@ -1,0 +1,215 @@
+"""hand_render.py — natural red-pen marks for the copy checker.
+
+Drop-in drawing layer: every function takes a PIL RGBA image (the page) and
+draws directly on it. Replace the current font-based text/tick calls in the
+renderer with these.
+
+Why the old output looked AI-generated:
+  * text was a bold condensed print font, not handwriting
+  * every glyph identical, perfectly horizontal baseline, uniform red
+  * ticks were straight two-segment lines of constant width
+  * the circled total was a clean ellipse
+
+What this does instead (all seeded per copy, so one copy = one teacher):
+  * handwriting font (Kalam by default - made for Indian hands - or Caveat)
+  * per-glyph jitter: size, baseline, rotation, letter spacing
+  * ink model: variable stroke width, slight pressure gaps, ballpoint red with
+    small darkness variation, 2-3 px bleed
+  * ticks/crosses/underlines/circle as wobbly Bezier strokes with pen lift
+  * whole annotation slightly rotated (-3..+3 deg) like a hand that isn't square
+    to the page
+"""
+from __future__ import annotations
+
+import math
+import random
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+FONT_DIR = Path(__file__).parent / "fonts"   # bundled with the copy checker
+DEFAULT_FONT = "Kalam.ttf"      # bundled; Caveat is an alternative if added to fonts/
+
+INK = (214, 28, 40)                      # red ballpoint
+
+
+class Pen:
+    """One teacher, one pen. Create once per copy with a fixed seed."""
+
+    def __init__(self, seed: int, font: str = DEFAULT_FONT, slant_deg: float | None = None):
+        self.rng = random.Random(seed)
+        self.font_path = str(FONT_DIR / font)
+        self.slant = slant_deg if slant_deg is not None else self.rng.uniform(-3.0, 2.0)
+        self.darkness = self.rng.uniform(0.85, 1.0)     # this pen's ink strength
+
+    # ------------------------------------------------------------ ink helpers
+    def _colour(self, alpha: float = 1.0) -> tuple[int, int, int, int]:
+        d = self.darkness * self.rng.uniform(0.9, 1.0)
+        r, g, b = INK
+        return (int(r * (0.92 + 0.08 * d)), int(g * d), int(b * d), int(255 * alpha))
+
+    def _stroke(self, layer: Image.Image, pts: list[tuple[float, float]], width: float) -> None:
+        """Polyline with width that swells and thins along the stroke."""
+        draw = ImageDraw.Draw(layer)
+        n = len(pts)
+        for i in range(n - 1):
+            t = i / max(1, n - 2)
+            w = width * (0.75 + 0.5 * math.sin(math.pi * t) + self.rng.uniform(-0.12, 0.12))
+            if self.rng.random() < 0.006:         # rare pressure skip
+                continue
+            draw.line([pts[i], pts[i + 1]], fill=self._colour(), width=max(1, int(round(w))))
+            draw.ellipse([pts[i][0] - w / 2, pts[i][1] - w / 2, pts[i][0] + w / 2, pts[i][1] + w / 2],
+                         fill=self._colour())
+
+    @staticmethod
+    def _bezier(p0, p1, p2, p3, n=28):
+        out = []
+        for i in range(n + 1):
+            t = i / n
+            x = (1 - t) ** 3 * p0[0] + 3 * (1 - t) ** 2 * t * p1[0] + 3 * (1 - t) * t ** 2 * p2[0] + t ** 3 * p3[0]
+            y = (1 - t) ** 3 * p0[1] + 3 * (1 - t) ** 2 * t * p1[1] + 3 * (1 - t) * t ** 2 * p2[1] + t ** 3 * p3[1]
+            out.append((x, y))
+        return out
+
+    def _wobble(self, pts, amp):
+        return [(x + self.rng.uniform(-amp, amp), y + self.rng.uniform(-amp, amp)) for x, y in pts]
+
+    def _blit(self, page: Image.Image, layer: Image.Image, rotate_deg: float, at: tuple[int, int]) -> None:
+        layer = layer.filter(ImageFilter.GaussianBlur(0.55))         # ink bleed
+        if abs(rotate_deg) > 0.05:
+            layer = layer.rotate(rotate_deg, resample=Image.BICUBIC, expand=True)
+        page.alpha_composite(layer, dest=(int(at[0]), int(at[1])))
+
+    # ------------------------------------------------------------- handwriting
+    def text(self, page: Image.Image, xy: tuple[float, float], s: str, size: int) -> tuple[int, int]:
+        """Write `s` with its baseline-left at xy. Returns (width, height) drawn."""
+        base = ImageFont.truetype(self.font_path, size)
+        pad = size
+        # measure roughly
+        est_w = int(base.getlength(s) * 1.15) + 2 * pad
+        est_h = int(size * 1.6) + 2 * pad
+        layer = Image.new("RGBA", (est_w, est_h), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(layer)
+        x = float(pad)
+        y0 = float(pad + size * 0.2)
+        drift = 0.0
+        for ch in s:
+            if ch == " ":
+                x += base.getlength(" ") * self.rng.uniform(0.8, 1.3)
+                continue
+            gs = int(size * self.rng.uniform(0.94, 1.06))
+            f = ImageFont.truetype(self.font_path, gs)
+            drift += self.rng.uniform(-0.6, 0.6)
+            drift = max(-size * 0.08, min(size * 0.08, drift))
+            gy = y0 + drift + self.rng.uniform(-size * 0.03, size * 0.03)
+            rot = self.rng.uniform(-4, 4)
+            gw = int(f.getlength(ch)) + gs
+            g = Image.new("RGBA", (gw + gs, gs * 2), (0, 0, 0, 0))
+            gd = ImageDraw.Draw(g)
+            col = self._colour(self.rng.uniform(0.86, 1.0))
+            # two slightly offset passes = ballpoint stroke weight without a bold font
+            gd.text((gs // 2, gs // 4), ch, font=f, fill=col)
+            gd.text((gs // 2 + self.rng.uniform(0.3, 0.9), gs // 4 + self.rng.uniform(0.2, 0.7)), ch, font=f, fill=col)
+            g = g.rotate(rot, resample=Image.BICUBIC)
+            layer.alpha_composite(g, dest=(int(x - gs // 2), int(gy - gs // 4)))
+            x += f.getlength(ch) * self.rng.uniform(0.96, 1.04) + self.rng.uniform(-0.5, 1.0)
+        self._blit(page, layer, self.slant + self.rng.uniform(-1.0, 1.0), (xy[0] - pad, xy[1] - pad - size * 0.2))
+        return int(x - pad), int(size * 1.2)
+
+    # -------------------------------------------------------------- pen marks
+    def tick(self, page: Image.Image, xy: tuple[float, float], h: float) -> None:
+        """Tick with its bottom vertex near xy. h = tick height (~1.5x line height)."""
+        pad = int(h)
+        layer = Image.new("RGBA", (int(h * 2) + 2 * pad, int(h * 1.6) + 2 * pad), (0, 0, 0, 0))
+        ox, oy = pad, pad + h * 1.2
+        r = self.rng.uniform
+        # short down-stroke, then long up-stroke that overshoots
+        p0 = (ox + r(0, h * 0.1), oy - h * r(0.35, 0.5))
+        p1 = (ox + h * r(0.15, 0.25), oy - h * r(0.05, 0.15))
+        p2 = (ox + h * r(0.3, 0.4), oy + h * r(-0.02, 0.05))
+        p3 = (ox + h * r(0.36, 0.44), oy)
+        q1 = (ox + h * r(0.55, 0.7), oy - h * r(0.35, 0.5))
+        q2 = (ox + h * r(0.9, 1.1), oy - h * r(0.8, 1.0))
+        q3 = (ox + h * r(1.1, 1.35), oy - h * r(1.05, 1.25))
+        pts = self._wobble(self._bezier(p0, p1, p2, p3, 12) + self._bezier(p3, q1, q2, q3, 26), h * 0.012)
+        self._stroke(layer, pts, h * 0.075)
+        self._blit(page, layer, r(-6, 6), (xy[0] - pad - h * 0.4, xy[1] - oy))
+
+    def cross(self, page: Image.Image, xy: tuple[float, float], h: float) -> None:
+        """Cross centred at xy, two separate strokes."""
+        pad = int(h)
+        layer = Image.new("RGBA", (int(h) + 2 * pad, int(h) + 2 * pad), (0, 0, 0, 0))
+        r = self.rng.uniform
+        c = (pad + h / 2, pad + h / 2)
+        for ang in (r(35, 55), r(125, 145)):
+            a = math.radians(ang)
+            d = h * r(0.42, 0.55)
+            p0 = (c[0] - d * math.cos(a), c[1] - d * math.sin(a))
+            p3 = (c[0] + d * math.cos(a), c[1] + d * math.sin(a))
+            p1 = (p0[0] * 0.66 + p3[0] * 0.34 + r(-h * 0.06, h * 0.06), p0[1] * 0.66 + p3[1] * 0.34 + r(-h * 0.06, h * 0.06))
+            p2 = (p0[0] * 0.34 + p3[0] * 0.66 + r(-h * 0.06, h * 0.06), p0[1] * 0.34 + p3[1] * 0.66 + r(-h * 0.06, h * 0.06))
+            self._stroke(layer, self._wobble(self._bezier(p0, p1, p2, p3, 18), h * 0.01), h * 0.09)
+        self._blit(page, layer, r(-5, 5), (xy[0] - c[0], xy[1] - c[1]))
+
+    def underline(self, page: Image.Image, x0: float, x1: float, y: float, lh: float) -> None:
+        pad = int(lh)
+        layer = Image.new("RGBA", (int(x1 - x0) + 2 * pad, 2 * pad), (0, 0, 0, 0))
+        r = self.rng.uniform
+        p0 = (pad, pad + r(-lh * 0.05, lh * 0.05))
+        p3 = (pad + (x1 - x0) + r(-lh * 0.1, lh * 0.15), pad + r(-lh * 0.05, lh * 0.08))
+        p1 = (pad + (x1 - x0) * 0.3, pad + r(-lh * 0.12, lh * 0.12))
+        p2 = (pad + (x1 - x0) * 0.7, pad + r(-lh * 0.12, lh * 0.12))
+        self._stroke(layer, self._wobble(self._bezier(p0, p1, p2, p3, 30), lh * 0.008), lh * 0.09)
+        self._blit(page, layer, 0, (x0 - pad, y - pad))
+
+    def strike(self, page: Image.Image, x0: float, x1: float, y: float, lh: float) -> None:
+        """Strike-through a word: same as underline but through the x-height."""
+        self.underline(page, x0, x1, y - lh * 0.35, lh)
+
+    def circled_total(self, page: Image.Image, xy: tuple[float, float], s: str, size: int) -> None:
+        """Big obtained/total with a hand-drawn loop around it. xy = text baseline-left."""
+        w, h = self.text(page, xy, s, size)
+        cx, cy = xy[0] + w / 2, xy[1] + h * 0.35
+        rx, ry = w * 0.72 + size * 0.25, h * 0.95
+        pad = int(size)
+        layer = Image.new("RGBA", (int(rx * 2) + 2 * pad, int(ry * 2) + 2 * pad), (0, 0, 0, 0))
+        c = (pad + rx, pad + ry)
+        r = self.rng.uniform
+        start = r(0.6, 1.4)                           # starts lower-right like a real loop
+        pts = []
+        n = 70
+        for i in range(n + 1):
+            t = start + 2 * math.pi * 1.06 * i / n     # 6% overlap at the end
+            wob = 1 + 0.04 * math.sin(3 * t + start) + r(-0.015, 0.015)
+            pts.append((c[0] + rx * wob * math.cos(t), c[1] + ry * wob * math.sin(t)))
+        self._stroke(layer, pts, size * 0.075)
+        self._blit(page, layer, r(-4, 4), (cx - c[0], cy - c[1]))
+
+
+# ---------------------------------------------------------------- self-test
+if __name__ == "__main__":
+    # Fake ruled page to preview the marks.
+    W, H, LH = 1400, 960, 48
+    page = Image.new("RGBA", (W, H), (250, 247, 240, 255))
+    d = ImageDraw.Draw(page)
+    for y in range(120, H, LH):
+        d.line([(0, y), (W, y)], fill=(170, 190, 215, 255), width=2)
+    d.line([(150, 0), (150, H)], fill=(220, 120, 150, 255), width=3)
+    pen = Pen(seed=42)
+    pen.circled_total(page, (760, 40), "30/36", int(LH * 2.3))
+    y = 120
+    for i, (label, kind) in enumerate([("1/1", "tick"), ("0/1", "cross"), ("2/3", "tick"), ("0.5/1", "tick"), ("4/5", "tick")]):
+        yy = y + i * LH * 3
+        d.text((170, yy + 10), f"Ans. sample student line {i+1}", fill=(40, 40, 140, 255))
+        if kind == "tick":
+            pen.tick(page, (860, yy + LH * 0.95), LH * 1.5)
+        else:
+            pen.cross(page, (860, yy + LH * 0.5), LH * 1.4)
+        pen.text(page, (1180, yy + LH * 0.95), label, int(LH * 1.4))
+    pen.text(page, (170, 120 + LH * 1.95), "Well explained.", int(LH * 1.1))
+    pen.text(page, (170, 264 + LH * 1.95), "Wrong option. Correct: (c)", int(LH * 1.1))
+    pen.text(page, (170, 408 + LH * 1.95), "Nature of image not stated: real, inverted.", int(LH * 1.1))
+    pen.underline(page, 200, 330, 552 + LH * 0.85, LH)
+    pen.text(page, (170, 552 + LH * 1.95), "Reasoning not given.", int(LH * 1.1))
+    page.convert("RGB").save("preview.png")
+    print("wrote preview.png")

--- a/ai_service/app/services/copy_check/orchestrator.py
+++ b/ai_service/app/services/copy_check/orchestrator.py
@@ -26,6 +26,7 @@ from .mathpix_fallback import MathpixFallback
 from .render_client import CopyCheckRenderClient, OcrCancelled
 from .rubric import RubricResolver, load_snapshot
 from .validator import validate_and_cap
+from .enforce_bridge import apply_enforcement
 
 logger = logging.getLogger(__name__)
 
@@ -262,9 +263,32 @@ async def run(req: dict[str, Any], job_id: str, db: Session) -> None:
         # Checkpoint first: a cancel that landed after the last question's check
         # would otherwise render, upload, and bill a copy the teacher stopped.
         cancellation.check(job_id, process_id)
-        evaluated_file_id = await annotator.render_and_upload(
-            pdf_url, layout_map, verdicts, req.get("attempt_id") or process_id,
-        )
+        # Between the grader and the renderer: enforce.py makes the marking
+        # correct whatever the model returned - exactly one score per attempted
+        # question in the right margin, one deduction note below the answer,
+        # praise only where the guide allows it, every annotation on a real
+        # row. It also names any question that ended with no ink, and a copy
+        # with one of those is not shipped: the grades are already reported,
+        # the file is withheld rather than sent out half-checked.
+        try:
+            questions_meta = [{
+                "question_id": q.get("question_id"),
+                "paper_label": q.get("paper_label") or q.get("label"),
+                "max_marks": q.get("max_marks"),
+                "question_type": q.get("question_type"),
+            } for q in questions]
+        except Exception:
+            questions_meta = None
+        verdicts, _total, enforce_report, unmarked = apply_enforcement(
+            verdicts, layout_map, questions_meta)
+        if unmarked:
+            logger.error("copy-check %s: enforce found unmarked questions %s; withholding the file",
+                         process_id, unmarked)
+            evaluated_file_id = None
+        else:
+            evaluated_file_id = await annotator.render_and_upload(
+                pdf_url, layout_map, verdicts, req.get("attempt_id") or process_id,
+            )
 
         # 5. Done.
         await callbacks.complete(

--- a/ai_service/app/services/copy_check/prompt_builder.py
+++ b/ai_service/app/services/copy_check/prompt_builder.py
@@ -1,14 +1,23 @@
 """Prompt construction for criteria generation and grading.
 
-Ported from Java AiCriteriaGenerationService + AiPromptBuilderService. Same
-type-specific branches (MCQ/ONE_WORD/LONG_ANSWER/CODING), same hard cap
-phrasing, but with two additions for the layout-anchored pipeline:
+Drop-in replacement for the previous prompt.py: same function names and
+signatures, same output JSON keys, same hard-cap phrasing. Changes:
 
-  1. Grading receives a numbered transcript of line_ids + text. The model
-     MUST reference line_ids as `target`s in its annotations[] output, never
-     pixel coordinates.
-  2. Output schema includes annotations[] so the FE overlay can draw on the
-     exact line each verdict refers to.
+  * GRADING_SYSTEM is generic (subject/class are parameters, not "Class 10
+    science").
+  * ONE annotation regime for all question types. The old MCQ/short regime
+    said "one tick, nothing else", so MCQ rows never got a score and whole
+    pages of MCQs (top of page 1, bottom of the last page) came back looking
+    unchecked. Now every attempted question gets exactly one `score`.
+  * Contradictions removed (4 vs 6 ticks, 12 vs 20 word notes, praise on
+    partial answers, "never at the top of a page" vs answers that end there).
+  * Deduction reason is always a `margin_note` below the last row of the
+    answer - the "Nature of image not stated..." style in the checked copy.
+  * Grand total is NOT produced by the model. This prompt grades one question
+    per call; sum marks_awarded in code and pass {"style":"total",
+    "text":"30/36"} to the renderer, which draws it large and hand-circled
+    below the Page No box on page 1. Sizes (tick 1.5x, score 1.4x, note 1.1x,
+    total 2.3x line height) are renderer settings, not prompt text.
 """
 from __future__ import annotations
 
@@ -30,6 +39,24 @@ def build_criteria_prompt(
     max_marks: float,
     question_text: str,
 ) -> str:
+    if (question_type or "").upper() in ("MCQ", "ONE_WORD", "SHORT_ANSWER", "TRUE_FALSE", "FILL_BLANK"):
+        return (
+            f"Create an evaluation rubric for the following {question_type} question.\n\n"
+            f"Subject: {subject}\nMax marks: {max_marks}\n\nQuestion:\n{question_text}\n\n"
+            "Return STRICT JSON:\n"
+            "{\n"
+            f'  "max_marks": {max_marks},\n'
+            '  "partial_marking_enabled": false,\n'
+            '  "evaluation_instructions": "Full marks if the chosen option/answer matches the key; otherwise 0.",\n'
+            '  "rubric": [\n'
+            f'    {{"criteria_name": "Correct answer", "max_marks": {max_marks}, "keywords": [], '
+            '"evaluation_guidelines": "Award full marks when the option or answer matches the key. '
+            'Do NOT require reasoning, elimination, equations or explanation: the question does not ask '
+            'for them and a bare correct answer earns full marks."}\n'
+            "  ]\n"
+            "}\n"
+            "Exactly ONE criterion. Never split the marks across option/reasoning/elimination."
+        )
     return (
         f"Create a detailed evaluation rubric for the following question.\n\n"
         f"Subject: {subject}\nType: {question_type}\nMax marks: {max_marks}\n\n"
@@ -52,8 +79,7 @@ def build_criteria_prompt(
         "Why this matters: guidance figures are written against whatever total the rubric was "
         "first drafted for. If that rubric is ever reused at a different weight, a grader reads "
         "the old figures literally against the new maxima and silently caps every answer below "
-        "full marks. Measured on a real 10-mark paper whose rubric had been drafted at 6: a "
-        "perfect script could not score above about 6.5, costing one student ~15 marks.\n"
+        "full marks.\n"
         "Section numbers, years and amounts are not mark figures - keep them exactly "
         "(e.g. 's. 30(5)', '1932', 'Rs. 12,00,000')."
     )
@@ -61,333 +87,108 @@ def build_criteria_prompt(
 
 # ---------------------------- Grading prompt ---------------------------------
 
-GRADING_SYSTEM = """
-You are a professional HUMAN EXAM CHECKER.
-
-Your task is to check the student's ORIGINAL HANDWRITTEN ANSWER COPY
-exactly like a real teacher checks a physical examination notebook with
-a red pen.
-
-IMPORTANT:
-You are EDITING/ANNOTATING the student's ORIGINAL COPY.
-
-You are NOT creating a new evaluation page.
-You are NOT creating a report beside the copy.
-You are NOT redesigning the page.
-You are NOT adding a white page.
-You are NOT creating a side panel.
-You are NOT creating boxes or cards.
-You are NOT drawing separator lines.
-You are NOT changing the notebook layout.
-
-The student's ORIGINAL PAPER MUST REMAIN THE MAIN AND ONLY CANVAS.
-
-========================================================
-ABSOLUTE VISUAL RULE - MOST IMPORTANT
-========================================================
-
-PRESERVE THE ORIGINAL STUDENT ANSWER SHEET EXACTLY.
-
-Do not change paper, notebook background, ruled lines, margins,
-handwriting, question numbers, page layout, paper colour, page borders,
-existing printed content or the student's writing.
-
-ONLY ADD TEACHER MARKINGS ON TOP OF THE ORIGINAL PAPER.
-
-Think of the operation as:
-
-ORIGINAL STUDENT COPY + RED TEACHER PEN MARKINGS = FINAL CHECKED COPY
-
-NOT: ORIGINAL COPY + NEW WHITE PAGE + SIDEBAR + REPORT = WRONG
-
-========================================================
-NO WHITE PAGE / NO SIDE PANEL / NO EXTRA CANVAS
-========================================================
-
-NEVER generate or add a white background beside the copy, a white page on
-the side, a separate feedback sheet, a side panel, an evaluation column, a
-floating feedback card, a summary card, a new margin area, artificial
-paper, a separate annotation canvas, boxes around comments, tables,
-horizontal or vertical separator lines, UI elements, a dashboard-style
-evaluation or an infographic-style layout.
-
-ALL feedback must be written DIRECTLY ON THE ORIGINAL STUDENT PAPER.
-
-If there is no blank space, place the annotation naturally in the nearest
-available margin/blank area.
-
-Do NOT create additional space.
-
-========================================================
-REAL PHYSICAL COPY-CHECKING BEHAVIOUR
-========================================================
-
-Imagine you are physically holding the student's notebook.
-
-You have ONE red pen.
-
-You read the student's answer. You naturally mark it with your pen. Then
-you move to the next answer.
-
-Follow the actual visual flow of the copy from top to bottom.
-
-Do NOT break the checking flow. Do NOT jump around the page
-unnecessarily. Do NOT create a separate feedback area.
-
-The result must look like: teacher reads answer -> teacher marks answer ->
-teacher writes short comment -> teacher gives marks -> teacher moves to
-the next question.
-
-========================================================
-QUESTION-BY-QUESTION CHECKING
-========================================================
-
-Every attempted question/sub-question must be checked individually.
-
-For each question: identify the question, read the complete answer,
-evaluate correctness, compare with the rubric/model answer, identify
-correct points, identify incorrect points, identify missing points,
-calculate marks, add natural teacher markings directly beside the relevant
-writing, add the question score near that question, and move naturally to
-the next question.
-
-NEVER skip an attempted question.
-
-========================================================
-QUESTION SCORE
-========================================================
-
-Every attempted question MUST receive its own score, written directly on
-the ORIGINAL PAPER: right side of the answer, nearby margin, beside the
-end of the answer, or nearby blank space.
-
-Do NOT move the score to a separate area. Do NOT place all scores at the
-top. Do NOT create a score table, a score sidebar or a separate marks
-section.
-
-========================================================
-LARGE TEACHER TICKS
-========================================================
-
-Correct meaningful points must receive LARGE, CLEAR handwritten ticks,
-approximately 1.5-2.5x the height of nearby handwriting.
-
-The tick must look like a teacher physically drew it with a red pen:
-natural hand movement, slightly irregular stroke, realistic pen pressure,
-slightly imperfect shape, natural angle.
-
-Do NOT use tiny digital check icons, UI icons or perfectly geometric
-vector ticks.
-
-Place it beside the relevant answer line.
-
-========================================================
-MARK CORRECT POINTS NATURALLY
-========================================================
-
-For every DISTINCT meaningful correct point, add a visible tick.
-
-Do NOT tick every sentence. If several lines form one connected correct
-explanation, one large tick is enough.
-
-Do NOT over-mark.
-
-========================================================
-EVERY ATTEMPTED QUESTION MUST SHOW MARKING
-========================================================
-
-Correct answer: tick + score.
-
-Partially correct: tick + correction + short deduction explanation + score.
-
-Incorrect: cross + corrective comment + short deduction explanation +
-score.
-
-An attempted answer must NEVER appear completely unchecked.
-
-========================================================
-MARK DEDUCTION EXPLANATION
-========================================================
-
-Whenever marks are deducted, explain WHY, directly on the original paper,
-in only 1-2 short sentences, specific to the student's answer:
-
-"Partially correct. One important point is missing."
-
-"Good attempt, but the conclusion is incomplete."
-
-"Correct method, but the final calculation is wrong."
-
-"Answer is incomplete. Capital should be paid last."
-
-Do NOT use generic comments such as "Needs improvement.", "Wrong." or
-"Explain more."
-
-========================================================
-FEEDBACK MUST LOOK HANDWRITTEN
-========================================================
-
-All teacher comments must use the SAME teacher handwriting style: natural
-cursive, slightly slanted, red pen, realistic handwriting, slightly
-irregular baseline, natural letter spacing, natural pen pressure,
-handwritten numbers and punctuation.
-
-The comments should look like the SAME TEACHER checked the whole copy.
-
-Do NOT switch fonts between annotations. Do NOT use typed UI fonts. Do NOT
-use Arial/Roboto/Inter/Helvetica-style text. Do NOT make feedback look
-digitally typeset.
-
-========================================================
-HANDWRITING SIZE
-========================================================
-
-Teacher feedback must be clearly visible, approximately 1.2-1.8x the
-height of normal student handwriting.
-
-Ticks must be EXTRA LARGE. Scores must be EXTRA LARGE.
-
-Visual hierarchy: student handwriting normal, teacher feedback large,
-teacher score extra large, teacher tick extra large.
-
-========================================================
-RED PEN ONLY FOR TEACHER MARKING
-========================================================
-
-Teacher annotations appear as natural RED PEN ink: ticks, crosses,
-underlines, circles, strikes, comments, corrections, marks.
-
-Do NOT change or recolour the student's blue/black handwriting.
-
-========================================================
-NATURAL TEACHER COMMENTS
-========================================================
-
-Use short comments such as "Good!", "Correct!", "Very good.",
-"Well explained!", "Good point.", "Nice example.", "Good reasoning.",
-"Clear.", "Good conclusion.", "Partially correct.", "Needs more detail.",
-"Important point missing.", "Check this.", "Not quite.", "Add an example."
-
-========================================================
-CORRECTIONS
-========================================================
-
-When the student is wrong, write the useful correction.
-
-BAD: "Wrong."
-
-GOOD: "Capital is paid last." / "Use F = ma." / "Risk remains with the
-seller." / "Add one relevant example."
-
-The correction must be short and directly related to the mistake.
-
-========================================================
-DO NOT DRAW ARTIFICIAL LINES
-========================================================
-
-NEVER create separator lines, boxes, columns, arrows connecting distant
-sections, vertical panels, horizontal sections, feedback containers or
-artificial margin lines.
-
-Only use natural teacher pen marks: tick, cross, underline, circle,
-strike, short handwritten note.
-
-A teacher may use a SMALL handwritten arrow if it naturally points to the
-relevant student text. Do not create long decorative arrows.
-
-========================================================
-USE EXISTING SPACE ONLY
-========================================================
-
-If blank space already exists on the student's paper, use it naturally.
-
-If no blank space exists, place the annotation in the nearest safe margin
-or beside the relevant line.
-
-NEVER create additional white space. NEVER expand the canvas. NEVER add
-another page.
-
-========================================================
-PRESERVE THE COPY-CHECKING FLOW
-========================================================
-
-The visual reading flow must remain: question -> student answer -> tick or
-cross -> short teacher feedback -> question score -> next question.
-
-The teacher's eye should be able to follow the copy naturally.
-
-Do NOT make the viewer look away from the notebook to a separate panel.
-
-========================================================
-NO PAGE-LEVEL GRADING
-========================================================
-
-Ignore page numbers. Do not mark page numbers, put scores near page
-numbers, create page totals, page summaries or page-level feedback.
-
-Grade QUESTIONS, not pages.
-
-========================================================
-MULTI-PAGE QUESTION
-========================================================
-
-If a question continues to another page, treat it as ONE continuous
-question. Mark correct points and mistakes wherever they occur. Give ONE
-final score for the complete question, at the logical end of that
-question. Do NOT create duplicate scores.
-
-========================================================
-EXTRACTED ANSWER
-========================================================
-
-The student's extracted answer must be VERBATIM.
-
-Do not correct spelling or grammar, rewrite sentences, add missing
-information, or include teacher comments, marks or page numbers.
-
-========================================================
-GRADING RULES
-========================================================
-
-Use the question, rubric, model answer and the actual student answer.
-
-Award marks based on demonstrated understanding. Accept equivalent
-wording. Accept valid alternative methods. Give partial credit when
-justified. Do not double-deduct the same mistake. Do not deduct marks
-without evidence.
-
-========================================================
-FINAL HUMAN EXAMINER TEST
-========================================================
-
-Before producing the final result, imagine the image is printed on paper.
-
-Ask: "Would a real teacher be able to create this exact checked copy
-simply by using a red pen on the student's original notebook?"
-
-If YES, keep it. If NO, remove anything that looks digitally added or
-artificially designed.
-
-The final result MUST remain the original student paper, with no new white
-page, no side panel, no separate feedback section, no boxes, no artificial
-separator lines and no UI elements; and MUST contain large handwritten
-ticks, handwritten scores, short handwritten feedback, an explanation for
-every meaningful mark deduction, marking on every attempted question, the
-student's handwriting preserved, the notebook lines preserved and the
-original layout preserved.
+GRADING_SYSTEM_TEMPLATE = """
+You are an experienced {subject} teacher (Class {klass}) checking a student's
+handwritten answer copy with a red pen. Another tool draws the marks; you decide
+every mark and say exactly on which transcript row it goes.
+
+INPUTS
+1. ONE question from the paper, with its paper number, max marks and rubric.
+2. TRANSCRIPT - the student's whole copy as numbered rows "[pX_rNN] text",
+   grouped by page. Row ids are the ONLY way to say where a mark goes.
+
+MATCHING THE ANSWER - READ THIS FIRST
+The student's question labels may NOT match the paper's numbering (restart per
+section, skip, shift). NEVER match by label alone. Identify the answer by
+CONTENT - topic, option letters, values and units, the section heading above
+it - and only then grade it. Report what you matched in student_label and
+answer_rows. If two places could answer this question, choose the one whose
+content matches the marking scheme.
+If the SAME question is answered twice and neither attempt is scribbled out,
+grade the FIRST attempt in page order and put a margin_note on the second:
+"Answered twice - first attempt taken." with no score there. Report both row
+ranges in answer_rows_duplicate.
+An answer in the copy that matches NO question in the paper is not yours to
+grade; leave it alone and list its rows in unmapped_rows so the pipeline can
+flag an incomplete question paper.
+
+PROCEDURE
+1. Read the whole transcript. Locate where THIS question's answer starts and
+   ends. An answer may span pages; the score goes where it ENDS, even if that
+   is the first row of a page.
+2. attempted   -> grade against the rubric, marks in 0.5 steps only. Give
+                  method marks in numericals even when the final value is
+                  wrong. If awarded < max, give ONE specific reason naming what
+                  is wrong or missing in THIS answer (5-15 words).
+   cancelled   -> written then scribbled out: award 0, score "0/x" on the
+                  scribbled row, margin_note "Attempt cancelled by student."
+   unattempted -> award 0, annotations [], extracted_answer "".
+3. Before returning, check: an attempted or cancelled question carries EXACTLY
+   ONE `score` annotation; if marks were deducted it also carries EXACTLY ONE
+   `margin_note` giving the reason.
+
+WHAT COUNTS AS THE PAPER
+Only the ruled notebook paper is writable. The margin line, ruled lines, the
+"Page No / Date" box and the subject heading are part of the blank notebook -
+never annotate them. Never place a mark on background, table, cloth or shadow.
+
+ANNOTATION REGIME - the same for every question type
+MCQ / one-word / fill-in:
+  correct -> `tick` on the answer row (right_of_line)
+             + `score` "x/y" on the same row (right_margin)
+  wrong   -> `cross` on the answer row (right_of_line)
+             + `score` "0/y" (right_margin)
+             + `margin_note` "Wrong option. Correct: (c)" (below_line).
+             ALWAYS name the correct option.
+Written / descriptive / numerical:
+  `tick`        on each row holding a correct point, correct formula or
+                correct final value - at most ONE tick per row, at most FOUR
+                ticks per question. Do not tick every sentence.
+  `cross`       on a row with a wrong statement, wrong sign/unit or wrong
+                final value.
+  `underline`   ONLY a wrong word, number or sign: put that word in
+                anchor_text, placement under_word. Never a whole line.
+  `score`       "x/y" right_margin on the LAST row of the answer.
+  `margin_note` only when marks were deducted: below_line under that last
+                row; if the last row is the foot of the page, use left_margin
+                on that row instead. This is the deduction reason.
+Diagram / labelled figure:
+  one `tick` on the caption or label row, `score` on the same row; deduct
+  with a `margin_note` naming the missing labels.
+Praise ("Good.", "Well explained.") only on a FULL-mark written answer, as a
+`margin_note` below the last row, at most one in three such answers, never on
+MCQ, never on a partial answer.
+
+ONE SCORE, NO TOTALS
+- Exactly ONE `score` per attempted or cancelled question, where the answer
+  ends. Continuation pages carry ticks/crosses only.
+- Never a page total, section total or running total; the grand total is
+  computed outside this call.
+- Never write a mark figure inside a margin_note - the score carries it.
+- Never emit an annotation that is not attached to a real row id.
+
+PLACEMENT
+  right_of_line  just right of the student's words on that row
+  right_margin   in the right margin, level with that row (scores only)
+  left_margin    in the left margin, level with that row
+  below_line     on the blank line under that row (notes)
+  under_word     a thin line under the word given in anchor_text only
+
+NEVER ADD
+Boxes, panels, white patches, tables, long lines across the page, arrows,
+large text, icons or stamps.
 """
 
-def _transcript_for_prompt(layout_map: dict[str, Any]) -> str:
-    """The student's pages, as text the grader can actually read.
+GRADING_SYSTEM = GRADING_SYSTEM_TEMPLATE.format(subject="school", klass="6-12")
 
-    Where a page has been re-read by the vision model (see
-    vision_transcript.py) its continuous `vision_text` leads, because that is
-    the reliable reading of the handwriting; the per-row list follows so the
-    model still has line_ids to anchor annotations to. Pages that fall back to
-    raw PaddleOCR say so explicitly - an unreliable transcript the model knows
-    is unreliable produces a low confidence score, which is what should happen,
-    instead of a confident grade invented from noise.
-    """
+
+def grading_system(subject: str = "school", klass: str = "6-12") -> str:
+    """Subject/class-specific system prompt. Use this instead of GRADING_SYSTEM
+    where the subject is known."""
+    return GRADING_SYSTEM_TEMPLATE.format(subject=subject, klass=klass)
+
+
+def _transcript_for_prompt(layout_map: dict[str, Any]) -> str:
     out: list[str] = []
     for page in layout_map.get("pages") or []:
         out.append("---- Page " + str(page.get("page_id")) + " ----")
@@ -418,7 +219,6 @@ def _transcript_for_prompt(layout_map: dict[str, Any]) -> str:
 
 
 def _question_context(question: dict[str, Any]) -> str:
-    """Format MCQ options + correct answer block. Empty for non-MCQ."""
     options = question.get("options") or []
     if not options:
         return ""
@@ -456,10 +256,6 @@ def _type_instructions(question_type: str) -> str:
             "the rubric. Spelling/OCR errors do NOT reduce marks."
         )
     if t == "CODING":
-        # This pipeline grades a scanned/handwritten copy: no sandbox execution
-        # results (verdict, pass counts, runtime, memory) are available. Do NOT
-        # ask the model to use data it cannot see — that invites hallucinated
-        # verdicts. Grade the written logic only.
         return (
             "CODING: No execution results (test verdicts, pass counts, runtime, or "
             "memory) are available for this answer. Grade the written code's logic and "
@@ -471,40 +267,31 @@ def _type_instructions(question_type: str) -> str:
 
 
 def _model_answer_block(question: dict[str, Any]) -> str:
-    """Teacher-authored reference answer, if provided. Used as a grading guide —
-    NOT a required verbatim match — so a teacher who writes a model answer
-    actually influences the grade (previously it was stored but never read)."""
     model_answer = question.get("model_answer")
     if not model_answer:
         return ""
     return (
         "**Model answer (teacher-provided reference):**\n"
-        "This is what a full-marks answer contains. Use it as your guide to award "
-        "marks per the rubric — reward answers that reach the same understanding, "
-        "even in different words or order. Do NOT require identical wording, and do "
-        "NOT penalise correct approaches that differ from it.\n"
+        "This is what a full-marks answer contains. Reward answers that reach the "
+        "same understanding in different words or order. Do NOT require identical "
+        "wording and do NOT penalise correct approaches that differ from it.\n"
         f"{model_answer}\n"
     )
 
 
 def _annotation_regime(question_type: str, max_marks: float) -> str:
-    """Short answers get a short pen, not the essay treatment."""
+    """One reminder line; the full regime is in the system prompt and is the
+    same for every type. The only per-type difference is the tick budget."""
     t = (question_type or "").upper()
-    if t == "MCQ":
+    if t in ("MCQ", "ONE_WORD", "SHORT_ANSWER") or max_marks <= 1:
         return (
-            "This is an MCQ. One annotation on the answer line: a `tick`, or a `cross` whose text "
-            "is the correct option (e.g. 'Correct: (B) Mitochondria'). Nothing else."
-        )
-    if t in ("ONE_WORD", "SHORT_ANSWER") or max_marks <= 2:
-        return (
-            "This is a short answer. One `tick`, or one `cross`/`circle` whose text is the correct "
-            "answer, plus at most one short praise note. Nothing else."
+            "Objective/short answer: `tick` or `cross` on the answer row, plus ONE `score`. "
+            "Wrong answer also gets a `margin_note` naming the correct answer. No praise."
         )
     return (
-        "This is a descriptive answer. Tick each distinct correct point (about 6 at most), correct "
-        "what is wrong with a `strike`/`cross`/`circle` carrying the right position, and add at "
-        "least one short piece of praise where the student has genuinely earned it. Do not mark "
-        "every sentence."
+        "Written answer: up to FOUR `tick`s on correct rows, `cross`/`underline` on wrong ones, "
+        "ONE `score` on the last row, and ONE `margin_note` with the deduction reason if any "
+        "marks were cut. Praise only if full marks."
     )
 
 
@@ -532,7 +319,7 @@ def build_grading_prompt(
 **Evaluation rubric (JSON):**
 {rubric_json}
 
-**Student's transcript (line_id + text per page):**
+**Student's transcript (row id + text per page):**
 {_transcript_for_prompt(layout_map)}
 
 **Type-specific grading:**
@@ -542,29 +329,68 @@ def build_grading_prompt(
 {_annotation_regime(question.get('question_type'), max_marks)}
 
 **Hard constraints (checked by code - a violation is re-prompted):**
-- Maximum marks {max_marks:.1f}. marks_awarded <= {max_marks:.1f}.
+- Maximum marks {max_marks:.1f}. marks_awarded <= {max_marks:.1f}, in 0.5 steps.
 - Sum of criteria_breakdown[].marks == marks_awarded.
 - criteria_breakdown has one entry per rubric criterion, with the rubric's exact criteria_name.
-- Every `target` is a line_id (or region_id) that exists in the transcript, on the stated page_id.
-- `text` is non-empty on strike, cross, circle, margin_note and region_note; null on tick and underline.
-- Praise is 1-4 words ("Good!", "Well explained!"). A note that explains a DEDUCTION is a short 1-2 sentence explanation naming what is missing or wrong in THIS answer, and it may run to about 20 words.
-- Every attempted question carries at least one visible annotation. Its score is placed near the END of that question, never at the top of a page.
-- If marks_awarded < {max_marks:.1f}, at least one strike/cross/circle/margin_note names what was missing or wrong.
-- extracted_answer is the student's writing VERBATIM, errors preserved, never the printed question. First ~250 words then '...' if longer. "" if unattempted.
+- Every `target` is a row id (or region_id) that exists in the transcript, on the stated page_id.
+- If attempted or cancelled: EXACTLY ONE annotation with style "score", text "x/{max_marks:g}",
+  placement right_margin, on the LAST row of the answer. Zero scores or two scores is an error.
+- If marks_awarded < {max_marks:.1f}: EXACTLY ONE "margin_note" with the deduction reason
+  (5-15 words, specific to this answer, no mark figures), placement below_line on the last row
+  (left_margin if that row is the foot of the page).
+- `text` is required on score, cross-for-MCQ, margin_note and region_note; null on tick and underline.
+- Praise (1-4 words) only if marks_awarded == {max_marks:.1f} and the answer is written, not MCQ.
+- extracted_answer is the student's writing VERBATIM, errors preserved, never the printed question.
+  First ~250 words then '...' if longer. "" if unattempted.
 - Unattempted question: marks_awarded 0, extracted_answer "", annotations [].
 
 **Output: STRICT JSON only, no prose before or after.**
 {{
   "marks_awarded": <float>,
+  "verdict": "correct|partial|wrong|cancelled|unattempted",
   "extracted_answer": "<verbatim>",
   "feedback": "<2 sentences grounded in the rubric>",
   "confidence": <0..1>,
   "criteria_breakdown": [
-    {{"criteria_name": "<exact rubric name>", "marks": <float>, "reason": "<'X mark(s) deducted because ...' with a line_id, or why full marks>"}}
+    {{"criteria_name": "<exact rubric name>", "marks": <float>, "reason": "<'X mark(s) deducted because ...' with a row id, or why full marks>"}}
   ],
+  "student_label": "<the label the student wrote above this answer, e.g. 'Q8', or null>",
+  "answer_rows": ["<first row id of the answer>", "<last row id>"],
+  "answer_rows_duplicate": ["<first row>", "<last row>"] or null,
   "annotations": [
-    {{"style": "tick|cross|circle|strike|underline|margin_note|region_note",
-      "target": "<line_id or region_id>", "page_id": "<page_id>",
-      "text": "<short teacher-style note, 1-8 words, or null>"}}
+    {{"style": "tick|cross|underline|score|margin_note|region_note",
+      "target": "<row id from the transcript>", "page_id": "<page_id>",
+      "anchor_text": "<the student's words on that row, copied VERBATIM>",
+      "placement": "right_of_line|right_margin|left_margin|below_line|under_word",
+      "text": "<'x/y' for score, the note for margin_note, else null>"}}
   ]
-}}"""
+}}
+
+ANCHORING - this decides whether the mark reaches the page at all.
+- target is a row id copied EXACTLY from the transcript, e.g. "p3_r12". Never
+  invent one, never give pixel coordinates, never give a page number alone.
+- anchor_text is REQUIRED on every annotation: the student's words on that row
+  exactly as written, misspellings and all. Never the printed question.
+- target and anchor_text must name the SAME row.
+- If you cannot find the exact row, anchor to the closest row you can quote.
+  A mark one row off is acceptable; an omitted mark is not.
+- under_word additionally needs the single wrong word or number in anchor_text.
+- student_label and answer_rows record WHERE this answer lives, from the
+  content match, not from the student's numbering."""
+
+
+# ---------------------------- Grand total (code, not model) -------------------
+
+def grand_total_annotation(results: list[dict[str, Any]], paper_max: float,
+                           first_page_id: str, first_row_id: str) -> dict[str, Any]:
+    """Build the circled obtained/total for page 1 after ALL questions are graded.
+    Renderer draws it ~2.3x line height with a hand-drawn circle just below the
+    Page No box. Never let the model write this."""
+    awarded = sum(float(r.get("marks_awarded") or 0) for r in results)
+    return {
+        "style": "total",
+        "target": first_row_id,
+        "page_id": first_page_id,
+        "placement": "right_margin",
+        "text": f"{awarded:g}/{paper_max:g}",
+    }

--- a/ai_service/app/services/copy_check/validator.py
+++ b/ai_service/app/services/copy_check/validator.py
@@ -4,12 +4,16 @@ Three jobs:
   1. Coerce loose LLM output into the QuestionVerdict shape (with safe defaults).
   2. Cap marks_awarded to question.max_marks and proportionally scale the
      criteria_breakdown so the sum still equals marks_awarded.
-  3. Drop annotations whose `target` doesn't match any line_id/region_id
-     in the layout_map — those would render to nowhere on the FE overlay.
+  3. Resolve every annotation to a real row: by `target` line_id/region_id
+     when that exists, else by matching the verbatim `anchor_text` the model
+     quoted from the student's writing. Only an annotation that matches
+     nothing at all is dropped — a mark placed a row off is a teacher being
+     untidy, a mark silently discarded is a page that comes back unmarked.
 """
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -18,7 +22,9 @@ logger = logging.getLogger(__name__)
 VALID_STYLES = {"tick", "cross", "circle", "strike", "underline", "margin_note",
                 "region_note", "brace", "summary",
                 # the marking vocabulary the current guide asks for
-                "score", "feedback", "deduction_reason"}
+                "score", "feedback", "deduction_reason",
+                # the copy's grand total, emitted by enforce.py, drawn once on page 1
+                "total"}
 # Styles that are really a teacher's written comment. They differ in intent -
 # praise vs the reason a mark was lost - but they are drawn the same way, and
 # keeping them distinct upstream lets the placer give a deduction priority over
@@ -27,6 +33,27 @@ NOTE_STYLES = {"margin_note", "region_note", "feedback", "deduction_reason"}
 # Styles that carry a mark figure of their own. A brace shows what a block of
 # the answer earned; a summary carries the question total at the foot of it.
 MARK_BEARING_STYLES = {"brace", "summary", "score"}
+# Where a mark sits relative to the row it is anchored to. The model states
+# this instead of the renderer inferring it, so a score lands in the margin
+# beside the last line of an answer rather than wherever there happened to be
+# room. Anything unrecognised falls back to the renderer's own choice.
+VALID_POSITIONS = {"right_of_line", "left_margin_same_line", "right_margin_same_line",
+                   "under_text", "below_line_left", "end_of_answer",
+                   # the marking guide's current names for the same six places
+                   "right_of_anchor", "right_margin", "left_margin",
+                   "below_anchor", "under_anchor", "below_line", "under_word"}
+# The guide has used two vocabularies for placement. Normalise to one so the
+# renderer has a single set to switch on, and a copy graded under the older
+# guide still places its marks.
+_POSITION_ALIASES = {
+    "right_of_anchor": "right_of_line",
+    "right_margin": "right_margin_same_line",
+    "left_margin": "left_margin_same_line",
+    "below_anchor": "below_line_left",
+    "under_anchor": "under_text",
+    "below_line": "below_line_left",
+    "under_word": "under_text",
+}
 
 
 def _layout_target_index(layout_map: dict[str, Any]) -> dict[str, str]:
@@ -39,6 +66,154 @@ def _layout_target_index(layout_map: dict[str, Any]) -> dict[str, str]:
         for region in page.get("regions", []):
             idx[region["region_id"]] = page_id
     return idx
+
+
+_MARK_IN_TEXT = re.compile(r"[\s(\[]*\b\d+(?:\.\d+)?\s*/\s*\d+(?:\.\d+)?\b[\s)\]]*\.?\s*$")
+
+
+def _strip_mark_from_note(text: Any) -> Any:
+    """Take a mark figure out of a written comment.
+
+    The score is its own annotation, drawn from the mark this module has
+    already capped, quantised to halves and reconciled. A figure the model
+    writes INSIDE a note goes through none of that: one copy came back
+    carrying "Nature not stated: real & inverted. 2.25/3" against a recorded
+    2.0/3.0 - a quarter mark no examiner writes, contradicting the grade the
+    student is actually given, and printed a second time beside the score.
+    """
+    if not isinstance(text, str):
+        return text
+    cleaned = _MARK_IN_TEXT.sub("", text).rstrip(" ,;:-")
+    # Never return an empty note: if the figure was the whole remark, the
+    # score annotation will carry it and the note has nothing left to say.
+    return cleaned if cleaned else None
+
+
+def _norm(text: Any) -> str:
+    """Lowercase, strip punctuation, collapse whitespace - for anchor matching."""
+    s = str(text or "").lower()
+    return " ".join("".join(c if c.isalnum() or c.isspace() else " " for c in s).split())
+
+
+def _layout_geom_index(layout_map: dict[str, Any]) -> list[tuple[str, str, float, float]]:
+    """[(line_id, page_id, cx, cy)] with centres normalised 0-1 per page."""
+    out: list[tuple[str, str, float, float]] = []
+    for page in layout_map.get("pages", []):
+        page_id = page["page_id"]
+        try:
+            pw = float(page.get("width") or 0) or None
+            ph = float(page.get("height") or 0) or None
+        except (TypeError, ValueError):
+            pw = ph = None
+        if not pw or not ph:
+            continue
+        for line in page.get("lines", []):
+            b = line.get("box")
+            if not isinstance(b, (list, tuple)) or len(b) != 4:
+                continue
+            try:
+                cx = (float(b[0]) + float(b[2]) / 2.0) / pw
+                cy = (float(b[1]) + float(b[3]) / 2.0) / ph
+            except (TypeError, ValueError):
+                continue
+            out.append((line["line_id"], page_id, cx, cy))
+    return out
+
+
+def _bbox_centre(bbox: Any) -> tuple[float, float] | None:
+    """Centre of a normalised [x_min, y_min, x_max, y_max], if it is usable."""
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+    try:
+        x0, y0, x1, y1 = (float(v) for v in bbox)
+    except (TypeError, ValueError):
+        return None
+    # The guide asks for 0-1. A model that answers in pixels would otherwise
+    # place every mark in the top-left corner of the page.
+    if not all(-0.01 <= v <= 1.01 for v in (x0, y0, x1, y1)):
+        return None
+    if x1 < x0 or y1 < y0:
+        return None
+    return (x0 + x1) / 2.0, (y0 + y1) / 2.0
+
+
+def _layout_text_index(layout_map: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """[(line_id, page_id, normalised_text)] for every line that has text."""
+    out: list[tuple[str, str, str]] = []
+    for page in layout_map.get("pages", []):
+        page_id = page["page_id"]
+        for line in page.get("lines", []):
+            norm = _norm(line.get("text"))
+            if norm:
+                out.append((line["line_id"], page_id, norm))
+    return out
+
+
+def _resolve_target(target: Any, anchor_text: Any, page_hint: Any,
+                    idx: dict[str, str],
+                    text_idx: list[tuple[str, str, str]],
+                    bbox: Any = None,
+                    geom_idx: list[tuple[str, str, float, float]] | None = None,
+                    ) -> tuple[str, str] | None:
+    """(line_id, page_id) for an annotation, or None if it truly cannot be placed.
+
+    A line_id that exists wins outright. When it does not - the model invented
+    an id, or drifted one row - fall back to the verbatim student text the
+    model quoted and find the row that actually carries it. Dropping was the
+    old behaviour and it is the worst of the three outcomes: the mark simply
+    vanishes and the page comes back blank with no trace in the output that
+    anything was meant to be there. A mark one row off is a teacher being
+    untidy; a missing mark is a teacher who did not read the answer.
+    """
+    if target and target in idx:
+        return str(target), idx[target]
+
+    anchor = _norm(anchor_text)
+    if not anchor or not text_idx:
+        return _resolve_by_bbox(bbox, page_hint, geom_idx)
+
+    from difflib import SequenceMatcher
+
+    best: tuple[float, str, str] | None = None
+    for line_id, page_id, norm in text_idx:
+        # Containment scores full: the model quotes a phrase out of a longer
+        # row far more often than it reproduces the whole row.
+        if anchor in norm or norm in anchor:
+            score = 1.0 if anchor in norm else len(norm) / max(len(anchor), 1)
+        else:
+            score = SequenceMatcher(None, anchor, norm).ratio()
+        if page_hint and page_id == page_hint:
+            score += 0.05          # tie-break toward the page the model named
+        if best is None or score > best[0]:
+            best = (score, line_id, page_id)
+
+    if best and best[0] >= 0.60:
+        return best[1], best[2]
+    # Nothing read like the quoted words. The geometry the model reported is
+    # the last chance to place the mark near the right writing.
+    return _resolve_by_bbox(bbox, page_hint, geom_idx)
+
+
+def _resolve_by_bbox(bbox: Any, page_hint: Any,
+                     geom_idx: list[tuple[str, str, float, float]] | None,
+                     ) -> tuple[str, str] | None:
+    """The transcript row whose centre is nearest the reported box."""
+    centre = _bbox_centre(bbox)
+    if centre is None or not geom_idx:
+        return None
+    cx, cy = centre
+    best: tuple[float, str, str] | None = None
+    for line_id, page_id, lx, ly in geom_idx:
+        if page_hint and page_id != page_hint:
+            continue
+        d = ((lx - cx) ** 2 + (ly - cy) ** 2) ** 0.5
+        if best is None or d < best[0]:
+            best = (d, line_id, page_id)
+    # A quarter of the page away is not "this line" by any reading; placing a
+    # mark there would be worse than the model having said nothing.
+    if best and best[0] <= 0.25:
+        return best[1], best[2]
+    return None
 
 
 def _unwrap_questions(raw: dict[str, Any], question: dict[str, Any]) -> dict[str, Any]:
@@ -130,36 +305,54 @@ def validate_and_cap(
             for it in breakdown:
                 it["marks"] = round(it["marks"] * factor, 2)
 
-    # Filter annotations to those whose target actually exists in the layout.
+    # Resolve every annotation to a real row. A bad line_id is rescued by the
+    # verbatim student text the model quoted; only an annotation that matches
+    # nothing at all is dropped.
     idx = _layout_target_index(layout_map)
+    text_idx = _layout_text_index(layout_map)
+    geom_idx = _layout_geom_index(layout_map)
     valid_annotations: list[dict[str, Any]] = []
     dropped = 0
+    rescued = 0
     for ann in raw.get("annotations") or []:
         target = ann.get("target")
         style = ann.get("style")
-        if not target or style not in VALID_STYLES:
+        if style not in VALID_STYLES:
             dropped += 1
             continue
-        page_id = idx.get(target)
-        if not page_id:
+        anchor_text = ann.get("anchor_text")
+        anchor_bbox = ann.get("anchor_bbox")
+        resolved = _resolve_target(target, anchor_text, ann.get("page_id"), idx,
+                                   text_idx, anchor_bbox, geom_idx)
+        if not resolved:
             dropped += 1
             continue
+        line_id, page_id = resolved
+        if line_id != target:
+            rescued += 1
+        # The guide has called this field both `placement` and `position`.
+        position = ann.get("placement") or ann.get("position")
+        position = _POSITION_ALIASES.get(position, position)
         entry = {
-            "target": target,
+            "target": line_id,
             "page_id": page_id,
             "style": style,
-            "text": ann.get("text"),
+            "text": (_strip_mark_from_note(ann.get("text"))
+                     if style in NOTE_STYLES else ann.get("text")),
+            "anchor_text": anchor_text,
+            "position": position if position in VALID_POSITIONS else None,
         }
         # A brace spans a block, so it needs its closing row - and it is only
         # meaningful if that row is real and on the same page, at or after the
         # opening one. A brace that runs backwards or off the page would be
         # drawn across unrelated writing.
         if style == "brace":
-            end = ann.get("target_end")
-            if not end or idx.get(end) != page_id:
+            end_resolved = _resolve_target(
+                ann.get("target_end"), ann.get("anchor_text_end"), page_id, idx, text_idx)
+            if not end_resolved or end_resolved[1] != page_id:
                 dropped += 1
                 continue
-            entry["target_end"] = end
+            entry["target_end"] = end_resolved[0]
         if style in MARK_BEARING_STYLES:
             try:
                 entry["marks"] = round(float(ann.get("marks")), 2)
@@ -167,6 +360,9 @@ def validate_and_cap(
                 # A brace or summary with no readable figure is just a note.
                 entry["marks"] = None
         valid_annotations.append(entry)
+    if rescued:
+        logger.info("Q%s: rescued %d annotations via anchor_text (bad line_id)",
+                    question["question_id"], rescued)
     if dropped:
         logger.info("Q%s: dropped %d annotations with no matching target", question["question_id"], dropped)
 
@@ -181,6 +377,18 @@ def validate_and_cap(
         for it in breakdown:
             it["marks"] = round(it["marks"] * factor, 2)
     marks_awarded = quantised
+
+    # The score written on the page IS the mark. Its text came from the model
+    # and went through none of the capping and quantising above: one copy
+    # carried "0.4/1" and "0.6/1" beside answers recorded as 0.5 - figures no
+    # examiner writes, disagreeing with the mark the student actually gets.
+    # Rewrite every score to the reconciled figure.
+    def _fmt(v: float) -> str:
+        return str(int(v)) if float(v).is_integer() else f"{v:g}"
+    for a in valid_annotations:
+        if a["style"] == "score":
+            a["text"] = f"{_fmt(marks_awarded)}/{_fmt(max_marks)}"
+            a["marks"] = marks_awarded
 
     # The figures written in the margin must reconcile with the total, because
     # that is the whole promise of brace marking: a student adds up the numbers
@@ -216,5 +424,24 @@ def validate_and_cap(
         "confidence": float(raw.get("confidence") or 0),
         "criteria_breakdown": breakdown,
         "annotations": valid_annotations,
+        # What the grader decided about WHERE the answer is and WHAT KIND of
+        # attempt it was. enforce.py places the score on answer_rows[-1] and
+        # applies the cancelled-attempt rule from verdict; dropping them here
+        # left it inferring the last row from the annotations and never
+        # seeing a cancellation at all.
+        "verdict": (str(raw.get("verdict") or "").strip().lower()
+                    if str(raw.get("verdict") or "").strip().lower()
+                    in ("correct", "partial", "wrong", "cancelled", "unattempted") else None),
+        "student_label": (str(raw.get("student_label")).strip()
+                          if raw.get("student_label") else None),
+        "answer_rows": [str(r) for r in (raw.get("answer_rows") or [])
+                        if r and str(r) in idx][:2] or None,
+        # A second attempt at the same question (graded first-in-page-order;
+        # the second gets a note) and rows that answer no question in the
+        # paper - enforce.py reports both so an incomplete paper is caught.
+        "answer_rows_duplicate": [str(r) for r in (raw.get("answer_rows_duplicate") or [])
+                                  if r and str(r) in idx][:2] or None,
+        "unmapped_rows": [str(r) for r in (raw.get("unmapped_rows") or [])
+                          if r and str(r) in idx] or None,
         "status": "COMPLETED",
     }

--- a/ai_service/tests/test_copy_check_annotator_marks.py
+++ b/ai_service/tests/test_copy_check_annotator_marks.py
@@ -161,8 +161,13 @@ def test_no_ink_leaves_the_paper() -> None:
     arr = np.frombuffer(pix.samples, np.uint8).reshape(pix.height, pix.width, pix.n)
     ink = (arr[:, :, 0].astype(int) - arr[:, :, 1].astype(int)) > 40
     ys, xs = np.nonzero(ink)
+    # Silence is not a pass. This sheet has four clear rows and room beside
+    # them, so a note that draws nothing has been dropped, not restrained -
+    # and skipping here let the boundary rule go unchecked for the whole
+    # suite while the gate was in fact rejecting almost every mark.
+    check("the note was actually written", xs.size > 0,
+          "nothing was drawn - the comment was silently dropped")
     if xs.size == 0:
-        print("  SKIP  nothing was drawn to check")
         doc.close()
         return
     scale = 150.0 / 72.0
@@ -350,7 +355,231 @@ def test_whole_paper_shape_is_unwrapped() -> None:
           f"got {len(out['annotations'])}")
 
 
+def test_bbox_anchors_and_placement_names() -> None:
+    print("\nvalidator — the reported geometry places a mark the text cannot")
+    from ai_service.app.services.copy_check.validator import validate_and_cap
+
+    layout = {"pages": [{"page_id": "P1", "width": 1000, "height": 2000, "lines": [
+        {"line_id": "L1", "box": [100, 100, 400, 40], "text": "Ans. (d)"},
+        {"line_id": "L2", "box": [100, 900, 400, 40], "text": "Magnified."},
+    ], "regions": []}]}
+    base = {"question_id": "Q1", "maximum_marks": 2, "marks_awarded": 1.0,
+            "extracted_answer": "x", "feedback": "f", "confidence": 0.9,
+            "criteria_breakdown": []}
+
+    def run(anns):
+        return validate_and_cap(dict(base, annotations=anns),
+                                {"question_id": "Q1", "max_marks": 2}, layout)["annotations"]
+
+    # Bad id AND unquotable text: the normalised bbox is the last chance.
+    got = run([{"style": "tick", "target": "BAD", "page_id": "P1",
+                "anchor_text": "zzz nothing like this at all",
+                "anchor_bbox": [0.10, 0.45, 0.50, 0.47],
+                "placement": "right_of_anchor"}])
+    check("geometry placed a mark text could not", len(got) == 1, f"got {len(got)}")
+    if got:
+        check("it landed on the nearest row", got[0]["target"] == "L2",
+              f"got {got[0]['target']}")
+        check("the guide's placement name is normalised",
+              got[0]["position"] == "right_of_line", f"got {got[0]['position']}")
+
+    check("a far-off bbox is refused, not forced onto a line",
+          run([{"style": "tick", "target": "BAD", "page_id": "P1",
+                "anchor_text": "zzz nothing like this",
+                "anchor_bbox": [0.9, 0.02, 0.99, 0.04]}]) == [], "a mark was placed")
+    # Pixels instead of the 0-1 the guide asks for would put every mark in the
+    # top-left corner. Refuse rather than trust it.
+    check("a bbox given in pixels is refused",
+          run([{"style": "tick", "target": "BAD", "page_id": "P1",
+                "anchor_text": "zzz nothing like this",
+                "anchor_bbox": [100, 100, 400, 140]}]) == [], "pixels were trusted")
+    good = run([{"style": "tick", "target": "L1", "page_id": "P1",
+                 "anchor_text": "Ans. (d)", "placement": "right_of_anchor"}])
+    check("a correct line_id still wins outright",
+          good and good[0]["target"] == "L1", "id was overridden")
+
+
+def test_mark_figure_never_hides_in_a_comment() -> None:
+    print("\nvalidator — a mark written inside a comment must not contradict the grade")
+    from ai_service.app.services.copy_check.validator import validate_and_cap
+
+    layout = {"pages": [{"page_id": "P1", "lines": [
+        {"line_id": "L1_01", "box": [40, 40, 300, 18], "text": "h' = 1.5 x 4 = -6 cm."},
+    ], "regions": []}]}
+    # Measured on a real copy: the grader recorded 2.0/3.0 and then wrote
+    # "2.25/3" inside the note. A quarter mark no examiner writes, disagreeing
+    # with the mark the student is actually given, printed beside the score.
+    raw = {
+        "question_id": "Q20", "maximum_marks": 3, "marks_awarded": 2.0,
+        "extracted_answer": "x", "feedback": "f", "confidence": 0.9,
+        "criteria_breakdown": [],
+        "annotations": [{"style": "margin_note", "target": "L1_01", "page_id": "P1",
+                         "anchor_text": "h' = 1.5 x 4 = -6 cm.",
+                         "text": "Nature not stated: real & inverted. 2.25/3"}],
+    }
+    out = validate_and_cap(raw, {"question_id": "Q20", "max_marks": 3}, layout)
+    note = out["annotations"][0]["text"]
+    check("the comment survives", note is not None, "note was dropped")
+    check("the stray mark figure is gone", "2.25" not in (note or ""),
+          f"still reads {note!r}")
+    check("the teacher's actual words are kept",
+          "Nature not stated" in (note or ""), f"got {note!r}")
+    check("the recorded mark is untouched", out["marks_awarded"] == 2.0,
+          f"got {out['marks_awarded']}")
+
+    # A fraction that is part of the remark, not a mark, must survive.
+    keep = dict(raw, annotations=[{"style": "margin_note", "target": "L1_01",
+                                   "page_id": "P1", "anchor_text": "h'",
+                                   "text": "Use 1/2 mv^2 here"}])
+    out2 = validate_and_cap(keep, {"question_id": "Q20", "max_marks": 3}, layout)
+    check("a formula containing a fraction is left alone",
+          out2["annotations"][0]["text"] == "Use 1/2 mv^2 here",
+          f"got {out2['annotations'][0]['text']!r}")
+
+
+def test_paper_boundary_finds_the_page() -> None:
+    print("\n_paper_rows — the notebook page, not the brightest patch of bedsheet")
+    from ai_service.app.services.copy_check.annotator import (
+        _paper_rows, _on_paper, _point_on_paper, _PAPER)
+
+    # A photograph: a near-white, achromatic sheet lying at a slight angle on a
+    # strongly coloured cloth. The old detector scored by brightness alone, so
+    # a well-lit patch of cloth outscored a shadowed half of the page and the
+    # gate then rejected 86% of the marks - three pages got none at all.
+    doc = fitz.open()
+    page = doc.new_page(width=400, height=600)
+    page.draw_rect(page.rect, color=(0.80, 0.10, 0.55), fill=(0.80, 0.10, 0.55))
+    # A bright but SATURATED distractor - the cartoon blanket in the real copies.
+    page.draw_rect(fitz.Rect(300, 20, 395, 120), color=(0.95, 0.85, 0.15),
+                   fill=(0.95, 0.85, 0.15))
+    sheet = [fitz.Point(62, 84), fitz.Point(338, 62),
+             fitz.Point(348, 520), fitz.Point(72, 542)]
+    page.draw_polyline(sheet + [sheet[0]], color=(1, 1, 1), fill=(0.99, 0.99, 0.98))
+    for i in range(8):                      # ruled lines and a little writing
+        y = 120 + i * 45
+        page.draw_line(fitz.Point(90, y), fitz.Point(320, y), color=(0.6, 0.6, 0.7))
+        page.insert_text(fitz.Point(95, y - 6), "the student wrote here", fontsize=11)
+
+    paper = _paper_rows(page)
+    check("the page was found", paper is not None, "no paper detected")
+    if paper is None:
+        doc.close()
+        return
+    check("a mask is returned, not only row spans", paper.get("mask") is not None,
+          "no mask")
+
+    _PAPER[0] = paper
+    try:
+        check("the middle of the sheet is paper", _point_on_paper(200, 300), "rejected")
+        check("a written line is paper", _point_on_paper(150, 210), "rejected")
+        # The saturated distractor and the cloth must NOT be paper, or the pen
+        # is free to write on the bedsheet.
+        check("the coloured distractor is not paper",
+              not _point_on_paper(350, 60), "accepted the blanket")
+        check("the cloth below the sheet is not paper",
+              not _point_on_paper(200, 580), "accepted the cloth")
+        check("the cloth beside the sheet is not paper",
+              not _point_on_paper(20, 300), "accepted the cloth")
+        check("a box inside the sheet is admitted",
+              _on_paper(paper, fitz.Rect(100, 200, 300, 240)), "rejected")
+        check("a box running off the sheet is refused",
+              not _on_paper(paper, fitz.Rect(300, 200, 396, 240)), "admitted")
+    finally:
+        _PAPER[0] = None
+        doc.close()
+
+    # A scan pasted on a white PDF canvas. Its own background is the SAME pure
+    # white as the canvas, so keeping the non-white pixels returns the
+    # handwriting only - which is how a scanned copy came back nearly unmarked.
+    doc = fitz.open()
+    page = doc.new_page(width=400, height=600)
+    page.draw_rect(fitz.Rect(40, 30, 360, 520), color=(0.93, 0.93, 0.91),
+                   fill=(0.93, 0.93, 0.91))
+    for i in range(6):
+        page.insert_text(fitz.Point(60, 90 + i * 60), "scanned answer text", fontsize=12)
+    paper = _paper_rows(page)
+    check("the scanned sheet was found", paper is not None, "no paper detected")
+    if paper is not None:
+        _PAPER[0] = paper
+        try:
+            check("blank paper BETWEEN the written lines is still paper",
+                  _point_on_paper(200, 120), "rejected - a blank row admits nothing")
+            check("the margin beside the text is paper",
+                  _point_on_paper(330, 300), "rejected - no room for a margin note")
+            check("the white canvas outside the scan is not paper",
+                  not _point_on_paper(390, 560), "accepted the bare canvas")
+        finally:
+            _PAPER[0] = None
+    doc.close()
+
+
+def test_annotation_rescued_by_anchor_text() -> None:
+    print("\nvalidator — a wrong line_id must not silently bin the mark")
+    from ai_service.app.services.copy_check.validator import validate_and_cap
+
+    layout = {"pages": [{"page_id": "P1", "lines": [
+        {"line_id": "L1_01", "box": [40, 40, 300, 18],
+         "text": "The incident ray, reflected ray and normal lie in the same plane"},
+        {"line_id": "L1_02", "box": [40, 60, 300, 18],
+         "text": "The angle of incidence equals the angle of reflection"},
+        {"line_id": "L1_03", "box": [40, 80, 300, 18],
+         "text": "principal focus."},
+    ], "regions": []}]}
+    base = {
+        "question_id": "Q1", "maximum_marks": 4, "marks_awarded": 2.0,
+        "extracted_answer": "x", "feedback": "f", "confidence": 0.9,
+        "criteria_breakdown": [],
+    }
+
+    # A hallucinated id used to be dropped without trace, which is how a page
+    # comes back unmarked while the grader reports it graded the answer.
+    raw = dict(base, annotations=[
+        {"style": "tick", "target": "L9_99", "page_id": "P1",
+         "anchor_text": "incidence equals the angle", "position": "right_of_line"},
+        {"style": "cross", "target": "nonsense", "page_id": "P1",
+         "anchor_text": "principal focus."},
+    ])
+    out = validate_and_cap(raw, {"question_id": "Q1", "max_marks": 4}, layout)
+    check("both marks survived a bad line_id", len(out["annotations"]) == 2,
+          f"got {len(out['annotations'])}")
+    by_style = {a["style"]: a for a in out["annotations"]}
+    check("the tick landed on the quoted row",
+          by_style.get("tick", {}).get("target") == "L1_02",
+          f"got {by_style.get('tick', {}).get('target')}")
+    check("the cross landed on the quoted row",
+          by_style.get("cross", {}).get("target") == "L1_03",
+          f"got {by_style.get('cross', {}).get('target')}")
+    check("a recognised position is carried through",
+          by_style.get("tick", {}).get("position") == "right_of_line",
+          f"got {by_style.get('tick', {}).get('position')}")
+
+    # The rescue must not become a way for anything to land anywhere.
+    junk = dict(base, annotations=[
+        {"style": "tick", "target": "L9_99", "page_id": "P1",
+         "anchor_text": "purple monkey dishwasher unrelated nonsense"},
+        {"style": "tick", "target": "L9_98", "page_id": "P1"},
+        {"style": "not_a_style", "target": "L1_01", "page_id": "P1"},
+    ])
+    out2 = validate_and_cap(junk, {"question_id": "Q1", "max_marks": 4}, layout)
+    check("unmatchable quote, absent quote and bad style are all dropped",
+          len(out2["annotations"]) == 0, f"got {len(out2['annotations'])}")
+
+    # An unrecognised position must not be passed on as if it were real.
+    odd = dict(base, annotations=[
+        {"style": "tick", "target": "L1_01", "page_id": "P1",
+         "anchor_text": "The incident ray", "position": "diagonally_across"},
+    ])
+    out3 = validate_and_cap(odd, {"question_id": "Q1", "max_marks": 4}, layout)
+    check("an invented position is discarded, not trusted",
+          out3["annotations"][0]["position"] is None,
+          f"got {out3['annotations'][0]['position']}")
+
+
 if __name__ == "__main__":
+    test_bbox_anchors_and_placement_names()
+    test_mark_figure_never_hides_in_a_comment()
+    test_paper_boundary_finds_the_page()
+    test_annotation_rescued_by_anchor_text()
     test_tick_tail_rises()
     test_free_band_finds_the_gap()
     test_note_survives_a_full_width_row()


### PR DESCRIPTION
…the paper gate

The checked copy came back with pages unmarked, ticks parked on the margin rule as vertical bars, scores in whichever margin had room, and comments in a bold print face. Measured causes, each fixed with a test that fails on the old code:

Paper boundary
- _paper_rows admitted 14% of the students' own handwriting (0% on three of thirteen pages): brightness-only segmentation lost the shadowed half of a photographed page. Replaced with a document-quadrilateral detector (Lab lightness minus chroma, two quads for a spread) and a content-extent path for scans; the gate now tests the mask, not a per-row span. Pen ink on paper admitted: 4.0% -> 99.9% on the photographed copy.
- _photo_bounds locked onto the pink margin rule on a white scan (the only column >50% non-white) and handed every mark a zero-width home. Guarded.
- _ink_map counted the printed ruling and the scan's edge shadow as ink, so every row ran edge to edge: no free band for notes, ticks pushed to the left margin, full-width underlines. Ruling and vertical borders removed; edge specks ignored when measuring where a line of writing ends.

Enforcement (enforce.py + enforce_bridge.py)
- A prompt can ask for one score per question; it cannot guarantee it. enforce.py runs between grader and renderer: resolves every annotation to a real row, forces exactly one score (right margin, last row of the answer), one deduction note where marks were lost, praise only where the guide allows, the grand total against the PAPER max, and reports every question that ended with no ink - the orchestrator withholds the file rather than ship a half-checked copy.
- MCQs with a key are graded deterministically from the FIRST attempt in page order; later attempts get "Answered twice - first attempt taken." Three from-scratch runs proved a per-question grader takes the second attempt whenever it carries the paper's own label.
- Key override reads an explicit option letter only: startswith(key) had matched the "A" of "(A) is false but (R) is true" against key "a".

Renderer
- placement is honoured for the first time: right_margin, left_margin, below_line, right_of_line, under_word, with the free-space search as the fallback only when the contract spot is off-paper or on writing.
- hand_render.py: text in Kalam with per-glyph jitter, ticks and crosses as wobbly Bezier strokes, the total in a hand-thrown loop, composited as a transparent layer over the untouched page. One pen per copy, seeded from the file. Footprints calibrated by measurement (1.9x the nominal size).
- A note is sized to the gap it goes into, never the row it hangs on; a 20pt note in a 20pt gap had been written across the next line.
- Comments longer than ~90 chars were silently dropped with 428pt of blank paper below; a last-ditch pass now writes one short line anywhere blank.
- Score text is rewritten to the reconciled mark: "0.4/1" and "2.25/3" had been drawn beside answers recorded as 0.5 and 2.0.

Validator / prompt
- Bad line_ids are rescued via the quoted anchor_text (or a normalised bbox) instead of dropped; verdict, student_label, answer_rows pass through so enforcement sees them.
- Grading prompt per the marking guide v3.1: match answers by CONTENT, not the student's numbering; MCQ rubrics are a single criterion (the old three-way split docked a correct option for lacking reasoning the question never asked for).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
