### PR TITLE
release(shikshanation): version bumps + SK iOS target plist for the 2026-09-12 store builds

### DIFF
--- a/frontend-learner-dashboard-app/android/app/build.gradle
+++ b/frontend-learner-dashboard-app/android/app/build.gradle
@@ -89,8 +89,8 @@ android {
 		shikshanation {
 			dimension "client"
 			applicationId "com.shikshanation.new.app"
-			versionCode 11
-			versionName "2.5.0"
+			versionCode 12
+			versionName "2.5.7"
 			// Change app name for Fivesep
 			resValue "string", "app_name", "Shiksha Nation"
 			// Set the deep link host for Fivesep (adjust to your domain)

--- a/frontend-learner-dashboard-app/electron/electron-builder.shikshanation-mas.json
+++ b/frontend-learner-dashboard-app/electron/electron-builder.shikshanation-mas.json
@@ -65,9 +65,9 @@
     "entitlementsLoginHelper": "entitlements.mas.loginhelper.plist"
   },
   "extraMetadata": {
-    "version": "1.0"
+    "version": "1.0.1"
   },
-  "buildVersion": "5",
+  "buildVersion": "6",
   "mac": {
     "category": "public.app-category.education",
     "icon": "assets/shiksha_nation.icns",

--- a/frontend-learner-dashboard-app/electron/electron-flavor.json
+++ b/frontend-learner-dashboard-app/electron/electron-flavor.json
@@ -1,1 +1,1 @@
-{"flavor":"shikshanation"}
+{"flavor":"shikshanation","otaAppId":"io.shikshanationapp.com"}

--- a/frontend-learner-dashboard-app/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend-learner-dashboard-app/ios/App/App.xcodeproj/project.pbxproj
@@ -3079,7 +3079,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = SNIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 7XKD5M7288;
 				INFOPLIST_FILE = "GoogleServiceConfigs/Shiksha-Nation-SK/GoogleService-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Shiksha Nation";
@@ -3102,7 +3102,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = SNIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = 7XKD5M7288;
 				INFOPLIST_FILE = "GoogleServiceConfigs/Shiksha-Nation-SK/GoogleService-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Shiksha Nation";

--- a/frontend-learner-dashboard-app/ios/App/GoogleServiceConfigs/Shiksha-Nation-SK/GoogleService-Info.plist
+++ b/frontend-learner-dashboard-app/ios/App/GoogleServiceConfigs/Shiksha-Nation-SK/GoogleService-Info.plist
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyDi599yoVEAeklFdYG21ZteLa00csKRXKU</string>
+	<key>BUNDLE_ID</key>
+	<string>io.shikshanationapp.com</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Shiksha Nation</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>GCM_SENDER_ID</key>
+	<string>117550803134</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:117550803134:ios:c717ee222b3e9ad0bdd6ef</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>We need access to your camera so you can upload a profile photo and share images or videos in course discussions and assignments.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>We need access to your microphone so you can record audio and video submissions for assignments and participate in live class sessions.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>We need access to add photos to your library so you can save course content and assignment materials.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>We need access to your photos so you can select and upload images for your profile and course assignments.</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>PROJECT_ID</key>
+	<string>vacademy-app</string>
+	<key>STORAGE_BUCKET</key>
+	<string>vacademy-app.firebasestorage.app</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreenSN</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
+</dict>
+</plist>

--- a/frontend-learner-dashboard-app/package.json
+++ b/frontend-learner-dashboard-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "capacitor-starter",
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Records the versions that were actually built and uploaded on 2026-09-12, so the next build doesn't collide with them or re-arm the OTA builtin-version trap.

| File | Change |
|---|---|
| `package.json` | 2.5.3 → **2.5.7** — newest active SN Android OTA bundle is 2.5.6 (published 26 Aug from an uncommitted bump); a binary built from main embedded 2.5.3 and got force-updated backwards on first launch. OTA now answers `update_available:false` for 2.5.7 on ANDROID / IOS / MACOS. **`publish-ota.sh` must publish > 2.5.7 from here on.** |
| `android/app/build.gradle` | shikshanation vc11 / 2.5.0 → **vc12 / 2.5.7** (Play live is 1.1.3; vc10 unreleased in console) |
| `ios/App/App.xcodeproj` | `Shiksha Nation SK` (`io.shikshanationapp.com`, the live app) `CURRENT_PROJECT_VERSION` 1 → **25** (live 1.0.2 = build 24) |
| `ios/App/GoogleServiceConfigs/Shiksha-Nation-SK/GoogleService-Info.plist` | **new** — the target referenced it since 24 Aug but it never existed, so the target had never built. Copied from Shiksha-Nation with `BUNDLE_ID` corrected; `GOOGLE_APP_ID` is still the `.learner` Firebase app (pushes won't route — SN push is already dead server-side). |
| `electron/electron-builder.shikshanation-mas.json` | buildVersion 5 → **6**, version 1.0 → **1.0.1** |
| `electron/electron-flavor.json` | adds `otaAppId: io.shikshanationapp.com` — without it the Mac shell reported `app.getName()` to the OTA endpoint and matched nothing |

## What shipped from these values
- iOS 1.0.3 build 25 → attached, **WAITING_FOR_REVIEW** (delivery `079a3f36…`)
- macOS 1.0.1 build 6 → attached, **WAITING_FOR_REVIEW** (delivery `146be9ae…`)
- Android `Shiksha-Nation-2.5.7-vc12.aab` built + verified (manifest, signature, OTA probe) — awaiting manual Play upload
- Windows 1.0.12 MSIX built by CI (#2855) — awaiting manual Partner Center upload

## Verification
- OTA probe: `check?platform={ANDROID,IOS,MACOS}&currentBundleVersion=2.5.7&appId=…` → `{"update_available":false}`
- `bundletool dump manifest` on the .aab: vc12 / 2.5.7 / `com.shikshanation.new.app`; `jarsigner -verify` OK
- iOS .ipa Info.plist: `io.shikshanationapp.com` 1.0.3 (25), `ITSAppUsesNonExemptEncryption=false`; `altool --validate-app` clean
- Mac .app: Apple Distribution signed, sandbox + audio-input only, 1.0.1 (6), `LSMinimumSystemVersion` 12.0, `app/ota-bundle-version.txt`=2.5.7 inside the asar

🤖 Generated with [Claude Code](https://claude.com/claude-code)