### PR TITLE
feat(whatsapp-templates): upload the header sample media instead of pasting a URL

### DIFF
--- a/frontend-admin-dashboard/public/locales/ar/communicationTemplateBuilder.json
+++ b/frontend-admin-dashboard/public/locales/ar/communicationTemplateBuilder.json
@@ -28,7 +28,11 @@
         "approvedByMeta": "تمت الموافقة على القالب من قبل Meta وهو جاهز للاستخدام.",
         "submittedToMeta": "تم إرسال القالب إلى Meta للموافقة عليه.",
         "metaRejected": "رفضت Meta القالب. تم حفظ مسودتك.",
-        "draftSavedRetry": "تم حفظ مسودتك — أصلح المشكلة أعلاه وأرسل مرة أخرى."
+        "draftSavedRetry": "تم حفظ مسودتك — أصلح المشكلة أعلاه وأرسل مرة أخرى.",
+        "sampleUploaded": "تم رفع نموذج {{kind}} — تم ملء الرابط العام.",
+        "sampleUploadFailed": "تعذر رفع نموذج {{kind}}.",
+        "sampleWrongType": "هذا الملف ليس {{kind}} مدعومًا. استخدم {{formats}}.",
+        "sampleTooLarge": "هذا الملف كبير جدًا. استخدم {{formats}}."
     },
     "problemsBanner": {
         "single": "يحتاج هذا القالب إلى إصلاح",
@@ -78,7 +82,15 @@
         "buttonPhonePlaceholder": "+919876543210",
         "addQuickReply": "+ رد سريع",
         "addUrlButton": "+ زر رابط",
-        "addPhone": "+ هاتف"
+        "addPhone": "+ هاتف",
+        "headerSampleUpload": "رفع",
+        "headerSampleUploading": "جارٍ الرفع…",
+        "headerSampleUrlHint": "ارفع ملفًا أو الصق رابطًا عامًا — تقوم Meta بتنزيله للمراجعة. {{formats}}.",
+        "headerSampleFormats": {
+            "image": "JPG أو PNG، حتى 5 ميغابايت",
+            "video": "MP4، حتى 16 ميغابايت",
+            "document": "PDF، حتى 100 ميغابايت"
+        }
     },
     "headerKind": {
         "image": "صورة",

--- a/frontend-admin-dashboard/public/locales/ar/communicationTemplateValidation.json
+++ b/frontend-admin-dashboard/public/locales/ar/communicationTemplateValidation.json
@@ -25,6 +25,7 @@
     "headerTooManyVariables_other": "يمكن أن تحتوي ترويسة النص على متغير واحد كحد أقصى؛ هذه تحتوي على {{count}}.",
     "headerSampleValueMissing": "يحتاج متغير الترويسة إلى قيمة نموذجية ليراجعها Meta.",
     "headerSampleUrlRequired": "رابط {{type}} نموذجي مطلوب لقوالب ترويسة {{type}}.",
+    "headerSampleUrlExpiring": "رابط نموذج {{type}} هو رابط موقّع مؤقت (يحتوي على معلمة Signature/Expires) وسيتوقف عن العمل بعد انتهاء صلاحيته — ستوافق Meta على القالب ثم يفشل كل إرسال. استخدم «رفع» لاستضافة الملف بشكل دائم بدلًا من ذلك.",
     "footerTooLong": "التذييل يحتوي على {{length}} حرفًا؛ يسمح Meta بحد أقصى {{max}}.",
     "footerCannotContainVariables": "لا يمكن أن تحتوي التذييلات على متغيرات — أزل {{token}} من التذييل.",
     "tooManyButtons": "يمكن أن يحتوي القالب على {{max}} أزرار كحد أقصى.",

--- a/frontend-admin-dashboard/public/locales/en/communicationTemplateBuilder.json
+++ b/frontend-admin-dashboard/public/locales/en/communicationTemplateBuilder.json
@@ -24,7 +24,11 @@
         "approvedByMeta": "Template approved by Meta and ready to use.",
         "submittedToMeta": "Template submitted to Meta for approval.",
         "metaRejected": "Meta rejected the template. Your draft has been saved.",
-        "draftSavedRetry": "Your draft is saved — fix the problem above and submit again."
+        "draftSavedRetry": "Your draft is saved — fix the problem above and submit again.",
+        "sampleUploaded": "Sample {{kind}} uploaded — the public URL has been filled in.",
+        "sampleUploadFailed": "Could not upload the sample {{kind}}.",
+        "sampleWrongType": "That file isn't a supported {{kind}}. Use {{formats}}.",
+        "sampleTooLarge": "That file is too large. Use {{formats}}."
     },
     "problemsBanner": {
         "single": "This template needs a fix",
@@ -70,7 +74,15 @@
         "buttonPhonePlaceholder": "+919876543210",
         "addQuickReply": "+ Quick Reply",
         "addUrlButton": "+ URL Button",
-        "addPhone": "+ Phone"
+        "addPhone": "+ Phone",
+        "headerSampleUpload": "Upload",
+        "headerSampleUploading": "Uploading…",
+        "headerSampleUrlHint": "Upload a file or paste a public URL — Meta downloads it for review. {{formats}}.",
+        "headerSampleFormats": {
+            "image": "JPG or PNG, up to 5 MB",
+            "video": "MP4, up to 16 MB",
+            "document": "PDF, up to 100 MB"
+        }
     },
     "headerKind": {
         "image": "image",

--- a/frontend-admin-dashboard/public/locales/en/communicationTemplateValidation.json
+++ b/frontend-admin-dashboard/public/locales/en/communicationTemplateValidation.json
@@ -21,6 +21,7 @@
     "headerTooManyVariables_other": "A text header can contain at most one variable; this one has {{count}}.",
     "headerSampleValueMissing": "The header variable needs a sample value for Meta to review it.",
     "headerSampleUrlRequired": "A sample {{type}} URL is required for {{type}}-header templates.",
+    "headerSampleUrlExpiring": "The sample {{type}} link is a temporary signed URL (it carries a Signature/Expires parameter) and will stop working once it expires — Meta would approve the template, then every send would fail. Use Upload to host the file permanently instead.",
     "footerTooLong": "Footer is {{length}} characters; Meta allows at most {{max}}.",
     "footerCannotContainVariables": "Footers cannot contain variables — remove the {{token}} from the footer.",
     "tooManyButtons": "A template can have at most {{max}} buttons.",

--- a/frontend-admin-dashboard/public/locales/fr/communicationTemplateBuilder.json
+++ b/frontend-admin-dashboard/public/locales/fr/communicationTemplateBuilder.json
@@ -25,7 +25,11 @@
         "approvedByMeta": "Modèle approuvé par Meta et prêt à l'emploi.",
         "submittedToMeta": "Modèle soumis à Meta pour approbation.",
         "metaRejected": "Meta a rejeté le modèle. Votre brouillon a été enregistré.",
-        "draftSavedRetry": "Votre brouillon est enregistré — corrigez le problème ci-dessus et soumettez à nouveau."
+        "draftSavedRetry": "Votre brouillon est enregistré — corrigez le problème ci-dessus et soumettez à nouveau.",
+        "sampleUploaded": "Exemple {{kind}} téléversé — l'URL publique a été renseignée.",
+        "sampleUploadFailed": "Impossible de téléverser l'exemple {{kind}}.",
+        "sampleWrongType": "Ce fichier n'est pas un {{kind}} pris en charge. Utilisez {{formats}}.",
+        "sampleTooLarge": "Ce fichier est trop volumineux. Utilisez {{formats}}."
     },
     "problemsBanner": {
         "single": "Ce modèle nécessite une correction",
@@ -72,7 +76,15 @@
         "buttonPhonePlaceholder": "+919876543210",
         "addQuickReply": "+ Réponse rapide",
         "addUrlButton": "+ Bouton URL",
-        "addPhone": "+ Téléphone"
+        "addPhone": "+ Téléphone",
+        "headerSampleUpload": "Téléverser",
+        "headerSampleUploading": "Téléversement…",
+        "headerSampleUrlHint": "Téléversez un fichier ou collez une URL publique — Meta la télécharge pour la révision. {{formats}}.",
+        "headerSampleFormats": {
+            "image": "JPG ou PNG, jusqu’à 5 Mo",
+            "video": "MP4, jusqu’à 16 Mo",
+            "document": "PDF, jusqu’à 100 Mo"
+        }
     },
     "headerKind": {
         "image": "image",

--- a/frontend-admin-dashboard/public/locales/fr/communicationTemplateValidation.json
+++ b/frontend-admin-dashboard/public/locales/fr/communicationTemplateValidation.json
@@ -22,6 +22,7 @@
     "headerTooManyVariables_other": "Un en-tête texte peut contenir au maximum une variable ; celui-ci en a {{count}}.",
     "headerSampleValueMissing": "La variable d'en-tête a besoin d'une valeur d'exemple pour l'examen par Meta.",
     "headerSampleUrlRequired": "Une URL {{type}} d'exemple est requise pour les modèles à en-tête {{type}}.",
+    "headerSampleUrlExpiring": "Le lien d'exemple {{type}} est une URL signée temporaire (elle contient un paramètre Signature/Expires) et cessera de fonctionner à son expiration — Meta approuverait le modèle, puis chaque envoi échouerait. Utilisez Téléverser pour héberger le fichier de façon permanente.",
     "footerTooLong": "Le pied de page contient {{length}} caractères ; Meta en autorise au maximum {{max}}.",
     "footerCannotContainVariables": "Les pieds de page ne peuvent pas contenir de variables — retirez {{token}} du pied de page.",
     "tooManyButtons": "Un modèle peut avoir au maximum {{max}} boutons.",

--- a/frontend-admin-dashboard/public/locales/hi/communicationTemplateBuilder.json
+++ b/frontend-admin-dashboard/public/locales/hi/communicationTemplateBuilder.json
@@ -24,7 +24,11 @@
         "approvedByMeta": "टेम्पलेट Meta द्वारा स्वीकृत हो गया है और उपयोग के लिए तैयार है।",
         "submittedToMeta": "टेम्पलेट अनुमोदन के लिए Meta को सबमिट किया गया।",
         "metaRejected": "Meta ने टेम्पलेट को अस्वीकार कर दिया। आपका ड्राफ्ट सहेज लिया गया है।",
-        "draftSavedRetry": "आपका ड्राफ्ट सहेजा गया है — ऊपर बताई गई समस्या ठीक करें और फिर से सबमिट करें।"
+        "draftSavedRetry": "आपका ड्राफ्ट सहेजा गया है — ऊपर बताई गई समस्या ठीक करें और फिर से सबमिट करें।",
+        "sampleUploaded": "सैंपल {{kind}} अपलोड हो गया — सार्वजनिक URL भर दिया गया है।",
+        "sampleUploadFailed": "सैंपल {{kind}} अपलोड नहीं हो सका।",
+        "sampleWrongType": "यह फ़ाइल समर्थित {{kind}} नहीं है। {{formats}} का उपयोग करें।",
+        "sampleTooLarge": "यह फ़ाइल बहुत बड़ी है। {{formats}} का उपयोग करें।"
     },
     "problemsBanner": {
         "single": "इस टेम्पलेट में एक सुधार चाहिए",
@@ -70,7 +74,15 @@
         "buttonPhonePlaceholder": "+919876543210",
         "addQuickReply": "+ त्वरित उत्तर",
         "addUrlButton": "+ URL बटन",
-        "addPhone": "+ फ़ोन"
+        "addPhone": "+ फ़ोन",
+        "headerSampleUpload": "अपलोड करें",
+        "headerSampleUploading": "अपलोड हो रहा है…",
+        "headerSampleUrlHint": "फ़ाइल अपलोड करें या सार्वजनिक URL पेस्ट करें — Meta समीक्षा के लिए इसे डाउनलोड करता है। {{formats}}।",
+        "headerSampleFormats": {
+            "image": "JPG या PNG, अधिकतम 5 MB",
+            "video": "MP4, अधिकतम 16 MB",
+            "document": "PDF, अधिकतम 100 MB"
+        }
     },
     "headerKind": {
         "image": "छवि",

--- a/frontend-admin-dashboard/public/locales/hi/communicationTemplateValidation.json
+++ b/frontend-admin-dashboard/public/locales/hi/communicationTemplateValidation.json
@@ -21,6 +21,7 @@
     "headerTooManyVariables_other": "एक टेक्स्ट हेडर में अधिकतम एक वेरिएबल हो सकता है; इसमें {{count}} हैं।",
     "headerSampleValueMissing": "हेडर वेरिएबल के लिए Meta की समीक्षा हेतु एक नमूना मान चाहिए।",
     "headerSampleUrlRequired": "{{type}}-हेडर टेम्पलेट के लिए एक नमूना {{type}} URL आवश्यक है।",
+    "headerSampleUrlExpiring": "सैंपल {{type}} लिंक एक अस्थायी साइन किया हुआ URL है (इसमें Signature/Expires पैरामीटर है) और समाप्त होने पर काम करना बंद कर देगा — Meta टेम्पलेट स्वीकृत कर देगा, फिर हर भेजना विफल होगा। इसके बजाय फ़ाइल को स्थायी रूप से होस्ट करने के लिए अपलोड करें का उपयोग करें।",
     "footerTooLong": "फ़ुटर {{length}} वर्णों का है; Meta अधिकतम {{max}} की अनुमति देता है।",
     "footerCannotContainVariables": "फ़ुटर में वेरिएबल नहीं हो सकते — फ़ुटर से {{token}} हटाएं।",
     "tooManyButtons": "एक टेम्पलेट में अधिकतम {{max}} बटन हो सकते हैं।",

--- a/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-components/template-builder.test.tsx
+++ b/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-components/template-builder.test.tsx
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// `t` is backed by the REAL en catalogs, one per namespace exactly as i18next scopes them (no
+// fallbackNS), so a key rendered from the wrong catalog shows up as the raw key — exactly what an
+// admin would see, and what these assertions catch.
+vi.mock('react-i18next', async () => {
+    const catalogs: Record<string, Record<string, unknown>> = {
+        communicationTemplateBuilder: (
+            await import('../../../../../public/locales/en/communicationTemplateBuilder.json')
+        ).default,
+        communicationTemplateValidation: (
+            await import('../../../../../public/locales/en/communicationTemplateValidation.json')
+        ).default,
+    };
+
+    const translateIn = (ns: string) => (key: string, vars?: Record<string, unknown>) => {
+        const en = catalogs[ns] ?? {};
+        const count = typeof vars?.count === 'number' ? (vars.count as number) : undefined;
+        const candidates =
+            count === undefined ? [key] : [`${key}_${count === 1 ? 'one' : 'other'}`, key];
+        for (const candidate of candidates) {
+            const value = candidate
+                .split('.')
+                .reduce<unknown>(
+                    (acc, part) =>
+                        acc && typeof acc === 'object'
+                            ? (acc as Record<string, unknown>)[part]
+                            : undefined,
+                    en
+                );
+            if (typeof value === 'string') {
+                return value.replace(/{{(\w+)}}/g, (_, name: string) => String(vars?.[name] ?? ''));
+            }
+        }
+        return key;
+    };
+
+    return { useTranslation: (ns: string) => ({ t: translateIn(ns) }) };
+});
+
+const { uploadFile, getPublicUrl, toast } = vi.hoisted(() => ({
+    uploadFile: vi.fn(),
+    getPublicUrl: vi.fn(),
+    toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-file-upload', () => ({ useFileUpload: () => ({ uploadFile }) }));
+vi.mock('@/services/upload_file', () => ({ getPublicUrl }));
+vi.mock('@/utils/userDetails', () => ({ getUserId: () => 'user-1' }));
+vi.mock('@/constants/helper', () => ({ getInstituteId: () => 'inst-1' }));
+vi.mock('sonner', () => ({ toast }));
+vi.mock('../-services/template-api', () => ({
+    createTemplateDraft: vi.fn(),
+    updateTemplate: vi.fn(),
+    submitToMeta: vi.fn(),
+}));
+
+import { TemplateBuilder } from './template-builder';
+import { looksLikeSignedUrl } from '../-utils/template-validation';
+
+const PUBLIC_URL = 'https://cdn.example.com/WHATSAPP_TEMPLATE_MEDIA/inst-1/2f1c9c7e-banner.png';
+
+/** Builds a File with a real byte length, since the size check reads `file.size`. */
+function fakeFile(name: string, type: string, bytes: number): File {
+    return new File([new Uint8Array(bytes)], name, { type });
+}
+
+function renderWithHeader(headerType: string) {
+    render(<TemplateBuilder template={null} onClose={() => {}} />);
+    const selects = screen.getAllByRole('combobox');
+    // Category, language, then header type — the header select is the one carrying the NONE option.
+    const headerSelect = selects.find((s) =>
+        Array.from((s as HTMLSelectElement).options).some((o) => o.value === 'NONE')
+    ) as HTMLSelectElement;
+    fireEvent.change(headerSelect, { target: { value: headerType } });
+    return {
+        urlInput: screen.getByPlaceholderText(/Sample .* URL/) as HTMLInputElement,
+        fileInput: screen.getByTestId('header-sample-file') as HTMLInputElement,
+    };
+}
+
+describe('TemplateBuilder — header sample upload', () => {
+    beforeEach(() => {
+        uploadFile.mockReset();
+        getPublicUrl.mockReset();
+        toast.success.mockReset();
+        toast.error.mockReset();
+    });
+
+    it('offers an upload next to the URL field only for media headers, with the format rule for that type', () => {
+        render(<TemplateBuilder template={null} onClose={() => {}} />);
+        expect(screen.queryByRole('button', { name: /upload/i })).toBeNull();
+
+        const { fileInput } = renderWithHeader('IMAGE');
+        expect(screen.getByRole('button', { name: 'Upload' })).toBeTruthy();
+        expect(screen.getByText(/JPG or PNG, up to 5 MB/)).toBeTruthy();
+        expect(fileInput.accept).toBe('image/jpeg,image/png');
+    });
+
+    it('uploads the picked image to the public bucket and fills the field with the permanent URL', async () => {
+        uploadFile.mockResolvedValue('file-123');
+        getPublicUrl.mockResolvedValue(PUBLIC_URL);
+        const { urlInput, fileInput } = renderWithHeader('IMAGE');
+
+        fireEvent.change(fileInput, {
+            target: { files: [fakeFile('banner.png', 'image/png', 1024)] },
+        });
+
+        await waitFor(() => expect(urlInput.value).toBe(PUBLIC_URL));
+        // publicUrl is what copies the object to the public bucket — without it the URL Meta and the
+        // send-time renderer read would be an expiring signed one.
+        expect(uploadFile).toHaveBeenCalledWith(
+            expect.objectContaining({
+                publicUrl: true,
+                source: 'WHATSAPP_TEMPLATE_MEDIA',
+                sourceId: 'inst-1',
+                userId: 'user-1',
+            })
+        );
+        expect(getPublicUrl).toHaveBeenCalledWith('file-123');
+        // The WhatsApp preview picks the uploaded image up straight away.
+        const preview = document.querySelector('img[src]') as HTMLImageElement;
+        expect(preview.getAttribute('src')).toBe(PUBLIC_URL);
+        expect(toast.success).toHaveBeenCalledWith(
+            expect.stringContaining('Sample image uploaded')
+        );
+    });
+
+    it('refuses a file Meta would reject before uploading anything', () => {
+        const { urlInput, fileInput } = renderWithHeader('IMAGE');
+
+        fireEvent.change(fileInput, {
+            target: { files: [fakeFile('banner.gif', 'image/gif', 1024)] },
+        });
+        expect(uploadFile).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith(
+            "That file isn't a supported image. Use JPG or PNG, up to 5 MB."
+        );
+
+        fireEvent.change(fileInput, {
+            target: { files: [fakeFile('huge.png', 'image/png', 5 * 1024 * 1024 + 1)] },
+        });
+        expect(uploadFile).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenLastCalledWith(
+            'That file is too large. Use JPG or PNG, up to 5 MB.'
+        );
+        expect(urlInput.value).toBe('');
+    });
+
+    it('leaves the field untouched and reports the failure when the upload dies', async () => {
+        uploadFile.mockRejectedValue(new Error('S3 said no'));
+        const { urlInput, fileInput } = renderWithHeader('DOCUMENT');
+        expect(fileInput.accept).toBe('application/pdf');
+
+        fireEvent.change(fileInput, {
+            target: { files: [fakeFile('brochure.pdf', 'application/pdf', 2048)] },
+        });
+
+        await waitFor(() => expect(toast.error).toHaveBeenCalled());
+        expect(urlInput.value).toBe('');
+        expect(screen.getByRole('button', { name: 'Upload' })).toBeTruthy();
+    });
+
+    it('still lets the admin paste a URL by hand', () => {
+        const { urlInput } = renderWithHeader('VIDEO');
+        fireEvent.change(urlInput, { target: { value: 'https://example.com/intro.mp4' } });
+        expect(urlInput.value).toBe('https://example.com/intro.mp4');
+    });
+
+    it('blocks submit on a pasted signed/expiring link and explains why in plain English', () => {
+        const { urlInput } = renderWithHeader('IMAGE');
+        fireEvent.change(screen.getByPlaceholderText(/Hello \{\{1\}\}/), {
+            target: { value: 'Hello there' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('order_confirmation'), {
+            target: { value: 'welcome_offer' },
+        });
+        // A real prod paste: the object lives only in the private bucket and the CDN link carried a
+        // signature that expired a week later, taking every send of the template down with it.
+        fireEvent.change(urlInput, {
+            target: {
+                value: 'https://d1om4dxj9e7kkd.cloudfront.net/ADMIN_UPLOAD/178b3266-banner.jpeg?Expires=1789627595&Signature=G3tSbwZy&Key-Pair-Id=K2ABC',
+            },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Submit for Approval' }));
+
+        expect(uploadFile).not.toHaveBeenCalled();
+        // The message comes from the validation catalog — it must not surface as the raw key.
+        expect(screen.getByText(/temporary signed URL/)).toBeTruthy();
+        expect(screen.queryByText('headerSampleUrlExpiring')).toBeNull();
+        expect(urlInput.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('renders every local validation problem from its own catalog, not as a raw key', () => {
+        render(<TemplateBuilder template={null} onClose={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Submit for Approval' }));
+        expect(screen.getByText('Give the template a name.')).toBeTruthy();
+        expect(screen.queryByText('nameRequired')).toBeNull();
+    });
+});
+
+describe('looksLikeSignedUrl', () => {
+    it('flags S3 presigned, CloudFront signed and Azure SAS links', () => {
+        expect(
+            looksLikeSignedUrl('https://x.cloudfront.net/a.jpg?Expires=1&Signature=s&Key-Pair-Id=k')
+        ).toBe(true);
+        expect(
+            looksLikeSignedUrl(
+                'https://b.s3.amazonaws.com/a.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc'
+            )
+        ).toBe(true);
+        expect(
+            looksLikeSignedUrl('https://acct.blob.core.windows.net/c/a.pdf?sv=2020&sig=abc')
+        ).toBe(true);
+    });
+
+    it('lets permanent public URLs through, including ones with harmless query strings', () => {
+        expect(looksLikeSignedUrl(PUBLIC_URL)).toBe(false);
+        expect(looksLikeSignedUrl('https://cdn.example.com/a.png?v=3&w=800')).toBe(false);
+        expect(
+            looksLikeSignedUrl('https://res.cloudinary.com/x/image/upload/f_auto,q_auto/img')
+        ).toBe(false);
+    });
+});

--- a/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-components/template-builder.tsx
+++ b/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-components/template-builder.tsx
@@ -1,9 +1,12 @@
-import { useState, useMemo } from 'react';
-import { ArrowLeft, Plus, Trash, WarningCircle } from '@phosphor-icons/react';
+import { useState, useMemo, useRef } from 'react';
+import { ArrowLeft, CircleNotch, Plus, Trash, UploadSimple, WarningCircle } from '@phosphor-icons/react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { getInstituteId } from '@/constants/helper';
+import { useFileUpload } from '@/hooks/use-file-upload';
+import { getPublicUrl } from '@/services/upload_file';
+import { getUserId } from '@/utils/userDetails';
 import { cn } from '@/lib/utils';
 import { getBackendErrorBody, reportApiError } from '@/lib/report-api-error';
 import { createTemplateDraft, updateTemplate, submitToMeta, WhatsAppTemplateDTO, TemplateButton } from '../-services/template-api';
@@ -39,8 +42,44 @@ const buttonFieldClass = 'w-full px-2 py-1 text-xs border rounded';
 /** Applied to whichever input the local check or the server pointed at. */
 const invalidClass = 'border-danger-400 bg-danger-50 focus:border-danger-500';
 
+/**
+ * What Meta accepts as a media-header sample, per header type. Checked before the upload so a
+ * wrong file is refused here, instead of surfacing as SAMPLE_MEDIA_UPLOAD_FAILED after the round
+ * trip through S3 and Meta's resumable-upload API.
+ */
+const SAMPLE_MEDIA_RULES: Record<string, { accept: string; mimes: string[]; extensions: string[]; maxBytes: number }> = {
+    IMAGE: {
+        accept: 'image/jpeg,image/png',
+        mimes: ['image/jpeg', 'image/png'],
+        extensions: ['.jpg', '.jpeg', '.png'],
+        maxBytes: 5 * 1024 * 1024,
+    },
+    VIDEO: {
+        accept: 'video/mp4,video/3gpp',
+        mimes: ['video/mp4', 'video/3gpp'],
+        extensions: ['.mp4', '.3gp'],
+        maxBytes: 16 * 1024 * 1024,
+    },
+    DOCUMENT: {
+        accept: 'application/pdf',
+        mimes: ['application/pdf'],
+        extensions: ['.pdf'],
+        maxBytes: 100 * 1024 * 1024,
+    },
+};
+
+/** Browsers leave `file.type` empty for unregistered extensions, so fall back to the name. */
+function isAllowedSampleFile(file: File, rule: (typeof SAMPLE_MEDIA_RULES)[string]): boolean {
+    if (file.type) return rule.mimes.includes(file.type.toLowerCase());
+    const name = file.name.toLowerCase();
+    return rule.extensions.some((ext) => name.endsWith(ext));
+}
+
 export function TemplateBuilder({ template, onClose }: Props) {
     const { t } = useTranslation('communicationTemplateBuilder');
+    // The validators' messages live in their own catalog; handing them the builder's `t` renders
+    // every problem as a raw key like `bodyRequired`.
+    const { t: tValidation } = useTranslation('communicationTemplateValidation');
     const LANGUAGES = useMemo(() => buildLanguages(t), [t]);
     const isEditing = !!template?.id;
     const instituteId = getInstituteId() || '';
@@ -65,9 +104,61 @@ export function TemplateBuilder({ template, onClose }: Props) {
     // to its id so a retry updates that row instead of creating a second one and hitting the
     // duplicate-name 409, which used to strand the admin with an invisible orphan draft.
     const [draftId, setDraftId] = useState<string | undefined>(template?.id);
+    const [uploadingSample, setUploadingSample] = useState(false);
+    const sampleFileInputRef = useRef<HTMLInputElement>(null);
+    const { uploadFile } = useFileUpload();
 
     const invalidFields = useMemo(() => problemFields(problems), [problems]);
     const isInvalid = (field: string) => invalidFields.has(field);
+
+    /**
+     * Upload the header sample and drop its public URL into the field, so the admin doesn't need
+     * somewhere else to host the file. `publicUrl` copies the object to the public bucket and the
+     * URL never expires — Meta downloads it during review, and the renderer reuses it as the header
+     * media on every send of this template, so a signed/expiring URL would break sends later.
+     */
+    const handleSampleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        // Clear the input so choosing the same file again after a rejection still fires onChange.
+        e.target.value = '';
+        const rule = SAMPLE_MEDIA_RULES[headerType];
+        if (!file || !rule) return;
+
+        const kind = t(`headerKind.${headerType.toLowerCase()}`);
+        const formats = t(`fields.headerSampleFormats.${headerType.toLowerCase()}`);
+        if (!isAllowedSampleFile(file, rule)) {
+            toast.error(t('toast.sampleWrongType', { kind, formats }));
+            return;
+        }
+        if (file.size > rule.maxBytes) {
+            toast.error(t('toast.sampleTooLarge', { formats }));
+            return;
+        }
+
+        setUploadingSample(true);
+        try {
+            const fileId = await uploadFile({
+                file,
+                setIsUploading: setUploadingSample,
+                userId: getUserId(),
+                source: 'WHATSAPP_TEMPLATE_MEDIA',
+                sourceId: instituteId || 'ADMIN',
+                publicUrl: true,
+            });
+            const url = fileId ? await getPublicUrl(fileId) : '';
+            if (!url) throw new Error('Upload finished but the media service returned no public URL');
+            setHeaderSampleUrl(url);
+            setProblems((prev) => prev.filter((p) => p.field !== 'headerSampleUrl'));
+            toast.success(t('toast.sampleUploaded', { kind }));
+        } catch (err) {
+            reportApiError(err, {
+                feature: 'whatsapp-template-sample-upload',
+                fallbackMessage: t('toast.sampleUploadFailed', { kind }),
+            });
+        } finally {
+            setUploadingSample(false);
+        }
+    };
 
     // How many distinct variables the body declares: {{1}} … {{N}}. Uses the highest index rather
     // than the match count so a body that repeats {{1}} still asks for exactly one sample.
@@ -144,7 +235,7 @@ export function TemplateBuilder({ template, onClose }: Props) {
     };
 
     const handleSaveDraft = async () => {
-        const found = validateDraft(t, { name, category, bodyText });
+        const found = validateDraft(tValidation, { name, category, bodyText });
         if (found.length > 0) { showLocalProblems(found); return; }
 
         setSaving(true);
@@ -164,7 +255,7 @@ export function TemplateBuilder({ template, onClose }: Props) {
     };
 
     const handleSubmit = async () => {
-        const found = validateForSubmit(t, {
+        const found = validateForSubmit(tValidation, {
             name,
             language,
             category,
@@ -322,12 +413,35 @@ export function TemplateBuilder({ template, onClose }: Props) {
                                 className={cn(fieldClass, 'mt-2', isInvalid('headerSampleValues') && invalidClass)} />
                         )}
                         {headerType !== 'NONE' && headerType !== 'TEXT' && (
-                            <input type="text" value={headerSampleUrl} onChange={(e) => setHeaderSampleUrl(e.target.value)}
-                                placeholder={t('fields.headerSampleUrlPlaceholder', {
-                                    kind: t(`headerKind.${headerType.toLowerCase()}`),
-                                })}
-                                aria-invalid={isInvalid('headerSampleUrl')}
-                                className={cn(fieldClass, 'mt-2', isInvalid('headerSampleUrl') && invalidClass)} />
+                            <div className="mt-2">
+                                <div className="flex items-start gap-2">
+                                    <input type="text" value={headerSampleUrl} onChange={(e) => setHeaderSampleUrl(e.target.value)}
+                                        placeholder={t('fields.headerSampleUrlPlaceholder', {
+                                            kind: t(`headerKind.${headerType.toLowerCase()}`),
+                                        })}
+                                        aria-invalid={isInvalid('headerSampleUrl')}
+                                        className={cn(fieldClass, 'min-w-0 flex-1', isInvalid('headerSampleUrl') && invalidClass)} />
+                                    {/* Hidden picker; `accept` follows the header type so the OS dialog
+                                        only offers files Meta will take. */}
+                                    <input ref={sampleFileInputRef} type="file" className="hidden"
+                                        accept={SAMPLE_MEDIA_RULES[headerType]?.accept}
+                                        onChange={handleSampleFile}
+                                        data-testid="header-sample-file" />
+                                    <button type="button" onClick={() => sampleFileInputRef.current?.click()}
+                                        disabled={uploadingSample || saving}
+                                        className="mt-1 flex shrink-0 items-center gap-1 rounded border px-2.5 py-1.5 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60">
+                                        {uploadingSample
+                                            ? <CircleNotch size={14} className="animate-spin" />
+                                            : <UploadSimple size={14} />}
+                                        {uploadingSample ? t('fields.headerSampleUploading') : t('fields.headerSampleUpload')}
+                                    </button>
+                                </div>
+                                <p className="mt-1 text-caption text-gray-500">
+                                    {t('fields.headerSampleUrlHint', {
+                                        formats: t(`fields.headerSampleFormats.${headerType.toLowerCase()}`),
+                                    })}
+                                </p>
+                            </div>
                         )}
                     </div>
 

--- a/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-utils/template-validation.ts
+++ b/frontend-admin-dashboard/src/routes/communication/whatsapp-templates/-utils/template-validation.ts
@@ -27,6 +27,17 @@ const BUTTON_TEXT_MAX = 25;
 /** Meta's own ceiling. The builder offers 3, but a template synced from Meta may carry more. */
 const MAX_BUTTONS = 10;
 
+/**
+ * Query parameters that only ever appear on temporary, signed links (S3 presigned GETs,
+ * CloudFront signed URLs, GCS/Azure SAS). Such a link passes Meta's review — the signature is
+ * still valid that day — and then the header media 403s on every send once it expires, because
+ * the send path attaches `header_sample_url` as the template's media on each message.
+ */
+const SIGNED_URL_PARAMS =
+    /[?&](Signature|Expires|X-Amz-Signature|X-Amz-Expires|Key-Pair-Id|Policy|sig)=/i;
+
+export const looksLikeSignedUrl = (url: string): boolean => SIGNED_URL_PARAMS.test(url.trim());
+
 /** Meta allows lowercase letters, digits and underscores, up to 512 characters. */
 export const normalizeTemplateName = (raw: string): string =>
     raw.toLowerCase().replace(/[^a-z0-9_]/g, '_');
@@ -212,6 +223,11 @@ export const validateForSubmit = (
         problems.push({
             field: 'headerSampleUrl',
             message: t('headerSampleUrlRequired', { type: dto.headerType.toLowerCase() }),
+        });
+    } else if (dto.headerType !== 'NONE' && looksLikeSignedUrl(dto.headerSampleUrl)) {
+        problems.push({
+            field: 'headerSampleUrl',
+            message: t('headerSampleUrlExpiring', { type: dto.headerType.toLowerCase() }),
         });
     }
 


### PR DESCRIPTION
## What

In the WhatsApp template builder, Image / Video / Document headers now have an **Upload** button next to the sample-URL field. The file is uploaded to S3 through the media service's public-bucket path and the permanent CDN URL is filled in automatically — clients no longer need somewhere else to host the sample to register a template with Meta. Pasting a URL by hand still works.

## Why the URL must be permanent (not just valid on review day)

`UnifiedSendService` attaches `header_sample_url` as the header media on **every send** of the template, not only during Meta review. Verified against live prod:

- media-service runs with `CDN_PUBLIC_BASE_URL=https://d1om4dxj9e7kkd.cloudfront.net`; uploads made with `publicUrl: true` → `get-public-url` return **200** unauthenticated, no signature, no expiry (same flow as catalogue images).
- A CDN URL for an object that was never copied to the public bucket returns **403**, and a pasted presigned link stops working when its signature expires. One prod template (`sn_unlockx`, approved 2026-09-10) is in exactly that state — its header link expires **2026-09-17 06:46 UTC** and needs a re-upload once this ships.

So `validateForSubmit` now rejects sample links carrying `Signature` / `Expires` / `X-Amz-*` / `Key-Pair-Id` / `Policy` / `sig` and points the admin at Upload.

## Also fixed

Since the i18n wiring commit (`2daa33d06f`), the builder passed its `communicationTemplateBuilder` `t()` into the validators, whose messages live in `communicationTemplateValidation`. With no `fallbackNS`, every local validation problem rendered as a raw key (`nameRequired`, `bodyRequired`, …). The builder now resolves them from the right namespace.

## Details

- Client-side checks mirror Meta's limits so a bad file is refused before the S3 → Meta round trip: JPG/PNG ≤ 5 MB, MP4/3GP ≤ 16 MB, PDF ≤ 100 MB; the OS file dialog's `accept` follows the header type.
- Files land under `WHATSAPP_TEMPLATE_MEDIA/<instituteId>/…`.
- Locale keys added to en / hi / fr / ar (builder + validation catalogs), purely additive.

## Tests

`template-builder.test.tsx` (new, 9 tests): button only appears for media headers with the right format rule; upload fills the URL + preview with `publicUrl: true`; wrong type / oversize refused without uploading; upload failure leaves the field untouched; manual paste still works; signed-URL rejection with the plain-English message; raw-key regression using a namespace-scoped i18n mock (fails on the old wiring, passes on the fix). `looksLikeSignedUrl` unit-tested for S3 presigned, CloudFront signed, Azure SAS and harmless query strings.

`build:tsc` exit 0; design-lint at the file's pre-existing baseline; validator fully lint-clean.
