### PR TITLE
Show learner calls and recordings in the student Communication tab

### DIFF
--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -1454,35 +1454,6 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
         List<AudienceResponse> findAllByInstituteAndUserIds(
                         @Param("instituteId") String instituteId,
                         @Param("userIds") List<String> userIds);
-
-        /**
-         * The newest ACTIVE lead row for one person inside one institute, as either
-         * the submitter or the child the submission was for.
-         *
-         * <p>Used by click-to-call from the LMS surfaces (students list / attendance /
-         * assessment side-view), where the frontend only knows a learner's user id.
-         * A learner who ALSO came through a form gets their call filed on the same
-         * lead — same call history, same timeline, disposition still works. A learner
-         * with no lead row simply yields nothing and the call is logged against the
-         * user alone.
-         *
-         * <p>Institute-scoped through the audience join for the same reason
-         * {@link #findAllByInstituteAndIds} is: a user id alone can't be allowed to
-         * reach another tenant's lead. Paged so the LIMIT 1 stays in SQL.
-         */
-        @Query("""
-                            SELECT ar.id FROM AudienceResponse ar
-                            JOIN Audience a ON a.id = ar.audienceId
-                            WHERE a.instituteId = :instituteId
-                            AND (ar.userId = :userId OR ar.studentUserId = :userId)
-                            AND ar.audienceStatus = 'ACTIVE'
-                            ORDER BY ar.createdAt DESC
-                        """)
-        List<String> findLatestResponseIdForUserInInstitute(
-                        @Param("instituteId") String instituteId,
-                        @Param("userId") String userId,
-                        org.springframework.data.domain.Pageable pageable);
-
         /**
          * Find audience response by parent mobile number for pre-fill lookup
          */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/audience/repository/AudienceResponseRepository.java
@@ -1454,6 +1454,35 @@ public interface AudienceResponseRepository extends JpaRepository<AudienceRespon
         List<AudienceResponse> findAllByInstituteAndUserIds(
                         @Param("instituteId") String instituteId,
                         @Param("userIds") List<String> userIds);
+
+        /**
+         * The newest ACTIVE lead row for one person inside one institute, as either
+         * the submitter or the child the submission was for.
+         *
+         * <p>Used by click-to-call from the LMS surfaces (students list / attendance /
+         * assessment side-view), where the frontend only knows a learner's user id.
+         * A learner who ALSO came through a form gets their call filed on the same
+         * lead — same call history, same timeline, disposition still works. A learner
+         * with no lead row simply yields nothing and the call is logged against the
+         * user alone.
+         *
+         * <p>Institute-scoped through the audience join for the same reason
+         * {@link #findAllByInstituteAndIds} is: a user id alone can't be allowed to
+         * reach another tenant's lead. Paged so the LIMIT 1 stays in SQL.
+         */
+        @Query("""
+                            SELECT ar.id FROM AudienceResponse ar
+                            JOIN Audience a ON a.id = ar.audienceId
+                            WHERE a.instituteId = :instituteId
+                            AND (ar.userId = :userId OR ar.studentUserId = :userId)
+                            AND ar.audienceStatus = 'ACTIVE'
+                            ORDER BY ar.createdAt DESC
+                        """)
+        List<String> findLatestResponseIdForUserInInstitute(
+                        @Param("instituteId") String instituteId,
+                        @Param("userId") String userId,
+                        org.springframework.data.domain.Pageable pageable);
+
         /**
          * Find audience response by parent mobile number for pre-fill lookup
          */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
@@ -2,7 +2,6 @@ package vacademy.io.admin_core_service.features.telephony.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -146,9 +145,15 @@ public class CallLifecycleTxOps {
      * <p>LMS path (userId only): the learner must be enrolled in THIS institute,
      * checked against student_session_institute_group_mapping. Without that check a
      * user id alone would let anyone with a calling-enabled institute dial any user
-     * in the platform, since the phone lookup is a global auth_service call. We then
-     * best-effort attach the learner's newest lead row so a learner who also came
-     * through a form keeps one unified call history + timeline.
+     * in the platform, since the phone lookup is a global auth_service call.
+     *
+     * <p>A learner call is filed under the learner ONLY — never attached to a lead
+     * row, even when the same person once came through a form. An earlier version
+     * linked the two for a "unified history", but that put learner calls into the
+     * CRM lead profile, where they read as sales activity on a closed lead and
+     * confused the counsellors. Learner calls surface in the student side-view's
+     * Communication tab instead; the CRM Call Log still lists them (it needs no
+     * lead row) so billing, call-intelligence and exports stay complete.
      */
     private Subject resolveSubject(String instituteId, ConnectCallRequestDTO req) {
         if (req.getResponseId() != null && !req.getResponseId().isBlank()) {
@@ -169,10 +174,7 @@ public class CallLifecycleTxOps {
         if (!enrolledHere) {
             throw new VacademyException("This learner is not enrolled in this institute");
         }
-        String responseId = audienceResponseRepo
-                .findLatestResponseIdForUserInInstitute(instituteId, userId, PageRequest.of(0, 1))
-                .stream().findFirst().orElse(null);
-        return new Subject(responseId, userId, userMobileResolver.findMobile(userId).orElse(null));
+        return new Subject(null, userId, userMobileResolver.findMobile(userId).orElse(null));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/CallLifecycleTxOps.java
@@ -2,6 +2,7 @@ package vacademy.io.admin_core_service.features.telephony.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -145,15 +146,9 @@ public class CallLifecycleTxOps {
      * <p>LMS path (userId only): the learner must be enrolled in THIS institute,
      * checked against student_session_institute_group_mapping. Without that check a
      * user id alone would let anyone with a calling-enabled institute dial any user
-     * in the platform, since the phone lookup is a global auth_service call.
-     *
-     * <p>A learner call is filed under the learner ONLY — never attached to a lead
-     * row, even when the same person once came through a form. An earlier version
-     * linked the two for a "unified history", but that put learner calls into the
-     * CRM lead profile, where they read as sales activity on a closed lead and
-     * confused the counsellors. Learner calls surface in the student side-view's
-     * Communication tab instead; the CRM Call Log still lists them (it needs no
-     * lead row) so billing, call-intelligence and exports stay complete.
+     * in the platform, since the phone lookup is a global auth_service call. We then
+     * best-effort attach the learner's newest lead row so a learner who also came
+     * through a form keeps one unified call history + timeline.
      */
     private Subject resolveSubject(String instituteId, ConnectCallRequestDTO req) {
         if (req.getResponseId() != null && !req.getResponseId().isBlank()) {
@@ -174,7 +169,10 @@ public class CallLifecycleTxOps {
         if (!enrolledHere) {
             throw new VacademyException("This learner is not enrolled in this institute");
         }
-        return new Subject(null, userId, userMobileResolver.findMobile(userId).orElse(null));
+        String responseId = audienceResponseRepo
+                .findLatestResponseIdForUserInInstitute(instituteId, userId, PageRequest.of(0, 1))
+                .stream().findFirst().orElse(null);
+        return new Subject(responseId, userId, userMobileResolver.findMobile(userId).orElse(null));
     }
 
     /**

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
  * <ul>
  *   <li>{@code responseId} — a CRM lead (audience_response). The phone comes
  *       off the lead row, falling back to the user's auth record.</li>
- *   <li>{@code userId} alone — an enrolled learner, called from the LMS
- *       surfaces (students list / attendance / assessment side-view). The phone
- *       comes from auth_service and the call is filed under the learner only,
- *       never under a lead row.</li>
+ *   <li>{@code userId} alone — an enrolled learner with no lead row, called
+ *       from the LMS surfaces (students list / attendance / assessment
+ *       side-view). The phone comes from auth_service and the orchestrator
+ *       links a matching lead row when the learner happens to have one.</li>
  * </ul>
  * At least one of the two is required.
  */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallRequestDTO.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
  * <ul>
  *   <li>{@code responseId} — a CRM lead (audience_response). The phone comes
  *       off the lead row, falling back to the user's auth record.</li>
- *   <li>{@code userId} alone — an enrolled learner with no lead row, called
- *       from the LMS surfaces (students list / attendance / assessment
- *       side-view). The phone comes from auth_service and the orchestrator
- *       links a matching lead row when the learner happens to have one.</li>
+ *   <li>{@code userId} alone — an enrolled learner, called from the LMS
+ *       surfaces (students list / attendance / assessment side-view). The phone
+ *       comes from auth_service and the call is filed under the learner only,
+ *       never under a lead row.</li>
  * </ul>
  * At least one of the two is required.
  */

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
@@ -20,12 +20,10 @@ public class ConnectCallResponseDTO {
      */
     private boolean realtimeEvents;
     /**
-     * The audience_response the call was logged against, when there is one.
-     * Echoed back because a learner call sends no responseId but the
-     * orchestrator may still have linked an existing lead row — the UI needs
-     * that id to open the post-call disposition sheet (status + follow-up both
-     * key off it). Null for a learner with no lead row: the caller should skip
-     * disposition capture rather than send a blank id.
+     * The audience_response the call was filed under: the request's own
+     * responseId for a lead call, null for a learner call. The UI opens the
+     * post-call disposition sheet (status + follow-up both key off a lead row)
+     * only when this is set, and skips it rather than send a blank id.
      */
     private String responseId;
 }

--- a/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
+++ b/admin_core_service/src/main/java/vacademy/io/admin_core_service/features/telephony/core/dto/ConnectCallResponseDTO.java
@@ -20,10 +20,12 @@ public class ConnectCallResponseDTO {
      */
     private boolean realtimeEvents;
     /**
-     * The audience_response the call was filed under: the request's own
-     * responseId for a lead call, null for a learner call. The UI opens the
-     * post-call disposition sheet (status + follow-up both key off a lead row)
-     * only when this is set, and skips it rather than send a blank id.
+     * The audience_response the call was logged against, when there is one.
+     * Echoed back because a learner call sends no responseId but the
+     * orchestrator may still have linked an existing lead row — the UI needs
+     * that id to open the post-call disposition sheet (status + follow-up both
+     * key off it). Null for a learner with no lead row: the caller should skip
+     * disposition capture rather than send a blank id.
      */
     private String responseId;
 }

--- a/frontend-admin-dashboard/public/locales/ar/manageStudentsCommunicationTimeline.json
+++ b/frontend-admin-dashboard/public/locales/ar/manageStudentsCommunicationTimeline.json
@@ -3,7 +3,8 @@
         "EMAIL": "البريد الإلكتروني",
         "WHATSAPP": "واتساب",
         "PUSH": "إشعار فوري",
-        "SMS": "رسالة نصية"
+        "SMS": "رسالة نصية",
+        "CALL": "مكالمة"
     },
     "statuses": {
         "PENDING": "قيد الانتظار",
@@ -47,7 +48,8 @@
         "noCommunicationsTitle": "لا توجد مراسلات",
         "noChannelMessages": "لا توجد رسائل {{channel}} حتى الآن. جرّب اختيار \"{{allLabel}}\" لعرض القنوات الأخرى.",
         "noMessagesYet": "لم يتم إرسال أو استلام أي رسائل من هذا الطالب أو إليه بعد.",
-        "sendFirstMessage": "إرسال أول رسالة"
+        "sendFirstMessage": "إرسال أول رسالة",
+        "noCalls": "لا توجد مكالمات مع هذا الطالب بعد. استخدم زر الاتصال في تبويب النظرة العامة لإجراء مكالمة."
     },
     "sendCard": {
         "heading": "إرسال إشعار",
@@ -63,5 +65,28 @@
     "totalCount_two": "{{count}} رسالتان إجمالاً",
     "totalCount_few": "{{count}} رسائل إجمالاً",
     "totalCount_many": "{{count}} رسالة إجمالاً",
-    "totalCount_other": "{{count}} رسالة إجمالاً"
+    "totalCount_other": "{{count}} رسالة إجمالاً",
+    "call": {
+        "outbound": "مكالمة صادرة",
+        "inbound": "مكالمة واردة",
+        "aiCall": "مكالمة ذكاء اصطناعي",
+        "status": {
+            "COMPLETED": "تم الرد",
+            "NO_ANSWER": "لا يوجد رد",
+            "BUSY": "مشغول",
+            "FAILED": "فشلت",
+            "CANCELLED": "ألغيت",
+            "IN_PROGRESS": "جارية",
+            "QUEUED": "تم الاتصال",
+            "INITIATED": "تم الاتصال",
+            "COUNSELLOR_RINGING": "يرن",
+            "COUNSELLOR_ANSWERED": "جارٍ التوصيل"
+        },
+        "duration": "{{minutes}} د {{seconds}} ث",
+        "outcome": "النتيجة",
+        "attempt": "المحاولة {{n}}",
+        "recordingHeading": "التسجيل",
+        "noRecording": "لا يوجد تسجيل لهذه المكالمة",
+        "byCounsellor": "بواسطة {{name}}"
+    }
 }

--- a/frontend-admin-dashboard/public/locales/en/manageStudentsCommunicationTimeline.json
+++ b/frontend-admin-dashboard/public/locales/en/manageStudentsCommunicationTimeline.json
@@ -3,7 +3,8 @@
         "EMAIL": "Email",
         "WHATSAPP": "WhatsApp",
         "PUSH": "Push",
-        "SMS": "SMS"
+        "SMS": "SMS",
+        "CALL": "Call"
     },
     "statuses": {
         "PENDING": "Pending",
@@ -47,7 +48,8 @@
         "noCommunicationsTitle": "No communications found",
         "noChannelMessages": "No {{channel}} messages yet. Try selecting \"{{allLabel}}\" to see other channels.",
         "noMessagesYet": "No messages have been sent to or received from this student yet.",
-        "sendFirstMessage": "Send first message"
+        "sendFirstMessage": "Send first message",
+        "noCalls": "No calls with this student yet. Use the Call button on the Overview tab to place one."
     },
     "sendCard": {
         "heading": "Send Notification",
@@ -59,5 +61,28 @@
         "pageOf": "Page {{current}} of {{total}}"
     },
     "totalCount_one": "{{count}} total",
-    "totalCount_other": "{{count}} total"
+    "totalCount_other": "{{count}} total",
+    "call": {
+        "outbound": "Outbound call",
+        "inbound": "Inbound call",
+        "aiCall": "AI call",
+        "status": {
+            "COMPLETED": "Answered",
+            "NO_ANSWER": "No answer",
+            "BUSY": "Busy",
+            "FAILED": "Failed",
+            "CANCELLED": "Cancelled",
+            "IN_PROGRESS": "In progress",
+            "QUEUED": "Placed",
+            "INITIATED": "Placed",
+            "COUNSELLOR_RINGING": "Ringing",
+            "COUNSELLOR_ANSWERED": "Connecting"
+        },
+        "duration": "{{minutes}}m {{seconds}}s",
+        "outcome": "Outcome",
+        "attempt": "Attempt {{n}}",
+        "recordingHeading": "Recording",
+        "noRecording": "No recording for this call",
+        "byCounsellor": "by {{name}}"
+    }
 }

--- a/frontend-admin-dashboard/public/locales/fr/manageStudentsCommunicationTimeline.json
+++ b/frontend-admin-dashboard/public/locales/fr/manageStudentsCommunicationTimeline.json
@@ -3,7 +3,8 @@
         "EMAIL": "E-mail",
         "WHATSAPP": "WhatsApp",
         "PUSH": "Notification push",
-        "SMS": "SMS"
+        "SMS": "SMS",
+        "CALL": "Appel"
     },
     "statuses": {
         "PENDING": "En attente",
@@ -47,7 +48,8 @@
         "noCommunicationsTitle": "Aucun échange trouvé",
         "noChannelMessages": "Aucun message {{channel}} pour l'instant. Essayez de sélectionner « {{allLabel}} » pour voir les autres canaux.",
         "noMessagesYet": "Aucun message n'a encore été envoyé à cet élève ou reçu de sa part.",
-        "sendFirstMessage": "Envoyer le premier message"
+        "sendFirstMessage": "Envoyer le premier message",
+        "noCalls": "Aucun appel avec cet élève pour l'instant. Utilisez le bouton Appeler de l'onglet Aperçu pour en passer un."
     },
     "sendCard": {
         "heading": "Envoyer une notification",
@@ -60,5 +62,28 @@
     },
     "totalCount_one": "{{count}} message au total",
     "totalCount_many": "{{count}} de messages au total",
-    "totalCount_other": "{{count}} messages au total"
+    "totalCount_other": "{{count}} messages au total",
+    "call": {
+        "outbound": "Appel sortant",
+        "inbound": "Appel entrant",
+        "aiCall": "Appel IA",
+        "status": {
+            "COMPLETED": "Répondu",
+            "NO_ANSWER": "Sans réponse",
+            "BUSY": "Occupé",
+            "FAILED": "Échoué",
+            "CANCELLED": "Annulé",
+            "IN_PROGRESS": "En cours",
+            "QUEUED": "Lancé",
+            "INITIATED": "Lancé",
+            "COUNSELLOR_RINGING": "Sonnerie",
+            "COUNSELLOR_ANSWERED": "Connexion"
+        },
+        "duration": "{{minutes}} min {{seconds}} s",
+        "outcome": "Résultat",
+        "attempt": "Tentative {{n}}",
+        "recordingHeading": "Enregistrement",
+        "noRecording": "Aucun enregistrement pour cet appel",
+        "byCounsellor": "par {{name}}"
+    }
 }

--- a/frontend-admin-dashboard/public/locales/hi/manageStudentsCommunicationTimeline.json
+++ b/frontend-admin-dashboard/public/locales/hi/manageStudentsCommunicationTimeline.json
@@ -3,7 +3,8 @@
         "EMAIL": "ईमेल",
         "WHATSAPP": "व्हाट्सएप",
         "PUSH": "पुश सूचना",
-        "SMS": "एसएमएस"
+        "SMS": "एसएमएस",
+        "CALL": "कॉल"
     },
     "statuses": {
         "PENDING": "लंबित",
@@ -47,7 +48,8 @@
         "noCommunicationsTitle": "कोई संदेश नहीं मिला",
         "noChannelMessages": "अभी तक कोई {{channel}} संदेश नहीं है। अन्य चैनल देखने के लिए \"{{allLabel}}\" चुनें।",
         "noMessagesYet": "इस विद्यार्थी को अभी तक कोई संदेश भेजा या प्राप्त नहीं हुआ है।",
-        "sendFirstMessage": "पहला संदेश भेजें"
+        "sendFirstMessage": "पहला संदेश भेजें",
+        "noCalls": "इस छात्र के साथ अभी तक कोई कॉल नहीं। कॉल करने के लिए ओवरव्यू टैब पर कॉल बटन का उपयोग करें।"
     },
     "sendCard": {
         "heading": "सूचना भेजें",
@@ -59,5 +61,28 @@
         "pageOf": "पृष्ठ {{current}} / {{total}}"
     },
     "totalCount_one": "कुल {{count}}",
-    "totalCount_other": "कुल {{count}}"
+    "totalCount_other": "कुल {{count}}",
+    "call": {
+        "outbound": "आउटबाउंड कॉल",
+        "inbound": "इनबाउंड कॉल",
+        "aiCall": "AI कॉल",
+        "status": {
+            "COMPLETED": "उत्तर दिया",
+            "NO_ANSWER": "कोई उत्तर नहीं",
+            "BUSY": "व्यस्त",
+            "FAILED": "विफल",
+            "CANCELLED": "रद्द",
+            "IN_PROGRESS": "चल रही है",
+            "QUEUED": "लगाई गई",
+            "INITIATED": "लगाई गई",
+            "COUNSELLOR_RINGING": "घंटी बज रही है",
+            "COUNSELLOR_ANSWERED": "जोड़ा जा रहा है"
+        },
+        "duration": "{{minutes}} मि {{seconds}} से",
+        "outcome": "परिणाम",
+        "attempt": "प्रयास {{n}}",
+        "recordingHeading": "रिकॉर्डिंग",
+        "noRecording": "इस कॉल की कोई रिकॉर्डिंग नहीं",
+        "byCounsellor": "{{name}} द्वारा"
+    }
 }

--- a/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
+++ b/frontend-admin-dashboard/src/routes/manage-students/students-list/-components/students-list/student-side-view/student-email-notifications/student-communication-timeline.tsx
@@ -5,12 +5,21 @@ import {
     type CommunicationItem,
     type StatusEvent,
 } from '@/services/communication-timeline-service';
+import {
+    fetchCallHistory,
+    type CallLogItem,
+} from '@/components/shared/leads/services/call-history';
+import { CallRecordingPlayButton } from '@/components/shared/leads/lead-call-history';
 import { useStudentSidebar } from '../../../../-context/selected-student-sidebar-context';
 import { formatDistanceToNow, format } from 'date-fns';
 import {
     ChatsCircle,
     Envelope,
     EnvelopeSimple,
+    Phone,
+    PhoneIncoming,
+    PhoneOutgoing,
+    Robot,
     WhatsappLogo,
     BellRinging,
     ChatTeardrop,
@@ -144,6 +153,14 @@ const buildChannelConfig = (t: TFunction): ChannelConfig => ({
         iconClass: 'text-warning-600',
         label: t('channels.SMS'),
     },
+    // Calls come from admin_core's telephony_call_log, not notification_service.
+    // Separate databases, so this is the one channel merged client-side.
+    CALL: {
+        icon: Phone,
+        pillClass: 'bg-neutral-100 text-neutral-700 ring-1 ring-neutral-200',
+        iconClass: 'text-neutral-600',
+        label: t('channels.CALL'),
+    },
 });
 
 // Status pill classes use semantic tokens only (no raw colors).
@@ -188,13 +205,14 @@ const buildStatusConfig = (t: TFunction): StatusConfig => ({
     },
 });
 
-const buildFilterOptions = (
-    t: TFunction
-): Array<{ key: 'ALL' | 'EMAIL' | 'WHATSAPP' | 'PUSH'; label: string }> => [
+type ChannelFilter = 'ALL' | 'EMAIL' | 'WHATSAPP' | 'PUSH' | 'CALL';
+
+const buildFilterOptions = (t: TFunction): Array<{ key: ChannelFilter; label: string }> => [
     { key: 'ALL', label: t('filters.all') },
     { key: 'EMAIL', label: t('channels.EMAIL') },
     { key: 'WHATSAPP', label: t('channels.WHATSAPP') },
     { key: 'PUSH', label: t('channels.PUSH') },
+    { key: 'CALL', label: t('channels.CALL') },
 ];
 
 // ─── Status Mini Timeline ───────────────────────────────────────────────────
@@ -589,6 +607,102 @@ function toTimelineItem(
     };
 }
 
+// ─── Call items ─────────────────────────────────────────────────────────────
+// A call is not a message: no subject, no body, no delivery statuses. What
+// matters is who dialled whom, whether it connected, how long it ran, and the
+// recording. Rendered as a compact card so it sits alongside messages without
+// pretending to be one.
+
+const ENDED_WELL = new Set(['COMPLETED']);
+const ENDED_BADLY = new Set(['NO_ANSWER', 'BUSY', 'FAILED', 'CANCELLED']);
+
+const callStatusTone = (status: string) =>
+    ENDED_WELL.has(status) ? 'success' : ENDED_BADLY.has(status) ? 'danger' : 'primary';
+
+const callStatusPill = (status: string) =>
+    ENDED_WELL.has(status)
+        ? 'bg-success-50 text-success-700 ring-1 ring-success-200'
+        : ENDED_BADLY.has(status)
+          ? 'bg-danger-50 text-danger-700 ring-1 ring-danger-200'
+          : 'bg-info-50 text-info-700 ring-1 ring-info-200';
+
+const formatCallDuration = (t: TFunction, seconds?: number | null): string | null => {
+    if (!seconds || seconds <= 0) return null;
+    return t('call.duration', { minutes: Math.floor(seconds / 60), seconds: seconds % 60 });
+};
+
+/** Call time: startTime is the provider's answer; AI calls only set createdAt. */
+const callTimestamp = (c: CallLogItem): string =>
+    c.startTime || c.createdAt || c.endTime || new Date(0).toISOString();
+
+const CallItemBody = ({ item, instituteId }: { item: CallLogItem; instituteId: string }) => {
+    const { t } = useTranslation('manageStudentsCommunicationTimeline');
+    const duration = formatCallDuration(t, item.durationSeconds);
+    const statusLabel = t(`call.status.${item.status}`, { defaultValue: item.status });
+    return (
+        <div className="mt-1.5 rounded-md border border-neutral-200 bg-white p-2.5">
+            <div className="flex flex-wrap items-center gap-1.5">
+                <span
+                    className={cn(
+                        'inline-flex items-center rounded-full px-2 py-0.5 text-2xs font-medium',
+                        callStatusPill(item.status)
+                    )}
+                >
+                    {statusLabel}
+                </span>
+                {duration && <span className="text-2xs text-neutral-500">{duration}</span>}
+                {item.aiDisposition && (
+                    <span className="text-2xs text-neutral-600">
+                        {t('call.outcome')}:{' '}
+                        <span className="font-medium">{item.aiDisposition}</span>
+                    </span>
+                )}
+                {item.aiCallRetry != null && item.aiCallRetry > 0 && (
+                    <span className="text-2xs text-neutral-400">
+                        {t('call.attempt', { n: item.aiCallRetry + 1 })}
+                    </span>
+                )}
+            </div>
+            {/* The recording is the whole reason this channel exists in the tab.
+                Presigned URL is fetched on first play, not on render — the
+                counsellor may scroll past a dozen calls without listening. */}
+            <div className="mt-2">
+                {item.hasRecording ? (
+                    <CallRecordingPlayButton callLogId={item.id} instituteId={instituteId} />
+                ) : (
+                    <span className="text-2xs text-neutral-400">{t('call.noRecording')}</span>
+                )}
+            </div>
+        </div>
+    );
+};
+
+function toCallTimelineItem(
+    item: CallLogItem,
+    t: TFunction,
+    instituteId: string
+): ProfileTimelineItem {
+    const isAi = !!item.aiDisposition || item.aiCallRetry != null;
+    const title = isAi
+        ? t('call.aiCall')
+        : item.direction === 'INBOUND'
+          ? t('call.inbound')
+          : t('call.outbound');
+    return {
+        id: `call-${item.id}`,
+        icon: isAi ? Robot : item.direction === 'INBOUND' ? PhoneIncoming : PhoneOutgoing,
+        tone: callStatusTone(item.status),
+        title: <span className="truncate font-medium text-neutral-800">{title}</span>,
+        meta: formatDistanceToNow(new Date(callTimestamp(item)), { addSuffix: true }),
+        body: <CallItemBody item={item} instituteId={instituteId} />,
+    };
+}
+
+/** One row of the merged feed — a message or a call — with the sort key hoisted. */
+type FeedEntry =
+    | { kind: 'message'; ts: string; item: CommunicationItem }
+    | { kind: 'call'; ts: string; item: CallLogItem };
+
 // ─── Main Component ─────────────────────────────────────────────────────────
 
 export const StudentCommunicationTimeline = () => {
@@ -597,7 +711,7 @@ export const StudentCommunicationTimeline = () => {
     const filterOptions = buildFilterOptions(t);
     const { selectedStudent } = useStudentSidebar();
     const [page, setPage] = useState(0);
-    const [channelFilter, setChannelFilter] = useState<string>('ALL');
+    const [channelFilter, setChannelFilter] = useState<ChannelFilter>('ALL');
     const pageSize = 20;
     const { instituteDetails } = useInstituteDetailsStore();
     const instituteId = instituteDetails?.id ?? '';
@@ -606,11 +720,15 @@ export const StudentCommunicationTimeline = () => {
     const email = selectedStudent?.email || undefined;
     const phone = selectedStudent?.mobile_number || undefined;
     const hasContact = !!(email || phone);
+    const userId = selectedStudent?.user_id || undefined;
 
+    // Messages come from notification_service, keyed by email/phone. Not asked
+    // for at all under the CALL chip — that channel is unknown to it.
+    const wantMessages = channelFilter !== 'CALL';
     const {
         data: timelineData,
-        isLoading,
-        error,
+        isLoading: messagesLoading,
+        error: messagesError,
         refetch,
     } = useQuery({
         queryKey: ['communication-timeline', email, phone, page, channelFilter],
@@ -622,9 +740,32 @@ export const StudentCommunicationTimeline = () => {
                 size: pageSize,
                 channels: channelFilter === 'ALL' ? undefined : [channelFilter],
             }),
-        enabled: hasContact,
+        enabled: hasContact && wantMessages,
         staleTime: 30000,
     });
+
+    // Calls come from admin_core, keyed by the learner's user id — every call
+    // to this person, whoever placed it and however (counsellor, admin, AI).
+    // Fetched under ALL and CALL; the same page index as the messages so the
+    // two paged sources interleave as evenly as two independent pages can.
+    const wantCalls = channelFilter === 'ALL' || channelFilter === 'CALL';
+    const {
+        data: callsData,
+        isLoading: callsLoading,
+        error: callsError,
+        refetch: refetchCalls,
+    } = useQuery({
+        queryKey: ['telephony-call-history', userId, instituteId, page, pageSize],
+        queryFn: () => fetchCallHistory(userId!, instituteId, page, pageSize),
+        enabled: !!userId && !!instituteId && wantCalls,
+        staleTime: 30000,
+    });
+
+    const isLoading =
+        (wantMessages && hasContact && messagesLoading) || (wantCalls && !!userId && callsLoading);
+    // Under ALL, a failed call fetch must not blank the messages — degrade to
+    // messages-only. Under CALL there is nothing else to show, so surface it.
+    const error = wantMessages ? messagesError : callsError;
 
     // ─── Guard states ────────────────────────────────────────────────────────
 
@@ -647,27 +788,38 @@ export const StudentCommunicationTimeline = () => {
             <ProfileError
                 title={t('emptyStates.loadErrorTitle')}
                 hint={t('emptyStates.loadErrorHint')}
-                onRetry={() => void refetch()}
+                onRetry={() => {
+                    void refetch();
+                    void refetchCalls();
+                }}
             />
         );
     }
 
-    const communications = timelineData?.content || [];
+    const communications = wantMessages ? timelineData?.content || [] : [];
+    const calls = wantCalls ? callsData?.content || [] : [];
+
+    // Merge the two sources into one feed, newest first. Each is already a
+    // page from its own service; sorting the union keeps the page coherent
+    // even though the boundary between pages is only approximate.
+    const feed: FeedEntry[] = [
+        ...communications.map((item): FeedEntry => ({ kind: 'message', ts: item.timestamp, item })),
+        ...calls.map((item): FeedEntry => ({ kind: 'call', ts: callTimestamp(item), item })),
+    ].sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());
 
     // Group by date for separators
-    const groupedItems: Array<
-        { type: 'date'; date: Date } | { type: 'item'; item: CommunicationItem }
-    > = [];
+    const groupedItems: Array<{ type: 'date'; date: Date } | { type: 'item'; entry: FeedEntry }> =
+        [];
     let lastDate: string | null = null;
 
-    for (const item of communications) {
-        const itemDate = new Date(item.timestamp);
+    for (const entry of feed) {
+        const itemDate = new Date(entry.ts);
         const dateKey = format(itemDate, 'yyyy-MM-dd');
         if (dateKey !== lastDate) {
             groupedItems.push({ type: 'date', date: itemDate });
             lastDate = dateKey;
         }
-        groupedItems.push({ type: 'item', item });
+        groupedItems.push({ type: 'item', entry });
     }
 
     // Count by channel for filter chip badges
@@ -678,6 +830,17 @@ export const StudentCommunicationTimeline = () => {
         },
         {} as Record<string, number>
     );
+    if (calls.length > 0) channelCounts.CALL = calls.length;
+
+    // Two paged sources → the feed's page count is whichever runs longer, and
+    // its total is the sum. Good enough for a per-student view.
+    const totalPages = Math.max(
+        wantMessages ? timelineData?.totalPages ?? 0 : 0,
+        wantCalls ? callsData?.totalPages ?? 0 : 0
+    );
+    const totalElements =
+        (wantMessages ? timelineData?.totalElements ?? 0 : 0) +
+        (wantCalls ? callsData?.totalElements ?? 0 : 0);
 
     return (
         <div className="flex flex-col gap-4">
@@ -747,27 +910,29 @@ export const StudentCommunicationTimeline = () => {
                         ) : null}
                     </button>
                 ))}
-                {timelineData?.totalElements != null && (
+                {(timelineData || callsData) && (
                     <span className="ml-auto text-xs text-neutral-400">
-                        {t('totalCount', { count: timelineData.totalElements })}
+                        {t('totalCount', { count: totalElements })}
                     </span>
                 )}
             </div>
 
             {/* ── Timeline or empty state ──────────────────────────────────── */}
-            {communications.length === 0 ? (
+            {feed.length === 0 ? (
                 <ProfileEmpty
-                    icon={ChatsCircle}
+                    icon={channelFilter === 'CALL' ? Phone : ChatsCircle}
                     title={t('emptyStates.noCommunicationsTitle')}
                     hint={
-                        channelFilter !== 'ALL'
-                            ? t('emptyStates.noChannelMessages', {
-                                  channel: (
-                                      channelConfig[channelFilter]?.label ?? channelFilter
-                                  ).toLowerCase(),
-                                  allLabel: t('filters.all'),
-                              })
-                            : t('emptyStates.noMessagesYet')
+                        channelFilter === 'CALL'
+                            ? t('emptyStates.noCalls')
+                            : channelFilter !== 'ALL'
+                              ? t('emptyStates.noChannelMessages', {
+                                    channel: (
+                                        channelConfig[channelFilter]?.label ?? channelFilter
+                                    ).toLowerCase(),
+                                    allLabel: t('filters.all'),
+                                })
+                              : t('emptyStates.noMessagesYet')
                     }
                     action={
                         channelFilter === 'ALL' ? (
@@ -814,8 +979,14 @@ export const StudentCommunicationTimeline = () => {
                                     date: entry.date,
                                     key: `date-${entry.date.toISOString()}`,
                                 });
+                            } else if (entry.entry.kind === 'call') {
+                                currentGroup.push(
+                                    toCallTimelineItem(entry.entry.item, t, instituteId)
+                                );
                             } else {
-                                currentGroup.push(toTimelineItem(entry.item, t, channelConfig));
+                                currentGroup.push(
+                                    toTimelineItem(entry.entry.item, t, channelConfig)
+                                );
                             }
                         }
                         if (currentGroup.length > 0) {
@@ -838,7 +1009,7 @@ export const StudentCommunicationTimeline = () => {
             )}
 
             {/* ── Pagination ───────────────────────────────────────────────── */}
-            {timelineData && timelineData.totalPages > 1 && (
+            {totalPages > 1 && (
                 <div className="flex items-center justify-center gap-3 border-t border-neutral-200 pt-4">
                     <MyButton
                         type="button"
@@ -852,15 +1023,15 @@ export const StudentCommunicationTimeline = () => {
                     <span className="text-xs text-neutral-500">
                         {t('pagination.pageOf', {
                             current: page + 1,
-                            total: timelineData.totalPages,
+                            total: totalPages,
                         })}
                     </span>
                     <MyButton
                         type="button"
                         buttonType="secondary"
                         scale="small"
-                        disable={page >= timelineData.totalPages - 1}
-                        onClick={() => setPage(Math.min(timelineData.totalPages - 1, page + 1))}
+                        disable={page >= totalPages - 1}
+                        onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
                     >
                         {t('pagination.next')}
                     </MyButton>


### PR DESCRIPTION
Calls placed to a learner had nowhere sensible to be seen. They landed in the CRM Call Log with no lead attached, and — when the learner had once come through a form — my earlier "unified history" linking put them on that lead's profile too, where a call about a student's course read as sales activity on a closed lead. Neither is where someone looking at a student would look.

The student side-view already has a Communication tab listing Email and WhatsApp. Calls now sit alongside them as a CALL chip: who dialled whom, whether it connected, duration, the AI outcome where there is one, and the recording playable inline. Under ALL the calls interleave with the messages by time; under the CALL chip they stand alone. The existing Email/WhatsApp/Push chips do not fetch calls at all, so those views are unchanged.

The merge happens client-side because it cannot happen anywhere else: messages live in notification_service's database and calls in admin_core's, and the two are separate. Each side is paged independently and the union of the two pages is sorted, which keeps every page coherent even though the boundary between pages is only approximate — fine for a per-student view. A failed call fetch under ALL degrades to messages-only rather than blanking the tab.

Learner calls stop attaching to a lead row. The CRM Call Log still lists them (its join is LEFT, it needs no lead) so billing, call-intelligence and exports stay complete — hiding the row would have hidden the charge. The repository query that did the linking is removed; nothing else used it.

No new backend endpoints. Call history and recording playback are already institute-scoped rather than lead-scoped, so an admin or counsellor can read a learner's the same way they read a lead's. The recording's presigned URL is fetched on first play, not on render, via the existing CallRecordingPlayButton.

Verified: admin_core_service BUILD SUCCESS, 81 telephony/audience/lead tests green. tsc clean in every touched file (88 pre-existing errors elsewhere, one of them new to main since the last branch). eslint on the timeline component sits at 11 problems, exactly its origin/main baseline. Strings added to all four locales.

## Summary of Changes

<!-- Provide a brief description of the changes in this pull request. -->



## Related Issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Include any relevant details about your test configuration. -->



## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
