### PR TITLE
fix(workflow): batch from the trigger, and search in the Event Setup picker

### DIFF
--- a/frontend-admin-dashboard/public/locales/ar/workflowEventEntityPicker.json
+++ b/frontend-admin-dashboard/public/locales/ar/workflowEventEntityPicker.json
@@ -38,6 +38,14 @@
         "summarySelected_two": "سيتم تشغيل سير العمل لـ {{type}}ين محددين. سيتم إنشاء صف مُشغّل لكل تحديد.",
         "summarySelected_few": "سيتم تشغيل سير العمل لعدد {{count}} من {{type}} المحددة. سيتم إنشاء صف مُشغّل لكل تحديد.",
         "summarySelected_many": "سيتم تشغيل سير العمل لعدد {{count}} من {{type}} المحددة. سيتم إنشاء صف مُشغّل لكل تحديد.",
-        "summarySelected_other": "سيتم تشغيل سير العمل لعدد {{count}} من {{type}} المحددة. سيتم إنشاء صف مُشغّل لكل تحديد."
+        "summarySelected_other": "سيتم تشغيل سير العمل لعدد {{count}} من {{type}} المحددة. سيتم إنشاء صف مُشغّل لكل تحديد.",
+        "searchPlaceholder": "ابحث في {{type}}...",
+        "noMatches": "لا توجد نتائج لـ ”{{search}}“.",
+        "hiddenBySearch_zero": "لا توجد عناصر محددة مخفية بسبب البحث",
+        "hiddenBySearch_one": "عنصر محدد واحد مخفي بسبب البحث",
+        "hiddenBySearch_two": "عنصران محددان مخفيان بسبب البحث",
+        "hiddenBySearch_few": "{{count}} عناصر محددة مخفية بسبب البحث",
+        "hiddenBySearch_many": "{{count}} عنصرًا محددًا مخفية بسبب البحث",
+        "hiddenBySearch_other": "{{count}} عنصر محدد مخفي بسبب البحث"
     }
 }

--- a/frontend-admin-dashboard/public/locales/en/workflowEventEntityPicker.json
+++ b/frontend-admin-dashboard/public/locales/en/workflowEventEntityPicker.json
@@ -30,6 +30,10 @@
         "noneFound": "No {{type}}s found",
         "summaryNone": "No selection — the workflow fires for every {{type}} in your institute.",
         "summarySelected_one": "Workflow fires only for the selected {{type}}.",
-        "summarySelected_other": "Workflow fires for {{count}} selected {{type}}(s). One trigger row will be created per selection."
+        "summarySelected_other": "Workflow fires for {{count}} selected {{type}}(s). One trigger row will be created per selection.",
+        "searchPlaceholder": "Search {{type}}s...",
+        "noMatches": "Nothing matches “{{search}}”.",
+        "hiddenBySearch_one": "{{count}} selected item is hidden by the search",
+        "hiddenBySearch_other": "{{count}} selected items are hidden by the search"
     }
 }

--- a/frontend-admin-dashboard/public/locales/fr/workflowEventEntityPicker.json
+++ b/frontend-admin-dashboard/public/locales/fr/workflowEventEntityPicker.json
@@ -32,6 +32,11 @@
         "summaryNone": "Aucune sélection — le workflow se déclenche pour chaque {{type}} de votre établissement.",
         "summarySelected_one": "Le workflow se déclenche uniquement pour le {{type}} sélectionné.",
         "summarySelected_many": "Le workflow se déclenche pour {{count}} {{type}} sélectionnés. Une ligne de déclenchement sera créée par sélection.",
-        "summarySelected_other": "Le workflow se déclenche pour {{count}} {{type}}(s) sélectionné(s). Une ligne de déclenchement sera créée par sélection."
+        "summarySelected_other": "Le workflow se déclenche pour {{count}} {{type}}(s) sélectionné(s). Une ligne de déclenchement sera créée par sélection.",
+        "searchPlaceholder": "Rechercher des {{type}}...",
+        "noMatches": "Aucun résultat pour « {{search}} ».",
+        "hiddenBySearch_one": "{{count}} élément sélectionné est masqué par la recherche",
+        "hiddenBySearch_many": "{{count}} éléments sélectionnés sont masqués par la recherche",
+        "hiddenBySearch_other": "{{count}} éléments sélectionnés sont masqués par la recherche"
     }
 }

--- a/frontend-admin-dashboard/public/locales/hi/workflowEventEntityPicker.json
+++ b/frontend-admin-dashboard/public/locales/hi/workflowEventEntityPicker.json
@@ -30,6 +30,10 @@
         "noneFound": "कोई {{type}} नहीं मिला",
         "summaryNone": "कोई चयन नहीं — वर्कफ़्लो आपके संस्थान के हर {{type}} के लिए चलेगा।",
         "summarySelected_one": "वर्कफ़्लो केवल चयनित {{type}} के लिए चलेगा।",
-        "summarySelected_other": "वर्कफ़्लो {{count}} चयनित {{type}}(ओं) के लिए चलेगा। प्रत्येक चयन के लिए एक ट्रिगर पंक्ति बनाई जाएगी।"
+        "summarySelected_other": "वर्कफ़्लो {{count}} चयनित {{type}}(ओं) के लिए चलेगा। प्रत्येक चयन के लिए एक ट्रिगर पंक्ति बनाई जाएगी।",
+        "searchPlaceholder": "{{type}} खोजें...",
+        "noMatches": "“{{search}}” से कुछ भी मेल नहीं खाता।",
+        "hiddenBySearch_one": "{{count}} चयनित आइटम खोज के कारण छिपा है",
+        "hiddenBySearch_other": "{{count}} चयनित आइटम खोज के कारण छिपे हैं"
     }
 }

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/event-entity-picker.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/event-entity-picker.tsx
@@ -12,6 +12,12 @@ import {
     INIT_INSTITUTE,
 } from '@/constants/urls';
 
+/**
+ * Show the search box only once the list is long enough to need it — filtering
+ * two batches is noise, filtering four hundred is the only way through.
+ */
+const SEARCHABLE_FROM = 8;
+
 interface EventEntityPickerProps {
     eventAppliedType: string;
     /** Single value — backward compat (used if multiValue not provided) */
@@ -168,6 +174,7 @@ function buildTypeLabels(t: TFunction): Record<string, string> {
 export function EventEntityPicker({ eventAppliedType, value, onChange, multiValue, onMultiChange, instituteId }: EventEntityPickerProps) {
     const { t } = useTranslation('workflowEventEntityPicker');
     const [showManual, setShowManual] = useState(false);
+    const [search, setSearch] = useState('');
     const hasDropdownSupport = ['PACKAGE_SESSION', 'AUDIENCE', 'LIVE_SESSION', 'ENROLL_INVITE'].includes(eventAppliedType);
     const { data: options = [], isLoading, isError } = useEntityOptions(eventAppliedType, instituteId);
 
@@ -240,6 +247,22 @@ export function EventEntityPicker({ eventAppliedType, value, onChange, multiValu
         );
     }
 
+    // Filter what's shown, never the selection: an institute with hundreds of
+    // batches can't scroll to the one it wants, but a ticked row that scrolls
+    // out of the filter must stay ticked. selectedIds is untouched, and the
+    // summary below says when the search is hiding some of it.
+    const needle = search.trim().toLowerCase();
+    const visibleOptions = needle
+        ? options.filter(
+            (opt) =>
+                opt.label.toLowerCase().includes(needle)
+                || (opt.subtitle?.toLowerCase().includes(needle) ?? false)
+        )
+        : options;
+    const hiddenSelectedCount = selectedIds.filter(
+        (id) => !visibleOptions.some((opt) => opt.id === id)
+    ).length;
+
     // Checkbox list mode for supported types (multi-select)
     return (
         <div className="space-y-2">
@@ -256,6 +279,17 @@ export function EventEntityPicker({ eventAppliedType, value, onChange, multiValu
                 </button>
             </div>
 
+            {/* Only worth the extra control once the list is long enough that
+                scrolling is the problem it solves. */}
+            {options.length > SEARCHABLE_FROM && (
+                <Input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder={t('checklist.searchPlaceholder', { type: typeLabel })}
+                />
+            )}
+
             <div className="max-h-48 overflow-y-auto rounded-lg border border-gray-300 bg-white">
                 {isLoading && (
                     <div className="px-3 py-2 text-xs text-gray-400">{t('checklist.loading')}</div>
@@ -263,7 +297,12 @@ export function EventEntityPicker({ eventAppliedType, value, onChange, multiValu
                 {!isLoading && options.length === 0 && (
                     <div className="px-3 py-2 text-xs text-gray-400">{t('checklist.noneFound', { type: typeLabel })}</div>
                 )}
-                {options.map((opt) => {
+                {!isLoading && options.length > 0 && visibleOptions.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-gray-400">
+                        {t('checklist.noMatches', { search: search.trim() })}
+                    </div>
+                )}
+                {visibleOptions.map((opt) => {
                     const checked = selectedIds.includes(opt.id);
                     return (
                         <label
@@ -295,6 +334,9 @@ export function EventEntityPicker({ eventAppliedType, value, onChange, multiValu
                     ? t('checklist.summaryNone', { type: typeLabel })
                     : t('checklist.summarySelected', { count: selectedIds.length, type: typeLabel })
                 }
+                {/* The count above covers the whole selection, so say when the
+                    search is hiding part of it rather than let it read wrong. */}
+                {hiddenSelectedCount > 0 && ` — ${t('checklist.hiddenBySearch', { count: hiddenSelectedCount })}`}
             </p>
         </div>
     );

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.test.ts
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.test.ts
@@ -5,7 +5,7 @@
  * number of params (0)". These cover the generator side of that contract.
  */
 import { describe, expect, it } from 'vitest';
-import { declaredParamsKey, getTemplatesForTrigger } from './use-case-templates';
+import { declaredParamsKey, getTemplatesForTrigger, isQuestionApplicable } from './use-case-templates';
 
 /** The audience-confirmation use case, which maps six named vars for email. */
 function confirmationTemplate() {
@@ -76,5 +76,52 @@ describe('makeChannelSendNodes — WhatsApp templateVars', () => {
             waTemplateName: 'unknown',
         });
         expect(config.templateVars).toMatchObject({ name: 'Full Name' });
+    });
+});
+
+/**
+ * Per-enrolment triggers already carry the batch the learner joined
+ * (`packageSessionIds` on the context), and the trigger's own scope decides
+ * which batches fire. Asking for a batch again in the wizard was worse than
+ * redundant: the hard-coded answer overrode the trigger scope — three batches
+ * selected on the trigger, one batch messaged.
+ */
+describe('email_batch_students — batch comes from the trigger when it can', () => {
+    function template(trigger: string) {
+        const tmpl = getTemplatesForTrigger(trigger, 'EVENT_DRIVEN')
+            .find((t) => t.id === 'email_batch_students');
+        if (!tmpl) throw new Error(`email_batch_students not offered for ${trigger}`);
+        return tmpl;
+    }
+
+    function queryBatchId(trigger: string, answers: Record<string, string | number | string[]>) {
+        const { nodes } = template(trigger).generateWorkflow(answers, trigger);
+        const query = nodes.find((n) => n.data.nodeType === 'QUERY');
+        const params = (query?.data.config as { params: { batchId: string } }).params;
+        return params.batchId;
+    }
+
+    const base = { channel: 'EMAIL', templateName: 'reminder' };
+
+    it('does not ask for a batch on LEARNER_BATCH_ENROLLMENT', () => {
+        const batchQ = template('LEARNER_BATCH_ENROLLMENT').questions.find((q) => q.id === 'batchId')!;
+        expect(isQuestionApplicable(batchQ, base, 'LEARNER_BATCH_ENROLLMENT')).toBe(false);
+        expect(isQuestionApplicable(batchQ, base, 'SUB_ORG_MEMBER_ENROLLMENT')).toBe(false);
+    });
+
+    it('reads the batch from the trigger context on enrolment events', () => {
+        expect(queryBatchId('LEARNER_BATCH_ENROLLMENT', base)).toBe("#ctx['packageSessionIds']");
+        expect(queryBatchId('SUB_ORG_MEMBER_ENROLLMENT', base)).toBe("#ctx['packageSessionIds']");
+    });
+
+    it('ignores a stale batch answer on enrolment events — the trigger wins', () => {
+        expect(queryBatchId('LEARNER_BATCH_ENROLLMENT', { ...base, batchId: 'stale-batch' }))
+            .toBe("#ctx['packageSessionIds']");
+    });
+
+    it('still asks for, and uses, the batch on triggers that do not carry one', () => {
+        const batchQ = template('LIVE_SESSION_START').questions.find((q) => q.id === 'batchId')!;
+        expect(isQuestionApplicable(batchQ, base, 'LIVE_SESSION_START')).toBe(true);
+        expect(queryBatchId('LIVE_SESSION_START', { ...base, batchId: 'batch-42' })).toBe('batch-42');
     });
 });

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.ts
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-templates.ts
@@ -36,6 +36,14 @@ export interface WizardQuestion {
     /** Only show this question if another answer matches */
     showIf?: { questionId: string; values: string[] };
     /**
+     * Skip this question when the workflow is built on one of these trigger
+     * events, because the event already supplies the answer at run time (and
+     * the generator reads it from the context instead). Asking anyway is not
+     * just redundant — a hard-coded answer silently overrides whatever scope
+     * the admin set on the trigger in the previous step.
+     */
+    hideForTriggers?: string[];
+    /**
      * Optional override for which entry in SAMPLE_TEMPLATES to offer as a
      * "Use sample" button alongside this template_select question. Defaults to
      * the use-case template's id. Set explicitly when a single use-case has
@@ -135,6 +143,52 @@ function whatsappTemplateQuestion(overrides: Partial<WizardQuestion> = {}): Wiza
         showIf: { questionId: 'channel', values: ['WHATSAPP', 'BOTH'] },
         ...overrides,
     };
+}
+
+/**
+ * Whether a question applies given the current answers and trigger event.
+ * The single source of truth for the wizard's "is this question asked?"
+ * decision — rendering, the Generate gate, and the preview all go through it
+ * so they cannot disagree about which questions are required.
+ */
+export function isQuestionApplicable(
+    question: WizardQuestion,
+    answers: Record<string, string | number | string[]>,
+    triggerEvent: string | undefined
+): boolean {
+    if (triggerEvent && question.hideForTriggers?.includes(triggerEvent)) return false;
+    if (!question.showIf) return true;
+    const depVal = String(answers[question.showIf.questionId] ?? '');
+    return question.showIf.values.includes(depVal);
+}
+
+// ─── Batch from the trigger ───
+//
+// Per-enrolment events put the batch the learner just joined on the workflow
+// context as `packageSessionIds` (a single id, despite the plural name —
+// StudentRegistrationManager.triggerEnrollmentWorkflow and
+// SubOrgMemberEnrollmentContext both write it that way). Templates that query
+// "students in the batch" read it from there rather than asking the admin to
+// pick one: the trigger's own scope (step 3) already decides which batches
+// fire, and a batch hard-coded here would override it — three batches selected
+// on the trigger, one batch messaged.
+
+/** Trigger events whose context carries the batch as `packageSessionIds`. */
+const BATCH_FROM_TRIGGER = ['LEARNER_BATCH_ENROLLMENT', 'SUB_ORG_MEMBER_ENROLLMENT'];
+
+/** SpEL that resolves to the batch from a BATCH_FROM_TRIGGER event's context. */
+const BATCH_FROM_CONTEXT = "#ctx['packageSessionIds']";
+
+/**
+ * The batch id a "students in batch" QUERY should use: the trigger's own
+ * batch when the event supplies one, else whatever the admin picked.
+ */
+function batchIdFor(
+    answers: Record<string, string | number | string[]>,
+    triggerEvent: string | undefined
+): string {
+    if (triggerEvent && BATCH_FROM_TRIGGER.includes(triggerEvent)) return BATCH_FROM_CONTEXT;
+    return answers.batchId as string;
 }
 
 /**
@@ -500,6 +554,7 @@ function buildUseCaseTemplates(): UseCaseTemplate[] {
                 helpText: wt('templates.email_batch_students.questions.batchId.helpText'),
                 type: 'batch_select',
                 required: true,
+                hideForTriggers: BATCH_FROM_TRIGGER,
             },
             channelQuestion(),
             {
@@ -532,7 +587,7 @@ function buildUseCaseTemplates(): UseCaseTemplate[] {
 
             const queryNode = makeNode('QUERY', wt('shared.nodes.fetchBatchStudents'), {
                 prebuiltKey: 'fetch_students_by_batch',
-                params: { batchId: answers.batchId as string },
+                params: { batchId: batchIdFor(answers, triggerEvent) },
             }, 250, 230);
 
             const send = makeChannelSendNodes(answers, {
@@ -1032,6 +1087,7 @@ function buildUseCaseTemplates(): UseCaseTemplate[] {
                 label: wt('shared.questions.batchId.label'),
                 type: 'batch_select',
                 required: true,
+                hideForTriggers: BATCH_FROM_TRIGGER,
             },
             channelQuestion(),
             {
@@ -1052,7 +1108,7 @@ function buildUseCaseTemplates(): UseCaseTemplate[] {
 
             const queryNode = makeNode('QUERY', wt('shared.nodes.fetchBatchStudents'), {
                 prebuiltKey: 'fetch_students_by_batch',
-                params: { batchId: answers.batchId as string },
+                params: { batchId: batchIdFor(answers, triggerEvent) },
             }, 250, 230);
 
             const send = makeChannelSendNodes(answers, {

--- a/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-wizard-step.tsx
+++ b/frontend-admin-dashboard/src/routes/workflow/create/-components/use-case-wizard-step.tsx
@@ -18,7 +18,7 @@ import { INIT_INSTITUTE, AUDIENCE_CAMPAIGNS_LIST, CREATE_MESSAGE_TEMPLATE, MESSA
 import { getMessageTemplates } from '@/services/message-template-service';
 import { getTemplatesByTypeQuery, whatsappTemplateParamKeys, type TemplateItem } from '@/services/workflow-service';
 import { useWorkflowBuilderStore } from '../-stores/workflow-builder-store';
-import { declaredParamsKey, getTemplatesForTrigger, type UseCaseTemplate, type WizardQuestion } from './use-case-templates';
+import { declaredParamsKey, getTemplatesForTrigger, isQuestionApplicable, type UseCaseTemplate, type WizardQuestion } from './use-case-templates';
 import { buildSampleTemplates } from './sample-email-templates';
 import { getInstituteId } from '@/constants/helper';
 
@@ -582,14 +582,10 @@ export function UseCaseWizardStep({
 
     const canGenerate = selectedTemplate
         ? selectedTemplate.questions
-            // Skip required-but-hidden questions (conditional via showIf) — otherwise
-            // a hidden required question would permanently block the Generate button.
-            .filter((q) => {
-                if (!q.required) return false;
-                if (!q.showIf) return true;
-                const depVal = String(answers[q.showIf.questionId] ?? '');
-                return q.showIf.values.includes(depVal);
-            })
+            // Skip required-but-hidden questions (showIf, or answered by the
+            // trigger) — otherwise a hidden required question would permanently
+            // block the Generate button.
+            .filter((q) => q.required && isQuestionApplicable(q, answers, triggerConfig.eventName || undefined))
             .every((q) => {
                 const val = answers[q.id];
                 if (val === undefined) return false;
@@ -733,11 +729,9 @@ export function UseCaseWizardStep({
     }
 
     // ─── Question wizard view ───
-    const visibleQuestions = selectedTemplate.questions.filter((q) => {
-        if (!q.showIf) return true;
-        const depVal = String(answers[q.showIf.questionId] ?? '');
-        return q.showIf.values.includes(depVal);
-    });
+    const visibleQuestions = selectedTemplate.questions.filter((q) =>
+        isQuestionApplicable(q, answers, triggerConfig.eventName || undefined)
+    );
 
     return (
         <div className="space-y-6">


### PR DESCRIPTION
Two commits on the workflow-creation wizard.

## 1. `259cfc8f5c` — take the batch from the trigger instead of asking again

**Message batch students** (`email_batch_students`) and **Email parents of batch students** (`email_parents_batch`) asked the admin to pick a batch in step 4 even when step 3 had just scoped the trigger to specific batches.

On `LEARNER_BATCH_ENROLLMENT` and `SUB_ORG_MEMBER_ENROLLMENT` the event already carries the batch the learner joined — both contexts put it on `packageSessionIds` (`StudentRegistrationManager.triggerEnrollmentWorkflow`, `SubOrgMemberEnrollmentContext`). So the question was redundant, and worse than redundant: **the hard-coded answer overrode the trigger scope.** Scope the trigger to three batches and every enrolment in any of them messaged only the one batch chosen in step 4.

- New `hideForTriggers` on `WizardQuestion` for "the event supplies this".
- Generator reads `#ctx['packageSessionIds']` on those triggers, so the trigger's scope decides; a stale batch answer is ignored.
- Triggers that don't carry a batch (live sessions, installment reminders) still ask and use the answer exactly as before.
- The wizard's render, Generate gate and preview now all go through one `isQuestionApplicable()` — previously each re-implemented the `showIf` check independently.

4 new tests pin this: not asked on either enrolment trigger; reads from context; trigger wins over a stale answer; still asked and used on `LIVE_SESSION_START`.

## 2. `4f97f12e92` — search in the step-3 Scope picker

The searchable list that landed in #2839 went into the step-4 wizard; the picker that actually shows a long list is the step-3 **Scope** control (`EventEntityPicker`, *Select Batch / Package Session(s)*), where an institute meets all of its batches, audiences, live sessions and invites at once.

- Box appears past 8 options; matches label **and** subtitle.
- Filters what is shown, never what is selected — a ticked row that falls out of the filter stays ticked; the summary keeps the true count and says how many the search is hiding.
- Strings in en/fr/ar/hi with full plural sets.

## Verification

`tsc --noEmit` clean over the changed files and their import graphs; `use-case-templates.test.ts` 9/9 passing. Not exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)