### PR TITLE
feat(payments): searchable payment-plan picker, creator tracking, aud…

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeManagementController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/fee_management/controller/FeeManagementController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.fee_management.dto.ComplexPaymentOptionDTO;
 import vacademy.io.admin_core_service.features.fee_management.service.FeeManagementService;
 import vacademy.io.common.auth.model.CustomUserDetails;
@@ -23,6 +24,11 @@ public class FeeManagementController {
      * POST /admin-core-service/v1/fee-management/cpo
      */
     @PostMapping("/cpo")
+    @Auditable(
+            entityType = "FEE_PLAN",
+            action = "CREATE",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "'created fee plan ' + #request?.name")
     public ResponseEntity<ComplexPaymentOptionDTO> createCpo(
             @RequestBody ComplexPaymentOptionDTO request,
             @RequestAttribute("user") CustomUserDetails userDetails) {
@@ -63,6 +69,11 @@ public class FeeManagementController {
      * PUT /admin-core-service/v1/fee-management/cpo/{cpoId}
      */
     @PutMapping("/cpo/{cpoId}")
+    @Auditable(
+            entityType = "FEE_PLAN",
+            action = "UPDATE",
+            entityIdExpr = "#cpoId",
+            descriptionExpr = "'updated fee plan ' + (#request?.name ?: #result?.body?.name)")
     public ResponseEntity<ComplexPaymentOptionDTO> updateCpo(
             @PathVariable String cpoId,
             @RequestBody ComplexPaymentOptionDTO request,
@@ -75,6 +86,11 @@ public class FeeManagementController {
      * PUT /admin-core-service/v1/fee-management/fee-type/{feeTypeId}
      */
     @PutMapping("/fee-type/{feeTypeId}")
+    @Auditable(
+            entityType = "FEE_PLAN",
+            action = "UPDATE",
+            entityIdExpr = "#feeTypeId",
+            descriptionExpr = "'updated fee type ' + (#request?.name ?: #result?.body?.name)")
     public ResponseEntity<ComplexPaymentOptionDTO.FeeTypeDTO> updateFeeType(
             @PathVariable String feeTypeId,
             @RequestBody ComplexPaymentOptionDTO.FeeTypeDTO request,
@@ -87,6 +103,11 @@ public class FeeManagementController {
      * PUT /admin-core-service/v1/fee-management/cpo/{cpoId}/soft-delete
      */
     @PutMapping("/cpo/{cpoId}/soft-delete")
+    @Auditable(
+            entityType = "FEE_PLAN",
+            action = "DELETE",
+            entityIdExpr = "#cpoId",
+            descriptionExpr = "'deleted fee plan ' + (#result?.body?.name ?: #cpoId)")
     public ResponseEntity<ComplexPaymentOptionDTO> softDeleteCpo(
             @PathVariable String cpoId,
             @RequestAttribute("user") CustomUserDetails userDetails) {
@@ -114,6 +135,11 @@ public class FeeManagementController {
      * POST /admin-core-service/v1/fee-management/cpo/{cpoId}/approve
      */
     @PostMapping("/cpo/{cpoId}/approve")
+    @Auditable(
+            entityType = "FEE_PLAN",
+            action = "APPROVE",
+            entityIdExpr = "#cpoId",
+            descriptionExpr = "'approved fee plan ' + (#result?.body?.name ?: #cpoId)")
     public ResponseEntity<ComplexPaymentOptionDTO> approveCpo(
             @PathVariable String cpoId,
             @RequestAttribute("user") CustomUserDetails userDetails) {

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/InstituteDefaultUserSubscriptionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/institute/service/InstituteDefaultUserSubscriptionService.java
@@ -41,6 +41,7 @@ public class InstituteDefaultUserSubscriptionService {
             .build();
         paymentOptionDTO.setPaymentPlans(List.of(paymentPlanDTO));
 
-        paymentOptionService.savePaymentOption(paymentOptionDTO);
+        // System-seeded on institute creation: there is no admin to credit as creator.
+        paymentOptionService.savePaymentOption(paymentOptionDTO, null);
     }
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/controller/PaymentOptionController.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/controller/PaymentOptionController.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.user_subscription.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import vacademy.io.admin_core_service.features.admin_activity_logs.annotation.Auditable;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentOptionDTO;
 import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentOptionFilterDTO;
@@ -18,9 +19,25 @@ public class PaymentOptionController {
     @Autowired
     private PaymentOptionService paymentOptionService;
 
+    /**
+     * Create — or, when the body carries an existing id (the Settings page edits
+     * this way), replace — a payment option. Returns the saved option so the client
+     * and the audit row get the server-generated id.
+     *
+     * <p>The audit action is decided by the pre-call snapshot: a row that already
+     * existed makes this an UPDATE, otherwise a CREATE.
+     */
     @PostMapping
-    public ResponseEntity<Boolean> savePaymentOption(@RequestBody PaymentOptionDTO paymentOptionDTO) {
-        return ResponseEntity.ok(paymentOptionService.savePaymentOption(paymentOptionDTO));
+    @Auditable(
+            entityType = "PAYMENT_PLAN",
+            action = "CREATE",
+            actionExpr = "#before != null ? 'UPDATE' : 'CREATE'",
+            captureBefore = "@paymentOptionService.auditSnapshot(#paymentOptionDTO?.id)",
+            entityIdExpr = "#result?.body?.id",
+            descriptionExpr = "(#before != null ? 'updated' : 'created') + ' payment plan ' + #paymentOptionDTO?.name")
+    public ResponseEntity<PaymentOptionDTO> savePaymentOption(@RequestBody PaymentOptionDTO paymentOptionDTO,
+                                                              @RequestAttribute("user") CustomUserDetails userDetails) {
+        return ResponseEntity.ok(paymentOptionService.savePaymentOption(paymentOptionDTO, userDetails));
     }
 
     @PostMapping("/get-payment-options")
@@ -29,6 +46,11 @@ public class PaymentOptionController {
     }
 
     @PostMapping("/make-default-payment-option")
+    @Auditable(
+            entityType = "PAYMENT_PLAN",
+            action = "MAKE_DEFAULT",
+            entityIdExpr = "#paymentOptionId",
+            descriptionExpr = "'made payment plan ' + @paymentOptionService.auditName(#paymentOptionId) + ' the default'")
     public ResponseEntity<String> changeDefaultPaymentOption(String source,
                                                                              String sourceId,
                                                                              String paymentOptionId,
@@ -37,11 +59,22 @@ public class PaymentOptionController {
     }
 
     @DeleteMapping
+    @Auditable(
+            entityType = "PAYMENT_PLAN",
+            action = "DELETE",
+            entityIdExpr = "T(java.lang.String).join(',', #paymentOptionIds)",
+            descriptionExpr = "'deleted ' + @paymentOptionService.auditLabel(#paymentOptionIds)")
     public ResponseEntity<String> deletePaymentOptions(@RequestBody List<String> paymentOptionIds, @RequestAttribute("user") CustomUserDetails userDetails) {
         return ResponseEntity.ok(paymentOptionService.deletePaymentOption(paymentOptionIds,userDetails));
     }
 
     @PutMapping
+    @Auditable(
+            entityType = "PAYMENT_PLAN",
+            action = "UPDATE",
+            captureBefore = "@paymentOptionService.auditSnapshot(#paymentOptionDTO?.id)",
+            entityIdExpr = "#paymentOptionDTO?.id",
+            descriptionExpr = "'updated payment plan ' + #paymentOptionDTO?.name")
     public ResponseEntity<PaymentOptionDTO> editPaymentOption(@RequestBody PaymentOptionDTO paymentOptionDTO) {
         return ResponseEntity.ok(paymentOptionService.editPaymentOption(paymentOptionDTO));
     }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/PaymentOptionDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/dto/PaymentOptionDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.Date;
 import java.util.List;
 
 @Data
@@ -30,4 +31,18 @@ public class PaymentOptionDTO {
     private String complexPaymentOptionId;
     private List<PaymentPlanDTO> paymentPlans;
     private String paymentOptionMetadataJson;
+
+    // ── Read-only provenance ──────────────────────────────────────────────
+    // Ignored on write: the service stamps the creator from the JWT and the
+    // database stamps the timestamps. Present so the admin plan picker can
+    // sort newest-first and say who added each plan.
+    private String createdByUserId;
+    /**
+     * Display name of {@link #createdByUserId}, resolved from auth_service on the
+     * list endpoint only. Null when the creator is unknown or auth_service could
+     * not be reached — the UI falls back to the id.
+     */
+    private String createdByName;
+    private Date createdAt;
+    private Date updatedAt;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/PaymentOption.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/entity/PaymentOption.java
@@ -76,6 +76,17 @@ public class PaymentOption {
     @Column(name = "complex_payment_option_id")
     private String complexPaymentOptionId;
 
+    /**
+     * auth_service user id of the admin who created this option. Stamped by the
+     * service on insert from the request's JWT, never from the client DTO.
+     *
+     * updatable = false on purpose: the Settings page edits a plan through the same
+     * POST, which rebuilds the entity from the DTO and merges it — with an updatable
+     * column that merge would silently null the creator on every edit.
+     */
+    @Column(name = "created_by_user_id", updatable = false)
+    private String createdByUserId;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Date createdAt;
 
@@ -129,6 +140,9 @@ public class PaymentOption {
                 .unit(this.unit)
                 .planChangeAllowed(Boolean.TRUE.equals(this.planChangeAllowed))
                 .complexPaymentOptionId(this.complexPaymentOptionId)
+                .createdByUserId(this.createdByUserId)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
                 .paymentPlans(this.paymentPlans != null
                         ? this.paymentPlans.stream()
                         .map(PaymentPlan::mapToPaymentPlanDTO)
@@ -151,6 +165,9 @@ public class PaymentOption {
             .unit(this.unit)
             .planChangeAllowed(Boolean.TRUE.equals(this.planChangeAllowed))
             .complexPaymentOptionId(this.complexPaymentOptionId)
+            .createdByUserId(this.createdByUserId)
+            .createdAt(this.createdAt)
+            .updatedAt(this.updatedAt)
             .build();
     }
 

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentOptionService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentOptionService.java
@@ -3,6 +3,7 @@ package vacademy.io.admin_core_service.features.user_subscription.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
 import vacademy.io.admin_core_service.features.common.enums.StatusEnum;
 import vacademy.io.admin_core_service.features.fee_management.entity.AftInstallment;
 import vacademy.io.admin_core_service.features.fee_management.entity.AssignedFeeValue;
@@ -19,6 +20,7 @@ import vacademy.io.admin_core_service.features.user_subscription.enums.PaymentOp
 import vacademy.io.admin_core_service.features.user_subscription.enums.PaymentOptionType;
 import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentOptionRepository;
 import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentPlanRepository;
+import vacademy.io.common.auth.dto.UserDTO;
 import vacademy.io.common.auth.model.CustomUserDetails;
 import vacademy.io.common.exceptions.VacademyException;
 
@@ -26,7 +28,10 @@ import java.math.BigDecimal;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -58,8 +63,34 @@ public class PaymentOptionService {
     @Autowired
     private AftInstallmentRepository aftInstallmentRepository;
 
-    public boolean savePaymentOption(PaymentOptionDTO paymentOptionDTO) {
+    @Autowired
+    private AuthService authService;
+
+    /**
+     * Creates a payment option, or — when the DTO carries the id of an existing row —
+     * edits it in place (the Settings page edits through this same POST). Returns the
+     * saved option so the caller and the audit log get the server-generated id.
+     *
+     * <p>An edit is routed through {@link #editPaymentOption} rather than merged as a
+     * rebuilt entity. The merge kept every stored plan ACTIVE next to the resent copies
+     * (a FREE/DONATION plan is resent without an id, so it was inserted anew on every
+     * save — prod had ~2,000 options carrying duplicate live plans), and it nulled the
+     * DEFAULT tag because the edit payload never carries one.
+     */
+    public PaymentOptionDTO savePaymentOption(PaymentOptionDTO paymentOptionDTO, CustomUserDetails userDetails) {
+        if (paymentOptionDTO.getId() != null && !paymentOptionDTO.getId().isBlank()
+                && paymentOptionRepository.existsById(paymentOptionDTO.getId())) {
+            return editPaymentOption(paymentOptionDTO, true);
+        }
+
         PaymentOption paymentOption = new PaymentOption(paymentOptionDTO);
+        // Any id that reached here is a client placeholder (the invite flow sends
+        // "plan_<timestamp>"). Clear it so the generator mints the real one and the
+        // repository takes the persist path instead of merging a phantom row.
+        paymentOption.setId(null);
+        paymentOption.getPaymentPlans().forEach(plan -> plan.setId(null));
+        // Creator is stamped from the JWT, never trusted from the client.
+        paymentOption.setCreatedByUserId(userDetails != null ? userDetails.getUserId() : null);
 
         if (PaymentOptionType.FREE.name().equalsIgnoreCase(paymentOption.getType()) && paymentOption.getPaymentPlans().isEmpty()) {
             PaymentPlan freePlan = new PaymentPlan();
@@ -72,8 +103,56 @@ public class PaymentOptionService {
             paymentOption.getPaymentPlans().add(freePlan);
         }
 
-        paymentOptionRepository.save(paymentOption);
-        return true;
+        PaymentOption saved = paymentOptionRepository.save(paymentOption);
+        return saved.mapToPaymentOptionDTO();
+    }
+
+    // -------------------------------------------------------------------------
+    // Audit helpers — called from @Auditable SpEL on PaymentOptionController.
+    // Every method is total: audit must never break the mutation it describes.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pre-mutation snapshot for {@code captureBefore}. Null when there is no id
+     * (a create) or no such row, which is how the controller tells CREATE from
+     * UPDATE on the shared POST.
+     */
+    public PaymentOptionDTO auditSnapshot(String paymentOptionId) {
+        if (paymentOptionId == null || paymentOptionId.isBlank()) return null;
+        try {
+            return paymentOptionRepository.findById(paymentOptionId)
+                    .map(PaymentOption::mapToPaymentOptionDTO)
+                    .orElse(null);
+        } catch (Exception e) {
+            log.warn("auditSnapshot failed for payment option {}: {}", paymentOptionId, e.getMessage());
+            return null;
+        }
+    }
+
+    /** Name of one option for the audit sentence, falling back to its id. */
+    public String auditName(String paymentOptionId) {
+        if (paymentOptionId == null || paymentOptionId.isBlank()) return null;
+        try {
+            return paymentOptionRepository.findById(paymentOptionId)
+                    .map(PaymentOption::getName)
+                    .filter(n -> n != null && !n.isBlank())
+                    .orElse(paymentOptionId);
+        } catch (Exception e) {
+            return paymentOptionId;
+        }
+    }
+
+    /**
+     * "payment plan Annual Membership" for one id, "3 payment plan(s)" for several —
+     * a bulk delete naming every plan would not fit the log row.
+     */
+    public String auditLabel(List<String> paymentOptionIds) {
+        List<String> ids = paymentOptionIds == null
+                ? List.of()
+                : paymentOptionIds.stream().filter(Objects::nonNull).filter(id -> !id.isBlank()).distinct().toList();
+        if (ids.isEmpty()) return null;
+        if (ids.size() > 1) return ids.size() + " payment plan(s)";
+        return "payment plan " + auditName(ids.get(0));
     }
 
     /**
@@ -107,7 +186,55 @@ public class PaymentOptionService {
                 paymentOptionFilterDTO.isRequireApproval(),
                 paymentOptionFilterDTO.isNotRequireApproval()
         );
-        return paymentOptions.stream().map(PaymentOption::mapToPaymentOptionDTO).toList();
+        List<PaymentOptionDTO> dtos = paymentOptions.stream().map(PaymentOption::mapToPaymentOptionDTO).toList();
+        // The learner app hits this same endpoint for admission payments; a learner has no
+        // use for who configured the plan, so the auth_service round-trip is admin-only.
+        if (!isLearnerOnly(userDetails)) {
+            attachCreatorNames(dtos);
+        }
+        return dtos;
+    }
+
+    private static final List<String> LEARNER_ROLES = List.of("STUDENT", "PARENT", "GUARDIAN");
+
+    private boolean isLearnerOnly(CustomUserDetails user) {
+        if (user == null || user.getAuthorities() == null || user.getAuthorities().isEmpty()) return false;
+        return user.getAuthorities().stream()
+                .allMatch(a -> a.getAuthority() != null
+                        && LEARNER_ROLES.stream().anyMatch(r -> r.equalsIgnoreCase(a.getAuthority())));
+    }
+
+    /**
+     * Resolves {@code createdByUserId} to a display name in one batched auth_service
+     * call. Best-effort: the list must still come back when auth_service is slow or
+     * down, so a failure leaves {@code createdByName} null and the UI shows the id.
+     */
+    private void attachCreatorNames(List<PaymentOptionDTO> dtos) {
+        List<String> creatorIds = dtos.stream()
+                .map(PaymentOptionDTO::getCreatedByUserId)
+                .filter(Objects::nonNull)
+                .filter(id -> !id.isBlank())
+                .distinct()
+                .toList();
+        if (creatorIds.isEmpty()) return;
+        Map<String, String> names = new HashMap<>();
+        try {
+            for (UserDTO user : authService.getUsersFromAuthServiceByUserIds(creatorIds)) {
+                if (user == null || user.getId() == null) continue;
+                String name = user.getFullName() != null && !user.getFullName().isBlank()
+                        ? user.getFullName().trim()
+                        : user.getEmail() != null && !user.getEmail().isBlank()
+                                ? user.getEmail()
+                                : user.getUsername();
+                if (name != null) names.put(user.getId(), name);
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve payment option creator names ({} ids): {}", creatorIds.size(), e.getMessage());
+            return;
+        }
+        for (PaymentOptionDTO dto : dtos) {
+            dto.setCreatedByName(names.get(dto.getCreatedByUserId()));
+        }
     }
 
     public Optional<PaymentOption> getPaymentOption(String source, String sourceId, String tag, List<String> statuses) {
@@ -163,7 +290,16 @@ public class PaymentOptionService {
         return "success";
     }
 
+    /** PUT edit: a partial payload, so null plan fields are left alone. */
     public PaymentOptionDTO editPaymentOption(PaymentOptionDTO paymentOptionDTO) {
+        return editPaymentOption(paymentOptionDTO, false);
+    }
+
+    /**
+     * @param fullPayload the caller resends every plan field (Settings save via POST), so a
+     *                    null validity is the admin choosing "no expiry" and must be written.
+     */
+    private PaymentOptionDTO editPaymentOption(PaymentOptionDTO paymentOptionDTO, boolean fullPayload) {
         PaymentOption paymentOption = findById(paymentOptionDTO.getId());
         paymentOption.setName(paymentOptionDTO.getName());
         paymentOption.setType(paymentOptionDTO.getType());
@@ -175,7 +311,7 @@ public class PaymentOptionService {
         if (paymentOptionDTO.getPlanChangeAllowed() != null) {
             paymentOption.setPlanChangeAllowed(paymentOptionDTO.getPlanChangeAllowed());
         }
-        List<PaymentPlan> paymentPlans = paymentPlanService.editPaymentPlans(paymentOption.getPaymentPlans(), paymentOptionDTO.getPaymentPlans(), paymentOption);
+        List<PaymentPlan> paymentPlans = paymentPlanService.editPaymentPlans(paymentOption.getPaymentPlans(), paymentOptionDTO.getPaymentPlans(), paymentOption, fullPayload);
         paymentOption.setPaymentPlans(paymentPlans);
         paymentOptionRepository.save(paymentOption);
         return paymentOption.mapToPaymentOptionDTO();
@@ -208,6 +344,8 @@ public class PaymentOptionService {
         mirror.setType(PaymentOptionType.CPO.name());
         mirror.setRequireApproval(false);
         mirror.setComplexPaymentOptionId(cpo.getId());
+        // The CPO row already knows its creator; the mirror is what the plan picker lists.
+        mirror.setCreatedByUserId(cpo.getCreatedBy());
 
         PaymentOption saved = paymentOptionRepository.save(mirror);
         upsertSyntheticPaymentPlan(cpo, saved);

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanService.java
@@ -31,15 +31,37 @@ public class PaymentPlanService {
         return paymentPlanRepository.findByPaymentOption(paymentOption);
     }
     public List<PaymentPlan>editPaymentPlans(List<PaymentPlan>existingPaymentPlans, List<PaymentPlanDTO>paymentPlanDTOS, PaymentOption paymentOption){
+        return editPaymentPlans(existingPaymentPlans, paymentPlanDTOS, paymentOption, false);
+    }
+
+    /**
+     * @param fullPayload true when the caller sends every plan field (the Settings page
+     *                    save). A null {@code validityInDays} then means "no expiry" —
+     *                    the FREE "Unlimited" / ONE_TIME "Lifetime" choice — and is
+     *                    written. With a partial payload (the Edit Payment Option dialog)
+     *                    null only means "not sent" and the stored value is kept.
+     */
+    public List<PaymentPlan>editPaymentPlans(List<PaymentPlan>existingPaymentPlans, List<PaymentPlanDTO>paymentPlanDTOS, PaymentOption paymentOption, boolean fullPayload){
         Map<String,PaymentPlan>existingPaymentPlanMap = existingPaymentPlans.stream().
                 collect(Collectors.toMap(PaymentPlan::getId, Function.identity()));
         List<PaymentPlan>toSave = new ArrayList<>();
         Set<String> retainedIds = new HashSet<>();
+        if (paymentPlanDTOS == null) paymentPlanDTOS = List.of();
+        // Single-plan option types (FREE / DONATION, and older clients for ONE_TIME) are
+        // resent by the Settings page without a plan id. One stored plan edited into one
+        // resent plan is an update of that plan, not a replacement: matching them keeps
+        // the id, so user_plan.plan_id of everyone already on it still points at a live
+        // row instead of a retired one.
+        if (paymentPlanDTOS.size() == 1 && existingPaymentPlans.size() == 1
+                && !StringUtils.hasText(paymentPlanDTOS.get(0).getId())) {
+            paymentPlanDTOS.get(0).setId(existingPaymentPlans.get(0).getId());
+        }
         for (PaymentPlanDTO paymentPlanDTO : paymentPlanDTOS) {
             if (StringUtils.hasText(paymentPlanDTO.getId())){
                 PaymentPlan paymentPlan = existingPaymentPlanMap.get(paymentPlanDTO.getId());
                 if (paymentPlan != null){
                     updatePaymentPlan(paymentPlan,paymentPlanDTO);
+                    if (fullPayload) paymentPlan.setValidityInDays(paymentPlanDTO.getValidityInDays());
                 }else{
                     throw new VacademyException("Payment Plan with id " + paymentPlanDTO.getId() + " not found");
                 }

--- a/admin_core_service/src/main/resources/db/migration/V507__payment_option_created_by.sql
+++ b/admin_core_service/src/main/resources/db/migration/V507__payment_option_created_by.sql
@@ -1,0 +1,27 @@
+-- =========================================================================
+-- V507: record who created each payment option
+--
+-- payment_option carried created_at but no creator, so the admin "Select a
+-- Payment Plan" picker could not say who added a plan and the audit trail
+-- for plan creation was empty. Column is stamped from the JWT on insert and
+-- never rewritten (the Settings page edits via the same POST, which rebuilds
+-- the entity from the DTO, so the entity marks it updatable = false).
+--
+-- Backfill: CPO mirrors are the only rows whose creator the schema already
+-- knows (complex_payment_option.created_by). Everything else stays NULL —
+-- there is no honest source for it, and the UI treats NULL as "unknown".
+-- Idempotent: guarded by IF NOT EXISTS / IS NULL.
+-- =========================================================================
+
+ALTER TABLE payment_option
+    ADD COLUMN IF NOT EXISTS created_by_user_id VARCHAR(255);
+
+COMMENT ON COLUMN payment_option.created_by_user_id IS
+    'auth_service user id of the admin who created the option. Set once on insert, never updated.';
+
+UPDATE payment_option po
+SET    created_by_user_id = cpo.created_by
+FROM   complex_payment_option cpo
+WHERE  po.complex_payment_option_id = cpo.id
+  AND  po.created_by_user_id IS NULL
+  AND  cpo.created_by IS NOT NULL;

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentOptionServiceSaveTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentOptionServiceSaveTest.java
@@ -1,0 +1,183 @@
+package vacademy.io.admin_core_service.features.user_subscription.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import vacademy.io.admin_core_service.features.auth_service.service.AuthService;
+import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentOptionDTO;
+import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentOptionFilterDTO;
+import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentPlanDTO;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentOption;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentPlan;
+import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentOptionRepository;
+import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentPlanRepository;
+import vacademy.io.common.auth.dto.UserDTO;
+import vacademy.io.common.auth.model.CustomUserDetails;
+import vacademy.io.common.exceptions.VacademyException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The Settings page creates AND edits a payment option through the same POST. The
+ * two cases must behave differently: a create stamps the caller as creator and mints
+ * a fresh id, an edit updates the stored row (and its plans) in place. Merging a
+ * rebuilt entity did neither cleanly — it left the old plan ACTIVE beside the resent
+ * one and dropped the creator — which is what these tests pin down.
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentOptionServiceSaveTest {
+
+    @Mock
+    private PaymentOptionRepository paymentOptionRepository;
+    @Mock
+    private PaymentPlanService paymentPlanService;
+    @Mock
+    private PaymentPlanRepository paymentPlanRepository;
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private PaymentOptionService service;
+
+    private static CustomUserDetails user(String userId) {
+        CustomUserDetails user = new CustomUserDetails();
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    @Test
+    @DisplayName("create: client placeholder ids are dropped and the caller is stamped as creator")
+    void createStampsCreatorAndClearsPlaceholderIds() {
+        PaymentOptionDTO dto = PaymentOptionDTO.builder()
+                .id("plan_1757600000000") // what the invite flow sends for a brand-new plan
+                .name("Annual")
+                .type("ONE_TIME")
+                .status("ACTIVE")
+                .paymentPlans(List.of(PaymentPlanDTO.builder().id("plan_x").name("Annual").status("ACTIVE").build()))
+                .build();
+        when(paymentOptionRepository.existsById("plan_1757600000000")).thenReturn(false);
+        when(paymentOptionRepository.save(any(PaymentOption.class))).thenAnswer(inv -> {
+            PaymentOption saved = inv.getArgument(0);
+            saved.setId("generated-uuid");
+            return saved;
+        });
+
+        PaymentOptionDTO result = service.savePaymentOption(dto, user("admin-1"));
+
+        ArgumentCaptor<PaymentOption> captor = ArgumentCaptor.forClass(PaymentOption.class);
+        verify(paymentOptionRepository).save(captor.capture());
+        PaymentOption persisted = captor.getValue();
+        assertEquals("admin-1", persisted.getCreatedByUserId());
+        assertNull(persisted.getPaymentPlans().get(0).getId(), "plan placeholder id must not be persisted");
+        assertEquals("generated-uuid", result.getId());
+        assertEquals("admin-1", result.getCreatedByUserId());
+        verify(paymentOptionRepository, never()).findById(anyString());
+    }
+
+    @Test
+    @DisplayName("create without a caller (institute seeding) leaves the creator null")
+    void createWithoutUserLeavesCreatorNull() {
+        PaymentOptionDTO dto = PaymentOptionDTO.builder().name("Institute Payment Option").type("FREE").build();
+        when(paymentOptionRepository.save(any(PaymentOption.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        PaymentOptionDTO result = service.savePaymentOption(dto, null);
+
+        assertNull(result.getCreatedByUserId());
+        // The FREE fallback plan is still minted for the seeded option.
+        assertEquals(1, result.getPaymentPlans().size());
+    }
+
+    @Test
+    @DisplayName("edit via POST updates the stored row in place and keeps the original creator")
+    void editViaPostUpdatesInPlace() {
+        PaymentOption stored = new PaymentOption();
+        stored.setId("po-1");
+        stored.setName("Old name");
+        stored.setType("ONE_TIME");
+        stored.setTag("DEFAULT");
+        stored.setCreatedByUserId("creator-0");
+        PaymentPlan storedPlan = new PaymentPlan();
+        storedPlan.setId("pp-1");
+        storedPlan.setPaymentOption(stored);
+        stored.setPaymentPlans(new ArrayList<>(List.of(storedPlan)));
+
+        PaymentOptionDTO edit = PaymentOptionDTO.builder()
+                .id("po-1")
+                .name("New name")
+                .type("ONE_TIME")
+                .requireApproval(true)
+                .paymentPlans(List.of(PaymentPlanDTO.builder().name("New name").status("ACTIVE").build()))
+                .build();
+        when(paymentOptionRepository.existsById("po-1")).thenReturn(true);
+        when(paymentOptionRepository.findById("po-1")).thenReturn(Optional.of(stored));
+        when(paymentPlanService.editPaymentPlans(anyList(), anyList(), any(PaymentOption.class), anyBoolean()))
+                .thenReturn(List.of(storedPlan));
+        when(paymentOptionRepository.save(any(PaymentOption.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        PaymentOptionDTO result = service.savePaymentOption(edit, user("editor-9"));
+
+        ArgumentCaptor<PaymentOption> captor = ArgumentCaptor.forClass(PaymentOption.class);
+        verify(paymentOptionRepository).save(captor.capture());
+        assertSame(stored, captor.getValue(), "must update the managed row, not merge a rebuilt copy");
+        assertEquals("New name", stored.getName());
+        assertEquals("DEFAULT", stored.getTag(), "an edit payload carries no tag and must not clear it");
+        assertEquals("creator-0", stored.getCreatedByUserId(), "editor must not become the creator");
+        assertEquals("po-1", result.getId());
+        // fullPayload=true: the Settings save resends every field, so a null validity is
+        // "no expiry" and must be written, unlike the partial PUT dialog.
+        verify(paymentPlanService).editPaymentPlans(eq(List.of(storedPlan)), eq(edit.getPaymentPlans()), eq(stored), eq(true));
+    }
+
+    @Test
+    @DisplayName("list: creator ids resolve to names in one auth_service call, and a failure degrades to null")
+    void listAttachesCreatorNames() {
+        PaymentOption a = new PaymentOption();
+        a.setId("a");
+        a.setCreatedByUserId("u1");
+        PaymentOption b = new PaymentOption();
+        b.setId("b");
+        b.setCreatedByUserId("u1");
+        PaymentOption c = new PaymentOption();
+        c.setId("c");
+        when(paymentOptionRepository.findPaymentOptionsWithPaymentPlansNative(
+                anyBoolean(), anyList(), anyBoolean(), anyList(), any(), any(),
+                anyBoolean(), anyList(), anyBoolean(), anyList(), anyBoolean(), anyBoolean()))
+                .thenReturn(List.of(a, b, c));
+        when(authService.getUsersFromAuthServiceByUserIds(List.of("u1")))
+                .thenReturn(List.of(UserDTO.builder().id("u1").fullName("Neeraj H").build()))
+                .thenThrow(new VacademyException("auth down"));
+
+        PaymentOptionFilterDTO filter = new PaymentOptionFilterDTO();
+        filter.setSource("INSTITUTE");
+        filter.setSourceId("inst-1");
+
+        List<PaymentOptionDTO> first = service.getPaymentOptions(filter, null);
+        assertEquals("Neeraj H", first.get(0).getCreatedByName());
+        assertEquals("Neeraj H", first.get(1).getCreatedByName());
+        assertNull(first.get(2).getCreatedByName());
+
+        List<PaymentOptionDTO> second = service.getPaymentOptions(filter, null);
+        assertEquals(3, second.size(), "auth_service failure must not fail the listing");
+        assertNull(second.get(0).getCreatedByName());
+        assertEquals("u1", second.get(0).getCreatedByUserId(), "the id still ships so the UI can fall back");
+    }
+}

--- a/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanServiceEditTest.java
+++ b/admin_core_service/src/test/java/vacademy/io/admin_core_service/features/user_subscription/service/PaymentPlanServiceEditTest.java
@@ -1,0 +1,112 @@
+package vacademy.io.admin_core_service.features.user_subscription.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vacademy.io.admin_core_service.features.user_subscription.dto.PaymentPlanDTO;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentOption;
+import vacademy.io.admin_core_service.features.user_subscription.entity.PaymentPlan;
+import vacademy.io.admin_core_service.features.user_subscription.repository.PaymentPlanRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Editing a single-plan option (FREE / DONATION / ONE_TIME) from Settings resends its
+ * one plan without an id. That must update the stored plan, not retire it and mint a
+ * new one — every user_plan already on it points at the stored id.
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentPlanServiceEditTest {
+
+    @Mock
+    private PaymentPlanRepository paymentPlanRepository;
+
+    @InjectMocks
+    private PaymentPlanService service;
+
+    private static PaymentPlan plan(String id, String name, Double price) {
+        PaymentPlan plan = new PaymentPlan();
+        plan.setId(id);
+        plan.setName(name);
+        plan.setStatus("ACTIVE");
+        plan.setActualPrice(price);
+        return plan;
+    }
+
+    @Test
+    @DisplayName("one stored plan + one id-less resent plan = update in place, nothing retired")
+    void singleIdlessPlanUpdatesTheStoredOne() {
+        PaymentOption option = new PaymentOption();
+        option.setId("po-1");
+        PaymentPlan stored = plan("pp-1", "Old", 100.0);
+        List<PaymentPlan> existing = new ArrayList<>(List.of(stored));
+        PaymentPlanDTO resent = PaymentPlanDTO.builder().name("New").actualPrice(150.0).status("ACTIVE").build();
+
+        List<PaymentPlan> result = service.editPaymentPlans(existing, new ArrayList<>(List.of(resent)), option);
+
+        assertEquals(1, result.size());
+        assertSame(stored, result.get(0));
+        assertEquals("pp-1", result.get(0).getId());
+        assertEquals("New", stored.getName());
+        assertEquals(150.0, stored.getActualPrice());
+        assertEquals("ACTIVE", stored.getStatus());
+        verify(paymentPlanRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("full payload: a null validity is 'no expiry' and clears the stored window")
+    void fullPayloadWritesNullValidity() {
+        PaymentOption option = new PaymentOption();
+        PaymentPlan stored = plan("pp-1", "Free", 0.0);
+        stored.setValidityInDays(30);
+        PaymentPlanDTO unlimited = PaymentPlanDTO.builder().name("Free").status("ACTIVE").validityInDays(null).build();
+
+        service.editPaymentPlans(new ArrayList<>(List.of(stored)), new ArrayList<>(List.of(unlimited)), option, true);
+
+        assertNull(stored.getValidityInDays(), "Limited -> Unlimited must actually drop the 30-day window");
+    }
+
+    @Test
+    @DisplayName("partial payload (PUT dialog): a null validity means 'not sent' and keeps the stored window")
+    void partialPayloadKeepsValidity() {
+        PaymentOption option = new PaymentOption();
+        PaymentPlan stored = plan("pp-1", "Annual", 100.0);
+        stored.setValidityInDays(365);
+        PaymentPlanDTO partial = PaymentPlanDTO.builder().id("pp-1").actualPrice(120.0).build();
+
+        service.editPaymentPlans(new ArrayList<>(List.of(stored)), new ArrayList<>(List.of(partial)), option);
+
+        assertEquals(365, stored.getValidityInDays());
+        assertEquals(120.0, stored.getActualPrice());
+        assertEquals("Annual", stored.getName(), "fields the dialog did not send are untouched");
+    }
+
+    @Test
+    @DisplayName("several stored plans + an id-less plan still replaces: no positional guess for ladders")
+    void multiplePlansAreNotGuessed() {
+        PaymentOption option = new PaymentOption();
+        PaymentPlan monthly = plan("pp-m", "Monthly", 10.0);
+        PaymentPlan yearly = plan("pp-y", "Yearly", 100.0);
+        List<PaymentPlan> existing = new ArrayList<>(List.of(monthly, yearly));
+        PaymentPlanDTO resent = PaymentPlanDTO.builder().name("Lifetime").actualPrice(500.0).status("ACTIVE").build();
+
+        List<PaymentPlan> result = service.editPaymentPlans(existing, new ArrayList<>(List.of(resent)), option);
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getId(), "a genuinely new plan gets a generated id");
+        assertEquals("DELETED", monthly.getStatus());
+        assertEquals("DELETED", yearly.getStatus());
+        verify(paymentPlanRepository).saveAll(List.of(monthly, yearly));
+    }
+}

--- a/frontend-admin-dashboard/public/locales/ar/manageStudentsPaymentPlansDialog.json
+++ b/frontend-admin-dashboard/public/locales/ar/manageStudentsPaymentPlansDialog.json
@@ -36,5 +36,22 @@
     },
     "actions": {
         "addNewPaymentPlan": "+ إضافة خطة دفع جديدة"
+    },
+    "search": {
+        "placeholder": "ابحث عن الخطط بالاسم…",
+        "noResults": "لا توجد خطط تطابق بحثك أو الفلتر.",
+        "clear": "مسح"
+    },
+    "filters": {
+        "all": "الكل",
+        "FREE": "مجاني",
+        "ONE_TIME": "دفعة واحدة",
+        "DONATION": "تبرع",
+        "SUBSCRIPTION": "اشتراك",
+        "CPO": "CPO"
+    },
+    "meta": {
+        "created": "أُنشئ في {{date}}",
+        "createdBy": "بواسطة {{name}}"
     }
 }

--- a/frontend-admin-dashboard/public/locales/en/manageStudentsPaymentPlansDialog.json
+++ b/frontend-admin-dashboard/public/locales/en/manageStudentsPaymentPlansDialog.json
@@ -32,5 +32,22 @@
     },
     "actions": {
         "addNewPaymentPlan": "+ Add New Payment Plan"
+    },
+    "search": {
+        "placeholder": "Search plans by name…",
+        "noResults": "No plans match your search or filter.",
+        "clear": "Clear"
+    },
+    "filters": {
+        "all": "All",
+        "FREE": "Free",
+        "ONE_TIME": "One-time",
+        "DONATION": "Donation",
+        "SUBSCRIPTION": "Subscription",
+        "CPO": "CPO"
+    },
+    "meta": {
+        "created": "Created {{date}}",
+        "createdBy": "by {{name}}"
     }
 }

--- a/frontend-admin-dashboard/public/locales/fr/manageStudentsPaymentPlansDialog.json
+++ b/frontend-admin-dashboard/public/locales/fr/manageStudentsPaymentPlansDialog.json
@@ -33,5 +33,22 @@
     },
     "actions": {
         "addNewPaymentPlan": "+ Ajouter un nouveau plan de paiement"
+    },
+    "search": {
+        "placeholder": "Rechercher un plan par nom…",
+        "noResults": "Aucun plan ne correspond à votre recherche ou filtre.",
+        "clear": "Effacer"
+    },
+    "filters": {
+        "all": "Tous",
+        "FREE": "Gratuit",
+        "ONE_TIME": "Paiement unique",
+        "DONATION": "Don",
+        "SUBSCRIPTION": "Abonnement",
+        "CPO": "CPO"
+    },
+    "meta": {
+        "created": "Créé le {{date}}",
+        "createdBy": "par {{name}}"
     }
 }

--- a/frontend-admin-dashboard/public/locales/hi/manageStudentsPaymentPlansDialog.json
+++ b/frontend-admin-dashboard/public/locales/hi/manageStudentsPaymentPlansDialog.json
@@ -32,5 +32,22 @@
     },
     "actions": {
         "addNewPaymentPlan": "+ नई भुगतान योजना जोड़ें"
+    },
+    "search": {
+        "placeholder": "नाम से योजनाएँ खोजें…",
+        "noResults": "आपकी खोज या फ़िल्टर से कोई योजना मेल नहीं खाती।",
+        "clear": "साफ़ करें"
+    },
+    "filters": {
+        "all": "सभी",
+        "FREE": "निःशुल्क",
+        "ONE_TIME": "एकमुश्त",
+        "DONATION": "दान",
+        "SUBSCRIPTION": "सदस्यता",
+        "CPO": "CPO"
+    },
+    "meta": {
+        "created": "{{date}} को बनाया गया",
+        "createdBy": "{{name}} द्वारा"
     }
 }

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogFilters.tsx
@@ -126,6 +126,8 @@ const RESOURCE_GROUPS: { group: string; options: MultiSelectOption[] }[] = [
     {
         group: 'Finance',
         options: [
+            { value: 'PAYMENT_PLAN', label: 'Payment plan' },
+            { value: 'FEE_PLAN', label: 'Fee plan (CPO)' },
             { value: 'ERP_JOURNAL', label: 'Journal entry' },
             { value: 'ERP_FINANCE_PNL', label: 'Profit and loss' },
         ],
@@ -148,6 +150,7 @@ const ACTIVITY_OPTIONS: MultiSelectOption[] = [
     { value: 'BULK_CREATE', label: 'Bulk created' },
     { value: 'BULK_UPDATE', label: 'Bulk updated' },
     { value: 'IMPORT', label: 'Imported' },
+    { value: 'MIGRATE', label: 'Migrated' },
     { value: 'EXPORT', label: 'Exported' },
     { value: 'DOWNLOAD', label: 'Downloaded' },
     { value: 'PURGE', label: 'Purged' },
@@ -187,6 +190,7 @@ const ACTIVITY_OPTIONS: MultiSelectOption[] = [
     { value: 'EXPORT_CREDENTIALS', label: 'Credentials exported' },
     { value: 'DEACTIVATE', label: 'Deactivated (record)' },
     { value: 'PROVISION_BOOKING_PAGE', label: 'Booking page provisioned' },
+    { value: 'MAKE_DEFAULT', label: 'Made default' },
     { value: 'APPROVE', label: 'Approved' },
     { value: 'REJECT', label: 'Rejected' },
     { value: 'DECLINE', label: 'Declined' },

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/ActivityLogTable.tsx
@@ -181,6 +181,13 @@ const NAMED_DESCRIPTION_PATTERNS: RegExp[] = [
 
     /^(switched WhatsApp provider to )(.+)$/i,
     /^((?:updated|removed) WhatsApp credentials for )(.+)$/i,
+
+    // ── Payment plans ────────────────────────────────────────────────
+    // "made ... the default" must precede the generic create/update/delete
+    // form, which would otherwise swallow the trailing clause into the name.
+    /^(made payment plan )(.+?)( the default)$/i,
+    /^((?:created|updated|deleted|approved) (?:payment|fee) plan )(.+)$/i,
+    /^(updated fee type )(.+)$/i,
 ];
 
 /**

--- a/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/activity-log-sentence.test.ts
+++ b/frontend-admin-dashboard/src/routes/admin-activity-logs/-components/activity-log-sentence.test.ts
@@ -22,6 +22,27 @@ describe('splitDescriptionParts', () => {
         return (parts as string[]).filter((_, index) => index % 2 === 1);
     };
 
+    it('bolds the plan name on payment and fee plan actions', () => {
+        expect(nameParts('created payment plan Annual Membership')).toEqual(['Annual Membership']);
+        expect(nameParts('updated payment plan Annual Membership')).toEqual(['Annual Membership']);
+        expect(nameParts('deleted payment plan Annual Membership')).toEqual(['Annual Membership']);
+        expect(nameParts('created fee plan Grade 10 Tuition 2026')).toEqual([
+            'Grade 10 Tuition 2026',
+        ]);
+        expect(nameParts('approved fee plan Grade 10 Tuition 2026')).toEqual([
+            'Grade 10 Tuition 2026',
+        ]);
+        expect(nameParts('updated fee type Admission Fee')).toEqual(['Admission Fee']);
+        // The trailing clause stays plain; only the plan name is emphasised.
+        expect(nameParts('made payment plan Annual Membership the default')).toEqual([
+            'Annual Membership',
+        ]);
+    });
+
+    it('leaves a bulk plan delete unemphasised — there is no single name to bold', () => {
+        expect(splitDescriptionParts('deleted 3 payment plan(s)')).toBeNull();
+    });
+
     it('bolds the audience name on campaign actions', () => {
         expect(nameParts('created audience Winter Admissions 2026')).toEqual([
             'Winter Admissions 2026',

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/helper.ts
@@ -79,7 +79,19 @@ type ApiCourseData = {
     }[];
 };
 
-type FreePlan = {
+/**
+ * Server-stamped provenance carried onto every picker plan so the dialog can sort
+ * newest-first and say who added a plan. All optional: rows created before the
+ * created_by column existed have no creator, and a plan appended locally right
+ * after "Add New Payment Plan" has neither until the list refetches.
+ */
+export interface PlanProvenance {
+    createdAt?: string | null;
+    createdByUserId?: string | null;
+    createdByName?: string | null;
+}
+
+type FreePlan = PlanProvenance & {
     id: string;
     name: string;
     description: string;
@@ -90,7 +102,7 @@ type FreePlan = {
     type?: string;
 };
 
-interface PaidPlan {
+interface PaidPlan extends PlanProvenance {
     id: string;
     name: string;
     description: string;
@@ -140,6 +152,9 @@ export interface PaymentOption {
     payment_option_metadata_json: string; // or parsed as: PaymentOptionMetadata if you want to parse it
     /** Set when type='CPO'. FK to the underlying ComplexPaymentOption row. */
     complex_payment_option_id?: string | null;
+    created_at?: string | null;
+    created_by_user_id?: string | null;
+    created_by_name?: string | null;
 }
 
 interface PaymentPlansInterface {
@@ -561,6 +576,77 @@ export function convertInviteData(
     return convertedData;
 }
 
+const provenanceOf = (item: PaymentOption): PlanProvenance => ({
+    createdAt: item.created_at ?? null,
+    createdByUserId: item.created_by_user_id ?? null,
+    createdByName: item.created_by_name ?? null,
+});
+
+const createdAtMillis = (plan: PlanProvenance): number => {
+    if (!plan.createdAt) return Number.POSITIVE_INFINITY;
+    const t = new Date(plan.createdAt).getTime();
+    return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
+};
+
+/**
+ * Newest plan first. A plan without a created date sorts to the top: the only
+ * way one reaches the picker is the local append right after "Add New Payment
+ * Plan", and that is exactly the plan the admin is looking for. Stable, so the
+ * backend's own created_at DESC order survives for ties.
+ */
+export function sortPlansNewestFirst<T extends PlanProvenance>(plans: T[]): T[] {
+    return plans
+        .map((plan, index) => ({ plan, index }))
+        .sort((a, b) => createdAtMillis(b.plan) - createdAtMillis(a.plan) || a.index - b.index)
+        .map(({ plan }) => plan);
+}
+
+/** Picker filter values. ONE_TIME also covers the legacy lowercase 'upfront' rows. */
+export type PlanTypeFilter = 'FREE' | 'ONE_TIME' | 'DONATION' | 'SUBSCRIPTION' | 'CPO';
+
+export const PLAN_TYPE_FILTERS: PlanTypeFilter[] = [
+    'FREE',
+    'ONE_TIME',
+    'DONATION',
+    'SUBSCRIPTION',
+    'CPO',
+];
+
+export const normalizePlanType = (type?: string | null): PlanTypeFilter | null => {
+    switch ((type ?? '').toLowerCase()) {
+        case 'free':
+            return 'FREE';
+        case 'one_time':
+        case 'upfront':
+            return 'ONE_TIME';
+        case 'donation':
+            return 'DONATION';
+        case 'subscription':
+            return 'SUBSCRIPTION';
+        case 'cpo':
+            return 'CPO';
+        default:
+            return null;
+    }
+};
+
+/**
+ * Applies the picker's search box and type pills. Search is a case-insensitive
+ * substring match on the plan name; an empty query and a null type mean "all".
+ */
+export function filterPlans<T extends PlanProvenance & { name: string; type?: string }>(
+    plans: T[],
+    query: string,
+    type: PlanTypeFilter | null
+): T[] {
+    const q = query.trim().toLowerCase();
+    return plans.filter((plan) => {
+        if (type && normalizePlanType(plan.type) !== type) return false;
+        if (q && !(plan.name ?? '').toLowerCase().includes(q)) return false;
+        return true;
+    });
+}
+
 export function splitPlansByType(data: PaymentOption[]): {
     freePlans: FreePlan[];
     paidPlans: PaidPlan[];
@@ -577,6 +663,7 @@ export function splitPlansByType(data: PaymentOption[]): {
             // that plan; metadata_json is typically empty for CPOs.
             const syntheticPlan = item.payment_plans?.[0];
             paidPlans.push({
+                ...provenanceOf(item),
                 id: item.id,
                 name: item.name,
                 description: i18next.t(
@@ -593,6 +680,7 @@ export function splitPlansByType(data: PaymentOption[]): {
             const parsedData = JSON.parse(item.payment_option_metadata_json);
             if (type === 'donation') {
                 freePlans.push({
+                    ...provenanceOf(item),
                     id: item.id,
                     name: item.name,
                     description: i18next.t(
@@ -608,6 +696,7 @@ export function splitPlansByType(data: PaymentOption[]): {
                 });
             } else {
                 freePlans.push({
+                    ...provenanceOf(item),
                     id: item.id,
                     name: item.name,
                     description: i18next.t(
@@ -621,6 +710,7 @@ export function splitPlansByType(data: PaymentOption[]): {
             const parsedData = JSON.parse(item.payment_option_metadata_json);
             if (type === 'upfront' || type === 'one_time') {
                 paidPlans.push({
+                    ...provenanceOf(item),
                     id: item.id,
                     name: item.name,
                     description: i18next.t(
@@ -632,6 +722,7 @@ export function splitPlansByType(data: PaymentOption[]): {
                 });
             } else {
                 paidPlans.push({
+                    ...provenanceOf(item),
                     id: item.id,
                     name: item.name,
                     description: i18next.t(

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/plan-picker-helpers.test.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/-utils/plan-picker-helpers.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterPlans,
+    normalizePlanType,
+    sortPlansNewestFirst,
+    splitPlansByType,
+    type PaymentOption,
+} from './helper';
+
+/**
+ * The "Select a Payment Plan" picker sorts newest-first, searches by name and
+ * filters by type. The backend already orders by created_at, but a plan appended
+ * locally after "Add New Payment Plan" has no date yet and legacy rows carry
+ * lowercase types — both would silently misplace or hide a plan.
+ */
+describe('sortPlansNewestFirst', () => {
+    it('orders by createdAt descending and floats undated plans (just created) to the top', () => {
+        const sorted = sortPlansNewestFirst([
+            { id: 'old', createdAt: '2026-01-01T00:00:00Z' },
+            { id: 'new', createdAt: '2026-09-01T00:00:00Z' },
+            { id: 'local' },
+            { id: 'mid', createdAt: '2026-05-01T00:00:00Z' },
+        ]);
+        expect(sorted.map((p) => p.id)).toEqual(['local', 'new', 'mid', 'old']);
+    });
+
+    it('is stable for ties so the backend order survives', () => {
+        const sorted = sortPlansNewestFirst([
+            { id: 'a', createdAt: '2026-09-01T00:00:00Z' },
+            { id: 'b', createdAt: '2026-09-01T00:00:00Z' },
+            { id: 'c', createdAt: 'not a date' },
+        ]);
+        expect(sorted.map((p) => p.id)).toEqual(['c', 'a', 'b']);
+    });
+});
+
+describe('normalizePlanType', () => {
+    it('maps legacy lowercase and upfront spellings onto the five filter values', () => {
+        expect(normalizePlanType('free')).toBe('FREE');
+        expect(normalizePlanType('FREE')).toBe('FREE');
+        expect(normalizePlanType('upfront')).toBe('ONE_TIME');
+        expect(normalizePlanType('ONE_TIME')).toBe('ONE_TIME');
+        expect(normalizePlanType('donation')).toBe('DONATION');
+        expect(normalizePlanType('SUBSCRIPTION')).toBe('SUBSCRIPTION');
+        expect(normalizePlanType('CPO')).toBe('CPO');
+        expect(normalizePlanType(undefined)).toBeNull();
+        expect(normalizePlanType('')).toBeNull();
+    });
+});
+
+describe('filterPlans', () => {
+    const plans = [
+        { id: '1', name: 'Annual Membership', type: 'SUBSCRIPTION' },
+        { id: '2', name: 'Focus on Dentistry 2026', type: 'ONE_TIME' },
+        { id: '3', name: 'Old upfront', type: 'upfront' },
+        { id: '4', name: 'Institute Payment Option', type: 'FREE' },
+    ];
+
+    it('matches the name case-insensitively as a substring', () => {
+        expect(filterPlans(plans, '  dentistry ', null).map((p) => p.id)).toEqual(['2']);
+        expect(filterPlans(plans, 'MEMBER', null).map((p) => p.id)).toEqual(['1']);
+    });
+
+    it('filters by normalised type, so ONE_TIME also finds legacy upfront rows', () => {
+        expect(filterPlans(plans, '', 'ONE_TIME').map((p) => p.id)).toEqual(['2', '3']);
+        expect(filterPlans(plans, '', 'FREE').map((p) => p.id)).toEqual(['4']);
+    });
+
+    it('combines search and type, and an empty query with no type returns everything', () => {
+        expect(filterPlans(plans, 'old', 'ONE_TIME').map((p) => p.id)).toEqual(['3']);
+        expect(filterPlans(plans, '', null)).toHaveLength(4);
+    });
+});
+
+describe('splitPlansByType provenance', () => {
+    it('carries created date and creator onto every picker plan', () => {
+        const base = {
+            status: 'ACTIVE',
+            source: 'INSTITUTE',
+            source_id: 'inst',
+            tag: '',
+            require_approval: false,
+            payment_plans: [],
+            created_at: '2026-09-11T08:53:52.705+00:00',
+            created_by_user_id: 'u-1',
+            created_by_name: 'Neeraj',
+        };
+        const data: PaymentOption[] = [
+            {
+                ...base,
+                id: 'free',
+                name: 'Free',
+                type: 'FREE',
+                payment_option_metadata_json: JSON.stringify({ freeData: { validityDays: 30 } }),
+            },
+            {
+                ...base,
+                id: 'one',
+                name: 'One-time',
+                type: 'ONE_TIME',
+                payment_option_metadata_json: JSON.stringify({
+                    currency: 'AUD',
+                    upfrontData: { fullPrice: '99' },
+                }),
+            },
+            {
+                ...base,
+                id: 'cpo',
+                name: 'Fee plan',
+                type: 'CPO',
+                payment_option_metadata_json: '',
+                complex_payment_option_id: 'cpo-1',
+                payment_plans: [{ actual_price: 1200, currency: 'INR' } as never],
+            },
+        ];
+        const { freePlans, paidPlans } = splitPlansByType(data);
+        for (const plan of [...freePlans, ...paidPlans]) {
+            expect(plan.createdAt).toBe(base.created_at);
+            expect(plan.createdByUserId).toBe('u-1');
+            expect(plan.createdByName).toBe('Neeraj');
+        }
+        expect(paidPlans.map((p) => p.id)).toEqual(['one', 'cpo']);
+    });
+});

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/AddPaymentPlanDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/AddPaymentPlanDialog.tsx
@@ -10,6 +10,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { buildCreateCPOPayload } from '@/routes/financial-management/fee-plans/-components/CreateCPODialog';
 import { useCreateCPO } from '@/routes/financial-management/fee-plans/-services/cpo-service';
 import { useTranslation } from 'react-i18next';
+import { splitPlansByType, type PaymentOption } from './-utils/helper';
 
 interface PaymentPlansDialogProps {
     form: UseFormReturn<InviteLinkFormValues>;
@@ -123,15 +124,23 @@ const AddPaymentPlanDialog = ({ form }: PaymentPlansDialogProps) => {
                 }),
             };
 
-            await savePaymentOption(paymentOptionRequest);
-            if (plan.type === 'FREE') {
-                const freePlans = form.getValues('freePlans');
-                form.setValue('freePlans', [...freePlans, paymentOptionRequest]);
-            } else {
-                const paidPlans = form.getValues('paidPlans');
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-expect-error
-                form.setValue('paidPlans', [...paidPlans, paymentOptionRequest]);
+            const saved = await savePaymentOption(paymentOptionRequest);
+            // Show the new plan immediately, in the picker's own shape (name, price,
+            // created date, creator), while the list refetches behind it. The server
+            // response is the source of truth: it carries the generated id, and the
+            // request object used to be pushed raw here and rendered as "Free for 0 days".
+            const { freePlans: newFree, paidPlans: newPaid } = splitPlansByType(
+                saved && saved.id ? [saved as unknown as PaymentOption] : []
+            );
+            if (newFree.length > 0) {
+                form.setValue('freePlans', [...form.getValues('freePlans'), ...newFree]);
+            }
+            if (newPaid.length > 0) {
+                form.setValue('paidPlans', [
+                    ...form.getValues('paidPlans'),
+                    // The form schema's price is a transformed string; the helper leaves it optional.
+                    ...newPaid.map((plan) => ({ ...plan, price: plan.price ?? '' })),
+                ]);
             }
             form.setValue('showAddPlanDialog', false);
             setEditingPlan(null);

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/GenerateInviteLinkSchema.ts
@@ -219,6 +219,10 @@ export const inviteLinkSchema = z.object({
                 minAmount: z.number().optional(),
                 currency: z.string().optional(),
                 type: z.string().optional(),
+                // Server-stamped; the picker sorts on createdAt and shows the creator.
+                createdAt: z.string().nullable().optional(),
+                createdByUserId: z.string().nullable().optional(),
+                createdByName: z.string().nullable().optional(),
             })
         )
         .default([]),
@@ -247,6 +251,9 @@ export const inviteLinkSchema = z.object({
                     )
                     .optional(),
                 type: z.string().optional(),
+                createdAt: z.string().nullable().optional(),
+                createdByUserId: z.string().nullable().optional(),
+                createdByName: z.string().nullable().optional(),
             })
         )
         .default([]),

--- a/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/PaymentPlansDialog.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/invite/-components/create-invite/PaymentPlansDialog.tsx
@@ -6,16 +6,36 @@ import {
     DialogDescription as ShadDialogDescription,
 } from '@/components/ui/dialog';
 import { Card } from '@/components/ui/card';
-import { Calendar, CreditCard, CurrencyDollar, Globe, Receipt } from '@phosphor-icons/react';
+import { Input } from '@/components/ui/input';
+import {
+    Calendar,
+    Clock,
+    CreditCard,
+    CurrencyDollar,
+    Globe,
+    MagnifyingGlass,
+    Receipt,
+    X,
+} from '@phosphor-icons/react';
 import { Badge } from '@/components/ui/badge';
 import { MyButton } from '@/components/design-system/button';
+import { ChipToggleGroup, type ChipToggleOption } from '@/components/design-system/chips';
 import { UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { InviteLinkFormValues } from './GenerateInviteLinkSchema';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { handleGetPaymentDetails } from './-services/get-payments';
-import { useEffect, useMemo } from 'react';
-import { getDefaultPlanFromPaymentsData, splitPlansByType } from './-utils/helper';
+import { useEffect, useMemo, useState } from 'react';
+import {
+    filterPlans,
+    getDefaultPlanFromPaymentsData,
+    normalizePlanType,
+    PLAN_TYPE_FILTERS,
+    sortPlansNewestFirst,
+    splitPlansByType,
+    type PlanProvenance,
+    type PlanTypeFilter,
+} from './-utils/helper';
 import { useCPOFullDetails } from '@/routes/financial-management/fee-plans/-services/cpo-service';
 import type { CPOFeeType } from '@/routes/financial-management/fee-plans/-types/cpo-types';
 import { formatPlanPrice } from '@/utils/finance-utils';
@@ -56,8 +76,44 @@ const countCpoInstallments = (feeTypes: CPOFeeType[] | undefined): number => {
     return count;
 };
 
+/**
+ * "Created 11 Sep 2026 · by Neeraj" under every plan card. Renders nothing when
+ * neither is known (rows that predate the created_by column) — a placeholder
+ * note there just adds noise to a list the admin is scanning by name. The
+ * creator falls back to the raw user id when auth_service could not resolve it.
+ */
+const PlanProvenanceLine = ({ plan }: { plan: PlanProvenance }) => {
+    const { t, i18n } = useTranslation('manageStudentsPaymentPlansDialog');
+    const parsed = plan.createdAt ? new Date(plan.createdAt) : null;
+    const createdAt = parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+    const creator = plan.createdByName || plan.createdByUserId || null;
+    if (!createdAt && !creator) return null;
+    return (
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 pl-8 text-2xs text-neutral-500">
+            <Clock className="size-3 shrink-0" />
+            {createdAt && (
+                <span>
+                    {t('meta.created', {
+                        date: createdAt.toLocaleDateString(i18n.language, {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                        }),
+                    })}
+                </span>
+            )}
+            {creator && (
+                <span className="truncate" title={plan.createdByUserId ?? undefined}>
+                    {createdAt ? '· ' : ''}
+                    {t('meta.createdBy', { name: creator })}
+                </span>
+            )}
+        </div>
+    );
+};
+
 interface CpoPlanCardProps {
-    plan: {
+    plan: PlanProvenance & {
         id: string;
         name: string;
         price?: string;
@@ -119,6 +175,7 @@ const CpoPlanCard = ({ plan, isSelected, onSelect }: CpoPlanCardProps) => {
                     </span>
                     <span>{t('common.currency', { currency: plan.currency || 'INR' })}</span>
                 </div>
+                <PlanProvenanceLine plan={plan} />
             </div>
         </Card>
     );
@@ -127,6 +184,9 @@ const CpoPlanCard = ({ plan, isSelected, onSelect }: CpoPlanCardProps) => {
 export function PaymentPlansDialog({ form }: PaymentPlansDialogProps) {
     const { t } = useTranslation('manageStudentsPaymentPlansDialog');
     const { data: paymentsData } = useSuspenseQuery(handleGetPaymentDetails());
+    const isOpen = form.watch('showPlansDialog');
+    const [query, setQuery] = useState('');
+    const [typeFilter, setTypeFilter] = useState<PlanTypeFilter | null>(null);
 
     useEffect(() => {
         form.reset({
@@ -136,6 +196,58 @@ export function PaymentPlansDialog({ form }: PaymentPlansDialogProps) {
             selectedPlan: getDefaultPlanFromPaymentsData(paymentsData),
         });
     }, [paymentsData]);
+
+    // A reopened picker starts clean — a filter left over from the last visit
+    // would make the list look mysteriously short.
+    useEffect(() => {
+        if (!isOpen) {
+            setQuery('');
+            setTypeFilter(null);
+        }
+    }, [isOpen]);
+
+    // watch(), not getValues(): AddPaymentPlanDialog appends the new plan to these
+    // arrays, and the list has to re-render for it to show up without a refetch.
+    const watchedFreePlans = form.watch('freePlans');
+    const watchedPaidPlans = form.watch('paidPlans');
+    const allFreePlans = useMemo(() => watchedFreePlans ?? [], [watchedFreePlans]);
+    const allPaidPlans = useMemo(() => watchedPaidPlans ?? [], [watchedPaidPlans]);
+
+    const freePlans = useMemo(
+        () => filterPlans(sortPlansNewestFirst(allFreePlans), query, typeFilter),
+        [allFreePlans, query, typeFilter]
+    );
+    const paidPlans = useMemo(
+        () => filterPlans(sortPlansNewestFirst(allPaidPlans), query, typeFilter),
+        [allPaidPlans, query, typeFilter]
+    );
+    const countsByType = useMemo(() => {
+        const counts: Record<PlanTypeFilter, number> = {
+            FREE: 0,
+            ONE_TIME: 0,
+            DONATION: 0,
+            SUBSCRIPTION: 0,
+            CPO: 0,
+        };
+        for (const plan of [...allFreePlans, ...allPaidPlans]) {
+            const key = normalizePlanType(plan.type);
+            if (key) counts[key] += 1;
+        }
+        return counts;
+    }, [allFreePlans, allPaidPlans]);
+    const totalPlans = allFreePlans.length + allPaidPlans.length;
+    const isFiltering = query.trim().length > 0 || typeFilter !== null;
+    const nothingMatches = isFiltering && freePlans.length === 0 && paidPlans.length === 0;
+
+    // 'ALL' is the group's "no filter" value; the count rides in the label so an
+    // admin can see at a glance how many plans each pill hides.
+    const typeOptions: ChipToggleOption<'ALL' | PlanTypeFilter>[] = [
+        { value: 'ALL', label: `${t('filters.all')} · ${totalPlans}` },
+        ...PLAN_TYPE_FILTERS.map((type) => ({
+            value: type,
+            label: `${t(`filters.${type}`)} · ${countsByType[type]}`,
+        })),
+    ];
 
     return (
         <ShadDialog
@@ -149,11 +261,59 @@ export function PaymentPlansDialog({ form }: PaymentPlansDialogProps) {
                         {t('dialog.description')}
                     </ShadDialogDescription>
                 </ShadDialogHeader>
+                <div className="flex flex-col gap-2">
+                    <div className="relative">
+                        <MagnifyingGlass
+                            size={15}
+                            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400"
+                        />
+                        <Input
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder={t('search.placeholder')}
+                            aria-label={t('search.placeholder')}
+                            className="h-9 w-full pl-9 pr-8 text-sm"
+                        />
+                        {query && (
+                            <button
+                                type="button"
+                                aria-label={t('search.clear')}
+                                onClick={() => setQuery('')}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-neutral-400 hover:text-neutral-600"
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
+                    </div>
+                    <ChipToggleGroup
+                        value={typeFilter ?? 'ALL'}
+                        onChange={(value) => setTypeFilter(value === 'ALL' ? null : value)}
+                        options={typeOptions}
+                        ariaLabel={t('filters.all')}
+                    />
+                </div>
                 <div className="flex-1 overflow-auto">
+                    {nothingMatches && (
+                        <div className="flex flex-col items-center gap-2 py-10 text-center text-sm text-neutral-500">
+                            <span>{t('search.noResults')}</span>
+                            <MyButton
+                                type="button"
+                                scale="small"
+                                buttonType="text"
+                                onClick={() => {
+                                    setQuery('');
+                                    setTypeFilter(null);
+                                }}
+                            >
+                                {t('search.clear')}
+                            </MyButton>
+                        </div>
+                    )}
+                    {freePlans.length > 0 && (
                     <div className="mb-4">
-                        <div className="mb-2 mt-4 font-semibold">{t('sections.freePlans')}</div>
+                        <div className="my-2 font-semibold">{t('sections.freePlans')}</div>
                         <div className="flex flex-col gap-4">
-                            {form.getValues('freePlans')?.map((plan) => (
+                            {freePlans.map((plan) => (
                                 <Card
                                     key={plan.id}
                                     className={`cursor-pointer border-2 ${form.watch('selectedPlan')?.id === plan.id ? 'border-primary' : 'border-gray-200'} transition-all`}
@@ -201,15 +361,18 @@ export function PaymentPlansDialog({ form }: PaymentPlansDialogProps) {
                                                 </span>
                                             </div>
                                         )}
+                                        <PlanProvenanceLine plan={plan} />
                                     </div>
                                 </Card>
                             ))}
                         </div>
                     </div>
+                    )}
+                    {paidPlans.length > 0 && (
                     <div>
                         <div className="mb-2 font-semibold">{t('sections.paidPlans')}</div>
                         <div className="flex flex-col gap-4">
-                            {form.getValues('paidPlans')?.map((plan) => {
+                            {paidPlans.map((plan) => {
                                 if (plan.type?.toLowerCase() === 'cpo') {
                                     return (
                                         <CpoPlanCard
@@ -280,12 +443,14 @@ export function PaymentPlansDialog({ form }: PaymentPlansDialogProps) {
                                                 </span>
                                             </div>
                                         )}
+                                        <PlanProvenanceLine plan={plan} />
                                     </div>
                                 </Card>
                                 );
                             })}
                         </div>
                     </div>
+                    )}
                 </div>
                 <div className="-mb-2 flex justify-center border-t bg-white pt-4">
                     <MyButton

--- a/frontend-admin-dashboard/src/routes/settings/-components/Payment/PaymentSettings.tsx
+++ b/frontend-admin-dashboard/src/routes/settings/-components/Payment/PaymentSettings.tsx
@@ -553,11 +553,23 @@ const PaymentSettings = () => {
                 // Add new plan to the list
                 const savedPlan = savedPaymentOption?.payment_plans?.[0];
                 if (savedPlan) {
-                    const transformedPlan = transformApiPlanToLocalFormat(savedPlan);
+                    // The plan row carries no type or metadata of its own — both live on
+                    // the option (loadPaymentOptions stitches them the same way). Without
+                    // them the transform throws on `type.toUpperCase()` and a successful
+                    // save surfaces as an error toast.
+                    const transformedPlan = transformApiPlanToLocalFormat({
+                        ...savedPlan,
+                        type: savedPaymentOption.type,
+                        payment_option_metadata_json:
+                            savedPaymentOption.payment_option_metadata_json,
+                    });
                     setPaymentPlans((plans) => [
                         ...plans,
                         {
                             ...transformedPlan,
+                            // Option id, not plan id — every list action keys on it.
+                            id: savedPaymentOption.id,
+                            name: savedPaymentOption.name,
                             tag:
                                 transformedPlan.type === PaymentPlans.FREE
                                     ? 'free'

--- a/frontend-admin-dashboard/src/types/payment.ts
+++ b/frontend-admin-dashboard/src/types/payment.ts
@@ -45,6 +45,13 @@ export interface PaymentOptionApi {
     plan_change_allowed?: boolean;
     /** Populated when type='CPO'. Points at the underlying ComplexPaymentOption row. */
     complex_payment_option_id?: string;
+    // Read-only provenance, server-stamped. The plan picker sorts on created_at and
+    // shows who added the plan; both are absent on rows created before V507.
+    created_at?: string | null;
+    updated_at?: string | null;
+    created_by_user_id?: string | null;
+    /** Resolved from auth_service on the list endpoint; null when unknown. */
+    created_by_name?: string | null;
 }
 
 export interface PaymentPlan {


### PR DESCRIPTION
…it log, in-place edits

Picker (shared by course-details, invite, package-session sidebar):
- search by name + type filter (Free / One-time / Donation / Subscription / CPO)
- newest first; created date + creator shown on each card

Backend:
- V507: payment_option.created_by_user_id, stamped from the JWT on create (CPO mirrors backfilled from complex_payment_option.created_by)
- list endpoint returns created_by_user_id / created_by_name / created_at
- @Auditable on payment-option and CPO mutations (PAYMENT_PLAN, FEE_PLAN)
- POST with an existing id now edits in place via editPaymentOption: the old JPA merge left the previous plan ACTIVE beside the new one (~2k prod options with duplicate live plans) and cleared the DEFAULT tag
- a single id-less resent plan updates the stored plan (id preserved); null validity on a full payload now really means unlimited/lifetime

Activity log UI: PAYMENT_PLAN / FEE_PLAN resources, MAKE_DEFAULT + MIGRATE actions, sentence patterns.

Deploy: apply V507 before the admin-core image; ship the admin FE with or before the backend (POST now returns the saved option instead of true).

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
