### PR TITLE
fix(page-builder): footer links editable again; root-mounted pages keep the tag when the app owns the name

### DIFF
--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/PropertyPanel.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/PropertyPanel.tsx
@@ -2705,16 +2705,28 @@ const FooterEditor = ({ component, pageId, updateComponent }: any) => {
         updateProp(sectionKey, { ...section, links });
     };
 
+    // One link row open at a time, keyed "<section>:<index>". The row used to
+    // put the label box, the whole LinkPicker (page search + page list) and
+    // the delete button side by side in the 320px panel: the picker took the
+    // width, the label shrank to a ~26px sliver with its text hidden and the
+    // delete button was pushed off-screen — admins could not rename a link at
+    // all (one typed "h" blind and published it). Same collapsed-row pattern
+    // as the header's navigation links.
+    const [expandedLink, setExpandedLink] = useState<string | null>(null);
+
     const addRightSectionLink = (sectionKey: string) => {
         const section = props[sectionKey] || { title: '', links: [] };
         const links = [...(section.links || []), { label: t('header.defaults.newLink'), route: '/' }];
         updateProp(sectionKey, { ...section, links });
+        // Open the new row so the label box is the next thing the admin sees.
+        setExpandedLink(`${sectionKey}:${links.length - 1}`);
     };
 
     const deleteRightSectionLink = (sectionKey: string, linkIndex: number) => {
         const section = props[sectionKey] || { title: '', links: [] };
         const links = (section.links || []).filter((_: any, i: number) => i !== linkIndex);
         updateProp(sectionKey, { ...section, links });
+        setExpandedLink(null);
     };
 
     const layout = props.layout || 'four-column';
@@ -2850,29 +2862,63 @@ const FooterEditor = ({ component, pageId, updateComponent }: any) => {
                                     <Plus className="me-1 size-3" /> {t('actions.add')}
                                 </Button>
                             </div>
-                            {(section.links || []).map((link: any, li: number) => (
-                                <div key={li} className="flex items-center gap-1.5">
-                                    <Input
-                                        className="h-7 text-xs"
-                                        placeholder={t('header.labelPlaceholder')}
-                                        value={link.label || ''}
-                                        onChange={(e) => updateRightSectionLink(sectionKey, li, 'label', e.target.value)}
-                                    />
-                                    <LinkPicker
-                                        label=""
-                                        value={link.route || ''}
-                                        onChange={(v) => updateRightSectionLink(sectionKey, li, 'route', v)}
-                                    />
-                                    <Button
-                                        size="sm"
-                                        variant="ghost"
-                                        className="size-7 shrink-0 p-0 text-red-500"
-                                        onClick={() => deleteRightSectionLink(sectionKey, li)}
-                                    >
-                                        <Trash2 className="size-3" />
-                                    </Button>
-                                </div>
-                            ))}
+                            {(section.links || []).map((link: any, li: number) => {
+                                const rowKey = `${sectionKey}:${li}`;
+                                const isOpen = expandedLink === rowKey;
+                                return (
+                                    <div key={li} className="rounded border bg-white p-2">
+                                        <div className="flex items-center justify-between gap-1">
+                                            <button
+                                                type="button"
+                                                onClick={() => setExpandedLink(isOpen ? null : rowKey)}
+                                                className="flex-1 truncate text-left text-sm font-medium"
+                                                aria-expanded={isOpen}
+                                            >
+                                                {isOpen ? (
+                                                    <ChevronUp className="mr-1 inline size-3" />
+                                                ) : (
+                                                    <ChevronDown className="mr-1 inline size-3" />
+                                                )}
+                                                {link.label || t('header.labelPlaceholder')}
+                                            </button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="size-6 shrink-0 p-0 text-red-500"
+                                                onClick={() => deleteRightSectionLink(sectionKey, li)}
+                                                title={t('actions.delete')}
+                                                aria-label={t('actions.delete')}
+                                            >
+                                                <Trash2 className="size-3" />
+                                            </Button>
+                                        </div>
+                                        {isOpen && (
+                                            <div className="mt-2 space-y-2">
+                                                <Input
+                                                    className="h-8 text-xs"
+                                                    placeholder={t('header.labelPlaceholder')}
+                                                    value={link.label || ''}
+                                                    onChange={(e) => updateRightSectionLink(sectionKey, li, 'label', e.target.value)}
+                                                />
+                                                <LinkPicker
+                                                    label={t('header.route')}
+                                                    value={link.route || ''}
+                                                    onChange={(v) => updateRightSectionLink(sectionKey, li, 'route', v)}
+                                                />
+                                                {/* The learner footer already honours openInSameTab
+                                                    for external links; the editor never exposed it. */}
+                                                <div className="flex items-center justify-between">
+                                                    <Label className="text-xs">{t('header.openInSameTab')}</Label>
+                                                    <Switch
+                                                        checked={!!link.openInSameTab}
+                                                        onCheckedChange={(c) => updateRightSectionLink(sectionKey, li, 'openInSameTab', c)}
+                                                    />
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
                         </div>
                     </div>
                 );

--- a/frontend-admin-dashboard/src/routes/manage-pages/-components/footer-editor-links.render.test.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-pages/-components/footer-editor-links.render.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PropertyPanel } from './PropertyPanel';
+import { useEditorStore } from '../-stores/editor-store';
+
+/**
+ * Footer link columns in the global footer editor. Each link used to be one
+ * horizontal row holding the label box, the entire LinkPicker (page search +
+ * page list) and the delete button, inside the 320px property panel — the
+ * picker took the width and the label input shrank to a ~26px sliver, so
+ * admins could not rename a link (one typed "h" blind and published it).
+ * Links are now collapsed rows that open into a stacked editor, like the
+ * header's navigation links. Renders the real panel against the real store.
+ */
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (k: string) => k }),
+    Trans: ({ i18nKey }: { i18nKey: string }) => <span>{i18nKey}</span>,
+}));
+vi.mock('@/stores/students/students-list/useInstituteDetailsStore', () => ({
+    useInstituteDetailsStore: () => ({ getAllLevels: () => [], getCourseFromPackage: () => [], instituteDetails: null }),
+}));
+vi.mock('@/lib/auth/instituteUtils', () => ({ getCurrentInstituteId: () => 'inst-1' }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@tanstack/react-query', async (orig) => ({
+    ...(await orig<Record<string, unknown>>()),
+    useQuery: () => ({ data: [], isLoading: false, isError: false }),
+    useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+const footer = {
+    id: 'footer-1',
+    type: 'footer',
+    enabled: true,
+    props: {
+        layout: 'four-column',
+        leftSection: { title: 'The7cs', text: 'x', socials: [] },
+        rightSection1: { title: 'Main Menu', links: [{ label: 'Home page', route: 'homepage' }] },
+        rightSection2: { title: 'Our Offerings', links: [{ label: 'All Content', route: 'books' }] },
+        rightSection3: { title: 'Support', links: [{ label: 'FAQs', route: 'faq' }, { label: 'Privacy Policy', route: 'privacy-policy' }] },
+    },
+};
+
+const footerLinks = (section: 'rightSection2' | 'rightSection3') =>
+    useEditorStore.getState().config!.globalSettings.layout.footer.props[section].links;
+
+describe('Global footer → link columns', () => {
+    beforeEach(() => {
+        useEditorStore.getState().setConfig({
+            pages: [
+                { id: 'home', route: 'home', title: 'Home', components: [] },
+                { id: 'p-books', route: 'books', title: 'Books', components: [] },
+            ],
+            globalSettings: { layout: { footer } },
+        } as never);
+        useEditorStore.getState().selectGlobalLayout('footer');
+    });
+
+    it('lists links collapsed, with the label box hidden until a row is opened', () => {
+        render(<PropertyPanel />);
+        expect(screen.getByRole('button', { name: /Privacy Policy/ })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByDisplayValue('Privacy Policy')).not.toBeInTheDocument();
+    });
+
+    it('opens a row into a stacked label + route editor and renames through it', () => {
+        render(<PropertyPanel />);
+        fireEvent.click(screen.getByRole('button', { name: /Privacy Policy/ }));
+        const input = screen.getByDisplayValue('Privacy Policy');
+        // The label box must own the panel width — the collapsed-row layout
+        // stacks it above the LinkPicker instead of beside it.
+        expect(input.parentElement).toHaveClass('space-y-2');
+        expect(input.parentElement!.querySelector('input[placeholder="Search pages..."]')).not.toBeNull();
+
+        fireEvent.change(input, { target: { value: 'Privacy' } });
+        expect(footerLinks('rightSection3')[1]).toMatchObject({ label: 'Privacy', route: 'privacy-policy' });
+        // The row header follows the label so the admin sees the rename land.
+        expect(screen.getByRole('button', { name: /^Privacy$/ })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('opens a newly added link so the label box is the next thing on screen', () => {
+        render(<PropertyPanel />);
+        const addButtons = screen.getAllByRole('button', { name: /actions\.add/ });
+        // Column order in the panel: socials, column 2, column 3, column 4.
+        fireEvent.click(addButtons[2]!);
+        expect(footerLinks('rightSection2')).toHaveLength(2);
+        expect(screen.getByDisplayValue('header.defaults.newLink')).toBeInTheDocument();
+    });
+
+    it('deletes a link from its row header', () => {
+        render(<PropertyPanel />);
+        const row = screen.getByRole('button', { name: /All Content/ }).parentElement!;
+        fireEvent.click(row.querySelector('button[aria-label="actions.delete"]')!);
+        expect(footerLinks('rightSection2')).toHaveLength(0);
+    });
+});

--- a/frontend-learner-dashboard-app/src/main.tsx
+++ b/frontend-learner-dashboard-app/src/main.tsx
@@ -20,6 +20,7 @@ import { ThemeProvider as ColorThemeProvider } from "./providers/theme/theme-pro
 import { ThemeProvider as ModeThemeProvider } from "./providers/theme-provider";
 import { SidebarProvider } from "./components/ui/sidebar";
 import { routeTree } from "./routeTree.gen";
+import { registerAppRoutePaths } from "./services/reserved-app-routes";
 import "./i18n";
 import { Toaster } from "./components/ui/sonner";
 import "./lib/debug";
@@ -239,6 +240,11 @@ const router = createRouter({
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
 });
+
+// Catalogue link builders need to know which first segments the app owns —
+// see reserved-app-routes.ts for why a root-mounted catalogue page named
+// "privacy-policy" would otherwise open the app's own page.
+registerAppRoutePaths(Object.keys(router.routesByPath));
 
 // Register the router instance for type safety
 declare module "@tanstack/react-router" {

--- a/frontend-learner-dashboard-app/src/routes/$tagName/$pageSlug.tsx
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/$pageSlug.tsx
@@ -58,7 +58,12 @@ function RouteComponent() {
   if (!domainRouting.instituteId) return <RootNotFoundComponent />;
 
   // "/new/about" on a host where `new` is mounted at the root → "/about".
-  if (RouteMatcher.isRootMounted(resolvedTagName)) {
+  // Not for a page named like an app route ("/new/privacy-policy"): "/privacy-policy"
+  // is the app's own page, so the tagged address IS this page's address.
+  if (
+    RouteMatcher.isRootMounted(resolvedTagName) &&
+    !RouteMatcher.isReservedRootPage(resolvedTagName, resolvedPageSlug)
+  ) {
     return <Navigate to={`/${resolvedPageSlug}` as never} search={true} replace />;
   }
 

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.reserved-routes.test.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.reserved-routes.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RouteMatcher } from "./route-matcher";
+import { registerAppRoutePaths } from "@/services/reserved-app-routes";
+
+// Root-mounted host: catalogue "new" answers on "/" (the7cs.co.in setup).
+let rootTag: string | null = "new";
+vi.mock("@/services/domain-routing", () => ({
+  getCachedRootCatalogueTag: () => rootTag,
+}));
+
+/**
+ * A catalogue page named like one of the app's own routes can never be served
+ * at "/<page>" on a root-mounted host — the static app route wins. The 7Cs
+ * footer's "Privacy Policy" (page route `privacy-policy`) opened Vacademy's
+ * privacy policy for exactly this reason.
+ */
+describe("RouteMatcher.pagePath on a root-mounted host", () => {
+  beforeEach(() => {
+    rootTag = "new";
+    // Shape of Object.keys(router.routesByPath)
+    registerAppRoutePaths(["/", "/privacy-policy/", "/courses/", "/login", "/$tagName/", "/$tagName/$pageSlug/"]);
+  });
+
+  it("drops the tag for ordinary pages", () => {
+    expect(RouteMatcher.pagePath("new", "about")).toBe("/about");
+    expect(RouteMatcher.pagePath("new", "home")).toBe("/");
+    expect(RouteMatcher.pagePath("new", "/books/")).toBe("/books");
+  });
+
+  it("keeps the tag for a page the app would shadow", () => {
+    expect(RouteMatcher.pagePath("new", "privacy-policy")).toBe("/new/privacy-policy");
+    expect(RouteMatcher.pagePath("new", "courses")).toBe("/new/courses");
+    expect(RouteMatcher.pagePath("new", "Login")).toBe("/new/Login");
+    expect(RouteMatcher.isReservedRootPage("new", "privacy-policy")).toBe(true);
+  });
+
+  it("does not treat a route param as a reserved name", () => {
+    expect(RouteMatcher.pagePath("new", "tagName")).toBe("/tagName");
+  });
+
+  it("leaves classic (non-root) catalogues untouched", () => {
+    expect(RouteMatcher.pagePath("other", "privacy-policy")).toBe("/other/privacy-policy");
+    expect(RouteMatcher.isReservedRootPage("other", "privacy-policy")).toBe(false);
+    rootTag = null;
+    expect(RouteMatcher.pagePath("new", "privacy-policy")).toBe("/new/privacy-policy");
+    expect(RouteMatcher.isReservedRootPage("new", "privacy-policy")).toBe(false);
+  });
+
+  it("is a no-op until routes are registered", () => {
+    registerAppRoutePaths([]);
+    expect(RouteMatcher.pagePath("new", "privacy-policy")).toBe("/privacy-policy");
+  });
+});

--- a/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.ts
+++ b/frontend-learner-dashboard-app/src/routes/$tagName/-services/route-matcher.ts
@@ -1,5 +1,6 @@
 import { CourseCatalogueData, Page } from "../-types/course-catalogue-types";
 import { getCachedRootCatalogueTag } from "@/services/domain-routing";
+import { isReservedAppRoute } from "@/services/reserved-app-routes";
 
 /**
  * Route matcher utility for handling dynamic page routing
@@ -56,7 +57,24 @@ export class RouteMatcher {
     // route like "Toddler-Reset" into a link to a page that reports not found.
     const clean = (route || "").trim().replace(/^\/+/, "").replace(/\/+$/, "");
     if (this.normalizeRoute(clean) === "home" || clean === "") return base || "/";
+    // Root-mounted, but the page is named like one of the app's own routes
+    // ("privacy-policy", "courses", "login"...): "/<page>" would open the
+    // app's page, not the catalogue's. Keep the tagged address, which the
+    // root-mounted host still serves (see isReservedRootPage).
+    if (!base && tagName && this.isReservedRootPage(tagName, clean)) {
+      return `/${tagName}/${clean}`;
+    }
     return `${base}/${clean}`;
+  }
+
+  /**
+   * A page of the root-mounted catalogue that cannot live at "/<page>"
+   * because the learner app answers that path itself. Such a page is
+   * addressed as "/<tag>/<page>" instead, and the "/<tag>/..." →
+   * "/<page>" canonical redirect must leave it alone.
+   */
+  static isReservedRootPage(tagName: string, pageSlug: string): boolean {
+    return this.isRootMounted(tagName) && isReservedAppRoute(pageSlug);
   }
 
   /**

--- a/frontend-learner-dashboard-app/src/services/reserved-app-routes.ts
+++ b/frontend-learner-dashboard-app/src/services/reserved-app-routes.ts
@@ -1,0 +1,31 @@
+/**
+ * First path segments the learner app itself owns ("/login", "/courses",
+ * "/privacy-policy", ...). A catalogue mounted at a host's root
+ * (institute_domain_routing.root_catalogue_tag) serves its pages at
+ * "/<page>", so a page whose route matches one of these can never be reached
+ * that way — the static app route wins the match and the visitor lands on,
+ * say, Vacademy's own privacy policy instead of the institute's page. Those
+ * pages keep the "/<tag>/<page>" address, which a root-mounted host still
+ * serves.
+ *
+ * Fed from the live route tree in main.tsx so a new top-level route can never
+ * drift out of sync with a hand-kept list.
+ */
+let reservedSegments: Set<string> = new Set();
+
+export const registerAppRoutePaths = (paths: Iterable<string>): void => {
+  const next = new Set<string>();
+  for (const path of paths) {
+    const first = path.split("/").filter(Boolean)[0];
+    // "$tagName" and friends are params, not reserved names.
+    if (!first || first.startsWith("$")) continue;
+    next.add(first.toLowerCase());
+  }
+  reservedSegments = next;
+};
+
+/** True when `route`'s first segment is a page the app answers itself. */
+export const isReservedAppRoute = (route: string): boolean => {
+  const first = route.split("/").filter(Boolean)[0];
+  return !!first && reservedSegments.has(first.toLowerCase());
+};


### PR DESCRIPTION
## Summary

Two bugs surfaced on the7cs.co.in (a catalogue mounted at the domain root):

**1. Admin — footer link labels could not be renamed.**
In the global footer editor each link was one horizontal `flex` row holding the label input, the *entire* `LinkPicker` (page search + page list) and the delete button, inside the 320px property panel. The picker took the width, the label input collapsed to a **26px sliver** with its text hidden, and the delete button was pushed off-screen — The7Cs shipped `New Link` and `h` in its footer. Links are now collapsed rows that open into a stacked label → route → "open in same tab" editor (the same pattern the header's navigation links already use); **Add** opens the new row. Measured in the running editor: label input 26px → 243px, panel no longer scrolls horizontally.

| before | after |
|---|---|
| row `flex items-center` with Input + LinkPicker + delete | collapsed row (label + delete) → stacked editor |

**2. Learner — a root-mounted catalogue page named like an app route is shadowed.**
`RouteMatcher.pagePath` builds `/<page>` on a root-mounted host, and TanStack matches the app's own static routes first, so a catalogue page called `privacy-policy` opened *Vacademy's* privacy policy (same reason The7Cs's courses page had to become `courses-2`). `/<tag>/<page>` did still serve the page, but `$pageSlug.tsx` canonical-redirected it straight back onto `/<page>`.
- New `services/reserved-app-routes.ts`, fed from `router.routesByPath` in `main.tsx` — the reserved list is derived from the live route tree and cannot drift.
- `RouteMatcher.pagePath` keeps `/<tag>/<page>` for a reserved name (`isReservedRootPage`); classic (non-root) catalogues are untouched.
- The `/<tag>/<page>` → `/<page>` canonical redirect skips reserved pages.

## Test plan
- [x] `footer-editor-links.render.test.tsx` — real editor store, `selectGlobalLayout('footer')`: rows start collapsed, opening a row exposes a full-width label input that renames through to the store, Add opens the new row, delete works (4 pass)
- [x] `route-matcher.reserved-routes.test.ts` — ordinary pages drop the tag, reserved names keep it, route params are not reserved, non-root catalogues unchanged, no-op before registration (5 pass)
- [x] Existing `global-settings-course-pages.render.test.tsx` still passes
- [x] Learner `tsc --noEmit`: 0 errors
- [x] Verified in the running admin editor with the live The7Cs catalogue JSON (headless Chromium, editor store driven): label input 243px wide, full label typed and persisted to the store
- [ ] After deploy: on the7cs.co.in, a footer link to a page named `privacy-policy` should open the catalogue page at `/new/privacy-policy` (the live site currently works around this with the page renamed to `privacy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
