### PR TITLE
ci(electron-store): pin pnpm to 10.17.0 so the Store package build installs again

### DIFF
--- a/.github/workflows/electron-store-build.yml
+++ b/.github/workflows/electron-store-build.yml
@@ -54,8 +54,13 @@ jobs:
         with:
           node-version: "20"
 
+      # Pin pnpm: an unpinned install now pulls a pnpm that fails with
+      # ERR_PNPM_IGNORED_BUILDS on CI (esbuild/sharp/canvas build scripts not
+      # approved). 10.17.0 is what build-zoe-appx.yml uses and is known-good here.
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.17.0 --activate
 
       - name: Install web deps
         run: pnpm install --frozen-lockfile || pnpm install


### PR DESCRIPTION
## Summary
- `electron-store-build.yml` installed an unpinned pnpm; the latest pnpm now fails `pnpm install` on CI with `ERR_PNPM_IGNORED_BUILDS` (esbuild/sharp/canvas build scripts not approved). Run [34637018558](https://github.com/Vacademy-io/vacademy_platform/actions/runs/34637018558) died at *Install web deps*.
- Pin pnpm via corepack to 10.17.0 — the same setup `build-zoe-appx.yml` already uses on the same runner.

## Verification
- Run [34637419741](https://github.com/Vacademy-io/vacademy_platform/actions/runs/34637419741) from this branch built the Shiksha Nation x64 + ia32 `.appx` (electron 1.0.12) end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)